### PR TITLE
[WIP] Upgrade React to version 16

### DIFF
--- a/web/app/editor/KurssiEditor.jsx
+++ b/web/app/editor/KurssiEditor.jsx
@@ -35,7 +35,7 @@ export class KurssiEditor extends React.Component {
     let className = buildClassNames(['tunniste', kurssinTyyppi, !edit && 'hoverable'])
     return (
       <li className="kurssi" ref={e => this.kurssiElement = e}>
-        <a onClick={showDetails} onMouseEnter={!edit && showDetails} onMouseLeave={!edit && hideDetails} className={className} title={modelTitle(kurssi, 'koulutusmoduuli')}>{koulutusmoduuli.tunniste.koodiarvo}</a>
+        <a onClick={showDetails} onMouseEnter={!edit ? showDetails : undefined} onMouseLeave={!edit ? hideDetails : undefined} className={className} title={modelTitle(kurssi, 'koulutusmoduuli')}>{koulutusmoduuli.tunniste.koodiarvo}</a>
         {
           edit && <a className="remove-value" onClick={() => pushRemoval(kurssi)}/>
         }


### PR DESCRIPTION
Issues to be resolved (may not be an exhaustive list):

- [x] React 16 expects listeners to be functions (or undefined) instead of booleans (commit be8f3d6)
  - unless https://github.com/facebook/react/issues/11027
- [ ] Tests are problematic, because React 16 relies on Map and Set (https://reactjs.org/blog/2017/09/26/react-v16.0.html#javascript-environment-requirements), but PhantomJS does not support them
  - Polyfill, or maybe in the long run move to https://github.com/GoogleChrome/puppeteer

Dependencies:

- [ ] https://github.com/akiran/react-highlight
	- wait for PR to be merged: see https://github.com/akiran/react-highlight/pull/43 (or fork?) 
- [ ] https://github.com/Dentosal/react-highlighter
	- merge upstream (adds React 16 as peer dependency: helior/react-highlighter@1151ef1)
- [ ] https://github.com/calmm-js/baret
	- causes `Warning: Accessing createClass via the main React package is deprecated`