### PR TITLE
Kansalaiskali restrict login

### DIFF
--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -67,7 +67,9 @@ class ScalatraBootstrap extends LifeCycle with Logging with GlobalExecutionConte
       mount("/user/login", new LocalLoginServlet)
     }
     mount("/user/logout", new LogoutServlet)
-    mount("/user/shibbolethlogin", new ShibbolethLoginServlet(application))
+    if (application.env.isDevEnvironment) {
+      mount("/user/shibbolethlogin", new ShibbolethLoginServlet(application))
+    }
     mount("/cas", new CasServlet)
     mount("/cache", new CacheServlet)
 

--- a/src/main/scala/fi/oph/koski/IndexServlet.scala
+++ b/src/main/scala/fi/oph/koski/IndexServlet.scala
@@ -16,7 +16,11 @@ class IndexServlet(implicit val application: KoskiApplication) extends ScalatraS
   }
 
   get("/") {
-    htmlIndex("koski-lander.js")
+    if (application.env.isDevEnvironment) {
+      htmlIndex("koski-landerWithLogin.js")
+    } else {
+      htmlIndex("koski-lander.js")
+    }
   }
 
   get("/virkailija") {

--- a/src/main/scala/fi/oph/koski/config/Environment.scala
+++ b/src/main/scala/fi/oph/koski/config/Environment.scala
@@ -11,6 +11,8 @@ case class Environment(application: KoskiApplication) {
   def databaseIsLarge = Environment.databaseIsLarge(application.masterDatabase.db)
 
   def indexIsLarge = application.koskiPulssi.opiskeluoikeusTilasto.opiskeluoikeuksienMäärä > 100
+
+  def isDevEnvironment = List("local", "OPHKoskiDev").contains(application.config.getString("env"))
 }
 
 object Environment {

--- a/src/main/scala/fi/oph/koski/config/KoskiApplication.scala
+++ b/src/main/scala/fi/oph/koski/config/KoskiApplication.scala
@@ -84,6 +84,7 @@ class KoskiApplication(val config: Config, implicit val cacheManager: CacheManag
   lazy val basicAuthSecurity = new BasicAuthSecurity(masterDatabase.db, config)
   lazy val localizationRepository = LocalizationRepository(config)
   lazy val oidGenerator = OidGenerator(config)
+  lazy val env = Environment(this)
 
   lazy val init: Future[Unit] = {
     perustiedotIndexer.init // This one will not be awaited for; it's ok that indexing continues while application is running

--- a/src/main/scala/fi/oph/koski/fixture/Fixtures.scala
+++ b/src/main/scala/fi/oph/koski/fixture/Fixtures.scala
@@ -26,14 +26,13 @@ class FixtureCreator(application: KoskiApplication) extends Logging with Timing 
     } else {
       KoskiDatabaseConfig(config).isLocal && config.getString("opintopolku.virkailija.url") == "mock"
     }
-    val environment = Environment(application)
     if (useFixtures && !Environment.isLocalDevelopmentEnvironment) {
       throw new RuntimeException("Trying to use fixtures when running in a server environment")
     }
-    if (useFixtures && environment.databaseIsLarge) {
+    if (useFixtures && application.env.databaseIsLarge) {
       throw new RuntimeException("Trying to use fixtures against a database with more than 100 rows")
     }
-    if (useFixtures && environment.indexIsLarge) {
+    if (useFixtures && application.env.indexIsLarge) {
       throw new RuntimeException("Trying to use fixtures against an ElasticSearch index with more than 100 rows")
     }
     useFixtures

--- a/web/app/lander/IdLogin.jsx
+++ b/web/app/lander/IdLogin.jsx
@@ -1,8 +1,8 @@
 import React from 'baret'
 import Bacon from 'baconjs'
 import Atom from 'bacon.atom'
-import Http from './http'
-import Text from './Text.jsx'
+import Http from '../http'
+import Text from '../Text.jsx'
 
 const LoginUrl = '/koski/user/shibbolethlogin'
 const RedirectUrl = '/koski/omattiedot'

--- a/web/app/lander/Lander.jsx
+++ b/web/app/lander/Lander.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import './style/main.less'
-import {TopBar} from './TopBar.jsx'
-import Text from './Text.jsx'
+import '../style/main.less'
+import {TopBar} from '../TopBar.jsx'
+import Text from '../Text.jsx'
 import {IdLogin} from './IdLogin.jsx'
 
 const Lander = () => (

--- a/web/app/lander/LanderInfo.jsx
+++ b/web/app/lander/LanderInfo.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import Text from '../Text.jsx'
+
+const LanderInfo = () => (
+  <div className={'lander'}>
+    <h1><Text name="Koski-palvelu"/></h1>
+    <p><Text name="Koulutustiedot luotettavasti yhdestä paikasta"/></p>
+    <div className={'lander__caption'}>
+      <p><Text name="Lander ingressi 1"/></p>
+      <p><Text name="Lander ingressi 2"/></p>
+    </div>
+  </div>
+)
+
+export {LanderInfo}

--- a/web/app/lander/LanderWithLogin.jsx
+++ b/web/app/lander/LanderWithLogin.jsx
@@ -3,11 +3,13 @@ import ReactDOM from 'react-dom'
 import '../style/main.less'
 import {TopBar} from '../TopBar.jsx'
 import {LanderInfo} from './LanderInfo.jsx'
+import {IdLogin} from './IdLogin.jsx'
 
 ReactDOM.render((
   <div>
     <TopBar user={null} saved={null} title={''}/>
     <LanderInfo/>
+    <IdLogin/>
   </div>
 ), document.getElementById('content'))
 

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -8,7 +8,8 @@ module.exports = {
     main: './app/Koski.jsx',
     login: './app/Login.jsx',
     pulssi: './app/Pulssi.jsx',
-    lander: './app/Lander.jsx'
+    lander: './app/lander/Lander.jsx',
+    landerWithLogin: './app/lander/LanderWithLogin.jsx'
   },
   output: {
     path: __dirname + '/../target/webapp',


### PR DESCRIPTION
**Summary**: Only show national identification number login form within lander page on development environments (local and dev).

**Implementation**: Conditionally serve a separate js bundle that includes/excludes the login form based on environment (in order to prevent leaking the client-side components to users in higher-than-dev environments).

**Note**: The js bundles are still accessible with a direct URI. Should they be?