### PR TITLE
Muotoile Virta-suoritukset käyttöliittymässä

### DIFF
--- a/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
+++ b/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
@@ -20,7 +20,8 @@ case class KorkeakoulunOpiskeluoikeus(
   tila: KorkeakoulunOpiskeluoikeudenTila,
   suoritukset: List[KorkeakouluSuoritus],
   @KoodistoKoodiarvo("korkeakoulutus")
-  tyyppi: Koodistokoodiviite = Koodistokoodiviite("korkeakoulutus", Some("Korkeakoulutus"), "opiskeluoikeudentyyppi", None)
+  tyyppi: Koodistokoodiviite = Koodistokoodiviite("korkeakoulutus", Some("Korkeakoulutus"), "opiskeluoikeudentyyppi", None),
+  synteettinen: Boolean = false
 ) extends Opiskeluoikeus {
   override def versionumero = None
   override def lisätiedot = None

--- a/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
+++ b/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
@@ -112,7 +112,10 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
       koulutusmoduuli = KorkeakoulunOpintojakso(
         tunniste = PaikallinenKoodi((suoritus \\ "@koulutusmoduulitunniste").text, nimi(suoritus)),
         nimi = nimi(suoritus),
-        laajuus = (suoritus \ "Laajuus" \ "Opintopiste").headOption.map(_.text.toFloat).filter(_ > 0).map(op => LaajuusOpintopisteissä(op))
+        laajuus = for {
+          yksikko <- koodistoViitePalvelu.getKoodistoKoodiViite("opintojenlaajuusyksikko", "2")
+          laajuus <- (suoritus \ "Laajuus" \ "Opintopiste").headOption.map(_.text.toFloat).filter(_ > 0)
+        } yield LaajuusOpintopisteissä(laajuus, yksikko)
       ),
       arviointi = arviointi(suoritus),
       vahvistus = None,

--- a/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
+++ b/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
@@ -60,7 +60,8 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
         oppilaitos = Some(organisaatio),
         koulutustoimija = None,
         suoritukset = suoritukset,
-        tila = KorkeakoulunOpiskeluoikeudenTila(Nil)
+        tila = KorkeakoulunOpiskeluoikeudenTila(Nil),
+        synteettinen = true
       )
     }
 

--- a/web/app/opiskeluoikeus/OpiskeluoikeusEditor.jsx
+++ b/web/app/opiskeluoikeus/OpiskeluoikeusEditor.jsx
@@ -22,7 +22,7 @@ export const OpiskeluoikeusEditor = ({model}) => {
     let context = mdl.context
     let suoritukset = modelItems(mdl, 'suoritukset')
     assignTabNames(suoritukset)
-    let excludedProperties = ['suoritukset', 'alkamispäivä', 'arvioituPäättymispäivä', 'päättymispäivä', 'oppilaitos', 'lisätiedot']
+    let excludedProperties = ['suoritukset', 'alkamispäivä', 'arvioituPäättymispäivä', 'päättymispäivä', 'oppilaitos', 'lisätiedot', 'synteettinen']
     var index = suoritusTabIndex(suoritukset)
     if (index < 0 || index >= suoritukset.length) {
       navigateTo(urlForTab(suoritukset, index))
@@ -36,50 +36,66 @@ export const OpiskeluoikeusEditor = ({model}) => {
       pushModel(modelSetValues(model, {'alkamispäivä' : value, 'tila.opiskeluoikeusjaksot.0.alku': value}))
     })
 
+    const hasAlkamispäivä = !!modelData(mdl, 'alkamispäivä')
+    const isSyntheticOpiskeluoikeus = modelData(model, 'synteettinen')
+
     return (
       <div className="opiskeluoikeus">
         <h3>
           <span className="otsikkotiedot">
             <span className="oppilaitos inline-text">{modelTitle(mdl, 'oppilaitos')}{','}</span>
             <span className="koulutus inline-text">{(näytettävätPäätasonSuoritukset(model)[0] || {}).title}</span>
-            { modelData(mdl, 'alkamispäivä')
-              ? <span className="inline-text">{'('}
+            {hasAlkamispäivä && (
+              <span className="inline-text">{'('}
                 <span className="alku pvm">{yearFromIsoDateString(modelTitle(mdl, 'alkamispäivä'))}</span>{'-'}
                 <span className="loppu pvm">{yearFromIsoDateString(modelTitle(mdl, 'päättymispäivä'))}{', '}</span>
                 <span className="tila">{modelTitle(mdl, 'tila.opiskeluoikeusjaksot.-1.tila').toLowerCase()}{')'}</span>
-                </span>
-              : null
-            }
+              </span>
+            )}
           </span>
           {!model.context.kansalainen && <Versiohistoria opiskeluoikeusOid={oid} oppijaOid={context.oppijaOid}/>}
           {!model.context.kansalainen && <OpiskeluoikeudenId opiskeluoikeus={mdl}/>}
         </h3>
         <div className={mdl.context.edit ? 'opiskeluoikeus-content editing' : 'opiskeluoikeus-content'}>
-          <div className="opiskeluoikeuden-tiedot">
-            {editLink}
-            <OpiskeluoikeudenOpintosuoritusoteLink opiskeluoikeus={mdl}/>
-            {
-              modelData(mdl, 'alkamispäivä') && <OpiskeluoikeudenVoimassaoloaika opiskeluoikeus={mdl}/>
-            }
-            <PropertiesEditor
-              model={mdl}
-              propertyFilter={ p => !excludedProperties.includes(p.key) }
-              getValueEditor={ (prop, getDefault) => prop.key === 'tila'
-                ? <OpiskeluoikeudenTilaEditor model={mdl} alkuChangeBus={alkuChangeBus}/>
-                : getDefault() }
-             />
-            {
-              modelLookup(mdl, 'lisätiedot') && <ExpandablePropertiesEditor model={mdl} propertyName="lisätiedot" propertyFilter={prop => context.edit || modelData(prop.model) !== false} />
-            }
-          </div>
-          <div className="suoritukset">
-            <Suoritukset opiskeluoikeus={mdl} valittuSuoritus={valittuSuoritus}/>
-          </div>
+          {!isSyntheticOpiskeluoikeus &&
+            <OpiskeluoikeudenTiedot
+              opiskeluoikeus={mdl}
+              excludedProperties={excludedProperties}
+              editLink={editLink}
+              alkuChangeBus={alkuChangeBus}
+            />
+          }
+          <Suoritukset opiskeluoikeus={mdl} valittuSuoritus={valittuSuoritus}/>
         </div>
       </div>)
     }
   } />)
 }
+
+const OpiskeluoikeudenTiedot = ({opiskeluoikeus, excludedProperties, editLink, alkuChangeBus}) => (
+  <div className="opiskeluoikeuden-tiedot">
+    {editLink}
+    <OpiskeluoikeudenOpintosuoritusoteLink opiskeluoikeus={opiskeluoikeus}/>
+    {
+      modelData(opiskeluoikeus, 'alkamispäivä') && <OpiskeluoikeudenVoimassaoloaika opiskeluoikeus={opiskeluoikeus}/>
+    }
+    <PropertiesEditor
+      model={opiskeluoikeus}
+      propertyFilter={ p => !excludedProperties.includes(p.key) }
+      getValueEditor={ (prop, getDefault) => prop.key === 'tila'
+        ? <OpiskeluoikeudenTilaEditor model={opiskeluoikeus} alkuChangeBus={alkuChangeBus}/>
+        : getDefault() }
+    />
+    {
+      modelLookup(opiskeluoikeus, 'lisätiedot') &&
+      <ExpandablePropertiesEditor
+        model={opiskeluoikeus}
+        propertyName="lisätiedot"
+        propertyFilter={prop => context.edit || modelData(prop.model) !== false}
+      />
+    }
+  </div>
+)
 
 const OpiskeluoikeudenId = ({opiskeluoikeus}) => {
   let selectAllText = (e) => {
@@ -109,15 +125,19 @@ const Suoritukset = ({opiskeluoikeus, valittuSuoritus}) => {
   const opiskeluoikeusTyyppi = modelData(opiskeluoikeus, 'tyyppi').koodiarvo
   const suoritukset = modelItems(opiskeluoikeus, 'suoritukset')
 
-  return opiskeluoikeusTyyppi === 'korkeakoulutus'
-    ? <Korkeakoulusuoritukset opiskeluoikeus={opiskeluoikeus}/>
-    : (
-      <div className="suoritukset">
-        <h4><Text name="Suoritukset"/></h4>
-        <SuoritusTabs model={opiskeluoikeus} suoritukset={suoritukset}/>
-        <Editor key={valittuSuoritus.tabName} model={valittuSuoritus} alwaysUpdate="true" />
-      </div>
-    )
+  return (
+    <div className="suoritukset">
+      {opiskeluoikeusTyyppi === 'korkeakoulutus'
+        ? <Korkeakoulusuoritukset opiskeluoikeus={opiskeluoikeus}/>
+        : (
+          <div className="suoritukset">
+            <h4><Text name="Suoritukset"/></h4>
+            <SuoritusTabs model={opiskeluoikeus} suoritukset={suoritukset}/>
+            <Editor key={valittuSuoritus.tabName} model={valittuSuoritus} alwaysUpdate="true" />
+          </div>
+        )}
+    </div>
+  )
 }
 
 class OpiskeluoikeudenOpintosuoritusoteLink extends React.Component {

--- a/web/app/opiskeluoikeus/OpiskeluoikeusEditor.jsx
+++ b/web/app/opiskeluoikeus/OpiskeluoikeusEditor.jsx
@@ -13,6 +13,7 @@ import {navigateTo} from '../util/location'
 import {suorituksenTyyppi, suoritusTitle} from '../suoritus/Suoritus'
 import Text from '../i18n/Text'
 import {assignTabNames, suoritusTabIndex, SuoritusTabs, urlForTab} from '../suoritus/SuoritusTabs'
+import {Korkeakoulusuoritukset} from '../virta/Korkeakoulusuoritukset'
 
 export const OpiskeluoikeusEditor = ({model}) => {
   let oid = modelData(model, 'oid')
@@ -72,9 +73,7 @@ export const OpiskeluoikeusEditor = ({model}) => {
             }
           </div>
           <div className="suoritukset">
-            <h4><Text name="Suoritukset"/></h4>
-            <SuoritusTabs model={mdl} suoritukset={suoritukset}/>
-            <Editor key={valittuSuoritus.tabName} model={valittuSuoritus} alwaysUpdate="true" />
+            <Suoritukset opiskeluoikeus={mdl} valittuSuoritus={valittuSuoritus}/>
           </div>
         </div>
       </div>)
@@ -104,6 +103,21 @@ const OpiskeluoikeudenVoimassaoloaika = ({opiskeluoikeus}) => {
     {' '}
     {päättymispäiväProperty == 'arvioituPäättymispäivä' && <Text name="(arvioitu)"/>}
   </div>)
+}
+
+const Suoritukset = ({opiskeluoikeus, valittuSuoritus}) => {
+  const opiskeluoikeusTyyppi = modelData(opiskeluoikeus, 'tyyppi').koodiarvo
+  const suoritukset = modelItems(opiskeluoikeus, 'suoritukset')
+
+  return opiskeluoikeusTyyppi === 'korkeakoulutus'
+    ? <Korkeakoulusuoritukset opiskeluoikeus={opiskeluoikeus}/>
+    : (
+      <div className="suoritukset">
+        <h4><Text name="Suoritukset"/></h4>
+        <SuoritusTabs model={opiskeluoikeus} suoritukset={suoritukset}/>
+        <Editor key={valittuSuoritus.tabName} model={valittuSuoritus} alwaysUpdate="true" />
+      </div>
+    )
 }
 
 class OpiskeluoikeudenOpintosuoritusoteLink extends React.Component {

--- a/web/app/style/opiskeluoikeus.less
+++ b/web/app/style/opiskeluoikeus.less
@@ -433,11 +433,13 @@
       }
 
       .suoritukset {
+        &:not(:first-child) {
+          margin-top: 20px;
+        }
+
         h4 {
           margin-bottom: 10px;
         }
-
-        margin-top: 20px;
 
         hr {
           margin: 18px 0 8px 0;

--- a/web/app/suoritus/Suoritus.js
+++ b/web/app/suoritus/Suoritus.js
@@ -18,10 +18,12 @@ export const arvioituTaiVahvistettu = suoritus => {
 }
 
 export const suoritusValmis = (suoritus) => {
-  if (suoritus.value.classes.includes('paatasonsuoritus')) {
+  const classes = suoritus.value.classes
+
+  if (classes.includes('paatasonsuoritus') && !classes.includes('korkeakoulusuoritus')) {
     let vahvistuspäivä = modelData(suoritus, 'vahvistus.päivä')
     return vahvistuspäivä && isInPast(vahvistuspäivä)
-  } else if (suoritus.value.classes.includes('arvioinniton')) {
+  } else if (classes.includes('arvioinniton')) {
     return true
   } else {
     let arviointi = modelData(suoritus, 'arviointi.0')

--- a/web/app/suoritus/SuoritusEditor.jsx
+++ b/web/app/suoritus/SuoritusEditor.jsx
@@ -24,7 +24,7 @@ const resolveEditor = (mdl) => {
   if (['esiopetuksensuoritus'].includes(mdl.value.classes[0])) {
     return <PropertiesEditor model={modelLookup(mdl, 'koulutusmoduuli')} propertyFilter={p => p.key === 'kuvaus'} />
   }
-  if (['ammatillinenpaatasonsuoritus', 'ylioppilastutkinnonsuoritus'].some(c => mdl.value.classes.includes(c))) {
+  if (['ammatillinenpaatasonsuoritus', 'ylioppilastutkinnonsuoritus', 'korkeakoulusuoritus'].some(c => mdl.value.classes.includes(c))) {
     return <Suoritustaulukko suorituksetModel={modelLookup(mdl, 'osasuoritukset')}/>
   }
   if (mdl.value.classes.includes('lukionoppimaaransuoritus')) {

--- a/web/app/suoritus/Suoritustaulukko.jsx
+++ b/web/app/suoritus/Suoritustaulukko.jsx
@@ -241,7 +241,12 @@ const ArvosanaColumn = {
   shouldShow: ({parentSuoritus, suoritukset, context}) => !näyttötutkintoonValmistava(parentSuoritus) && (context.edit || suoritukset.find(hasArvosana) !== undefined),
   renderHeader: () => <td key="arvosana" className="arvosana"><Text name="Arvosana"/></td>,
   renderData: ({model}) => {
-    let arvosanaModel = modelLookup(fixArviointi(model), 'arviointi.-1.arvosana')
+    let fullArvosanaModel = modelLookup(fixArviointi(model), 'arviointi.-1.arvosana')
+
+    const arvosanaModel = fullArvosanaModel.value.classes && fullArvosanaModel.value.classes.includes('paikallinenkoodi')
+      ? modelLookup(fullArvosanaModel, 'nimi')
+      : fullArvosanaModel
+
     // TODO, Parempi tapa erotella eri koodistoista tulevat arvot
     let sortByKoodistoUriAndGrade = (grades) => {
       let sort = (x, y) => {

--- a/web/app/virta/Korkeakoulusuoritukset.jsx
+++ b/web/app/virta/Korkeakoulusuoritukset.jsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import R from 'ramda'
+import {Editor} from '../editor/Editor'
+import {addContext, modelData, modelItems, modelLookup, modelSetValue} from '../editor/EditorModel'
+import Text from '../i18n/Text'
+import {Suoritustaulukko} from '../suoritus/Suoritustaulukko'
+
+const Korkeakoulusuoritukset = ({opiskeluoikeus}) => {
+  const suoritukset = modelItems(opiskeluoikeus, 'suoritukset')
+  const [tutkinnot, opintojaksot] = R.partition(s => modelData(s, 'tyyppi').koodiarvo === 'korkeakoulututkinto', suoritukset)
+  const modelWithoutTutkinnot = modelSetValue(opiskeluoikeus, opintojaksot, 'suoritukset')
+
+  const hasTutkintoja = tutkinnot.length > 0
+  const hasOpintojaksoja = opintojaksot.length > 0
+
+  return (
+    <div className='suoritukset'>
+      {tutkinnot.map((t, i) => <Editor key={i} model={t} alwaysUpdate='true'/>)}
+
+      {hasOpintojaksoja && (
+        <div>
+          {hasTutkintoja && <h4><Text name='Opintojaksot'/></h4>}
+          <IrrallisetOpintojaksot opiskeluoikeus={modelWithoutTutkinnot}/>
+        </div>
+      )}
+    </div>
+  )
+}
+
+const IrrallisetOpintojaksot = ({opiskeluoikeus}) => {
+  const model = addContext(opiskeluoikeus, {suoritus: opiskeluoikeus})
+  return <Suoritustaulukko suorituksetModel={modelLookup(model, 'suoritukset')}/>
+}
+
+export {Korkeakoulusuoritukset}


### PR DESCRIPTION
Näytetään suoritukset taulukkomuodossa. 

Mikäli opiskeluoikeuteen liittyy tutkintosuoritus, näytetään 1) sen tiedot ja 2) siihen liittyvät suoritukset taulukossa. Mikäli "opiskeluoikeus" on ainoastaan kooste irrallisista (samassa paikassa suoritetuista) suorituksista, näytetään nämä ilman muita tietoja taulukoituna.