### PR TITLE
Muotoile Virta-suoritukset käyttöliittymässä

### DIFF
--- a/src/main/resources/localization/default-texts.json
+++ b/src/main/resources/localization/default-texts.json
@@ -792,6 +792,7 @@
   "Tutkintokerta" : "Tutkintokerta",
   "Vuodenaika" : "Vuodenaika",
   "Vuosi" : "Vuosi",
-  "Pakolliset kokeet suoritettu": "Pakolliset kokeet suoritettu"
+  "Pakolliset kokeet suoritettu": "Pakolliset kokeet suoritettu",
+  "Synteettinen" : "Synteettinen"
 }
 

--- a/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
+++ b/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
@@ -43,7 +43,7 @@ case class KorkeakoulututkinnonSuoritus(
   koulutusmoduuli: Korkeakoulututkinto,
   toimipiste: Oppilaitos,
   arviointi: Option[List[KorkeakoulunArviointi]],
-  vahvistus: Option[HenkilövahvistusPaikkakunnalla],
+  vahvistus: Option[Päivämäärävahvistus],
   suorituskieli: Option[Koodistokoodiviite],
   @Description("Tutkintoon kuuluvien opintojaksojen suoritukset")
   @Title("Opintojaksot")
@@ -59,7 +59,7 @@ case class KorkeakoulunOpintojaksonSuoritus(
   koulutusmoduuli: KorkeakoulunOpintojakso,
   toimipiste: Oppilaitos,
   arviointi: Option[List[KorkeakoulunArviointi]],
-  vahvistus: Option[HenkilövahvistusValinnaisellaPaikkakunnalla],
+  vahvistus: Option[Päivämäärävahvistus],
   suorituskieli: Option[Koodistokoodiviite],
   @Description("Opintojaksoon sisältyvien opintojaksojen suoritukset")
   @Title("Sisältyvät opintojaksot")

--- a/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
+++ b/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
@@ -20,7 +20,8 @@ case class KorkeakoulunOpiskeluoikeus(
   tila: KorkeakoulunOpiskeluoikeudenTila,
   suoritukset: List[KorkeakouluSuoritus],
   @KoodistoKoodiarvo("korkeakoulutus")
-  tyyppi: Koodistokoodiviite = Koodistokoodiviite("korkeakoulutus", Some("Korkeakoulutus"), "opiskeluoikeudentyyppi", None)
+  tyyppi: Koodistokoodiviite = Koodistokoodiviite("korkeakoulutus", Some("Korkeakoulutus"), "opiskeluoikeudentyyppi", None),
+  synteettinen: Boolean = false
 ) extends Opiskeluoikeus {
   override def versionumero = None
   override def lisätiedot = None

--- a/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
+++ b/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
@@ -16,8 +16,8 @@ case class KorkeakoulunOpiskeluoikeus(
   arvioituPäättymispäivä: Option[LocalDate] = None,
   päättymispäivä: Option[LocalDate] = None,
   @Description("Jos tämä on opiskelijan ensisijainen opiskeluoikeus tässä oppilaitoksessa, ilmoitetaan tässä ensisijaisuuden tiedot")
-  ensisijaisuus: Option[Ensisijaisuus] = None,
   tila: KorkeakoulunOpiskeluoikeudenTila,
+  ensisijaisuus: Option[Ensisijaisuus] = None,
   suoritukset: List[KorkeakouluSuoritus],
   @KoodistoKoodiarvo("korkeakoulutus")
   tyyppi: Koodistokoodiviite = Koodistokoodiviite("korkeakoulutus", Some("Korkeakoulutus"), "opiskeluoikeudentyyppi", None),

--- a/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
+++ b/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
@@ -30,9 +30,9 @@ case class KorkeakoulunOpiskeluoikeus(
 
 @Description("Ensisijaisuustiedot sisältävät alku- ja loppupäivämäärän")
 case class Ensisijaisuus(
-  alkamispäivä: LocalDate,
-  päättymispäivä: Option[LocalDate]
-)
+  alku: LocalDate,
+  loppu: Option[LocalDate]
+) extends Jakso
 
 trait KorkeakouluSuoritus extends PäätasonSuoritus with MahdollisestiSuorituskielellinen with Toimipisteellinen {
   def toimipiste: Oppilaitos

--- a/src/main/scala/fi/oph/koski/schema/Vahvistus.scala
+++ b/src/main/scala/fi/oph/koski/schema/Vahvistus.scala
@@ -34,6 +34,14 @@ trait VahvistusValinnaisellaPaikkakunnalla extends Vahvistus {
 
 trait HenkilövahvistusValinnaisellaTittelillä extends Vahvistus {}
 
+case class Päivämäärävahvistus(
+  päivä: LocalDate,
+  myöntäjäOrganisaatio: Organisaatio,
+) extends VahvistusValinnaisellaPaikkakunnalla {
+  def paikkakunta = None
+  def myöntäjäHenkilöt = Nil
+}
+
 @Description("Suorituksen vahvistus organisaatio- ja henkilötiedoilla")
 case class HenkilövahvistusPaikkakunnalla(
   päivä: LocalDate,

--- a/src/main/scala/fi/oph/koski/suoritusote/OpintosuoritusoteHtml.scala
+++ b/src/main/scala/fi/oph/koski/suoritusote/OpintosuoritusoteHtml.scala
@@ -30,7 +30,7 @@ class OpintosuoritusoteHtml(implicit val user: KoskiSession, val localizationRep
   def korkeakoulu(ht: TäydellisetHenkilötiedot, opiskeluoikeudet: List[KorkeakoulunOpiskeluoikeus]): Elem = {
     def ensisijainenOpiskeluoikeus(opiskeluoikeudet: List[Opiskeluoikeus]): Option[KorkeakoulunOpiskeluoikeus] = {
       opiskeluoikeudet.collect { case oo: KorkeakoulunOpiskeluoikeus => oo }
-        .find(_.ensisijaisuus.exists { _.päättymispäivä match {
+        .find(_.ensisijaisuus.exists { _.loppu match {
         case None => true
         case Some(pp) => pp.isAfter(LocalDate.now())
       }
@@ -58,7 +58,7 @@ class OpintosuoritusoteHtml(implicit val user: KoskiSession, val localizationRep
               </tr>
               <tr>
                 <td>Voimassa</td>
-                <td>{ensisijainen.ensisijaisuus.toList.map(e => dateFormatter.format(e.alkamispäivä) + " - " + e.päättymispäivä.map(dateFormatter.format(_)).getOrElse(""))}</td>
+                <td>{ensisijainen.ensisijaisuus.toList.map(e => dateFormatter.format(e.alku) + " - " + e.loppu.map(dateFormatter.format(_)).getOrElse(""))}</td>
               </tr>
             </table>
           </section>

--- a/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
+++ b/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
@@ -112,7 +112,10 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
       koulutusmoduuli = KorkeakoulunOpintojakso(
         tunniste = PaikallinenKoodi((suoritus \\ "@koulutusmoduulitunniste").text, nimi(suoritus)),
         nimi = nimi(suoritus),
-        laajuus = (suoritus \ "Laajuus" \ "Opintopiste").headOption.map(_.text.toFloat).filter(_ > 0).map(op => LaajuusOpintopisteissä(op))
+        laajuus = for {
+          yksikko <- koodistoViitePalvelu.getKoodistoKoodiViite("opintojenlaajuusyksikko", "2")
+          laajuus <- (suoritus \ "Laajuus" \ "Opintopiste").headOption.map(_.text.toFloat).filter(_ > 0)
+        } yield LaajuusOpintopisteissä(laajuus, yksikko)
       ),
       arviointi = arviointi(suoritus),
       vahvistus = None,

--- a/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
+++ b/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
@@ -92,7 +92,7 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
           KorkeakoulututkinnonSuoritus(
             koulutusmoduuli = tutkinto(koulutuskoodi),
             arviointi = arviointi(suoritus),
-            vahvistus = None,
+            vahvistus = vahvistus(suoritus),
             suorituskieli = None,
             toimipiste = oppilaitos(suoritus),
             osasuoritukset = optionalList(osasuoritukset)
@@ -119,7 +119,7 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
         } yield LaajuusOpintopisteissä(laajuus, yksikko)
       ),
       arviointi = arviointi(suoritus),
-      vahvistus = None,
+      vahvistus = vahvistus(suoritus),
       suorituskieli = (suoritus \\ "Kieli").headOption.map(kieli => requiredKoodi("kieli", kieli.text.toUpperCase)),
       toimipiste = oppilaitos(suoritus),
       osasuoritukset = optionalList(osasuoritukset)
@@ -146,6 +146,12 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
           LocalDate.parse(suoritus \ "SuoritusPvm" text)
         ))
       }
+  }
+
+  private def vahvistus(suoritus: Node): Option[Päivämäärävahvistus] = {
+    arviointi(suoritus).flatMap(_.lastOption.flatMap(arviointi =>
+      Some(Päivämäärävahvistus(arviointi.päivä, oppilaitos(suoritus)))
+    ))
   }
 
   private def isRoot(suoritukset: Seq[Node])(node: Node) = {

--- a/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
+++ b/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
@@ -60,7 +60,8 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
         oppilaitos = Some(organisaatio),
         koulutustoimija = None,
         suoritukset = suoritukset,
-        tila = KorkeakoulunOpiskeluoikeudenTila(Nil)
+        tila = KorkeakoulunOpiskeluoikeudenTila(Nil),
+        synteettinen = true
       )
     }
 

--- a/src/test/scala/fi/oph/koski/api/KorkeakouluSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/KorkeakouluSpec.scala
@@ -59,7 +59,7 @@ class KorkeakouluSpec extends FreeSpec with Matchers with OpiskeluoikeusTestMeth
           """Suoritetut tutkinnot
             |751101 Dipl.ins., konetekniikka 22.3.2016
             |Opintosuoritukset
-            |Opintopistettä Arvosana Suor.pvm
+            |Op Arvosana Suor.pvm
             |751101 Dipl.ins., konetekniikka 123 OIV 22.3.2016
             |IA3027 Mechanical Engineering 65 4 4.12.2015
             |K410-3 Product Development 20 5 4.12.2015
@@ -109,7 +109,7 @@ class KorkeakouluSpec extends FreeSpec with Matchers with OpiskeluoikeusTestMeth
             |Voimassa 1.8.2008 - 31.7.2030
             |Suoritetut tutkinnot
             |Opintosuoritukset
-            |Opintopistettä Arvosana Suor.pvm
+            |Op Arvosana Suor.pvm
             |KE-35.1200 Epäorgaaninen kemia I 4 2 15.12.2009
             |KE-35.1210 Epäorgaanisen kemian laboratoriotyöt 4 hyväksytty 10.12.2009
             |Tfy-3.1241 Fysiikka IA 3 5 28.10.2009
@@ -121,7 +121,7 @@ class KorkeakouluSpec extends FreeSpec with Matchers with OpiskeluoikeusTestMeth
         opintosuoritusoteOppilaitokselle("100193-948U", "1.2.246.562.10.25619624254") should equal(
           """|Suoritetut tutkinnot
             |Opintosuoritukset
-            |Opintopistettä Arvosana Suor.pvm
+            |Op Arvosana Suor.pvm
             |106000 Anatomi och fysiologi 5 1 15.11.2013
             |106000 Engelska, Akutvård 5 3 3.4.2014
             |106000 Hälsovård 5 4 13.9.2013
@@ -143,7 +143,7 @@ class KorkeakouluSpec extends FreeSpec with Matchers with OpiskeluoikeusTestMeth
           """|Suoritetut tutkinnot
             |671112 Fysioterapeutti (AMK) 29.5.2015
             |Opintosuoritukset
-            |Opintopistettä Arvosana Suor.pvm
+            |Op Arvosana Suor.pvm
             |671112 Fysioterapeutti (AMK) hyväksytty 29.5.2015
             |116000 Anatomi, fysiologi och biomekanik 5 3 11.11.2011
             |116000 Arbetslivsorienterade projekt 0,5 hyväksytty 27.5.2015
@@ -186,7 +186,7 @@ class KorkeakouluSpec extends FreeSpec with Matchers with OpiskeluoikeusTestMeth
         opintosuoritusoteOppilaitokselle("090888-929X", "1.2.246.562.10.27756776996") should equal(
           """|Suoritetut tutkinnot
             |Opintosuoritukset
-            |Opintopistettä Arvosana Suor.pvm
+            |Op Arvosana Suor.pvm
             |05AVOIN/MI00AX91/3 Graafisen suunnittelun perusteet 5 hyväksytty 7.11.2015
             |05AVOIN/MI00BB13/3 Typografian perusteet 4 hyväksytty 11.4.2016""".stripMargin
         )

--- a/web/app/opiskeluoikeus/OpiskeluoikeusEditor.jsx
+++ b/web/app/opiskeluoikeus/OpiskeluoikeusEditor.jsx
@@ -12,6 +12,7 @@ import {Editor} from '../editor/Editor'
 import {navigateTo} from '../util/location'
 import {suorituksenTyyppi, suoritusTitle} from '../suoritus/Suoritus'
 import Text from '../i18n/Text'
+import {PäivämääräväliEditor} from '../date/PaivamaaravaliEditor'
 import {assignTabNames, suoritusTabIndex, SuoritusTabs, urlForTab} from '../suoritus/SuoritusTabs'
 import {Korkeakoulusuoritukset} from '../virta/Korkeakoulusuoritukset'
 
@@ -75,9 +76,13 @@ const OpiskeluoikeudenTiedot = ({opiskeluoikeus, excludedProperties, editLink, a
     <PropertiesEditor
       model={opiskeluoikeus}
       propertyFilter={ p => !excludedProperties.includes(p.key) }
-      getValueEditor={ (prop, getDefault) => prop.key === 'tila'
-        ? <OpiskeluoikeudenTilaEditor model={opiskeluoikeus} alkuChangeBus={alkuChangeBus}/>
-        : getDefault() }
+      getValueEditor={ (prop, getDefault) => {
+        switch (prop.key) {
+          case 'tila': return <OpiskeluoikeudenTilaEditor model={opiskeluoikeus} alkuChangeBus={alkuChangeBus}/>
+          case 'ensisijaisuus': return <PäivämääräväliEditor model={modelLookup(opiskeluoikeus, 'ensisijaisuus')}/>
+          default: return getDefault()
+        }
+      }}
     />
     {
       modelLookup(opiskeluoikeus, 'lisätiedot') &&

--- a/web/app/opiskeluoikeus/OpiskeluoikeusEditor.jsx
+++ b/web/app/opiskeluoikeus/OpiskeluoikeusEditor.jsx
@@ -20,14 +20,17 @@ export const OpiskeluoikeusEditor = ({model}) => {
   model = addContext(model, {opiskeluoikeus: model})
   return (<TogglableEditor model={model} renderChild={ (mdl, editLink) => {
     let context = mdl.context
-    let excludedProperties = ['suoritukset', 'alkamispäivä', 'arvioituPäättymispäivä', 'päättymispäivä', 'oppilaitos', 'lisätiedot']
+    let excludedProperties = ['suoritukset', 'alkamispäivä', 'arvioituPäättymispäivä', 'päättymispäivä', 'oppilaitos', 'lisätiedot', 'synteettinen']
 
     const alkuChangeBus = Bacon.Bus()
     alkuChangeBus.onValue(v => {
       const value = v[0].value
       pushModel(modelSetValues(model, {'alkamispäivä' : value, 'tila.opiskeluoikeusjaksot.0.alku': value}))
     })
+
     let hasOppilaitos = !!modelData(mdl, 'oppilaitos')
+    const hasAlkamispäivä = !!modelData(mdl, 'alkamispäivä')
+    const isSyntheticOpiskeluoikeus = !!modelData(model, 'synteettinen')
 
     return (
       <div className="opiskeluoikeus">
@@ -35,42 +38,57 @@ export const OpiskeluoikeusEditor = ({model}) => {
           <span className="otsikkotiedot">
             { hasOppilaitos && <span className="oppilaitos inline-text">{modelTitle(mdl, 'oppilaitos')}{','}</span> }
             <span className="koulutus inline-text" style={hasOppilaitos ? { 'text-transform': 'lowercase' } : undefined}>{(näytettävätPäätasonSuoritukset(model)[0] || {}).title}</span>
-            { modelData(mdl, 'alkamispäivä')
-              ? <span className="inline-text">{'('}
+            {hasAlkamispäivä && (
+              <span className="inline-text">{'('}
                 <span className="alku pvm">{yearFromIsoDateString(modelTitle(mdl, 'alkamispäivä'))}</span>{'-'}
                 <span className="loppu pvm">{yearFromIsoDateString(modelTitle(mdl, 'päättymispäivä'))}{', '}</span>
                 <span className="tila">{modelTitle(mdl, 'tila.opiskeluoikeusjaksot.-1.tila').toLowerCase()}{')'}</span>
-                </span>
-              : null
-            }
+              </span>
+            )}
           </span>
           {!model.context.kansalainen && <Versiohistoria opiskeluoikeusOid={oid} oppijaOid={context.oppijaOid}/>}
           {!model.context.kansalainen && <OpiskeluoikeudenId opiskeluoikeus={mdl}/>}
         </h3>
         <div className={mdl.context.edit ? 'opiskeluoikeus-content editing' : 'opiskeluoikeus-content'}>
-          <div className="opiskeluoikeuden-tiedot">
-            {editLink}
-            <OpiskeluoikeudenOpintosuoritusoteLink opiskeluoikeus={mdl}/>
-            {
-              modelData(mdl, 'alkamispäivä') && <OpiskeluoikeudenVoimassaoloaika opiskeluoikeus={mdl}/>
-            }
-            <PropertiesEditor
-              model={mdl}
-              propertyFilter={ p => !excludedProperties.includes(p.key) }
-              getValueEditor={ (prop, getDefault) => prop.key === 'tila'
-                ? <OpiskeluoikeudenTilaEditor model={mdl} alkuChangeBus={alkuChangeBus}/>
-                : getDefault() }
-             />
-            {
-              modelLookup(mdl, 'lisätiedot') && <ExpandablePropertiesEditor model={mdl} propertyName="lisätiedot" propertyFilter={prop => context.edit || modelData(prop.model) !== false} />
-            }
-          </div>
+          {!isSyntheticOpiskeluoikeus &&
+            <OpiskeluoikeudenTiedot
+              opiskeluoikeus={mdl}
+              excludedProperties={excludedProperties}
+              editLink={editLink}
+              alkuChangeBus={alkuChangeBus}
+            />
+          }
           <Suoritukset opiskeluoikeus={mdl}/>
         </div>
       </div>)
     }
   } />)
 }
+
+const OpiskeluoikeudenTiedot = ({opiskeluoikeus, excludedProperties, editLink, alkuChangeBus}) => (
+  <div className="opiskeluoikeuden-tiedot">
+    {editLink}
+    <OpiskeluoikeudenOpintosuoritusoteLink opiskeluoikeus={opiskeluoikeus}/>
+    {
+      modelData(opiskeluoikeus, 'alkamispäivä') && <OpiskeluoikeudenVoimassaoloaika opiskeluoikeus={opiskeluoikeus}/>
+    }
+    <PropertiesEditor
+      model={opiskeluoikeus}
+      propertyFilter={ p => !excludedProperties.includes(p.key) }
+      getValueEditor={ (prop, getDefault) => prop.key === 'tila'
+        ? <OpiskeluoikeudenTilaEditor model={opiskeluoikeus} alkuChangeBus={alkuChangeBus}/>
+        : getDefault() }
+    />
+    {
+      modelLookup(opiskeluoikeus, 'lisätiedot') &&
+      <ExpandablePropertiesEditor
+        model={opiskeluoikeus}
+        propertyName="lisätiedot"
+        propertyFilter={prop => opiskeluoikeus.context.edit || modelData(prop.model) !== false}
+      />
+    }
+  </div>
+)
 
 const OpiskeluoikeudenId = ({opiskeluoikeus}) => {
   let selectAllText = (e) => {

--- a/web/app/style/opiskeluoikeus.less
+++ b/web/app/style/opiskeluoikeus.less
@@ -429,11 +429,13 @@
       }
 
       .suoritukset {
+        &:not(:first-child) {
+          margin-top: 20px;
+        }
+
         h4 {
           margin-bottom: 10px;
         }
-
-        margin-top: 20px;
 
         hr {
           margin: 18px 0 8px 0;

--- a/web/app/suoritus/ArvosanaEditor.jsx
+++ b/web/app/suoritus/ArvosanaEditor.jsx
@@ -1,6 +1,6 @@
 import React from 'baret'
 import {Editor} from '../editor/Editor'
-import {wrapOptional} from '../editor/EditorModel'
+import {wrapOptional, modelEmpty} from '../editor/EditorModel'
 import * as L from 'partial.lenses'
 import {lensedModel, modelData, modelLookup, modelSetValue, oneOfPrototypes} from '../editor/EditorModel'
 import {sortGrades} from '../util/sorting'
@@ -9,7 +9,7 @@ import {fixArviointi} from './Suoritus'
 
 export const ArvosanaEditor = ({model}) => {
   if (!model.context.edit) {
-    let arvosanaModel = modelLookup(model, 'arviointi.-1.arvosana')
+    const arvosanaModel = resolveArvosanaModel(model)
     return arvosanaModel ? <Editor model={ arvosanaModel }/> : null
   }
   model = fixArviointi(model)
@@ -41,4 +41,13 @@ export const ArvosanaEditor = ({model}) => {
       return <Editor key={alternatives.length} model={ arvosanaModel } sortBy={sortGrades} fetchAlternatives={() => arvosanatP} showEmptyOption="true"/>
     })
   }</span>)
+}
+
+const resolveArvosanaModel = model => {
+  const arviointi = modelLookup(model, 'arviointi.-1')
+  const arvosana = arviointi ? modelLookup(model, 'arviointi.-1.arvosana') : null
+
+  const isPaikallinenArviointi = arviointi && !modelEmpty(arviointi) && arviointi.value.classes.includes('paikallinenarviointi')
+
+  return isPaikallinenArviointi ? modelLookup(arvosana, 'nimi') : arvosana
 }

--- a/web/app/suoritus/SuoritusEditor.jsx
+++ b/web/app/suoritus/SuoritusEditor.jsx
@@ -24,7 +24,7 @@ const resolveEditor = (mdl) => {
   if (['esiopetuksensuoritus'].includes(mdl.value.classes[0])) {
     return <PropertiesEditor model={modelLookup(mdl, 'koulutusmoduuli')} propertyFilter={p => p.key === 'kuvaus'} />
   }
-  if (['ammatillinenpaatasonsuoritus', 'ylioppilastutkinnonsuoritus'].some(c => mdl.value.classes.includes(c))) {
+  if (['ammatillinenpaatasonsuoritus', 'ylioppilastutkinnonsuoritus', 'korkeakoulusuoritus'].some(c => mdl.value.classes.includes(c))) {
     return <Suoritustaulukko suorituksetModel={modelLookup(mdl, 'osasuoritukset')}/>
   }
   if (mdl.value.classes.includes('lukionoppimaaransuoritus')) {

--- a/web/app/virta/Korkeakoulusuoritukset.jsx
+++ b/web/app/virta/Korkeakoulusuoritukset.jsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import R from 'ramda'
+import {Editor} from '../editor/Editor'
+import {addContext, modelData, modelItems, modelLookup, modelSetValue} from '../editor/EditorModel'
+import Text from '../i18n/Text'
+import {Suoritustaulukko} from '../suoritus/Suoritustaulukko'
+
+const Korkeakoulusuoritukset = ({opiskeluoikeus}) => {
+  const suoritukset = modelItems(opiskeluoikeus, 'suoritukset')
+  const [tutkinnot, opintojaksot] = R.partition(s => modelData(s, 'tyyppi').koodiarvo === 'korkeakoulututkinto', suoritukset)
+  const modelWithoutTutkinnot = modelSetValue(opiskeluoikeus, opintojaksot, 'suoritukset')
+
+  const hasTutkintoja = tutkinnot.length > 0
+  const hasOpintojaksoja = opintojaksot.length > 0
+
+  return (
+    <div className='suoritukset'>
+      {tutkinnot.map((t, i) => <Editor key={i} model={t} alwaysUpdate='true'/>)}
+
+      {hasOpintojaksoja && (
+        <div>
+          {hasTutkintoja && <h4><Text name='Opintojaksot'/></h4>}
+          <IrrallisetOpintojaksot opiskeluoikeus={modelWithoutTutkinnot}/>
+        </div>
+      )}
+    </div>
+  )
+}
+
+const IrrallisetOpintojaksot = ({opiskeluoikeus}) => {
+  const model = addContext(opiskeluoikeus, {suoritus: opiskeluoikeus})
+  return <Suoritustaulukko suorituksetModel={modelLookup(model, 'suoritukset')}/>
+}
+
+export {Korkeakoulusuoritukset}

--- a/web/test/spec/korkeakouluSpec.js
+++ b/web/test/spec/korkeakouluSpec.js
@@ -20,7 +20,7 @@ describe('Korkeakoulutus', function() {
     describe('Kaikki tiedot näkyvissä', function() {
       before(opinnot.expandAll)
       it('toimii', function() {
-        expect(S('.korkeakoulututkinnonsuoritus .korkeakoulunopintojaksonsuoritus:eq(0) .koulutusmoduuli:eq(0) .tunniste .nimi .value').text()).to.equal('Vapaasti valittavat opinnot (KON)')
+        expect(S('.korkeakoulututkinnonsuoritus .tutkinnon-osa:eq(0) .suoritus:eq(0) .nimi').text()).to.equal('Vapaasti valittavat opinnot (KON)')
       })
     })
     describe('Opintosuoritusote', function() {


### PR DESCRIPTION
Näytetään suoritukset taulukkomuodossa.

- Mikäli opiskeluoikeuteen liittyy tutkintosuoritus, näytetään 1) sen tiedot ja 2) hierarkkisesti taulukoituna siihen liittyvät suoritukset sekä niiden osasuoritukset 
- Mikäli "opiskeluoikeus" on ainoastaan kooste irrallisista (samassa paikassa suoritetuista) suorituksista, näytetään nämä vastaavasti taulukoituna (kuitenkin ilman opiskeluoikeus- ja tutkintotietoja)