### PR TITLE
TOR-343

### DIFF
--- a/web/app/date/JaksoEditor.jsx
+++ b/web/app/date/JaksoEditor.jsx
@@ -23,4 +23,3 @@ InlineJaksoEditor.validateModel = JaksoEditor.validateModel
 
 JaksoEditor.validateModel = PäivämääräväliEditor.validateModel
 JaksoEditor.isEmpty = recursivelyEmpty
-JaksoEditor.handlesOptional = (modifier) => modifier != 'array'

--- a/web/app/date/PaivamaaravaliEditor.jsx
+++ b/web/app/date/PaivamaaravaliEditor.jsx
@@ -14,7 +14,6 @@ export const PäivämääräväliEditor = ({model}) => {
 }
 
 PäivämääräväliEditor.canShowInline = () => true
-PäivämääräväliEditor.handlesOptional = (modifier) => modifier != 'array'
 PäivämääräväliEditor.validateModel = (model) => {
   let alkuData = modelData(model, 'alku')
   let loppuData = modelData(model, 'loppu')

--- a/web/app/editor/EditorModel.js
+++ b/web/app/editor/EditorModel.js
@@ -136,6 +136,7 @@ export const modelEmpty = (mainModel, path) => {
 
 export const recursivelyEmpty = (m) => {
   if (!m.value) return true
+  if (m.optional) return false
   if (m.type == 'object') {
     if (!m.value.properties) return true
     for (var i in m.value.properties) {

--- a/web/app/style/opiskeluoikeus.less
+++ b/web/app/style/opiskeluoikeus.less
@@ -733,6 +733,10 @@
         float: right;
       }
 
+      .optional-wrapper > .date-range + a.remove-value {
+        display: initial;
+      }
+
       .oppiaineensuoritus .korotus {
         margin-left: 8px;
       }

--- a/web/test/spec/perusopetusSpec.js
+++ b/web/test/spec/perusopetusSpec.js
@@ -873,8 +873,11 @@ describe('Perusopetus', function() {
         })
 
         describe('Päivämäärän syöttö', function() {
-          var pidennettyOppivelvollisuus = editor.property('pidennettyOppivelvollisuus').toPäivämääräväli()
-          before(editor.edit, opinnot.expandAll)
+          var pidennettyOppivelvollisuusProperty = editor.property('pidennettyOppivelvollisuus')
+          var pidennettyOppivelvollisuus = pidennettyOppivelvollisuusProperty.toPäivämääräväli()
+
+          before(editor.edit, opinnot.expandAll, pidennettyOppivelvollisuusProperty.addValue)
+
           describe('Virheellinen päivämäärä', function() {
             before(pidennettyOppivelvollisuus.setAlku('34.9.2000'))
             it('Estää tallennuksen', function() {
@@ -887,11 +890,22 @@ describe('Perusopetus', function() {
               expect(pidennettyOppivelvollisuus.getAlku()).to.equal(currentDate)
             })
           })
+
+          after(editor.edit, pidennettyOppivelvollisuusProperty.removeValue, editor.saveChanges, wait.until(page.isSavedLabelShown))
         })
 
         describe('Virheellinen päivämääräväli', function() {
-          var pidennettyOppivelvollisuus = editor.property('pidennettyOppivelvollisuus').toPäivämääräväli()
-          before(editor.edit, opinnot.expandAll, pidennettyOppivelvollisuus.setAlku(currentDate), pidennettyOppivelvollisuus.setLoppu('1.2.2008'))
+          var pidennettyOppivelvollisuusProperty = editor.property('pidennettyOppivelvollisuus')
+          var pidennettyOppivelvollisuus = pidennettyOppivelvollisuusProperty.toPäivämääräväli()
+
+          before(
+            editor.edit,
+            opinnot.expandAll,
+            pidennettyOppivelvollisuusProperty.addValue,
+            pidennettyOppivelvollisuus.setAlku(currentDate),
+            pidennettyOppivelvollisuus.setLoppu('1.2.2008')
+          )
+
           it('Estää tallennuksen', function() {
             expect(pidennettyOppivelvollisuus.isValid()).to.equal(false)
             expect(opinnot.onTallennettavissa()).to.equal(false)

--- a/web/test/spec/perusopetusSpec.js
+++ b/web/test/spec/perusopetusSpec.js
@@ -858,14 +858,39 @@ describe('Perusopetus', function() {
         })
 
         describe('Erityisen tuen päätös', function() {
-          describe('lisätään, kun erityisen tuen tietoja asetetaan', function() {
-            before(editor.edit, opinnot.expandAll, editor.property('opiskeleeToimintaAlueittain').setValue(true), editor.saveChanges, wait.until(page.isSavedLabelShown))
+          describe('lisätään, kun valinnainen malli lisätään', function() {
+            before(
+              editor.edit,
+              opinnot.expandAll,
+              editor.property('erityisenTuenPäätös').addValue,
+              editor.saveChanges,
+              wait.until(page.isSavedLabelShown)
+            )
+            it('Toimii', function() {
+              expect(isElementVisible(S('.property.erityisenTuenPäätös'))).to.equal(true)
+              expect(editor.property('opiskeleeToimintaAlueittain').getValue()).to.equal('ei')
+            })
+          })
+          describe('päivittyy, kun erityisen tuen tietoja muutetaan', function() {
+            before(
+              editor.edit,
+              opinnot.expandAll,
+              editor.property('opiskeleeToimintaAlueittain').setValue(true),
+              editor.saveChanges,
+              wait.until(page.isSavedLabelShown)
+            )
             it('Toimii', function() {
               expect(editor.property('opiskeleeToimintaAlueittain').getValue()).to.equal('kyllä')
             })
           })
-          describe('poistetaan, kun erityisen tuen tiedot tyhjennetään', function() {
-            before(editor.edit, opinnot.expandAll, editor.property('opiskeleeToimintaAlueittain').setValue(false), editor.saveChanges, wait.until(page.isSavedLabelShown))
+          describe('poistetaan, kun valinnainen malli poistetaan', function() {
+            before(
+              editor.edit,
+              opinnot.expandAll,
+              editor.property('erityisenTuenPäätös').removeValue,
+              editor.saveChanges,
+              wait.until(page.isSavedLabelShown)
+            )
             it('Toimii', function() {
               expect(isElementVisible(S('.property.erityisenTuenPäätös'))).to.equal(false)
             })
@@ -2628,6 +2653,7 @@ describe('Perusopetus', function() {
           before(
             editor.edit,
             opinnot.expandAll,
+            editor.property('erityisenTuenPäätös').addValue,
             editor.property('opiskeleeToimintaAlueittain').setValue(true),
             uusiOppiaine.selectValue('kognitiiviset taidot'),
             kognitiivisetTaidot.propertyBySelector('.arvosana').selectValue('8'),


### PR DESCRIPTION
TOR-343

Kääritään opiskeluoikeuden lisätietojen (valinnaiset) jaksorakenteet valinnaisiksi editoreiksi. Tämä mahdollistaa jakson poistamisen ja ehkäisee epäselvän tilanteen, jossa valinnaisen jakson pakollinen alkupäivämäärä on editorissa esitäytetty (vaikka jaksoa ei todellisuudessa ole).