### PR TITLE
Muutoksia Valma- ja Telma-käleihin

### DIFF
--- a/src/main/scala/fi/oph/koski/tutkinto/Koulutustyyppi.scala
+++ b/src/main/scala/fi/oph/koski/tutkinto/Koulutustyyppi.scala
@@ -11,6 +11,7 @@ object Koulutustyyppi {
   val lukiokoulutus = apply(2)
   val korkeakoulutus = apply(3)
   val ammatillinenPerustutkintoErityisopetuksena = apply(4)
+  val telma = apply(5)
   val ammattitutkinto = apply(11)
   val erikoisammattitutkinto = apply(12)
   val ammatillinenPerustutkintoNäyttötutkintona = apply(13)

--- a/web/app/suoritus/Suoritustaulukko.jsx
+++ b/web/app/suoritus/Suoritustaulukko.jsx
@@ -180,12 +180,21 @@ export class TutkinnonOsanSuoritusEditor extends React.Component {
 }
 
 const suoritusProperties = suoritus => {
-  let properties = modelProperties(modelLookup(suoritus, 'koulutusmoduuli'), p => p.key === 'kuvaus').concat(
-    suoritus.context.edit
-      ? modelProperties(suoritus, p => ['näyttö', 'tunnustettu', 'lisätiedot'].includes(p.key))
-      : modelProperties(suoritus, p => !(['koulutusmoduuli', 'arviointi', 'tutkinnonOsanRyhmä', 'tutkintokerta'].includes(p.key)))
-      .concat(modelProperties(modelLookup(suoritus, 'arviointi.-1'), p => !(['arvosana', 'päivä', 'arvioitsijat']).includes(p.key)))
+  const includeProperties = (...properties) => p => properties.includes(p.key)
+  const excludeProperties = (...properties) => p => !properties.includes(p.key)
+
+  const kuvaus = modelProperties(modelLookup(suoritus, 'koulutusmoduuli'), p => p.key === 'kuvaus')
+  const simplifiedArviointi = modelProperties(modelLookup(suoritus, 'arviointi.-1'),
+    p => !(['arvosana', 'päivä', 'arvioitsijat']).includes(p.key)
   )
+
+  const properties = kuvaus.concat(
+    suoritus.context.edit
+      ? modelProperties(suoritus, includeProperties('näyttö', 'tunnustettu', 'lisätiedot'))
+      : modelProperties(suoritus, excludeProperties('koulutusmoduuli', 'arviointi', 'tutkinnonOsanRyhmä', 'tutkintokerta'))
+        .concat(simplifiedArviointi)
+  )
+
   return properties.filter(shouldShowProperty(suoritus.context))
 }
 

--- a/web/app/suoritus/Suoritustaulukko.jsx
+++ b/web/app/suoritus/Suoritustaulukko.jsx
@@ -13,7 +13,7 @@ import {
 import R from 'ramda'
 import {buildClassNames} from '../components/classnames'
 import {accumulateExpandedState} from '../editor/ExpandableItems'
-import {fixArviointi, hasArvosana, suoritusValmis, tilaText} from './Suoritus'
+import {fixArviointi, hasArvosana, suorituksenTyyppi, suoritusValmis, tilaText} from './Suoritus'
 import {t} from '../i18n/i18n'
 import Text from '../i18n/Text'
 import {ammatillisentutkinnonosanryhmaKoodisto} from '../koodisto/koodistot'
@@ -180,22 +180,34 @@ export class TutkinnonOsanSuoritusEditor extends React.Component {
 }
 
 const suoritusProperties = suoritus => {
-  const includeProperties = (...properties) => p => properties.includes(p.key)
-  const excludeProperties = (...properties) => p => !properties.includes(p.key)
+  const filterProperties = filter => modelProperties(suoritus, filter)
+  const includeProperties = (...properties) => filterProperties(p => properties.includes(p.key))
+  const excludeProperties = (...properties) => filterProperties(p => !properties.includes(p.key))
+
+  const propertiesForSuoritustyyppi = (tyyppi, isEdit) => {
+    const defaultsForEdit = includeProperties('näyttö', 'tunnustettu', 'lisätiedot')
+    const defaultsForView = excludeProperties('koulutusmoduuli', 'arviointi', 'tutkinnonOsanRyhmä', 'tutkintokerta')
+      .concat(simplifiedArviointi)
+
+    switch (tyyppi) {
+      case 'valma': return isEdit
+        ? includeProperties('näyttö', 'tunnustettu', 'lisätiedot').concat(simplifiedArviointi)
+        : defaultsForView
+
+      default: return isEdit ? defaultsForEdit : defaultsForView
+    }
+  }
 
   const kuvaus = modelProperties(modelLookup(suoritus, 'koulutusmoduuli'), p => p.key === 'kuvaus')
   const simplifiedArviointi = modelProperties(modelLookup(suoritus, 'arviointi.-1'),
     p => !(['arvosana', 'päivä', 'arvioitsijat']).includes(p.key)
   )
 
-  const properties = kuvaus.concat(
-    suoritus.context.edit
-      ? modelProperties(suoritus, includeProperties('näyttö', 'tunnustettu', 'lisätiedot'))
-      : modelProperties(suoritus, excludeProperties('koulutusmoduuli', 'arviointi', 'tutkinnonOsanRyhmä', 'tutkintokerta'))
-        .concat(simplifiedArviointi)
-  )
+  const parentSuorituksenTyyppi = suorituksenTyyppi(suoritus.context.suoritus)
 
-  return properties.filter(shouldShowProperty(suoritus.context))
+  return kuvaus
+    .concat(propertiesForSuoritustyyppi(parentSuorituksenTyyppi, suoritus.context.edit))
+    .filter(shouldShowProperty(suoritus.context))
 }
 
 const TutkintokertaColumn = {


### PR DESCRIPTION
TOR-341: kälissä

- Poista Telmalta mahdollisuus tutkinnon osan lisäämiseen toisesta tutkinnosta (4325e7e)
- Lisää Valmalle mahdollisuus tutkinnon osan sanallisen arvioinnin syöttämiseen
  