### PR TITLE
Rajoita kälissä suoritusten lisäämistä ammatilliseen opiskeluoikeuteen

### DIFF
--- a/web/app/uusisuoritus/UusiAmmatillisenTutkinnonSuoritus.jsx
+++ b/web/app/uusisuoritus/UusiAmmatillisenTutkinnonSuoritus.jsx
@@ -48,6 +48,12 @@ let tutkintoLens = L.lens(
 
 const hasValmistavaTutkinto = (opiskeluoikeus) => modelItems(opiskeluoikeus, 'suoritukset').find(suoritus => suorituksenTyyppi(suoritus) == 'nayttotutkintoonvalmistavakoulutus')
 const hasAmmatillinenTutkinto = (opiskeluoikeus) => modelItems(opiskeluoikeus, 'suoritukset').find(suoritus => suorituksenTyyppi(suoritus) == 'ammatillinentutkinto')
+const hasContradictingSuoritus = opiskeluoikeus => {
+  const disallowedSuoritustyypit = ['telma', 'valma', 'ammatillinentutkintoosittainen']
+  return modelItems(opiskeluoikeus, 'suoritukset')
+    .map(suoritus => modelData(suoritus, 'tyyppi.koodiarvo'))
+    .some(suoritustyyppi => disallowedSuoritustyypit.includes(suoritustyyppi))
+}
 
 const Popup = (isValmistava) => ({opiskeluoikeus, resultCallback}) => {
   let submitBus = Bacon.Bus()
@@ -113,12 +119,16 @@ const Popup = (isValmistava) => ({opiskeluoikeus, resultCallback}) => {
 
 export const UusiAmmatillisenTutkinnonSuoritus = Popup(false)
 UusiAmmatillisenTutkinnonSuoritus.canAddSuoritus = (opiskeluoikeus) => {
-  return modelData(opiskeluoikeus, 'tyyppi.koodiarvo') == 'ammatillinenkoulutus' && !hasAmmatillinenTutkinto(opiskeluoikeus)
+  return modelData(opiskeluoikeus, 'tyyppi.koodiarvo') == 'ammatillinenkoulutus'
+    && !hasAmmatillinenTutkinto(opiskeluoikeus)
+    && !hasContradictingSuoritus(opiskeluoikeus)
 }
 UusiAmmatillisenTutkinnonSuoritus.addSuoritusTitle = () => <Text name="lisää ammatillisen tutkinnon suoritus"/>
 
 export const UusiNäyttötutkintoonValmistavanKoulutuksenSuoritus = Popup(true)
 UusiNäyttötutkintoonValmistavanKoulutuksenSuoritus.canAddSuoritus = (opiskeluoikeus) => {
-  return modelData(opiskeluoikeus, 'tyyppi.koodiarvo') == 'ammatillinenkoulutus' && !hasValmistavaTutkinto(opiskeluoikeus)
+  return modelData(opiskeluoikeus, 'tyyppi.koodiarvo') == 'ammatillinenkoulutus'
+    && !hasValmistavaTutkinto(opiskeluoikeus)
+    && !hasContradictingSuoritus(opiskeluoikeus)
 }
 UusiNäyttötutkintoonValmistavanKoulutuksenSuoritus.addSuoritusTitle = () => <Text name="lisää näyttötutkintoon valmistavan koulutuksen suoritus"/>

--- a/web/app/uusisuoritus/UusiAmmatillisenTutkinnonSuoritus.jsx
+++ b/web/app/uusisuoritus/UusiAmmatillisenTutkinnonSuoritus.jsx
@@ -46,8 +46,8 @@ let tutkintoLens = L.lens(
   }
 )
 
-let hasValmistavaTutkinto = (opiskeluoikeus) => modelItems(opiskeluoikeus, 'suoritukset').find(suoritus => suorituksenTyyppi(suoritus) == 'nayttotutkintoonvalmistavakoulutus')
-let hasAmmatillinenTutkinto = (opiskeluoikeus) => modelItems(opiskeluoikeus, 'suoritukset').find(suoritus => suorituksenTyyppi(suoritus) == 'ammatillinentutkinto')
+const hasValmistavaTutkinto = (opiskeluoikeus) => modelItems(opiskeluoikeus, 'suoritukset').find(suoritus => suorituksenTyyppi(suoritus) == 'nayttotutkintoonvalmistavakoulutus')
+const hasAmmatillinenTutkinto = (opiskeluoikeus) => modelItems(opiskeluoikeus, 'suoritukset').find(suoritus => suorituksenTyyppi(suoritus) == 'ammatillinentutkinto')
 
 const Popup = (isValmistava) => ({opiskeluoikeus, resultCallback}) => {
   let submitBus = Bacon.Bus()

--- a/web/test/spec/ammatillinenSpec.js
+++ b/web/test/spec/ammatillinenSpec.js
@@ -346,6 +346,10 @@ describe('Ammatillinen koulutus', function() {
           lisääSuoritus.open('lisää näyttötutkintoon valmistavan koulutuksen suoritus')
         )
         describe('Ennen lisäystä', function() {
+          it('Lisäyspainike on näkyvissä', function() {
+            expect(lisääSuoritus.isLinkVisible('lisää näyttötutkintoon valmistavan koulutuksen suoritus')).to.equal(true)
+          })
+
           it('Esitäyttää oppilaitoksen', function() {
             expect(lisääSuoritus.toimipiste.oppilaitos()).to.equal('Stadin ammattiopisto')
           })
@@ -361,6 +365,25 @@ describe('Ammatillinen koulutus', function() {
           )
           it('Näyttötutkintoon valmistavan koulutuksen suoritus näytetään', function() {
             expect(opinnot.getTutkinto()).to.equal('Näyttötutkintoon valmistava koulutus')
+          })
+        })
+      })
+
+      describe('Lisääminen olemassa olevaan opiskeluoikeuteen, jossa VALMA-suoritus', function() {
+        var lisääSuoritus = opinnot.lisääSuoritusDialog
+
+        before(
+          resetFixtures,
+          prepareForNewOppija('kalle', '230872-7258'),
+          addOppija.enterValidDataAmmatillinen(),
+          addOppija.selectOppimäärä('Ammatilliseen peruskoulutukseen valmentava koulutus (VALMA)'),
+          addOppija.submitAndExpectSuccess('Tyhjä, Tero (230872-7258)', 'Ammatilliseen koulutukseen valmentava koulutus (VALMA)'),
+          editor.edit
+        )
+
+        describe('Lisäyspainike', function() {
+          it('Ei ole näkyvissä', function() {
+            expect(lisääSuoritus.isLinkVisible('lisää näyttötutkintoon valmistavan koulutuksen suoritus')).to.equal(false)
           })
         })
       })
@@ -409,6 +432,19 @@ describe('Ammatillinen koulutus', function() {
       it('Lisätty opiskeluoikeus näytetään', function () {
         expect(opinnot.getTutkinto()).to.equal('Ammatilliseen koulutukseen valmentava koulutus (VALMA)')
         expect(opinnot.getOppilaitos()).to.equal('Stadin ammattiopisto')
+      })
+
+      describe('Ammatillisen tutkinnon suorituksen lisääminen', function() {
+        var lisääSuoritus = opinnot.lisääSuoritusDialog
+
+        describe('Lisäyspainike', function() {
+          before(editor.edit)
+          it('Ei ole näkyvissä', function() {
+            expect(lisääSuoritus.isLinkVisible('lisää ammatillisen tutkinnon suoritus')).to.equal(false)
+          })
+          after(editor.cancelChanges)
+        })
+
       })
 
       var suoritustapa = editor.property('suoritustapa')


### PR DESCRIPTION
TOR-340

Rajoita kälissä suoritusten lisäämistä ammatilliseen opiskeluoikeuteen seuraavasti:

- Kun Valma, Telma tai "ammatillisen tutkinnon osa / osia", poista kälistä mahdollisuus lisätä:
  - ammatillisen tutkinnon suoritus
  - näyttötutkintoon valmistavan koulutuksen suoritus
  