### PR TITLE
Muutoksia Valma- ja Telma-käleihin

### DIFF
--- a/src/main/scala/fi/oph/koski/tutkinto/Koulutustyyppi.scala
+++ b/src/main/scala/fi/oph/koski/tutkinto/Koulutustyyppi.scala
@@ -11,6 +11,7 @@ object Koulutustyyppi {
   val lukiokoulutus = apply(2)
   val korkeakoulutus = apply(3)
   val ammatillinenPerustutkintoErityisopetuksena = apply(4)
+  val telma = apply(5)
   val ammattitutkinto = apply(11)
   val erikoisammattitutkinto = apply(12)
   val ammatillinenPerustutkintoNäyttötutkintona = apply(13)

--- a/web/app/suoritus/Suoritustaulukko.jsx
+++ b/web/app/suoritus/Suoritustaulukko.jsx
@@ -180,12 +180,21 @@ export class TutkinnonOsanSuoritusEditor extends React.Component {
 }
 
 const suoritusProperties = suoritus => {
-  let properties = modelProperties(modelLookup(suoritus, 'koulutusmoduuli'), p => p.key === 'kuvaus').concat(
-    suoritus.context.edit
-      ? modelProperties(suoritus, p => ['näyttö', 'tunnustettu', 'lisätiedot'].includes(p.key))
-      : modelProperties(suoritus, p => !(['koulutusmoduuli', 'arviointi', 'tutkinnonOsanRyhmä', 'tutkintokerta'].includes(p.key)))
-      .concat(modelProperties(modelLookup(suoritus, 'arviointi.-1'), p => !(['arvosana', 'päivä', 'arvioitsijat']).includes(p.key)))
+  const includeProperties = (...properties) => p => properties.includes(p.key)
+  const excludeProperties = (...properties) => p => !properties.includes(p.key)
+
+  const kuvaus = modelProperties(modelLookup(suoritus, 'koulutusmoduuli'), p => p.key === 'kuvaus')
+  const simplifiedArviointi = modelProperties(modelLookup(suoritus, 'arviointi.-1'),
+    p => !(['arvosana', 'päivä', 'arvioitsijat']).includes(p.key)
   )
+
+  const properties = kuvaus.concat(
+    suoritus.context.edit
+      ? modelProperties(suoritus, includeProperties('näyttö', 'tunnustettu', 'lisätiedot'))
+      : modelProperties(suoritus, excludeProperties('koulutusmoduuli', 'arviointi', 'tutkinnonOsanRyhmä', 'tutkintokerta'))
+        .concat(simplifiedArviointi)
+  )
+
   return properties.filter(shouldShowProperty(suoritus.context))
 }
 

--- a/web/app/suoritus/Suoritustaulukko.jsx
+++ b/web/app/suoritus/Suoritustaulukko.jsx
@@ -194,9 +194,11 @@ const suoritusProperties = suoritus => {
       .concat(simplifiedArviointi)
 
     switch (tyyppi) {
-      case 'valma': return isEdit
-        ? includeProperties('näyttö', 'tunnustettu', 'lisätiedot').concat(simplifiedArviointi)
-        : defaultsForView
+      case 'valma':
+      case 'telma':
+        return isEdit
+          ? includeProperties('näyttö', 'tunnustettu', 'lisätiedot').concat(simplifiedArviointi)
+          : defaultsForView
 
       default: return isEdit ? defaultsForEdit : defaultsForView
     }

--- a/web/test/page/opinnotPage.js
+++ b/web/test/page/opinnotPage.js
@@ -266,6 +266,9 @@ function TutkinnonOsat(groupId) {
         osanOsat: function() {
           return TutkinnonOsat('999999')
         },
+        sanallinenArviointi: function() {
+          return api.propertyBySelector('.property.kuvaus:eq(1)')
+        },
         lueNäyttöModal: function() {
           function extractDropdownArray(elem) {
             return elem.find('ul.array > li').map(function() {return Page(this).getInput('.dropdown').value()}).get().slice(0, -1)

--- a/web/test/page/opinnotPage.js
+++ b/web/test/page/opinnotPage.js
@@ -356,6 +356,9 @@ function TutkinnonOsat(groupId) {
           .then(click(subElement(modalElement, 'button:not(:disabled)')))
       }
     },
+    isLisääTutkinnonOsaToisestaTutkinnostaVisible: function() {
+      return isElementVisible(subElement(uusiTutkinnonOsaElement, ('.osa-toisesta-tutkinnosta a')))
+    },
     tutkinnonosavaihtoehdot: function() {
       return Page(uusiTutkinnonOsaElement).getInputOptions(".dropdown")
     },

--- a/web/test/spec/ammatillinenSpec.js
+++ b/web/test/spec/ammatillinenSpec.js
@@ -479,7 +479,7 @@ describe('Ammatillinen koulutus', function() {
       })
 
       var suoritustapa = editor.property('suoritustapa')
-      describe('Tutkinnon osan lisääminen', function () {
+      describe('Paikallisen tutkinnon osan lisääminen', function () {
         before(
           editor.edit,
           opinnot.tutkinnonOsat().lisääPaikallinenTutkinnonOsa('Uimaliikunta ja vesiturvallisuus'),
@@ -489,6 +489,14 @@ describe('Ammatillinen koulutus', function() {
 
         it('näyttää oikeat tiedot', function () {
           expect(opinnot.tutkinnonOsat().tutkinnonOsa(0).nimi()).to.equal('Uimaliikunta ja vesiturvallisuus')
+        })
+      })
+
+      describe('Lisäysmahdollisuutta tutkinnon osan lisäämiselle toisesta tutkinnosta', function () {
+        before(editor.edit)
+
+        it('ei ole näkyvissä', function() {
+          expect(opinnot.tutkinnonOsat().isLisääTutkinnonOsaToisestaTutkinnostaVisible()).to.equal(false)
         })
       })
     })

--- a/web/test/spec/ammatillinenSpec.js
+++ b/web/test/spec/ammatillinenSpec.js
@@ -1183,6 +1183,76 @@ describe('Ammatillinen koulutus', function() {
         })
       })
 
+      describe('Sanallisen arvioinnin muokkaus', function() {
+        describe('Ammatillisen tutkinnon suorituksen osille', function() {
+          before(
+            editor.edit,
+            opinnot.tutkinnonOsat('1').tutkinnonOsa(0).poistaTutkinnonOsa,
+            opinnot.tutkinnonOsat('1').lisääTutkinnonOsa('Huolto- ja korjaustyöt'),
+            opinnot.tutkinnonOsat('1').tutkinnonOsa(0).propertyBySelector('.arvosana').setValue('3', 1)
+          )
+
+          it('Syöttökenttää ei näytetä', function() {
+            expect(opinnot.tutkinnonOsat('1').tutkinnonOsa(0).sanallinenArviointi().isVisible()).to.equal(false)
+          })
+        })
+
+        describe('VALMA-suorituksen osille', function() {
+          var sanallinenArviointi = opinnot.tutkinnonOsat().tutkinnonOsa(0).sanallinenArviointi()
+
+          before(
+            resetFixtures,
+            prepareForNewOppija('kalle', '230872-7258'),
+            addOppija.enterValidDataAmmatillinen(),
+            addOppija.selectOppimäärä('Ammatilliseen peruskoulutukseen valmentava koulutus (VALMA)'),
+            addOppija.submitAndExpectSuccess('Tyhjä, Tero (230872-7258)', 'Ammatilliseen koulutukseen valmentava koulutus (VALMA)'),
+            editor.edit,
+            opinnot.tutkinnonOsat().lisääPaikallinenTutkinnonOsa('Hassut temput'),
+          )
+
+          describe('Alussa', function() {
+            it('syöttökenttä ei näytetä', function() {
+              expect(sanallinenArviointi.isVisible()).to.equal(false)
+            })
+          })
+
+          describe('Kun arvosana lisätty', function() {
+            before(opinnot.tutkinnonOsat().tutkinnonOsa(0).propertyBySelector('.arvosana').setValue('3', 1))
+
+            it('syöttökenttä näytetään', function() {
+              expect(sanallinenArviointi.isVisible()).to.equal(true)
+            })
+          })
+
+          describe('Muokkaus', function() {
+            before(sanallinenArviointi.setValue('Hyvin meni'))
+
+            it('näyttää oikeat tiedot', function() {
+              expect(sanallinenArviointi.getValue()).to.equal('Hyvin meni')
+            })
+          })
+
+          describe('Tallentamisen jälkeen', function() {
+            before(editor.saveChanges, editor.edit, opinnot.expandAll)
+
+            it('näyttää edelleen oikeat tiedot', function() {
+              expect(sanallinenArviointi.getValue()).to.equal('Hyvin meni')
+            })
+          })
+
+          describe('Arvosanan poistamisen ja uudelleenlisäämisen jälkeen', function() {
+            before(
+              opinnot.tutkinnonOsat().tutkinnonOsa(0).propertyBySelector('.arvosana').setValue('Ei valintaa'),
+              opinnot.tutkinnonOsat().tutkinnonOsa(0).propertyBySelector('.arvosana').setValue('3', 1)
+            )
+
+            it('syöttökenttä on tyhjä', function() {
+              expect(sanallinenArviointi.getValue()).to.equal('')
+            })
+          })
+        })
+      })
+
       describe('Kun suoritustapana on näyttö', function() {
         before(
           resetFixtures,


### PR DESCRIPTION
TOR-341: kälissä

1. Poista Telmalta mahdollisuus tutkinnon osan lisäämiseen toisesta tutkinnosta (edd2214)
1. Lisää Telmalle ja Valmalle mahdollisuus tutkinnon osan sanallisen arvioinnin syöttämiseen