### PR TITLE
Defensiivinen virta kielikoodien käsittely

### DIFF
--- a/src/main/resources/mockdata/virta/opintotiedot/090888-929X.xml
+++ b/src/main/resources/mockdata/virta/opintotiedot/090888-929X.xml
@@ -72,7 +72,7 @@
               <virta:Myontaja>02470</virta:Myontaja>
               <virta:Laji>2</virta:Laji>
               <virta:Nimi>Graafisen suunnittelun perusteet</virta:Nimi>
-              <virta:Kieli>fi</virta:Kieli>
+              <virta:Kieli>20</virta:Kieli>
               <virta:Koulutusala>
                 <virta:Koodi versio="opmala">2</virta:Koodi>
                 <virta:Osuus>1.000000</virta:Osuus>

--- a/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
+++ b/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
@@ -120,7 +120,7 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
       ),
       arviointi = arviointi(suoritus),
       vahvistus = vahvistus(suoritus),
-      suorituskieli = (suoritus \\ "Kieli").headOption.map(kieli => requiredKoodi("kieli", kieli.text.toUpperCase)),
+      suorituskieli = (suoritus \\ "Kieli").headOption.flatMap(kieli => koodistoViitePalvelu.validate(Koodistokoodiviite(kieli.text.toUpperCase, "kieli"))),
       toimipiste = oppilaitos(suoritus),
       osasuoritukset = optionalList(osasuoritukset)
     )


### PR DESCRIPTION
Tuotannon virtadatasta tullut epävalidi suorituskieliarvo on johtanut virheeseen. Ei heitetä poikkeusta vaan palautetaan tyhjä arvo. 