### PR TITLE
Korjaa henkilotiedot update

### DIFF
--- a/src/main/scala/fi/oph/koski/henkilo/KoskiHenkiloCache.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/KoskiHenkiloCache.scala
@@ -25,7 +25,7 @@ class KoskiHenkilöCache(val db: DB, val henkilöt: HenkilöRepository) extends 
     TäydellisetHenkilötiedotWithMasterInfo(row.toHenkilötiedot, masterRow.map(_.toHenkilötiedot))
   })
 
-  def filterOidsByCache(oids: List[String]) = {
+  def filterOidsByCache(oids: List[String]): Iterator[String] = {
     // split to groups of 10000 to ensure this works with larger batches. Tested: 10000 works, 100000 does not.
     oids.grouped(10000).flatMap(group => runDbSync(Henkilöt.map(_.oid).filter(_ inSetBind(group)).result))
   }

--- a/src/test/scala/fi/oph/koski/henkilo/HetuGenerator.scala
+++ b/src/test/scala/fi/oph/koski/henkilo/HetuGenerator.scala
@@ -1,0 +1,24 @@
+package fi.oph.koski.henkilo
+
+import java.time.{Instant, LocalDateTime, ZoneId, ZonedDateTime}
+import java.time.format.DateTimeFormatter
+
+import fi.oph.koski.henkilo.Hetu.checkChars
+
+import scala.util.Random
+
+object HetuGenerator {
+  private val hetuFormatter = DateTimeFormatter.ofPattern("ddMMyy")
+
+  def generateHetu = {
+    val date = hetuFormatter.format(randomDate)
+    val randomPart = s"${Random.nextInt(10)}${Random.nextInt(10)}${Random.nextInt(10)}"
+    s"$date-$randomPart${checkChars(Math.round((s"$date$randomPart".toInt / 31.0 % 1) * 31).toInt)}"
+  }
+
+  private def randomDate = {
+    val beforeY2K = ZonedDateTime.of(1999, 12, 31, 0, 0, 0, 0, ZoneId.systemDefault).toInstant.toEpochMilli
+    def randomInstant = (Random.nextDouble * beforeY2K).toLong
+    LocalDateTime.ofInstant(Instant.ofEpochMilli(randomInstant), ZoneId.systemDefault)
+  }
+}

--- a/src/test/scala/fi/oph/koski/schedule/UpdateHenkilotTaskSpec.scala
+++ b/src/test/scala/fi/oph/koski/schedule/UpdateHenkilotTaskSpec.scala
@@ -3,8 +3,11 @@ package fi.oph.koski.schedule
 import java.lang.System.currentTimeMillis
 
 import fi.oph.koski.KoskiApplicationForTests
+import fi.oph.koski.henkilo.HetuGenerator.generateHetu
 import fi.oph.koski.henkilo.MockOpintopolkuHenkilöFacade
 import fi.oph.koski.henkilo.MockOppijat.{eero, eerola}
+import fi.oph.koski.henkilo.oppijanumerorekisteriservice.UusiHenkilö
+import fi.oph.koski.json.JsonSerializer
 import fi.oph.koski.schema.{TäydellisetHenkilötiedot, TäydellisetHenkilötiedotWithMasterInfo}
 import fi.oph.koski.util.Futures
 import org.json4s.jackson.JsonMethods.{parse => parseJson}
@@ -15,6 +18,9 @@ class UpdateHenkilotTaskSpec extends FreeSpec with Matchers with BeforeAndAfterE
   "Nimitietojen päivittyminen" - {
     Futures.await(application.perustiedotIndexer.init)
     "Päivittää muuttuneet oppijat oppijanumerorekisteristä" in {
+      1 to 1100 foreach { x =>
+        henkilöFacade.findOrCreate(UusiHenkilö(Some(generateHetu), "Changed", x.toString, x.toString, "", None))
+      }
       modify(TäydellisetHenkilötiedotWithMasterInfo(TäydellisetHenkilötiedot(eero.oid, eero.etunimet, eero.kutsumanimi, "Uusisukunimi"), None))
       val päivitetytPerustiedot = application.perustiedotRepository.findHenkilöPerustiedotByHenkilöOid(eero.oid).get
       päivitetytPerustiedot.sukunimi should equal("Uusisukunimi")
@@ -42,8 +48,14 @@ class UpdateHenkilotTaskSpec extends FreeSpec with Matchers with BeforeAndAfterE
 
   private def modify(tiedot: TäydellisetHenkilötiedotWithMasterInfo): Unit = {
     henkilöFacade.modify(tiedot)
-    new UpdateHenkilotTask(application).updateHenkilöt(Some(parseJson(s"""{"lastRun": ${currentTimeMillis}}""")))
+    runHenkilötiedotUpdateTwice
     application.elasticSearch.refreshIndex
+  }
+
+  private def runHenkilötiedotUpdateTwice = {
+    val ctx = new UpdateHenkilotTask(application).updateHenkilöt(Some(parseJson(s"""{"lastRun": ${currentTimeMillis - 120 * 60 * 1000}}""")))
+    val newCtx = JsonSerializer.extract[HenkilöUpdateContext](ctx.get)
+    new UpdateHenkilotTask(application).updateHenkilöt(Some(parseJson(s"""{"lastRun": ${newCtx.lastRun}}""")))
   }
 
   override def afterEach(): Unit = henkilöFacade.reset()


### PR DESCRIPTION
Henkilötiedot update toimi väärin jos yksikään oppijanumerorekisterin palauttamista muuttuneista henkilöistä ei ollut Kosken omassa kannassa. 