### PR TITLE
Kutista henkilötiedotpäivityksen batchin koko 5000:n

### DIFF
--- a/src/main/scala/fi/oph/koski/schedule/UpdateHenkilotTask.scala
+++ b/src/main/scala/fi/oph/koski/schedule/UpdateHenkilotTask.scala
@@ -33,7 +33,7 @@ class UpdateHenkilotTask(application: KoskiApplication) extends Timing {
   }
 
   private def findChangedOppijaOids(since: Long): (List[Oid], List[String]) = {
-    val batchSize = 10000
+    val batchSize = 5000
     var offset = 0
     def changedOids = {
       val oids = application.opintopolkuHenkilöFacade.findChangedOppijaOids(since, offset, batchSize)


### PR DESCRIPTION
Oppijanumerorekisterin hyväksymä maksimikoko