### PR TITLE
Lukiotietojen syöttökäyttöliittymä

### DIFF
--- a/src/main/scala/fi/oph/koski/schema/Lukio.scala
+++ b/src/main/scala/fi/oph/koski/schema/Lukio.scala
@@ -96,7 +96,6 @@ case class LukionOppimääränSuoritus(
 @Description("Lukion oppiaineen oppimäärän suoritustiedot")
 case class LukionOppiaineenOppimääränSuoritus(
   @Title("Oppiaine")
-  @FlattenInUI
   koulutusmoduuli: LukionOppiaine,
   toimipiste: OrganisaatioWithOid,
   @Description("Lukion oppiaineen oppimäärän arviointi")

--- a/web/app/ib/IB.jsx
+++ b/web/app/ib/IB.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import R from 'ramda'
-import {LukionOppiaineEditor} from '../lukio/LukionOppiaineEditor'
+import {LukionOppiaineRowEditor} from '../lukio/LukionOppiaineEditor'
 import {LukionOppiaineetTableHead} from '../lukio/fragments/LukionOppiaineetTable'
 import {modelData, modelLookup} from '../editor/EditorModel'
 import {FootnoteDescriptions} from '../components/footnote'
@@ -29,7 +29,7 @@ export const IBTutkinnonOppiaineetEditor = ({oppiaineet}) => {
             </tr>,
             aineet.map((oppiaine, oppiaineIndex) => {
               const footnote = modelLookup(oppiaine, 'arviointi.-1.predicted') && ArvosanaFootnote
-              return <LukionOppiaineEditor key={oppiaineIndex} oppiaine={oppiaine} footnote={footnote} />
+              return <LukionOppiaineRowEditor key={oppiaineIndex} oppiaine={oppiaine} footnote={footnote} />
             })
           ])
         }

--- a/web/app/ib/IB.jsx
+++ b/web/app/ib/IB.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import R from 'ramda'
-import {LukionOppiaineEditor} from '../lukio/Lukio'
+import {LukionOppiaineEditor} from '../lukio/LukionOppiaineEditor'
 import {LukionOppiaineetTableHead} from '../lukio/fragments/LukionOppiaineetTable'
 import {modelData, modelLookup} from '../editor/EditorModel'
 import {FootnoteDescriptions} from '../components/footnote'

--- a/web/app/kurssi/UusiKurssiPopup.jsx
+++ b/web/app/kurssi/UusiKurssiPopup.jsx
@@ -5,9 +5,16 @@ import {accumulateModelState, modelItems, modelLookup, modelValid} from '../edit
 import Text from '../i18n/Text'
 import ModalDialog from '../editor/ModalDialog'
 import {UusiKurssiDropdown} from './UusiKurssiDropdown'
-import {isPaikallinen, koulutusModuuliprototypes} from '../suoritus/Koulutusmoduuli'
+import {isLukionKurssi, isPaikallinen, koulutusModuuliprototypes} from '../suoritus/Koulutusmoduuli'
 import {PropertiesEditor} from '../editor/PropertiesEditor'
 import {t} from '../i18n/i18n'
+
+const propertyFilterForPaikallinen = p => !['koodistoUri'].includes(p.key)
+const propertyFilterForLukio = p => !['tunniste'].includes(p.key)
+const propertyFilterForModel = model =>
+  isPaikallinen(model) ? propertyFilterForPaikallinen
+    : isLukionKurssi(model) ? propertyFilterForLukio
+    : undefined
 
 export default ({oppiaineenSuoritus, resultCallback, toimipiste, uusiKurssinSuoritus}) => {
   let oppiaine = modelLookup(oppiaineenSuoritus, 'koulutusmoduuli')
@@ -34,10 +41,10 @@ export default ({oppiaineenSuoritus, resultCallback, toimipiste, uusiKurssinSuor
                                                      placeholder={t('Lisää kurssi')}/></span>
         { // TODO: check placeholders from i18n
           selectedPrototypeAtom.flatMap(selectedProto => {
-            if (!isPaikallinen(selectedProto)) return null
+            if (!isPaikallinen(selectedProto) && !isLukionKurssi(selectedProto)) return null
             let modelP = accumulateModelState(selectedProto)
             modelP.map(model => modelValid(model) ? model : undefined).forEach(model => selectedAtom.set(model)) // set selected atom to non-empty only when valid data
-            return modelP.map(model => <PropertiesEditor key="kurssi-props" model={model} propertyFilter={p => !['koodistoUri'].includes(p.key)}/>)
+            return modelP.map(model => <PropertiesEditor key="kurssi-props" model={model} propertyFilter={propertyFilterForModel(model)}/>)
           }).toProperty()
         }
       </ModalDialog>

--- a/web/app/lukio/LukionOppiaineEditor.jsx
+++ b/web/app/lukio/LukionOppiaineEditor.jsx
@@ -61,7 +61,7 @@ const Arviointi = ({oppiaine, suoritetutKurssit, footnote}) => {
   )
 }
 
-export const LukionOppiaineRowEditor = ({oppiaine, footnote}) => {
+export const LukionOppiaineRowEditor = ({oppiaine, footnote, allowOppiaineRemoval = true}) => {
   const kurssit = modelItems(oppiaine, 'osasuoritukset')
   const suoritetutKurssit = kurssit.map(k => modelData(k)).filter(k => k.arviointi)
   const {edit} = oppiaine.context
@@ -85,7 +85,7 @@ export const LukionOppiaineRowEditor = ({oppiaine, footnote}) => {
         <Arviointi oppiaine={oppiaine} suoritetutKurssit={suoritetutKurssit} footnote={footnote}/>
       </td>
       {
-        edit && (
+        edit && allowOppiaineRemoval && (
           <td className='remove-row'>
             <a className='remove-value' onClick={() => pushRemoval(oppiaine)}/>
           </td>

--- a/web/app/lukio/LukionOppiaineEditor.jsx
+++ b/web/app/lukio/LukionOppiaineEditor.jsx
@@ -6,6 +6,7 @@ import {suorituksenTilaSymbol} from '../suoritus/Suoritustaulukko'
 import {KurssitEditor} from '../kurssi/KurssitEditor'
 import {tilaText} from '../suoritus/Suoritus'
 import {FootnoteHint} from '../components/footnote'
+import {pushRemoval} from '../editor/EditorModel'
 
 export const LukionOppiaineEditor = ({oppiaine, footnote}) => {
   const arviointi = modelData(oppiaine, 'arviointi')
@@ -15,6 +16,7 @@ export const LukionOppiaineEditor = ({oppiaine, footnote}) => {
   const kurssitNumeerisellaArvosanalla = suoritetutKurssit.filter(kurssi => !isNaN(numeerinenArvosana(kurssi)))
   const keskiarvo = kurssitNumeerisellaArvosanalla.length > 0 && Math.round((kurssitNumeerisellaArvosanalla.map(numeerinenArvosana).reduce((a, b) => a + b) / kurssitNumeerisellaArvosanalla.length) * 10) / 10
   const oppiaineTitle = t(modelData(oppiaine, 'koulutusmoduuli.tunniste.nimi'))
+  const {edit} = oppiaine.context
 
   return (
     <tr className={'oppiaine oppiaine-rivi ' + modelData(oppiaine, 'koulutusmoduuli.tunniste.koodiarvo')}>
@@ -35,6 +37,13 @@ export const LukionOppiaineEditor = ({oppiaine, footnote}) => {
         </div>
         <div className="keskiarvo">{keskiarvo ? '(' + keskiarvo.toFixed(1).replace('.', ',') + ')' : ''}</div>
       </td>
+      {
+        edit && (
+          <td>
+            <a className="remove-value" onClick={() => pushRemoval(oppiaine)}/>
+          </td>
+        )
+      }
     </tr>
   )
 }

--- a/web/app/lukio/LukionOppiaineEditor.jsx
+++ b/web/app/lukio/LukionOppiaineEditor.jsx
@@ -7,12 +7,12 @@ import {tilaText} from '../suoritus/Suoritus'
 import {FootnoteHint} from '../components/footnote'
 
 export const LukionOppiaineEditor = ({oppiaine, footnote}) => {
-  let arviointi = modelData(oppiaine, 'arviointi')
-  let kurssit = modelItems(oppiaine, 'osasuoritukset')
-  let suoritetutKurssit = kurssit.map(k => modelData(k)).filter(k => k.arviointi)
-  let numeerinenArvosana = kurssi => parseInt(kurssi.arviointi.last().arvosana.koodiarvo)
-  let kurssitNumeerisellaArvosanalla = suoritetutKurssit.filter(kurssi => !isNaN(numeerinenArvosana(kurssi)))
-  let keskiarvo = kurssitNumeerisellaArvosanalla.length > 0 && Math.round((kurssitNumeerisellaArvosanalla.map(numeerinenArvosana).reduce((a, b) => a + b) / kurssitNumeerisellaArvosanalla.length) * 10) / 10
+  const arviointi = modelData(oppiaine, 'arviointi')
+  const kurssit = modelItems(oppiaine, 'osasuoritukset')
+  const suoritetutKurssit = kurssit.map(k => modelData(k)).filter(k => k.arviointi)
+  const numeerinenArvosana = kurssi => parseInt(kurssi.arviointi.last().arvosana.koodiarvo)
+  const kurssitNumeerisellaArvosanalla = suoritetutKurssit.filter(kurssi => !isNaN(numeerinenArvosana(kurssi)))
+  const keskiarvo = kurssitNumeerisellaArvosanalla.length > 0 && Math.round((kurssitNumeerisellaArvosanalla.map(numeerinenArvosana).reduce((a, b) => a + b) / kurssitNumeerisellaArvosanalla.length) * 10) / 10
 
   return (
     <tr className={'oppiaine oppiaine-rivi ' + modelData(oppiaine, 'koulutusmoduuli.tunniste.koodiarvo')}>

--- a/web/app/lukio/LukionOppiaineEditor.jsx
+++ b/web/app/lukio/LukionOppiaineEditor.jsx
@@ -61,7 +61,7 @@ const Arviointi = ({oppiaine, suoritetutKurssit, footnote}) => {
   )
 }
 
-export const LukionOppiaineEditor = ({oppiaine, footnote}) => {
+export const LukionOppiaineRowEditor = ({oppiaine, footnote}) => {
   const kurssit = modelItems(oppiaine, 'osasuoritukset')
   const suoritetutKurssit = kurssit.map(k => modelData(k)).filter(k => k.arviointi)
   const {edit} = oppiaine.context

--- a/web/app/lukio/LukionOppiaineEditor.jsx
+++ b/web/app/lukio/LukionOppiaineEditor.jsx
@@ -9,6 +9,7 @@ import {FootnoteHint} from '../components/footnote'
 import {modelLookup, modelTitle, pushRemoval} from '../editor/EditorModel'
 import {isKieliaine, isLukionMatematiikka} from '../suoritus/Koulutusmoduuli'
 import {Editor} from '../editor/Editor'
+import {ArvosanaEditor} from '../suoritus/ArvosanaEditor'
 
 const Nimi = ({oppiaine}) => {
   const {edit} = oppiaine.context
@@ -37,13 +38,32 @@ const KoulutusmoduuliPropertiesEditor = ({oppiaine}) => {
   )
 }
 
-export const LukionOppiaineEditor = ({oppiaine, footnote}) => {
+const Arviointi = ({oppiaine, suoritetutKurssit, footnote}) => {
+  const {edit} = oppiaine.context
+
   const arviointi = modelData(oppiaine, 'arviointi')
-  const kurssit = modelItems(oppiaine, 'osasuoritukset')
-  const suoritetutKurssit = kurssit.map(k => modelData(k)).filter(k => k.arviointi)
   const numeerinenArvosana = kurssi => parseInt(kurssi.arviointi.last().arvosana.koodiarvo)
   const kurssitNumeerisellaArvosanalla = suoritetutKurssit.filter(kurssi => !isNaN(numeerinenArvosana(kurssi)))
   const keskiarvo = kurssitNumeerisellaArvosanalla.length > 0 && Math.round((kurssitNumeerisellaArvosanalla.map(numeerinenArvosana).reduce((a, b) => a + b) / kurssitNumeerisellaArvosanalla.length) * 10) / 10
+
+  return (
+    <div>
+      <div className='annettuArvosana'>
+        {
+          edit || arviointi
+            ? <ArvosanaEditor model={oppiaine}/>
+            : '-'
+        }
+        {arviointi && footnote && <FootnoteHint title={footnote.title} hint={footnote.hint} />}
+      </div>
+      <div className='keskiarvo'>{keskiarvo ? '(' + keskiarvo.toFixed(1).replace('.', ',') + ')' : ''}</div>
+    </div>
+  )
+}
+
+export const LukionOppiaineEditor = ({oppiaine, footnote}) => {
+  const kurssit = modelItems(oppiaine, 'osasuoritukset')
+  const suoritetutKurssit = kurssit.map(k => modelData(k)).filter(k => k.arviointi)
   const {edit} = oppiaine.context
 
   return (
@@ -62,11 +82,7 @@ export const LukionOppiaineEditor = ({oppiaine, footnote}) => {
       </td>
       <td className='maara'>{suoritetutKurssit.length}</td>
       <td className='arvosana'>
-        <div className='annettuArvosana'>
-          {arviointi ? modelData(oppiaine, 'arviointi.-1.arvosana').koodiarvo : '-'}
-          {arviointi && footnote && <FootnoteHint title={footnote.title} hint={footnote.hint} />}
-        </div>
-        <div className='keskiarvo'>{keskiarvo ? '(' + keskiarvo.toFixed(1).replace('.', ',') + ')' : ''}</div>
+        <Arviointi oppiaine={oppiaine} suoritetutKurssit={suoritetutKurssit} footnote={footnote}/>
       </td>
       {
         edit && (

--- a/web/app/lukio/LukionOppiaineEditor.jsx
+++ b/web/app/lukio/LukionOppiaineEditor.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
-import {modelData, modelItems, modelTitle} from '../editor/EditorModel.js'
+import {t} from '../i18n/i18n'
+import {modelData, modelItems} from '../editor/EditorModel.js'
 import {suorituksenTilaSymbol} from '../suoritus/Suoritustaulukko'
 import {KurssitEditor} from '../kurssi/KurssitEditor'
 import {tilaText} from '../suoritus/Suoritus'
@@ -13,6 +14,7 @@ export const LukionOppiaineEditor = ({oppiaine, footnote}) => {
   const numeerinenArvosana = kurssi => parseInt(kurssi.arviointi.last().arvosana.koodiarvo)
   const kurssitNumeerisellaArvosanalla = suoritetutKurssit.filter(kurssi => !isNaN(numeerinenArvosana(kurssi)))
   const keskiarvo = kurssitNumeerisellaArvosanalla.length > 0 && Math.round((kurssitNumeerisellaArvosanalla.map(numeerinenArvosana).reduce((a, b) => a + b) / kurssitNumeerisellaArvosanalla.length) * 10) / 10
+  const oppiaineTitle = t(modelData(oppiaine, 'koulutusmoduuli.tunniste.nimi'))
 
   return (
     <tr className={'oppiaine oppiaine-rivi ' + modelData(oppiaine, 'koulutusmoduuli.tunniste.koodiarvo')}>
@@ -22,7 +24,7 @@ export const LukionOppiaineEditor = ({oppiaine, footnote}) => {
         </div>
       </td>
       <td className="oppiaine">
-        <div className="nimi">{modelTitle(oppiaine, 'koulutusmoduuli')}</div>
+        <div className="nimi">{oppiaineTitle}</div>
         <KurssitEditor model={oppiaine}/>
       </td>
       <td className="maara">{suoritetutKurssit.length}</td>

--- a/web/app/lukio/LukionOppiaineEditor.jsx
+++ b/web/app/lukio/LukionOppiaineEditor.jsx
@@ -39,7 +39,7 @@ export const LukionOppiaineEditor = ({oppiaine, footnote}) => {
       </td>
       {
         edit && (
-          <td>
+          <td className='remove-row'>
             <a className='remove-value' onClick={() => pushRemoval(oppiaine)}/>
           </td>
         )

--- a/web/app/lukio/LukionOppiaineEditor.jsx
+++ b/web/app/lukio/LukionOppiaineEditor.jsx
@@ -1,28 +1,10 @@
 import React from 'react'
+
 import {modelData, modelItems, modelTitle} from '../editor/EditorModel.js'
 import {suorituksenTilaSymbol} from '../suoritus/Suoritustaulukko'
-import {LukionOppiaineetTableHead} from './fragments/LukionOppiaineetTable'
 import {KurssitEditor} from '../kurssi/KurssitEditor'
 import {tilaText} from '../suoritus/Suoritus'
 import {FootnoteHint} from '../components/footnote'
-
-export class LukionOppiaineetEditor extends React.Component {
-  render() {
-    let {oppiaineet} = this.props
-    return (
-      <table className="suoritukset oppiaineet">
-        <LukionOppiaineetTableHead />
-        <tbody>
-        {
-          oppiaineet.map((oppiaine, oppiaineIndex) =>
-            <LukionOppiaineEditor key={oppiaineIndex} oppiaine={oppiaine} />
-          )
-        }
-        </tbody>
-      </table>
-    )
-  }
-}
 
 export class LukionOppiaineEditor extends React.Component {
   render() {

--- a/web/app/lukio/LukionOppiaineEditor.jsx
+++ b/web/app/lukio/LukionOppiaineEditor.jsx
@@ -15,7 +15,7 @@ const Nimi = ({oppiaine}) => {
   const {edit} = oppiaine.context
   const koulutusmoduuli = modelLookup(oppiaine, 'koulutusmoduuli')
   const nimi = t(modelData(oppiaine, 'koulutusmoduuli.tunniste.nimi'))
-  const nimiJaKieli = modelTitle(oppiaine, 'koulutusmoduuli.tunniste')
+  const nimiJaKieli = modelTitle(oppiaine, 'koulutusmoduuli')
   const hasOptions = isKieliaine(koulutusmoduuli) || isLukionMatematiikka(koulutusmoduuli)
 
   return (

--- a/web/app/lukio/LukionOppiaineEditor.jsx
+++ b/web/app/lukio/LukionOppiaineEditor.jsx
@@ -6,7 +6,36 @@ import {suorituksenTilaSymbol} from '../suoritus/Suoritustaulukko'
 import {KurssitEditor} from '../kurssi/KurssitEditor'
 import {tilaText} from '../suoritus/Suoritus'
 import {FootnoteHint} from '../components/footnote'
-import {pushRemoval} from '../editor/EditorModel'
+import {modelLookup, modelTitle, pushRemoval} from '../editor/EditorModel'
+import {isKieliaine, isLukionMatematiikka} from '../suoritus/Koulutusmoduuli'
+import {Editor} from '../editor/Editor'
+
+const Nimi = ({oppiaine}) => {
+  const {edit} = oppiaine.context
+  const koulutusmoduuli = modelLookup(oppiaine, 'koulutusmoduuli')
+  const nimi = t(modelData(oppiaine, 'koulutusmoduuli.tunniste.nimi'))
+  const nimiJaKieli = modelTitle(oppiaine, 'koulutusmoduuli.tunniste')
+  const hasOptions = isKieliaine(koulutusmoduuli) || isLukionMatematiikka(koulutusmoduuli)
+
+  return (
+    <span className='nimi'>
+      {edit && hasOptions ? `${nimi}, ` : nimiJaKieli}
+    </span>
+  )
+}
+
+const KoulutusmoduuliPropertiesEditor = ({oppiaine}) => {
+  if (!oppiaine.context.edit) return null
+
+  const koulutusmoduuli = modelLookup(oppiaine, 'koulutusmoduuli')
+
+  return (
+    <span className='properties'>
+      {isKieliaine(koulutusmoduuli) && <Editor model={koulutusmoduuli} path='kieli' inline={true}/>}
+      {isLukionMatematiikka(koulutusmoduuli) && <Editor model={koulutusmoduuli} path='oppimäärä' inline={true}/>}
+    </span>
+  )
+}
 
 export const LukionOppiaineEditor = ({oppiaine, footnote}) => {
   const arviointi = modelData(oppiaine, 'arviointi')
@@ -15,7 +44,6 @@ export const LukionOppiaineEditor = ({oppiaine, footnote}) => {
   const numeerinenArvosana = kurssi => parseInt(kurssi.arviointi.last().arvosana.koodiarvo)
   const kurssitNumeerisellaArvosanalla = suoritetutKurssit.filter(kurssi => !isNaN(numeerinenArvosana(kurssi)))
   const keskiarvo = kurssitNumeerisellaArvosanalla.length > 0 && Math.round((kurssitNumeerisellaArvosanalla.map(numeerinenArvosana).reduce((a, b) => a + b) / kurssitNumeerisellaArvosanalla.length) * 10) / 10
-  const oppiaineTitle = t(modelData(oppiaine, 'koulutusmoduuli.tunniste.nimi'))
   const {edit} = oppiaine.context
 
   return (
@@ -26,7 +54,10 @@ export const LukionOppiaineEditor = ({oppiaine, footnote}) => {
         </div>
       </td>
       <td className='oppiaine'>
-        <div className='nimi'>{oppiaineTitle}</div>
+        <div className='title'>
+          <Nimi oppiaine={oppiaine}/>
+          <KoulutusmoduuliPropertiesEditor oppiaine={oppiaine}/>
+        </div>
         <KurssitEditor model={oppiaine}/>
       </td>
       <td className='maara'>{suoritetutKurssit.length}</td>

--- a/web/app/lukio/LukionOppiaineEditor.jsx
+++ b/web/app/lukio/LukionOppiaineEditor.jsx
@@ -20,27 +20,27 @@ export const LukionOppiaineEditor = ({oppiaine, footnote}) => {
 
   return (
     <tr className={'oppiaine oppiaine-rivi ' + modelData(oppiaine, 'koulutusmoduuli.tunniste.koodiarvo')}>
-      <td className="suorituksentila" title={tilaText(oppiaine)}>
+      <td className='suorituksentila' title={tilaText(oppiaine)}>
         <div>
           {suorituksenTilaSymbol(oppiaine)}
         </div>
       </td>
-      <td className="oppiaine">
-        <div className="nimi">{oppiaineTitle}</div>
+      <td className='oppiaine'>
+        <div className='nimi'>{oppiaineTitle}</div>
         <KurssitEditor model={oppiaine}/>
       </td>
-      <td className="maara">{suoritetutKurssit.length}</td>
-      <td className="arvosana">
-        <div className="annettuArvosana">
+      <td className='maara'>{suoritetutKurssit.length}</td>
+      <td className='arvosana'>
+        <div className='annettuArvosana'>
           {arviointi ? modelData(oppiaine, 'arviointi.-1.arvosana').koodiarvo : '-'}
           {arviointi && footnote && <FootnoteHint title={footnote.title} hint={footnote.hint} />}
         </div>
-        <div className="keskiarvo">{keskiarvo ? '(' + keskiarvo.toFixed(1).replace('.', ',') + ')' : ''}</div>
+        <div className='keskiarvo'>{keskiarvo ? '(' + keskiarvo.toFixed(1).replace('.', ',') + ')' : ''}</div>
       </td>
       {
         edit && (
           <td>
-            <a className="remove-value" onClick={() => pushRemoval(oppiaine)}/>
+            <a className='remove-value' onClick={() => pushRemoval(oppiaine)}/>
           </td>
         )
       }

--- a/web/app/lukio/LukionOppiaineEditor.jsx
+++ b/web/app/lukio/LukionOppiaineEditor.jsx
@@ -6,37 +6,33 @@ import {KurssitEditor} from '../kurssi/KurssitEditor'
 import {tilaText} from '../suoritus/Suoritus'
 import {FootnoteHint} from '../components/footnote'
 
-export class LukionOppiaineEditor extends React.Component {
-  render() {
+export const LukionOppiaineEditor = ({oppiaine, footnote}) => {
+  let arviointi = modelData(oppiaine, 'arviointi')
+  let kurssit = modelItems(oppiaine, 'osasuoritukset')
+  let suoritetutKurssit = kurssit.map(k => modelData(k)).filter(k => k.arviointi)
+  let numeerinenArvosana = kurssi => parseInt(kurssi.arviointi.last().arvosana.koodiarvo)
+  let kurssitNumeerisellaArvosanalla = suoritetutKurssit.filter(kurssi => !isNaN(numeerinenArvosana(kurssi)))
+  let keskiarvo = kurssitNumeerisellaArvosanalla.length > 0 && Math.round((kurssitNumeerisellaArvosanalla.map(numeerinenArvosana).reduce((a, b) => a + b) / kurssitNumeerisellaArvosanalla.length) * 10) / 10
 
-    let {oppiaine, footnote} = this.props
-    let arviointi = modelData(oppiaine, 'arviointi')
-    let kurssit = modelItems(oppiaine, 'osasuoritukset')
-    let suoritetutKurssit = kurssit.map(k => modelData(k)).filter(k => k.arviointi)
-    let numeerinenArvosana = kurssi => parseInt(kurssi.arviointi.last().arvosana.koodiarvo)
-    let kurssitNumeerisellaArvosanalla = suoritetutKurssit.filter(kurssi => !isNaN(numeerinenArvosana(kurssi)))
-    let keskiarvo = kurssitNumeerisellaArvosanalla.length > 0 && Math.round((kurssitNumeerisellaArvosanalla.map(numeerinenArvosana).reduce((a, b) => a + b) / kurssitNumeerisellaArvosanalla.length) * 10) / 10
-
-    return (
-      <tr className={'oppiaine oppiaine-rivi ' + modelData(oppiaine, 'koulutusmoduuli.tunniste.koodiarvo')}>
-        <td className="suorituksentila" title={tilaText(oppiaine)}>
-          <div>
-            {suorituksenTilaSymbol(oppiaine)}
-          </div>
-        </td>
-        <td className="oppiaine">
-          <div className="nimi">{modelTitle(oppiaine, 'koulutusmoduuli')}</div>
-          <KurssitEditor model={oppiaine}/>
-        </td>
-        <td className="maara">{suoritetutKurssit.length}</td>
-        <td className="arvosana">
-          <div className="annettuArvosana">
-            {arviointi ? modelData(oppiaine, 'arviointi.-1.arvosana').koodiarvo : '-'}
-            {arviointi && footnote && <FootnoteHint title={footnote.title} hint={footnote.hint} />}
-          </div>
-          <div className="keskiarvo">{keskiarvo ? '(' + keskiarvo.toFixed(1).replace('.', ',') + ')' : ''}</div>
-        </td>
-      </tr>
-    )
-  }
+  return (
+    <tr className={'oppiaine oppiaine-rivi ' + modelData(oppiaine, 'koulutusmoduuli.tunniste.koodiarvo')}>
+      <td className="suorituksentila" title={tilaText(oppiaine)}>
+        <div>
+          {suorituksenTilaSymbol(oppiaine)}
+        </div>
+      </td>
+      <td className="oppiaine">
+        <div className="nimi">{modelTitle(oppiaine, 'koulutusmoduuli')}</div>
+        <KurssitEditor model={oppiaine}/>
+      </td>
+      <td className="maara">{suoritetutKurssit.length}</td>
+      <td className="arvosana">
+        <div className="annettuArvosana">
+          {arviointi ? modelData(oppiaine, 'arviointi.-1.arvosana').koodiarvo : '-'}
+          {arviointi && footnote && <FootnoteHint title={footnote.title} hint={footnote.hint} />}
+        </div>
+        <div className="keskiarvo">{keskiarvo ? '(' + keskiarvo.toFixed(1).replace('.', ',') + ')' : ''}</div>
+      </td>
+    </tr>
+  )
 }

--- a/web/app/lukio/LukionOppiaineenOppimaaranSuoritusEditor.jsx
+++ b/web/app/lukio/LukionOppiaineenOppimaaranSuoritusEditor.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import {modelErrorMessages} from '../editor/EditorModel'
+import {LukionOppiaineRowEditor} from './LukionOppiaineEditor'
+import {LukionOppiaineetTableHead} from './fragments/LukionOppiaineetTable'
+
+export const LukionOppiaineenOppimaaranSuoritusEditor = ({model}) => (
+  <section>
+    <table className="suoritukset oppiaineet">
+      <LukionOppiaineetTableHead />
+      <tbody>
+      <LukionOppiaineRowEditor oppiaine={model} />
+      {
+        modelErrorMessages(model).map((error, i) =>
+          <tr key={'error-' + i} className='error'><td colSpan='42' className='error'>{error}</td></tr>
+        )
+      }
+      </tbody>
+    </table>
+  </section>
+)

--- a/web/app/lukio/LukionOppiaineenOppimaaranSuoritusEditor.jsx
+++ b/web/app/lukio/LukionOppiaineenOppimaaranSuoritusEditor.jsx
@@ -8,7 +8,7 @@ export const LukionOppiaineenOppimaaranSuoritusEditor = ({model}) => (
     <table className="suoritukset oppiaineet">
       <LukionOppiaineetTableHead />
       <tbody>
-      <LukionOppiaineRowEditor oppiaine={model} />
+      <LukionOppiaineRowEditor oppiaine={model} allowOppiaineRemoval={false} />
       {
         modelErrorMessages(model).map((error, i) =>
           <tr key={'error-' + i} className='error'><td colSpan='42' className='error'>{error}</td></tr>

--- a/web/app/lukio/LukionOppiaineetEditor.jsx
+++ b/web/app/lukio/LukionOppiaineetEditor.jsx
@@ -3,12 +3,14 @@ import R from 'ramda'
 import {LukionOppiaineRowEditor} from './LukionOppiaineEditor'
 import {LukionOppiaineetTableHead} from './fragments/LukionOppiaineetTable'
 import {UusiLukionOppiaineDropdown} from './UusiLukionOppiaineDropdown'
-import {modelErrorMessages} from '../editor/EditorModel'
+import {modelErrorMessages, modelItems} from '../editor/EditorModel'
 
-export const LukionOppiaineetEditor = ({oppiaineet}) => {
-  if (!oppiaineet || R.isEmpty(oppiaineet)) return null
+export const LukionOppiaineetEditor = ({suorituksetModel}) => {
+  const {edit, suoritus: päätasonSuoritusModel} = suorituksetModel.context
+  const oppiaineet = modelItems(suorituksetModel)
 
-  const päätasonSuoritusModel = oppiaineet[0].context.suoritus
+  if (!edit && R.isEmpty(oppiaineet)) return null
+
   const oppiaineRows = oppiaineet.map((oppiaine, oppiaineIndex) =>
     <LukionOppiaineRowEditor key={oppiaineIndex} oppiaine={oppiaine} />
   )
@@ -22,7 +24,7 @@ export const LukionOppiaineetEditor = ({oppiaineet}) => {
   return (
     <section>
       <table className="suoritukset oppiaineet">
-        <LukionOppiaineetTableHead />
+        {!R.isEmpty(oppiaineet) && <LukionOppiaineetTableHead />}
         <tbody>
         {oppiaineetWithErrorRows}
         </tbody>

--- a/web/app/lukio/LukionOppiaineetEditor.jsx
+++ b/web/app/lukio/LukionOppiaineetEditor.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import {LukionOppiaineEditor} from './LukionOppiaineEditor'
+import {LukionOppiaineetTableHead} from './fragments/LukionOppiaineetTable'
+
+export class LukionOppiaineetEditor extends React.Component {
+  render() {
+    let {oppiaineet} = this.props
+    return (
+      <table className="suoritukset oppiaineet">
+        <LukionOppiaineetTableHead />
+        <tbody>
+        {
+          oppiaineet.map((oppiaine, oppiaineIndex) =>
+            <LukionOppiaineEditor key={oppiaineIndex} oppiaine={oppiaine} />
+          )
+        }
+        </tbody>
+      </table>
+    )
+  }
+}

--- a/web/app/lukio/LukionOppiaineetEditor.jsx
+++ b/web/app/lukio/LukionOppiaineetEditor.jsx
@@ -2,20 +2,15 @@ import React from 'react'
 import {LukionOppiaineEditor} from './LukionOppiaineEditor'
 import {LukionOppiaineetTableHead} from './fragments/LukionOppiaineetTable'
 
-export class LukionOppiaineetEditor extends React.Component {
-  render() {
-    let {oppiaineet} = this.props
-    return (
-      <table className="suoritukset oppiaineet">
-        <LukionOppiaineetTableHead />
-        <tbody>
-        {
-          oppiaineet.map((oppiaine, oppiaineIndex) =>
-            <LukionOppiaineEditor key={oppiaineIndex} oppiaine={oppiaine} />
-          )
-        }
-        </tbody>
-      </table>
-    )
-  }
-}
+export const LukionOppiaineetEditor = ({oppiaineet}) => (
+  <table className="suoritukset oppiaineet">
+    <LukionOppiaineetTableHead />
+    <tbody>
+    {
+      oppiaineet.map((oppiaine, oppiaineIndex) =>
+        <LukionOppiaineEditor key={oppiaineIndex} oppiaine={oppiaine} />
+      )
+    }
+    </tbody>
+  </table>
+)

--- a/web/app/lukio/LukionOppiaineetEditor.jsx
+++ b/web/app/lukio/LukionOppiaineetEditor.jsx
@@ -1,14 +1,16 @@
 import React from 'react'
 import R from 'ramda'
-import {LukionOppiaineEditor} from './LukionOppiaineEditor'
+import {LukionOppiaineRowEditor} from './LukionOppiaineEditor'
 import {LukionOppiaineetTableHead} from './fragments/LukionOppiaineetTable'
 import {UusiLukionOppiaineDropdown} from './UusiLukionOppiaineDropdown'
 import {modelErrorMessages} from '../editor/EditorModel'
 
-export const LukionOppiaineetEditor = ({päätasonSuoritusModel, suoritukset}) => {
-  const oppiaineet = suoritukset || modelItems(päätasonSuoritusModel, 'osasuoritukset') || []
+export const LukionOppiaineetEditor = ({oppiaineet}) => {
+  if (!oppiaineet || R.isEmpty(oppiaineet)) return null
+
+  const päätasonSuoritusModel = oppiaineet[0].context.suoritus
   const oppiaineRows = oppiaineet.map((oppiaine, oppiaineIndex) =>
-    <LukionOppiaineEditor key={oppiaineIndex} oppiaine={oppiaine} />
+    <LukionOppiaineRowEditor key={oppiaineIndex} oppiaine={oppiaine} />
   )
   const errorRows = oppiaineet.map(oppiaine =>
     modelErrorMessages(oppiaine).map((error, i) =>

--- a/web/app/lukio/LukionOppiaineetEditor.jsx
+++ b/web/app/lukio/LukionOppiaineetEditor.jsx
@@ -1,16 +1,31 @@
 import React from 'react'
+import R from 'ramda'
 import {LukionOppiaineEditor} from './LukionOppiaineEditor'
 import {LukionOppiaineetTableHead} from './fragments/LukionOppiaineetTable'
+import {UusiLukionOppiaineDropdown} from './UusiLukionOppiaineDropdown'
+import {modelErrorMessages} from '../editor/EditorModel'
 
-export const LukionOppiaineetEditor = ({oppiaineet}) => (
-  <table className="suoritukset oppiaineet">
-    <LukionOppiaineetTableHead />
-    <tbody>
-    {
-      oppiaineet.map((oppiaine, oppiaineIndex) =>
-        <LukionOppiaineEditor key={oppiaineIndex} oppiaine={oppiaine} />
-      )
-    }
-    </tbody>
-  </table>
-)
+export const LukionOppiaineetEditor = ({päätasonSuoritusModel, suoritukset}) => {
+  const oppiaineet = suoritukset || modelItems(päätasonSuoritusModel, 'osasuoritukset') || []
+  const oppiaineRows = oppiaineet.map((oppiaine, oppiaineIndex) =>
+    <LukionOppiaineEditor key={oppiaineIndex} oppiaine={oppiaine} />
+  )
+  const errorRows = oppiaineet.map(oppiaine =>
+    modelErrorMessages(oppiaine).map((error, i) =>
+      <tr key={'error-' + i} className='error'><td colSpan='42' className='error'>{error}</td></tr>
+    )
+  )
+  const oppiaineetWithErrorRows = R.zip(oppiaineRows, errorRows)
+
+  return (
+    <section>
+      <table className="suoritukset oppiaineet">
+        <LukionOppiaineetTableHead />
+        <tbody>
+        {oppiaineetWithErrorRows}
+        </tbody>
+      </table>
+      <UusiLukionOppiaineDropdown model={päätasonSuoritusModel} />
+    </section>
+  )
+}

--- a/web/app/lukio/LukionOppiaineetEditor.jsx
+++ b/web/app/lukio/LukionOppiaineetEditor.jsx
@@ -5,9 +5,9 @@ import {LukionOppiaineetTableHead} from './fragments/LukionOppiaineetTable'
 import {UusiLukionOppiaineDropdown} from './UusiLukionOppiaineDropdown'
 import {modelErrorMessages, modelItems} from '../editor/EditorModel'
 
-export const LukionOppiaineetEditor = ({suorituksetModel}) => {
+export const LukionOppiaineetEditor = ({suorituksetModel, classForUusiOppiaineenSuoritus, suoritusFilter}) => {
   const {edit, suoritus: päätasonSuoritusModel} = suorituksetModel.context
-  const oppiaineet = modelItems(suorituksetModel)
+  const oppiaineet = modelItems(suorituksetModel).filter(suoritusFilter || R.identity)
 
   if (!edit && R.isEmpty(oppiaineet)) return null
 
@@ -29,7 +29,10 @@ export const LukionOppiaineetEditor = ({suorituksetModel}) => {
         {oppiaineetWithErrorRows}
         </tbody>
       </table>
-      <UusiLukionOppiaineDropdown model={päätasonSuoritusModel} />
+      <UusiLukionOppiaineDropdown
+        model={päätasonSuoritusModel}
+        oppiaineenSuoritusClass={classForUusiOppiaineenSuoritus}
+      />
     </section>
   )
 }

--- a/web/app/lukio/LuvaEditor.jsx
+++ b/web/app/lukio/LuvaEditor.jsx
@@ -4,9 +4,7 @@ import Text from '../i18n/Text'
 
 export class LuvaEditor extends React.Component {
   render() {
-    const {päätasonSuoritusModel} = this.props
-
-    const suoritukset = modelItems(päätasonSuoritusModel, 'osasuoritukset') || []
+    const suoritukset = this.props.oppiaineet || []
     const lukionkurssinsuoritukset = suoritukset.filter(s => s.value.classes.includes('lukionoppiaineenopintojensuorituslukioonvalmistavassakoulutuksessa'))
     const lukioonvalmistavankurssinsuoritukset = suoritukset.filter(s => s.value.classes.includes('lukioonvalmistavankoulutuksenoppiaineensuoritus'))
 
@@ -16,20 +14,14 @@ export class LuvaEditor extends React.Component {
           lukioonvalmistavankurssinsuoritukset.length > 0 &&
           <div>
             <h5><Text name="Lukioon valmistavat opinnot"/></h5>
-            <LukionOppiaineetEditor
-              päätasonSuoritusModel={päätasonSuoritusModel}
-              suoritukset={lukioonvalmistavankurssinsuoritukset}
-            />
+            <LukionOppiaineetEditor oppiaineet={lukioonvalmistavankurssinsuoritukset} />
           </div>
         }
         {
           lukionkurssinsuoritukset.length > 0 &&
           <div>
             <h5><Text name="Valinnaisena suoritetut lukiokurssit"/></h5>
-            <LukionOppiaineetEditor
-              päätasonSuoritusModel={päätasonSuoritusModel}
-              suoritukset={lukionkurssinsuoritukset}
-            />
+            <LukionOppiaineetEditor oppiaineet={lukionkurssinsuoritukset} />
           </div>
         }
       </div>

--- a/web/app/lukio/LuvaEditor.jsx
+++ b/web/app/lukio/LuvaEditor.jsx
@@ -1,31 +1,38 @@
 import React from 'react'
 import {LukionOppiaineetEditor} from './LukionOppiaineetEditor'
 import Text from '../i18n/Text'
-import {modelItems, modelSetValue} from '../editor/EditorModel'
+import {modelItems} from '../editor/EditorModel'
 
 export const LuvaEditor = ({suorituksetModel}) => {
   const {edit} = suorituksetModel.context
-  const suoritukset = modelItems(suorituksetModel)
-  const lukionkurssinsuoritukset = suoritukset.filter(s => s.value.classes.includes('lukionoppiaineenopintojensuorituslukioonvalmistavassakoulutuksessa'))
-  const lukioonvalmistavankurssinsuoritukset = suoritukset.filter(s => s.value.classes.includes('lukioonvalmistavankoulutuksenoppiaineensuoritus'))
+
+  const lukionkurssinsuorituksetFilter = s => s.value.classes.includes('lukionoppiaineenopintojensuorituslukioonvalmistavassakoulutuksessa')
+  const lukioonvalmistavankurssinsuorituksetFilter = s => s.value.classes.includes('lukioonvalmistavankoulutuksenoppiaineensuoritus')
+
+  const hasLukionKursseja = modelItems(suorituksetModel).filter(lukionkurssinsuorituksetFilter).length > 0
+  const hasValmistaviaKursseja = modelItems(suorituksetModel).filter(lukioonvalmistavankurssinsuorituksetFilter).length > 0
 
   return (
     <div>
       {
-        (edit || lukioonvalmistavankurssinsuoritukset.length > 0) &&
-        <div>
+        (edit || hasValmistaviaKursseja) &&
+        <div className='lukioon-valmistavat-opinnot'>
           <h5><Text name="Lukioon valmistavat opinnot"/></h5>
           <LukionOppiaineetEditor
-            suorituksetModel={modelSetValue(suorituksetModel, lukioonvalmistavankurssinsuoritukset)}
+            suorituksetModel={suorituksetModel}
+            classForUusiOppiaineenSuoritus='lukioonvalmistavankoulutuksenoppiaineensuoritus'
+            suoritusFilter={lukioonvalmistavankurssinsuorituksetFilter}
           />
         </div>
       }
       {
-        (edit || lukionkurssinsuoritukset.length > 0) &&
-        <div>
+        (edit || hasLukionKursseja) &&
+        <div className='valinnaisena-suoritetut-lukiokurssit'>
           <h5><Text name="Valinnaisena suoritetut lukiokurssit"/></h5>
           <LukionOppiaineetEditor
-            suorituksetModel={modelSetValue(suorituksetModel, lukionkurssinsuoritukset)}
+            suorituksetModel={suorituksetModel}
+            classForUusiOppiaineenSuoritus='lukionoppiaineenopintojensuorituslukioonvalmistavassakoulutuksessa'
+            suoritusFilter={lukionkurssinsuorituksetFilter}
           />
         </div>
       }

--- a/web/app/lukio/LuvaEditor.jsx
+++ b/web/app/lukio/LuvaEditor.jsx
@@ -4,23 +4,32 @@ import Text from '../i18n/Text'
 
 export class LuvaEditor extends React.Component {
   render() {
-    let {suoritukset} = this.props
-    let lukionkurssinsuoritukset = suoritukset.filter(s => s.value.classes.includes('lukionoppiaineenopintojensuorituslukioonvalmistavassakoulutuksessa'))
-    let lukioonvalmistavankurssinsuoritukset = suoritukset.filter(s => s.value.classes.includes('lukioonvalmistavankoulutuksenoppiaineensuoritus'))
+    const {päätasonSuoritusModel} = this.props
+
+    const suoritukset = modelItems(päätasonSuoritusModel, 'osasuoritukset') || []
+    const lukionkurssinsuoritukset = suoritukset.filter(s => s.value.classes.includes('lukionoppiaineenopintojensuorituslukioonvalmistavassakoulutuksessa'))
+    const lukioonvalmistavankurssinsuoritukset = suoritukset.filter(s => s.value.classes.includes('lukioonvalmistavankoulutuksenoppiaineensuoritus'))
+
     return (
       <div>
         {
           lukioonvalmistavankurssinsuoritukset.length > 0 &&
           <div>
             <h5><Text name="Lukioon valmistavat opinnot"/></h5>
-            <LukionOppiaineetEditor oppiaineet={lukioonvalmistavankurssinsuoritukset} />
+            <LukionOppiaineetEditor
+              päätasonSuoritusModel={päätasonSuoritusModel}
+              suoritukset={lukioonvalmistavankurssinsuoritukset}
+            />
           </div>
         }
         {
           lukionkurssinsuoritukset.length > 0 &&
           <div>
             <h5><Text name="Valinnaisena suoritetut lukiokurssit"/></h5>
-            <LukionOppiaineetEditor oppiaineet={lukionkurssinsuoritukset} />
+            <LukionOppiaineetEditor
+              päätasonSuoritusModel={päätasonSuoritusModel}
+              suoritukset={lukionkurssinsuoritukset}
+            />
           </div>
         }
       </div>

--- a/web/app/lukio/LuvaEditor.jsx
+++ b/web/app/lukio/LuvaEditor.jsx
@@ -1,26 +1,32 @@
 import React from 'react'
 import {LukionOppiaineetEditor} from './LukionOppiaineetEditor'
 import Text from '../i18n/Text'
+import {modelItems, modelSetValue} from '../editor/EditorModel'
 
-export const LuvaEditor = ({oppiaineet}) => {
-  const suoritukset = oppiaineet || []
+export const LuvaEditor = ({suorituksetModel}) => {
+  const {edit} = suorituksetModel.context
+  const suoritukset = modelItems(suorituksetModel)
   const lukionkurssinsuoritukset = suoritukset.filter(s => s.value.classes.includes('lukionoppiaineenopintojensuorituslukioonvalmistavassakoulutuksessa'))
   const lukioonvalmistavankurssinsuoritukset = suoritukset.filter(s => s.value.classes.includes('lukioonvalmistavankoulutuksenoppiaineensuoritus'))
 
   return (
     <div>
       {
-        lukioonvalmistavankurssinsuoritukset.length > 0 &&
+        (edit || lukioonvalmistavankurssinsuoritukset.length > 0) &&
         <div>
           <h5><Text name="Lukioon valmistavat opinnot"/></h5>
-          <LukionOppiaineetEditor oppiaineet={lukioonvalmistavankurssinsuoritukset}/>
+          <LukionOppiaineetEditor
+            suorituksetModel={modelSetValue(suorituksetModel, lukioonvalmistavankurssinsuoritukset)}
+          />
         </div>
       }
       {
-        lukionkurssinsuoritukset.length > 0 &&
+        (edit || lukionkurssinsuoritukset.length > 0) &&
         <div>
           <h5><Text name="Valinnaisena suoritetut lukiokurssit"/></h5>
-          <LukionOppiaineetEditor oppiaineet={lukionkurssinsuoritukset}/>
+          <LukionOppiaineetEditor
+            suorituksetModel={modelSetValue(suorituksetModel, lukionkurssinsuoritukset)}
+          />
         </div>
       }
     </div>

--- a/web/app/lukio/LuvaEditor.jsx
+++ b/web/app/lukio/LuvaEditor.jsx
@@ -2,29 +2,27 @@ import React from 'react'
 import {LukionOppiaineetEditor} from './LukionOppiaineetEditor'
 import Text from '../i18n/Text'
 
-export class LuvaEditor extends React.Component {
-  render() {
-    const suoritukset = this.props.oppiaineet || []
-    const lukionkurssinsuoritukset = suoritukset.filter(s => s.value.classes.includes('lukionoppiaineenopintojensuorituslukioonvalmistavassakoulutuksessa'))
-    const lukioonvalmistavankurssinsuoritukset = suoritukset.filter(s => s.value.classes.includes('lukioonvalmistavankoulutuksenoppiaineensuoritus'))
+export const LuvaEditor = ({oppiaineet}) => {
+  const suoritukset = oppiaineet || []
+  const lukionkurssinsuoritukset = suoritukset.filter(s => s.value.classes.includes('lukionoppiaineenopintojensuorituslukioonvalmistavassakoulutuksessa'))
+  const lukioonvalmistavankurssinsuoritukset = suoritukset.filter(s => s.value.classes.includes('lukioonvalmistavankoulutuksenoppiaineensuoritus'))
 
-    return (
-      <div>
-        {
-          lukioonvalmistavankurssinsuoritukset.length > 0 &&
-          <div>
-            <h5><Text name="Lukioon valmistavat opinnot"/></h5>
-            <LukionOppiaineetEditor oppiaineet={lukioonvalmistavankurssinsuoritukset} />
-          </div>
-        }
-        {
-          lukionkurssinsuoritukset.length > 0 &&
-          <div>
-            <h5><Text name="Valinnaisena suoritetut lukiokurssit"/></h5>
-            <LukionOppiaineetEditor oppiaineet={lukionkurssinsuoritukset} />
-          </div>
-        }
-      </div>
-    )
-  }
+  return (
+    <div>
+      {
+        lukioonvalmistavankurssinsuoritukset.length > 0 &&
+        <div>
+          <h5><Text name="Lukioon valmistavat opinnot"/></h5>
+          <LukionOppiaineetEditor oppiaineet={lukioonvalmistavankurssinsuoritukset}/>
+        </div>
+      }
+      {
+        lukionkurssinsuoritukset.length > 0 &&
+        <div>
+          <h5><Text name="Valinnaisena suoritetut lukiokurssit"/></h5>
+          <LukionOppiaineetEditor oppiaineet={lukionkurssinsuoritukset}/>
+        </div>
+      }
+    </div>
+  )
 }

--- a/web/app/lukio/LuvaEditor.jsx
+++ b/web/app/lukio/LuvaEditor.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { LukionOppiaineetEditor } from './Lukio'
+import {LukionOppiaineetEditor} from './LukionOppiaineetEditor'
 import Text from '../i18n/Text'
 
 export class LuvaEditor extends React.Component {

--- a/web/app/lukio/UusiLukionOppiaineDropdown.jsx
+++ b/web/app/lukio/UusiLukionOppiaineDropdown.jsx
@@ -1,0 +1,47 @@
+import React from 'baret'
+import {t} from '../i18n/i18n'
+import DropDown from '../components/Dropdown'
+import {
+  contextualizeSubModel, ensureArrayKey, modelData, modelItems, modelLookup, modelSet, oneOfPrototypes, pushModel,
+  wrapOptional
+} from '../editor/EditorModel'
+import {koulutusModuuliprototypes} from '../suoritus/Koulutusmoduuli'
+import {fetchAlternativesBasedOnPrototypes} from '../editor/EnumEditor'
+
+const createOppiaineenSuoritus = model => {
+  const oppiaineet = wrapOptional(modelLookup(model, 'osasuoritukset'))
+  const newItemIndex = modelItems(oppiaineet).length
+  const oppiaineenSuoritusProto = contextualizeSubModel(oppiaineet.arrayPrototype, oppiaineet, newItemIndex)
+  const options = oneOfPrototypes(oppiaineenSuoritusProto)
+  return contextualizeSubModel(options[0], oppiaineet, newItemIndex)
+}
+
+const fetchOppiaineOptions = uusiOppiaineenSuoritus => {
+  const oppiaineModels = koulutusModuuliprototypes(uusiOppiaineenSuoritus)
+  return fetchAlternativesBasedOnPrototypes(oppiaineModels, 'tunniste')
+}
+
+export const UusiLukionOppiaineDropdown = ({model}) => {
+  if (!model || !model.context.edit) return null
+
+  const uusiOppiaineenSuoritus = createOppiaineenSuoritus(model)
+  const options = fetchOppiaineOptions(uusiOppiaineenSuoritus)
+  const placeholderText = t('Lisää oppiaine')
+
+  const addOppiaine = oppiaine => {
+    const suoritusUudellaOppiaineella = modelSet(uusiOppiaineenSuoritus, oppiaine, 'koulutusmoduuli')
+    pushModel(suoritusUudellaOppiaineella, model.context.changeBus)
+    ensureArrayKey(suoritusUudellaOppiaineella)
+  }
+
+  return (
+    <DropDown
+      options={options}
+      keyValue={oppiaine => modelData(oppiaine, 'tunniste').koodiarvo}
+      displayValue={oppiaine => modelLookup(oppiaine, 'tunniste').value.title}
+      onSelectionChanged={addOppiaine}
+      selectionText={placeholderText}
+      isRemovable={() => false}
+    />
+  )
+}

--- a/web/app/lukio/UusiLukionOppiaineDropdown.jsx
+++ b/web/app/lukio/UusiLukionOppiaineDropdown.jsx
@@ -9,12 +9,13 @@ import {
 import {koulutusModuuliprototypes} from '../suoritus/Koulutusmoduuli'
 import {fetchAlternativesBasedOnPrototypes} from '../editor/EnumEditor'
 
-const createOppiaineenSuoritus = model => {
+const createOppiaineenSuoritus = (model, suoritusClass) => {
   const oppiaineet = wrapOptional(modelLookup(model, 'osasuoritukset'))
   const newItemIndex = modelItems(oppiaineet).length
   const oppiaineenSuoritusProto = contextualizeSubModel(oppiaineet.arrayPrototype, oppiaineet, newItemIndex)
   const options = oneOfPrototypes(oppiaineenSuoritusProto)
-  return contextualizeSubModel(options[0], oppiaineet, newItemIndex)
+  const proto = suoritusClass && options.find(p => p.value.classes.includes(suoritusClass)) || options[0]
+  return contextualizeSubModel(proto, oppiaineet, newItemIndex)
 }
 
 const fetchOppiaineOptions = uusiOppiaineenSuoritus => {
@@ -25,10 +26,10 @@ const fetchOppiaineOptions = uusiOppiaineenSuoritus => {
 const oppiaineToKoodiarvo = oppiaine => modelData(oppiaine, 'koulutusmoduuli.tunniste').koodiarvo
 const koulutusmoduuliToKoodiarvo = koulutusmoduuli => modelData(koulutusmoduuli, 'tunniste').koodiarvo
 
-export const UusiLukionOppiaineDropdown = ({model}) => {
+export const UusiLukionOppiaineDropdown = ({model, oppiaineenSuoritusClass}) => {
   if (!model || !model.context.edit) return null
 
-  const uusiOppiaineenSuoritus = createOppiaineenSuoritus(model)
+  const uusiOppiaineenSuoritus = createOppiaineenSuoritus(model, oppiaineenSuoritusClass)
   const käytössäOlevatKoodiarvot = modelItems(model, 'osasuoritukset').map(oppiaineToKoodiarvo)
   const options = fetchOppiaineOptions(uusiOppiaineenSuoritus).map(oppiaineOptions =>
     oppiaineOptions

--- a/web/app/lukio/UusiLukionOppiaineDropdown.jsx
+++ b/web/app/lukio/UusiLukionOppiaineDropdown.jsx
@@ -17,15 +17,22 @@ const createOppiaineenSuoritus = model => {
 }
 
 const fetchOppiaineOptions = uusiOppiaineenSuoritus => {
-  const oppiaineModels = koulutusModuuliprototypes(uusiOppiaineenSuoritus)
-  return fetchAlternativesBasedOnPrototypes(oppiaineModels, 'tunniste')
+  const koulutusmoduuliModels = koulutusModuuliprototypes(uusiOppiaineenSuoritus)
+  return fetchAlternativesBasedOnPrototypes(koulutusmoduuliModels, 'tunniste')
 }
+
+const oppiaineToKoodiarvo = oppiaine => modelData(oppiaine, 'koulutusmoduuli.tunniste').koodiarvo
+const koulutusmoduuliToKoodiarvo = koulutusmoduuli => modelData(koulutusmoduuli, 'tunniste').koodiarvo
 
 export const UusiLukionOppiaineDropdown = ({model}) => {
   if (!model || !model.context.edit) return null
 
   const uusiOppiaineenSuoritus = createOppiaineenSuoritus(model)
-  const options = fetchOppiaineOptions(uusiOppiaineenSuoritus)
+  const käytössäOlevatKoodiarvot = modelItems(model, 'osasuoritukset').map(oppiaineToKoodiarvo)
+  const options = fetchOppiaineOptions(uusiOppiaineenSuoritus).map(oppiaineOptions =>
+    oppiaineOptions
+      .filter(option => !käytössäOlevatKoodiarvot.includes(koulutusmoduuliToKoodiarvo(option)))
+  )
   const placeholderText = t('Lisää oppiaine')
 
   const addOppiaine = oppiaine => {

--- a/web/app/lukio/UusiLukionOppiaineDropdown.jsx
+++ b/web/app/lukio/UusiLukionOppiaineDropdown.jsx
@@ -45,13 +45,15 @@ export const UusiLukionOppiaineDropdown = ({model}) => {
   }
 
   return (
-    <DropDown
-      options={options}
-      keyValue={oppiaine => modelData(oppiaine, 'tunniste').koodiarvo}
-      displayValue={oppiaine => modelLookup(oppiaine, 'tunniste').value.title}
-      onSelectionChanged={addOppiaine}
-      selectionText={placeholderText}
-      isRemovable={() => false}
-    />
+    <div className='uusi-oppiaine'>
+      <DropDown
+        options={options}
+        keyValue={oppiaine => modelData(oppiaine, 'tunniste').koodiarvo}
+        displayValue={oppiaine => modelLookup(oppiaine, 'tunniste').value.title}
+        onSelectionChanged={addOppiaine}
+        selectionText={placeholderText}
+        isRemovable={() => false}
+      />
+    </div>
   )
 }

--- a/web/app/lukio/UusiLukionOppiaineDropdown.jsx
+++ b/web/app/lukio/UusiLukionOppiaineDropdown.jsx
@@ -2,7 +2,8 @@ import React from 'baret'
 import {t} from '../i18n/i18n'
 import DropDown from '../components/Dropdown'
 import {
-  contextualizeSubModel, ensureArrayKey, modelData, modelItems, modelLookup, modelSet, oneOfPrototypes, pushModel,
+  contextualizeSubModel, ensureArrayKey, modelData, modelItems, modelLookup, modelSet, modelSetTitle, oneOfPrototypes,
+  pushModel,
   wrapOptional
 } from '../editor/EditorModel'
 import {koulutusModuuliprototypes} from '../suoritus/Koulutusmoduuli'
@@ -36,7 +37,9 @@ export const UusiLukionOppiaineDropdown = ({model}) => {
   const placeholderText = t('Lisää oppiaine')
 
   const addOppiaine = oppiaine => {
-    const suoritusUudellaOppiaineella = modelSet(uusiOppiaineenSuoritus, oppiaine, 'koulutusmoduuli')
+    const nimi = t(modelData(oppiaine, 'tunniste.nimi'))
+    const oppiaineWithTitle = modelSetTitle(oppiaine, nimi)
+    const suoritusUudellaOppiaineella = modelSet(uusiOppiaineenSuoritus, oppiaineWithTitle, 'koulutusmoduuli')
     pushModel(suoritusUudellaOppiaineella, model.context.changeBus)
     ensureArrayKey(suoritusUudellaOppiaineella)
   }

--- a/web/app/style/dropdown.less
+++ b/web/app/style/dropdown.less
@@ -1,5 +1,5 @@
-.dropdown {
-  &.inline:not(:hover) {
+.dropdown-wrapper:not(.error) {
+  .dropdown.inline:not(:hover) {
     .select:after, .input-container:after {
       border: 1px solid rgba(0, 0, 0, 0);
     }
@@ -14,7 +14,9 @@
       }
     }
   }
+}
 
+.dropdown {
   position: relative;
   outline: none;
 

--- a/web/app/style/kurssi.less
+++ b/web/app/style/kurssi.less
@@ -37,6 +37,7 @@
       .details {
         position: absolute;
         padding: 25px;
+        margin-bottom: 80px;
         background-color: white;
         box-shadow: 0 2px 5px rgba(0, 0, 0, .15);
         z-index: @z-index-base + 2;

--- a/web/app/style/lukio.less
+++ b/web/app/style/lukio.less
@@ -11,8 +11,12 @@
             text-transform: lowercase;
           }
 
-          .dropdown.inline:not(:hover) .input-container input {
-            background: none;
+          .dropdown-wrapper:not(.error) {
+            .dropdown.inline:not(:hover) {
+              .input-container input {
+                background: none;
+              }
+            }
           }
         }
       }

--- a/web/app/style/lukio.less
+++ b/web/app/style/lukio.less
@@ -62,6 +62,11 @@
                 width: 0;
               }
             }
+            &.remove-row {
+              background-color: @color-white;
+              width: 10px;
+              padding: 0;
+            }
           }
           &.error {
             td.error {

--- a/web/app/style/lukio.less
+++ b/web/app/style/lukio.less
@@ -10,7 +10,7 @@
     table.suoritukset {
       width: 100%;
 
-      > tbody > tr:not(.aineryhmä) {
+      > tbody > tr:not(.aineryhmä):not(.error) {
         background: @color-neutral-gray;
       }
 
@@ -61,6 +61,11 @@
               div {
                 width: 0;
               }
+            }
+          }
+          &.error {
+            td.error {
+              color: @color-red;
             }
           }
         }

--- a/web/app/style/lukio.less
+++ b/web/app/style/lukio.less
@@ -57,6 +57,7 @@
             border-bottom: 5px solid white;
             &.maara, &.arvosana {
               text-align: right;
+              max-width: 76px;
 
               > .annettuArvosana > .footnote-hint {
                 cursor: pointer;

--- a/web/app/style/lukio.less
+++ b/web/app/style/lukio.less
@@ -2,8 +2,19 @@
   .lukionoppimaaransuoritus, .lukionoppiaineenoppimaaransuoritus, .lukioonvalmistavankoulutuksensuoritus,
   .preibsuoritus, .ibtutkinnonsuoritus {
     .oppiaine {
-      > .nimi {
-        color: @color-label;
+      .title {
+        > .nimi {
+          color: @color-label;
+        }
+        > .properties {
+          input {
+            text-transform: lowercase;
+          }
+
+          .dropdown.inline:not(:hover) .input-container input {
+            background: none;
+          }
+        }
       }
     }
 

--- a/web/app/style/opiskeluoikeus.less
+++ b/web/app/style/opiskeluoikeus.less
@@ -1,5 +1,4 @@
 .oppija {
-  padding-bottom: 150px;
   .opiskeluoikeus {
     padding: 0;
     position: relative;

--- a/web/app/suoritus/Koulutusmoduuli.js
+++ b/web/app/suoritus/Koulutusmoduuli.js
@@ -7,4 +7,5 @@ export const isUusi = (oppiaine) => {
   return !modelData(oppiaine, 'tunniste').koodiarvo
 }
 export const isLukionKurssi = (m) => m && m.value.classes.includes('lukionkurssi')
+export const isLukionMatematiikka = (m) => m && m.value.classes.includes('lukionmatematiikka')
 export const koulutusModuuliprototypes = (suoritus) => oneOfPrototypes(modelLookup(suoritus, 'koulutusmoduuli'))

--- a/web/app/suoritus/Koulutusmoduuli.js
+++ b/web/app/suoritus/Koulutusmoduuli.js
@@ -6,4 +6,5 @@ export const isÄidinkieli = (m) => m && m.value.classes.includes('aidinkieli')
 export const isUusi = (oppiaine) => {
   return !modelData(oppiaine, 'tunniste').koodiarvo
 }
+export const isLukionKurssi = (m) => m && m.value.classes.includes('lukionkurssi')
 export const koulutusModuuliprototypes = (suoritus) => oneOfPrototypes(modelLookup(suoritus, 'koulutusmoduuli'))

--- a/web/app/suoritus/suoritusEditorMapping.jsx
+++ b/web/app/suoritus/suoritusEditorMapping.jsx
@@ -36,13 +36,13 @@ export const resolveOsasuorituksetEditor = (mdl) => {
     return <Suoritustaulukko suorituksetModel={modelLookup(mdl, 'osasuoritukset')}/>
   }
   if (oneOf('lukionoppimaaransuoritus', 'preibsuoritus')) {
-    return <LukionOppiaineetEditor oppiaineet={modelItems(mdl, 'osasuoritukset') || []} />
+    return <LukionOppiaineetEditor päätasonSuoritusModel={mdl} />
   }
   if (oneOf('lukionoppiaineenoppimaaransuoritus')) {
-    return <LukionOppiaineetEditor oppiaineet={[mdl]} />
+    return <LukionOppiaineetEditor päätasonSuoritusModel={mdl} suoritukset={[mdl]} />
   }
   if (oneOf('lukioonvalmistavankoulutuksensuoritus')) {
-    return <LuvaEditor suoritukset={modelItems(mdl, 'osasuoritukset') || []}/>
+    return <LuvaEditor päätasonSuoritusModel={mdl}/>
   }
   if (oneOf('ibtutkinnonsuoritus')) {
     return <IBTutkinnonOppiaineetEditor oppiaineet={modelItems(mdl, 'osasuoritukset') || []} />

--- a/web/app/suoritus/suoritusEditorMapping.jsx
+++ b/web/app/suoritus/suoritusEditorMapping.jsx
@@ -12,6 +12,7 @@ import {PropertyEditor} from '../editor/PropertyEditor'
 import {Editor} from '../editor/Editor'
 import {sortLanguages} from '../util/sorting'
 import {ArvosanaEditor} from './ArvosanaEditor'
+import {LukionOppiaineenOppimaaranSuoritusEditor} from '../lukio/LukionOppiaineenOppimaaranSuoritusEditor'
 
 export const resolveOsasuorituksetEditor = (mdl) => {
   const oneOf = (...classes) => classes.some(c => mdl.value.classes.includes(c))
@@ -36,13 +37,13 @@ export const resolveOsasuorituksetEditor = (mdl) => {
     return <Suoritustaulukko suorituksetModel={modelLookup(mdl, 'osasuoritukset')}/>
   }
   if (oneOf('lukionoppimaaransuoritus', 'preibsuoritus')) {
-    return <LukionOppiaineetEditor päätasonSuoritusModel={mdl} />
+    return <LukionOppiaineetEditor oppiaineet={modelItems(mdl, 'osasuoritukset')} />
   }
   if (oneOf('lukionoppiaineenoppimaaransuoritus')) {
-    return <LukionOppiaineetEditor päätasonSuoritusModel={mdl} suoritukset={[mdl]} />
+    return <LukionOppiaineenOppimaaranSuoritusEditor model={mdl} />
   }
   if (oneOf('lukioonvalmistavankoulutuksensuoritus')) {
-    return <LuvaEditor päätasonSuoritusModel={mdl}/>
+    return <LuvaEditor oppiaineet={modelItems(mdl, 'osasuoritukset')}/>
   }
   if (oneOf('ibtutkinnonsuoritus')) {
     return <IBTutkinnonOppiaineetEditor oppiaineet={modelItems(mdl, 'osasuoritukset') || []} />

--- a/web/app/suoritus/suoritusEditorMapping.jsx
+++ b/web/app/suoritus/suoritusEditorMapping.jsx
@@ -37,13 +37,13 @@ export const resolveOsasuorituksetEditor = (mdl) => {
     return <Suoritustaulukko suorituksetModel={modelLookup(mdl, 'osasuoritukset')}/>
   }
   if (oneOf('lukionoppimaaransuoritus', 'preibsuoritus')) {
-    return <LukionOppiaineetEditor oppiaineet={modelItems(mdl, 'osasuoritukset')} />
+    return <LukionOppiaineetEditor suorituksetModel={modelLookup(mdl, 'osasuoritukset')} />
   }
   if (oneOf('lukionoppiaineenoppimaaransuoritus')) {
     return <LukionOppiaineenOppimaaranSuoritusEditor model={mdl} />
   }
   if (oneOf('lukioonvalmistavankoulutuksensuoritus')) {
-    return <LuvaEditor oppiaineet={modelItems(mdl, 'osasuoritukset')}/>
+    return <LuvaEditor suorituksetModel={modelLookup(mdl, 'osasuoritukset')}/>
   }
   if (oneOf('ibtutkinnonsuoritus')) {
     return <IBTutkinnonOppiaineetEditor oppiaineet={modelItems(mdl, 'osasuoritukset') || []} />

--- a/web/app/suoritus/suoritusEditorMapping.jsx
+++ b/web/app/suoritus/suoritusEditorMapping.jsx
@@ -5,7 +5,7 @@ import {PerusopetuksenOppiaineetEditor} from '../perusopetus/PerusopetuksenOppia
 import PerusopetuksenOppiaineenOppimääränSuoritusEditor from '../perusopetus/PerusopetuksenOppiaineenOppimaaranSuoritusEditor'
 import {PropertiesEditor} from '../editor/PropertiesEditor'
 import {Suoritustaulukko} from './Suoritustaulukko'
-import * as Lukio from '../lukio/Lukio'
+import {LukionOppiaineetEditor} from '../lukio/LukionOppiaineetEditor'
 import {LuvaEditor} from '../lukio/LuvaEditor'
 import {IBTutkinnonOppiaineetEditor} from '../ib/IB'
 import {PropertyEditor} from '../editor/PropertyEditor'
@@ -36,10 +36,10 @@ export const resolveOsasuorituksetEditor = (mdl) => {
     return <Suoritustaulukko suorituksetModel={modelLookup(mdl, 'osasuoritukset')}/>
   }
   if (oneOf('lukionoppimaaransuoritus', 'preibsuoritus')) {
-    return <Lukio.LukionOppiaineetEditor oppiaineet={modelItems(mdl, 'osasuoritukset') || []} />
+    return <LukionOppiaineetEditor oppiaineet={modelItems(mdl, 'osasuoritukset') || []} />
   }
   if (oneOf('lukionoppiaineenoppimaaransuoritus')) {
-    return <Lukio.LukionOppiaineetEditor oppiaineet={[mdl]} />
+    return <LukionOppiaineetEditor oppiaineet={[mdl]} />
   }
   if (oneOf('lukioonvalmistavankoulutuksensuoritus')) {
     return <LuvaEditor suoritukset={modelItems(mdl, 'osasuoritukset') || []}/>

--- a/web/test/spec/lukioSpec.js
+++ b/web/test/spec/lukioSpec.js
@@ -131,10 +131,29 @@ describe('Lukiokoulutus', function( ){
 
   describe('Lukion oppiaineen oppimäärän suoritus', function() {
     before(page.openPage, page.oppijaHaku.searchAndSelect('210163-2367'))
+
     describe('Oppijan suorituksissa', function() {
       it('näytetään', function() {
         expect(opinnot.getTutkinto()).to.equal("Historia")
         expect(opinnot.getOppilaitos()).to.equal("Jyväskylän normaalikoulu")
+      })
+    })
+
+    describe('Kaikki tiedot näkyvissä', function () {
+      it('näyttää opiskeluoikeuden tiedot', function() {
+        expect(extractAsText(S('.opiskeluoikeuden-tiedot'))).to.equal(
+          'Opiskeluoikeuden voimassaoloaika : 1.9.2015 — 10.1.2016\n' +
+          'Tila 10.1.2016 Valmistunut\n' +
+          '1.9.2015 Läsnä')
+      })
+
+      it('näyttää suorituksen tiedot', function() {
+        expect(extractAsText(S('.suoritus > .properties, .suoritus > .tila-vahvistus'))).to.equal(
+          'Oppiaine Historia 60/011/2015\n' +
+          'Oppilaitos / toimipiste Jyväskylän normaalikoulu\n' +
+          'Arviointi 9\n' +
+          'Suorituskieli suomi\n' +
+          'Suoritus valmis Vahvistus : 10.1.2016 Jyväskylä Reijo Reksi , rehtori')
       })
 
       it('näyttää oppiaineiden ja kurssien arvosanat', function() {

--- a/web/test/spec/lukioSpec.js
+++ b/web/test/spec/lukioSpec.js
@@ -133,7 +133,7 @@ describe('Lukiokoulutus', function( ){
     before(page.openPage, page.oppijaHaku.searchAndSelect('210163-2367'))
     describe('Oppijan suorituksissa', function() {
       it('näytetään', function() {
-        expect(S('.opiskeluoikeus .suoritus .property.tunniste .value').text()).to.equal("Historia")
+        expect(opinnot.getTutkinto()).to.equal("Historia")
         expect(opinnot.getOppilaitos()).to.equal("Jyväskylän normaalikoulu")
       })
 

--- a/web/test/spec/lukioSpec.js
+++ b/web/test/spec/lukioSpec.js
@@ -167,14 +167,38 @@ describe('Lukiokoulutus', function( ){
 
   describe('Lukioon valmistava koulutus', function() {
     before(page.openPage, page.oppijaHaku.searchAndSelect('211007-442N'))
+
     describe('Oppijan suorituksissa', function() {
       it('näytetään', function() {
         expect(opinnot.getTutkinto()).to.equal("Lukiokoulutukseen valmistava koulutus")
         expect(opinnot.getOppilaitos()).to.equal("Jyväskylän normaalikoulu")
       })
     })
+
     describe('Kaikki tiedot näkyvissä', function() {
       before(opinnot.expandAll)
+
+      it('näyttää opiskeluoikeuden tiedot', function() {
+        expect(extractAsText(S('.opiskeluoikeuden-tiedot'))).to.equal(
+          'Opiskeluoikeuden voimassaoloaika : 15.8.2008 — 4.6.2016\n' +
+          'Tila 4.6.2016 Valmistunut\n' +
+          '15.8.2008 Läsnä\n' +
+          'Lisätiedot\n' +
+          'Pidennetty päättymispäivä kyllä\n' +
+          'Ulkomaanjaksot 1.9.2012 — 1.9.2013 Maa Ruotsi Kuvaus Harjoittelua ulkomailla\n' +
+          'Oikeus maksuttomaan asuntolapaikkaan kyllä\n' +
+          'Sisäoppilaitosmainen majoitus 1.9.2013 — 12.12.2013')
+      })
+
+      it('näyttää suorituksen tiedot', function() {
+        expect(extractAsText(S('.suoritus > .properties, .suoritus > .tila-vahvistus'))).to.equal(
+          'Koulutus Lukiokoulutukseen valmistava koulutus 56/011/2015\n' +
+          'Opetussuunnitelma Lukio suoritetaan nuorten opetussuunnitelman mukaan\n' +
+          'Oppilaitos / toimipiste Jyväskylän normaalikoulu\n' +
+          'Suorituskieli suomi\n' +
+          'Suoritus valmis Vahvistus : 4.6.2016 Jyväskylä Reijo Reksi , rehtori')
+      })
+
       it('näyttää oppiaineiden ja kurssien arvosanat', function() {
         expect(extractAsText(S('.osasuoritukset'))).to.equal(
           'Lukioon valmistavat opinnot\n' +

--- a/web/test/spec/lukioSpec.js
+++ b/web/test/spec/lukioSpec.js
@@ -274,6 +274,83 @@ describe('Lukiokoulutus', function( ){
           'HI1\n7 HI2\n8 HI3\n7 HI4\n6 4 9\n(7,0)')
       })
     })
+
+    describe('Tietojen muuttaminen', function() {
+      describe('Suoritusten tiedot', function () {
+        describe('Oppiaine', function () {
+          before(editor.edit)
+
+          var hi = opinnot.oppiaineet.oppiaine('oppiaine.HI')
+          var arvosana = hi.propertyBySelector('td.arvosana')
+
+          describe('Alkutila', function () {
+            it('on oikein', function () {
+              expect(editor.canSave()).to.equal(false)
+              expect(arvosana.getValue()).to.equal('9')
+            })
+          })
+
+          describe('Arvosanan muuttaminen', function () {
+            before(arvosana.selectValue(8), editor.saveChanges, wait.until(page.isSavedLabelShown))
+
+            it('onnistuu', function () {
+              expect(findSingle('.oppiaine.HI .arvosana .annettuArvosana')().text()).to.equal('8')
+            })
+          })
+
+          describe('Oppiaineen', function () {
+            before(editor.edit)
+
+            it('lisääminen ei ole mahdollista', function () {
+              expect(findSingle('.uusi-oppiaine')).to.throw(Error, /not found/)
+            })
+
+            it('poistaminen ei ole mahdollista', function () {
+              expect(findSingle('.oppiaine-rivi > .remove-row')).to.throw(Error, /not found/)
+            })
+          })
+
+          describe('Oppiaineen kurssi', function () {
+            before(
+              editor.edit,
+              editor.property('tila').removeItem(0),
+              opinnot.tilaJaVahvistus.merkitseKeskeneräiseksi
+            )
+
+            describe('Arvosanan muuttaminen', function () {
+              var kurssi = opinnot.oppiaineet.oppiaine('HI').kurssi('HI4')
+
+              before(kurssi.arvosana.selectValue('10'), editor.saveChanges, wait.until(page.isSavedLabelShown))
+
+              it('Toimii', function () {
+                expect(kurssi.arvosana.getText()).to.equal('10')
+              })
+            })
+
+            // describe('Lisääminen', function () {
+            //   it('toimii', function () {
+            //     //TODO rajaa kurssivaihtoehtoja hakemalla vain opetussuunnitelmaan kuuluvat
+            //   })
+            // })
+
+            describe('Poistaminen', function () {
+              var hi1 = hi.kurssi('HI1')
+
+              before(
+                editor.edit,
+                hi1.poistaKurssi,
+                editor.saveChanges,
+                wait.until(page.isSavedLabelShown)
+              )
+
+              it('toimii', function () {
+                expect(extractAsText(S('.oppiaineet .HI'))).to.not.contain('HI1')
+              })
+            })
+          })
+        })
+      })
+    })
   })
 
   describe('Lukioon valmistava koulutus', function() {

--- a/web/test/spec/lukioSpec.js
+++ b/web/test/spec/lukioSpec.js
@@ -439,5 +439,246 @@ describe('Lukiokoulutus', function( ){
         expect(todistus.vahvistus()).to.equal('Jyväskylä 4.6.2016 Reijo Reksi rehtori')
       })
     })
+
+    describe('Tietojen muuttaminen', function() {
+      before(page.openPage, page.oppijaHaku.searchAndSelect('211007-442N'))
+
+      describe('Suoritusten tiedot', function () {
+        describe('Oppiaine', function () {
+          before(editor.edit)
+
+          var valmistavaAi = opinnot.oppiaineet.oppiaine('oppiaine.LVAIK')
+          var valmistavaAiArvosana = valmistavaAi.propertyBySelector('td.arvosana')
+          var valmistavaAiKieli = valmistavaAi.propertyBySelector('.title .properties')
+
+          var valinnainenEn = opinnot.oppiaineet.oppiaine('oppiaine.A1')
+          var valinnainenEnArvosana = valinnainenEn.propertyBySelector('td.arvosana')
+          var valinnainenEnKieli = valinnainenEn.propertyBySelector('.title .properties')
+
+          describe('Alkutila', function () {
+            it('on oikein', function () {
+              expect(editor.canSave()).to.equal(false)
+              expect(valmistavaAiArvosana.getValue()).to.equal('S')
+              expect(valinnainenEnArvosana.getValue()).to.equal('S')
+            })
+          })
+
+          describe('Kieliaineen kielen muuttaminen', function() {
+            describe('valmistavalle äidinkielelle', function () {
+              before(valmistavaAiKieli.selectValue('Ruotsi toisena kielenä ja kirjallisuus'))
+              it('toimii', function() {
+                expect(valmistavaAiKieli.getValue()).to.equal('Ruotsi toisena kielenä ja kirjallisuus')
+                expect(editor.canSave()).to.equal(true)
+              })
+            })
+
+            describe('valinnaiselle vieraalle kielelle', function () {
+              before(valinnainenEnKieli.selectValue('portugali'))
+              it('toimii', function() {
+                expect(valinnainenEnKieli.getValue()).to.equal('portugali')
+                expect(editor.canSave()).to.equal(true)
+              })
+            })
+
+            describe('tallennus', function () {
+              before(editor.saveChanges, wait.until(page.isSavedLabelShown))
+              it('toimii', function () {
+                expect(findSingle('.oppiaine.LVAIK .title .nimi')().text()).to.equal('Äidinkieli ja kirjallisuus, Ruotsi toisena kielenä ja kirjallisuus')
+                expect(findSingle('.oppiaine.A1 .title .nimi')().text()).to.equal('A1-kieli, portugali')
+              })
+            })
+          })
+
+          describe('Arvosanan muuttaminen', function () {
+            describe('valmistavalle aineelle', function () {
+              before(
+                editor.edit,
+                valmistavaAiArvosana.selectValue(8),
+                editor.saveChanges,
+                wait.until(page.isSavedLabelShown)
+              )
+
+              it('toimii', function() {
+                expect(findSingle('.oppiaine.LVAIK .arvosana .annettuArvosana')().text()).to.equal('8')
+              })
+            })
+
+            describe('valinnaiselle aineelle', function () {
+              before(
+                editor.edit,
+                valinnainenEnArvosana.selectValue(9),
+                editor.saveChanges,
+                wait.until(page.isSavedLabelShown)
+              )
+
+              it('onnistuu', function() {
+                expect(findSingle('.oppiaine.A1 .arvosana .annettuArvosana')().text()).to.equal('9')
+              })
+            })
+          })
+
+          describe('Valmistava oppiaine', function () {
+            var valmistavatSelector = '.lukioon-valmistavat-opinnot'
+            var uusiOppiaine = opinnot.oppiaineet.uusiOppiaine(valmistavatSelector)
+            var mat = editor.subEditor(valmistavatSelector + ' .oppiaine.LVMALUO:eq(0)')
+
+            before(editor.edit)
+
+            describe('Valtakunnallisen valmistavan oppiaineen', function () {
+              describe('poistaminen', function () {
+                before(
+                  editor.edit,
+                  mat.propertyBySelector('.remove-row').removeValue,
+                  editor.saveChanges,
+                  wait.until(page.isSavedLabelShown)
+                )
+
+                it('toimii', function () {
+                  expect(extractAsText(S(valmistavatSelector))).to.not.contain('Matemaattiset ja luonnontieteelliset opinnot')
+                })
+              })
+
+              describe('lisääminen', function () {
+                before(
+                  editor.edit,
+                  uusiOppiaine.selectValue('Matemaattiset ja luonnontieteelliset opinnot')
+                )
+
+                it('toimii', function () {
+                  expect(extractAsText(S('.oppiaineet'))).to.contain('Matemaattiset ja luonnontieteelliset opinnot')
+                })
+
+                it('arvosana vaaditaan kun päätason suoritus on merkitty valmiiksi', function () {
+                  expect(editor.canSave()).to.equal(false)
+                  expect(extractAsText(S('.oppiaineet'))).to.contain('Arvosana vaaditaan, koska päätason suoritus on merkitty valmiiksi.')
+                })
+
+                describe('Kun päätason suoritus merkitään keskeneräiseksi', function () {
+                  before(
+                    editor.property('tila').removeItem(0),
+                    opinnot.tilaJaVahvistus.merkitseKeskeneräiseksi
+                  )
+
+                  it('tallennus toimii', function () {
+                    mat.propertyBySelector('.arvosana').selectValue('9')
+                  })
+                })
+              })
+
+              describe('oppiaineen kurssin', function () {
+                before(editor.edit)
+
+                describe('arvosanan muuttaminen', function () {
+                  var kurssi = opinnot.oppiaineet.oppiaine('LVAIK').kurssi('STK')
+
+                  before(
+                    kurssi.arvosana.selectValue('5'),
+                    editor.saveChanges,
+                    wait.until(page.isSavedLabelShown)
+                  )
+
+                  it('toimii', function () {
+                    expect(kurssi.arvosana.getText()).to.equal('5')
+                  })
+                })
+
+                // describe('Lisääminen', function () {
+                //   it('toimii', function () {
+                //     //TODO rajaa kurssivaihtoehtoja hakemalla vain opetussuunnitelmaan kuuluvat
+                //   })
+                // })
+
+                describe('poistaminen', function () {
+                  var stk = valmistavaAi.kurssi('STK')
+
+                  before(
+                    editor.edit,
+                    stk.poistaKurssi,
+                    editor.saveChanges,
+                    wait.until(page.isSavedLabelShown)
+                  )
+
+                  it('toimii', function () {
+                    expect(extractAsText(S('.oppiaineet .LVAIK'))).to.not.contain('STK')
+                  })
+                })
+              })
+            })
+          })
+
+          describe('Valtakunnallisen valinnaisen oppiaineen', function () {
+            var valinnaisetSelector = '.valinnaisena-suoritetut-lukiokurssit'
+            var uusiOppiaine = opinnot.oppiaineet.uusiOppiaine(valinnaisetSelector)
+            var kotitalous = editor.subEditor(valinnaisetSelector + ' .oppiaine.KO:eq(0)')
+
+            before(editor.edit)
+
+            describe('lisääminen', function () {
+              before(
+                editor.edit,
+                uusiOppiaine.selectValue('Kotitalous'),
+                editor.saveChanges,
+                wait.until(page.isSavedLabelShown)
+              )
+
+              it('toimii', function () {
+                expect(extractAsText(S('.oppiaineet'))).to.contain('Kotitalous')
+              })
+            })
+
+            describe('poistaminen', function () {
+              before(
+                editor.edit,
+                kotitalous.propertyBySelector('.remove-row').removeValue,
+                editor.saveChanges,
+                wait.until(page.isSavedLabelShown)
+              )
+
+              it('toimii', function () {
+                expect(extractAsText(S(valinnaisetSelector))).to.not.contain('Kotitalous')
+              })
+            })
+
+            describe('oppiaineen kurssin', function () {
+              describe('arvosanan muuttaminen', function () {
+                var kurssi = opinnot.oppiaineet.oppiaine('A1').kurssi('ENA1')
+
+                before(
+                  editor.edit,
+                  kurssi.arvosana.selectValue('6'),
+                  editor.saveChanges,
+                  wait.until(page.isSavedLabelShown)
+                )
+
+                it('toimii', function () {
+                  expect(kurssi.arvosana.getText()).to.equal('6')
+                })
+              })
+
+              // describe('Lisääminen', function () {
+              //   it('toimii', function () {
+              //     //TODO rajaa kurssivaihtoehtoja hakemalla vain opetussuunnitelmaan kuuluvat
+              //   })
+              // })
+
+              describe('poistaminen', function () {
+                var ena1 = valinnainenEn.kurssi('ENA1')
+
+                before(
+                  editor.edit,
+                  ena1.poistaKurssi,
+                  editor.saveChanges,
+                  wait.until(page.isSavedLabelShown)
+                )
+
+                it('toimii', function () {
+                  expect(extractAsText(S('.oppiaineet .A1'))).to.not.contain('ENA1')
+                })
+              })
+            })
+          })
+        })
+      })
+    })
   })
 })


### PR DESCRIPTION
**TOR-355**: Lukiotietojen syöttökäyttöliittymä (koulutustoimijalle)

- Mahdollistetaan lukiosuoritusten muokkaaminen käyttöliittymän kautta

Haaran ulkopuolelle jää:

- Uuden lukiosuorituksen luominen
- Paikallisten oppiaineiden lisäys
- Kurssien lisäyksessä kurssivaihtoehtojen rajoitus ePerusteiden kautta (https://github.com/Opetushallitus/koski/tree/lukio-eperusteet)