### PR TITLE
Lukiokurssien lisäys ePerusteiden avulla

### DIFF
--- a/src/main/scala/fi/oph/koski/editor/EditorServlet.scala
+++ b/src/main/scala/fi/oph/koski/editor/EditorServlet.scala
@@ -102,9 +102,9 @@ class EditorServlet(implicit val application: KoskiApplication) extends ApiServl
         kurssiKoodi
       }
     }
-    val kieliKoodisto = params.get("kieliKoodisto") // vieraan kielen kursseille
-    val kieliKoodiarvo = params.get("kieliKoodiarvo")
-    val oppimääränDiaarinumero = params.get("oppimaaranDiaarinumero")
+    val kieliKoodisto = params.get("oppimaaraKoodisto") // vieraan kielen kursseille
+    val kieliKoodiarvo = params.get("oppimaaraKoodiarvo")
+    val oppimääränDiaarinumero = params.get("oppimaaraDiaarinumero")
     val oppiaineKoodistoUri = params("oppiaineKoodisto")
 
     val ePerusteetRakenne = oppimääränDiaarinumero.flatMap(application.ePerusteet.findRakenne)

--- a/src/main/scala/fi/oph/koski/editor/EditorServlet.scala
+++ b/src/main/scala/fi/oph/koski/editor/EditorServlet.scala
@@ -102,10 +102,13 @@ class EditorServlet(implicit val application: KoskiApplication) extends ApiServl
         kurssiKoodi
       }
     }
-    val kieliKoodisto = params.get("oppimaaraKoodisto") // vieraan kielen kursseille
-    val kieliKoodiarvo = params.get("oppimaaraKoodiarvo")
+
+    val oppiaineKoodisto = params("oppiaineKoodisto")
+    val oppiaineKoodiarvo = params("oppiaineKoodiarvo")
+
+    val oppimaaraKoodisto = params.get("oppimaaraKoodisto") // vieraan kielen, äidinkielen ja matematiikan kursseille
+    val oppimaaraKoodiarvo = params.get("oppimaaraKoodiarvo")
     val oppimääränDiaarinumero = params.get("oppimaaraDiaarinumero")
-    val oppiaineKoodistoUri = params("oppiaineKoodisto")
 
     val ePerusteetRakenne = oppimääränDiaarinumero.flatMap(application.ePerusteet.findRakenne)
 
@@ -120,15 +123,15 @@ class EditorServlet(implicit val application: KoskiApplication) extends ApiServl
 
       val oppimääränKurssit = for {
         aine <- oppiaine
-        koodiarvo <- kieliKoodiarvo
+        koodiarvo <- oppimaaraKoodiarvo
         oppimaara <- aine.oppimaarat.find(_.koodiArvo == koodiarvo)
       } yield oppimaara.kurssit
 
       oppiaineenKurssit ++ oppimääränKurssit.getOrElse(List())
     }
 
-    val oppiaineeseenSisältyvätKurssit = sisältyvätKurssit(params("oppiaineKoodisto"), params("oppiaineKoodiarvo"))
-    val oppiaineeseenJaKieleenSisältyvätKurssit = (kieliKoodisto, kieliKoodiarvo) match {
+    val oppiaineeseenSisältyvätKurssit = sisältyvätKurssit(oppiaineKoodisto, oppiaineKoodiarvo)
+    val oppiaineeseenJaKieleenSisältyvätKurssit = (oppimaaraKoodisto, oppimaaraKoodiarvo) match {
       case (Some(kieliKoodisto), Some(kieliKoodiarvo)) =>
         sisältyvätKurssit(kieliKoodisto, kieliKoodiarvo) match {
           case Nil => oppiaineeseenSisältyvätKurssit

--- a/src/main/scala/fi/oph/koski/eperusteet/EPerusteRakenne.scala
+++ b/src/main/scala/fi/oph/koski/eperusteet/EPerusteRakenne.scala
@@ -3,7 +3,8 @@ package fi.oph.koski.eperusteet
 import fi.oph.scalaschema.annotation.Discriminator
 
 case class EPerusteRakenne(id: Long, nimi: Map[String, String], diaarinumero: String, koulutustyyppi: String,
-                           koulutukset: List[EPerusteKoulutus], suoritustavat: Option[List[ESuoritustapa]], tutkinnonOsat: Option[List[ETutkinnonOsa]], osaamisalat: List[EOsaamisala]) {
+                           koulutukset: List[EPerusteKoulutus], suoritustavat: Option[List[ESuoritustapa]], tutkinnonOsat: Option[List[ETutkinnonOsa]], osaamisalat: List[EOsaamisala],
+                           lukiokoulutus: Option[ELukiokoulutus]) {
   def toEPeruste = EPeruste(id, nimi, diaarinumero, koulutukset)
 }
 
@@ -13,6 +14,11 @@ case class EOsaamisala(nimi: Map[String, String], arvo: String)
 case class EOsaamisalaViite(osaamisalakoodiArvo: String)
 case class ETutkinnonOsa(id: Long, nimi: Map[String, String], koodiArvo: String)
 
+case class ELukiokoulutus(rakenne: ERakenneLukio)
+case class EOppiaine(koodiArvo: String, oppimaarat: List[EOppimaara], kurssit: List[EKurssi])
+case class EOppimaara(koodiArvo: String, kurssit: List[EKurssi])
+case class EKurssi(koodiArvo: String)
+
 case class ELaajuus(minimi: Option[Long], maksimi: Option[Long], yksikko: Option[String])
 case class EKoko(minimi: Option[Long], maksimi: Option[Long])
 case class EMuodostumisSaanto(laajuus: Option[ELaajuus], koko: Option[EKoko])
@@ -20,3 +26,4 @@ case class EMuodostumisSaanto(laajuus: Option[ELaajuus], koko: Option[EKoko])
 sealed trait ERakenneOsa
 case class ERakenneModuuli(nimi: Option[Map[String, String]], @Discriminator osat: List[ERakenneOsa], osaamisala: Option[EOsaamisalaViite], rooli: Option[String], muodostumisSaanto: Option[EMuodostumisSaanto]) extends ERakenneOsa
 case class ERakenneTutkinnonOsa(@Discriminator _tutkinnonOsaViite: String) extends ERakenneOsa
+case class ERakenneLukio(oppiaineet: List[EOppiaine]) extends ERakenneOsa

--- a/web/app/kurssi/UusiKurssiDropdown.jsx
+++ b/web/app/kurssi/UusiKurssiDropdown.jsx
@@ -53,18 +53,18 @@ export const UusiKurssiDropdown = ({oppiaine, suoritukset, paikallinenKurssiProt
 const completeWithFieldAlternatives = (oppiaine, kurssiPrototypes) => {
   const oppiaineKoodisto = modelData(oppiaine, 'tunniste.koodistoUri')
   const oppiaineKoodiarvo = modelData(oppiaine, 'tunniste.koodiarvo')
-  const kieliKoodisto = modelData(oppiaine, 'kieli.koodistoUri')
-  const kieliKoodiarvo = modelData(oppiaine, 'kieli.koodiarvo')
-  const oppimaaranDiaarinumero = modelData(oppiaine.context.suoritus, 'koulutusmoduuli.perusteenDiaarinumero')
+  const oppimaaraKoodisto = modelData(oppiaine, 'kieli.koodistoUri') || modelData(oppiaine, 'oppimäärä.koodistoUri')
+  const oppimaaraKoodiarvo = modelData(oppiaine, 'kieli.koodiarvo') || modelData(oppiaine, 'oppimäärä.koodiarvo')
+  const oppimaaraDiaarinumero = modelData(oppiaine.context.suoritus, 'koulutusmoduuli.perusteenDiaarinumero')
 
   const alternativesForField = (model) => {
     if (!oppiaineKoodisto) return []
 
     const kurssiKoodistot = modelLookup(model, 'tunniste').alternativesPath.split('/').last()
     const koodistot = kurssiKoodistot.split(',')
-    const queryKoodistot = findKoodistoByDiaarinumero(koodistot, oppimaaranDiaarinumero) || kurssiKoodistot
+    const queryKoodistot = findKoodistoByDiaarinumero(koodistot, oppimaaraDiaarinumero) || kurssiKoodistot
     const loc = parseLocation(`/koski/api/editor/kurssit/${oppiaineKoodisto}/${oppiaineKoodiarvo}/${queryKoodistot}`)
-      .addQueryParams({kieliKoodisto, kieliKoodiarvo, oppimaaranDiaarinumero})
+      .addQueryParams({oppimaaraKoodisto, oppimaaraKoodiarvo, oppimaaraDiaarinumero})
 
     return Http.cachedGet(loc.toString())
       .map(alternatives => alternatives.map(enumValue => modelSetValue(model, enumValue, 'tunniste')))

--- a/web/app/kurssi/kurssi.js
+++ b/web/app/kurssi/kurssi.js
@@ -1,0 +1,21 @@
+export const findKoodistoByDiaarinumero = (kurssiKoodistot, oppimaaranDiaarinumero) => {
+  if (!kurssiKoodistot) return null
+
+  return kurssiKoodistot.length > 1
+    ? kurssiKoodistot.find(k => {
+      const diaarinumeroaVastaavaKurssikoodisto = () => {
+        switch (oppimaaranDiaarinumero) {
+          case '60/011/2015':
+          case '70/011/2015':
+            return 'lukionkurssit'
+          case '33/011/2003':
+            return 'lukionkurssitops2003nuoret'
+          case '4/011/2004':
+            return 'lukionkurssitops2004aikuiset'
+        }
+      }
+
+      return k === diaarinumeroaVastaavaKurssikoodisto()
+    })
+    : kurssiKoodistot[0]
+}

--- a/web/app/kurssi/kurssi.js
+++ b/web/app/kurssi/kurssi.js
@@ -7,6 +7,7 @@ export const findKoodistoByDiaarinumero = (kurssiKoodistot, oppimaaranDiaarinume
         switch (oppimaaranDiaarinumero) {
           case '60/011/2015':
           case '70/011/2015':
+          case '56/011/2015': // Lukiokoulutukseen valmistava koulutus (valinnaisina suoritetut lukiokurssit)
             return 'lukionkurssit'
           case '33/011/2003':
             return 'lukionkurssitops2003nuoret'

--- a/web/test/page/opinnotPage.js
+++ b/web/test/page/opinnotPage.js
@@ -169,9 +169,19 @@ function Oppiaine(oppiaineElem) {
   var oppiaineApi = _.merge({
     text: function() { return extractAsText(oppiaineElem) },
     avaaLisääKurssiDialog: click(findSingle('.uusi-kurssi a', oppiaineElem)),
-    lisääKurssi: function(kurssi) { return seq(
+    lisääKurssi: function(kurssi, tyyppi) { return seq(
       oppiaineApi.avaaLisääKurssiDialog,
-      oppiaineApi.lisääKurssiDialog.valitseKurssi('Kieli ja kulttuuri'),
+      oppiaineApi.lisääKurssiDialog.valitseKurssi(kurssi || 'Kieli ja kulttuuri'),
+      oppiaineApi.lisääKurssiDialog.valitseKurssinTyyppi(tyyppi || 'Pakollinen'),
+      oppiaineApi.lisääKurssiDialog.lisääKurssi
+    )},
+    lisääPaikallinenKurssi: function(tunniste, nimi, kuvaus) { return seq(
+      oppiaineApi.avaaLisääKurssiDialog,
+      oppiaineApi.lisääKurssiDialog.valitseKurssi('paikallinen'),
+      oppiaineApi.lisääKurssiDialog.asetaTunniste(tunniste),
+      oppiaineApi.lisääKurssiDialog.asetaNimi(nimi),
+      oppiaineApi.lisääKurssiDialog.asetaKuvaus(kuvaus),
+      oppiaineApi.lisääKurssiDialog.valitseKurssinTyyppi('Soveltava'),
       oppiaineApi.lisääKurssiDialog.lisääKurssi
     )},
     lisääKurssiDialog: LisääKurssiDialog(),
@@ -186,9 +196,34 @@ function Oppiaine(oppiaineElem) {
   function LisääKurssiDialog() {
     var modalElem = findSingle('.uusi-kurssi-modal', oppiaineElem)
     function kurssiDropdown() { return api.propertyBySelector('.kurssi') }
+    function kurssinTyyppiDropdown() { return api.propertyBySelector('.kurssinTyyppi') }
+
+    /* Paikallinen kurssi */
+    function tunniste() { return api.propertyBySelector('.koodiarvo') }
+    function nimi() { return api.propertyBySelector('.nimi') }
+    function kuvaus() { return api.propertyBySelector('.kuvaus') }
+
     var api = _.merge({
       valitseKurssi: function(kurssi) {
         return kurssiDropdown().setValue(kurssi)
+      },
+      valitseKurssinTyyppi: function(tyyppi) {
+        return function() {
+          try {
+            return kurssinTyyppiDropdown().setValue(tyyppi)()
+          } catch(e) {
+            // valitaan tyyppi vain kun se on mahdollista
+          }
+        }
+      },
+      asetaTunniste: function(arvo) {
+        return tunniste().setValue(arvo || 'PA')
+      },
+      asetaNimi: function(arvo) {
+        return nimi().setValue(arvo || 'Paikallinen kurssi')
+      },
+      asetaKuvaus: function(arvo) {
+        return kuvaus().setValue(arvo || 'Paikallisen kurssin kuvaus')
       },
       lisääKurssi: click(subElement(modalElem, 'button')),
       kurssit: function() {


### PR DESCRIPTION
Liittyy **TOR-355**

Koska lukion oppiaine-/kurssikoodistoista puuttuu linkkaukset oppiaineeseen sisältyvistä kursseista, niin:

Käytetään 

- opetussuunnitelman diaarinumeroa
- oppiaineen oppimäärää (kieliaine / matematiikka) ja 
- ePerusteita 

rajaamaan kurssivaihtoehtoja, kun lisätään kurssia lukion oppiaineeseen.

