### PR TITLE
Ei suorituksia kirjautuneella

### DIFF
--- a/web/app/EiSuorituksia.jsx
+++ b/web/app/EiSuorituksia.jsx
@@ -4,7 +4,6 @@ import './style/main.less'
 
 export const EiSuorituksia = () => (
   <div className='ei-suorituksia'>
-    <div className='koski-heading'><h1>{'KOSKI'}</h1></div>
     <div className='info'>
       <h2>{'Tiedoillasi ei löydy opintosuorituksia eikä opiskeluoikeuksia.'}</h2>
       <p>{'Koski-palvelussa pystytään näyttämään seuraavat tiedot:'}</p>
@@ -20,6 +19,7 @@ export const EiSuorituksia = () => (
 
 ReactDOM.render((
   <div>
+    <div className='koski-heading'><h1>{'KOSKI'}</h1></div>
     <EiSuorituksia/>
   </div>
 ), document.getElementById('content'))

--- a/web/app/EiSuorituksia.jsx
+++ b/web/app/EiSuorituksia.jsx
@@ -10,7 +10,7 @@ export const EiSuorituksia = () => (
       <p>{'Koski-palvelussa pystytään näyttämään seuraavat tiedot:'}</p>
       <ul>
         <li>{'Vuoden 2018 tammikuun jälkeen suoritetut peruskoulun, lukion ja ammattikoulun opinnot ja voimassa olevat opiskeluoikeudet.'}</li>
-        <li>{'vuoden 1990 jälkeen suoritetut ylioppilastutkinnot.'}</li>
+        <li>{'Vuoden 1990 jälkeen suoritetut ylioppilastutkinnot.'}</li>
         <li>{'Korkeakoulutusuoritukset ja opiskeluoikeudet ovat näkyvissä pääsääntöisesti vuodesta 1995 eteenpäin, mutta tässä voi olla korkeakoulukohtaisia poikkeuksia.'}</li>
       </ul>
       <p>{'Mikäli tiedoistasi puuttuu opintosuorituksia tai opiskeluoikeuksia, joiden kuuluisi ylläolevien tietojen perusteella näkyä Koski-palvelussa, voit ilmoittaa asiasta oppilaitoksellesi.'}</p>

--- a/web/app/OmatTiedot.jsx
+++ b/web/app/OmatTiedot.jsx
@@ -13,6 +13,7 @@ import editorMapping from './oppija/editors'
 import {userP} from './util/user'
 import {addContext, modelData} from './editor/EditorModel'
 import {locationP} from './util/location'
+import {EiSuorituksia} from './EiSuorituksia'
 
 const omatTiedotP = () => Bacon.combineWith(
   Http.cachedGet('/koski/api/editor/omattiedot', { errorMapper: (e) => e.httpStatus === 404 ? null : new Bacon.Error}).toProperty(),
@@ -27,7 +28,7 @@ const topBarP = userP.map(user => <OmatTiedotTopBar user={user}/>)
 const contentP = locationP.flatMapLatest(() => omatTiedotP().map(oppija =>
     oppija
       ? <div className="main-content oppija"><Oppija oppija={Editor.setupContext(oppija, {editorMapping})} stateP={Bacon.constant('viewing')}/></div>
-      : <div className="main-content ei-opiskeluoikeuksia"><Text name="Tiedoillasi ei löydy opiskeluoikeuksia"/></div>
+      : <div className="main-content"><EiSuorituksia/></div>
     )
 ).toProperty().startWith(<div className="main-content ajax-indicator-bg"><Text name="Ladataan..."/></div>)
 

--- a/web/app/style/omattiedot.less
+++ b/web/app/style/omattiedot.less
@@ -2,9 +2,4 @@
   .sidebar.omattiedot-navi {
     width: ~"calc(50px + (100vw - 1200px) / 2)";
   }
-
-  .ei-opiskeluoikeuksia {
-    margin: 10px 0;
-    text-align: center;
-  }
 }

--- a/web/test/page/omatTiedotPage.js
+++ b/web/test/page/omatTiedotPage.js
@@ -14,7 +14,7 @@ function OmatTiedotPage() {
       return S('.main-content.oppija h2').text().replace('JSON', '')
     },
     virhe: function() {
-      return S('.ei-opiskeluoikeuksia').text()
+      return S('.ei-suorituksia').text()
     }
   }
   return api

--- a/web/test/spec/omatTiedotSpec.js
+++ b/web/test/spec/omatTiedotSpec.js
@@ -17,7 +17,13 @@ describe('Omat tiedot', function() {
     describe("Kun virkailijalla ei ole opiskeluoikeuksia", function() {
       before(authentication.login(), omattiedot.openPage)
       it('näytetään viesti', function() {
-        expect(omattiedot.virhe()).to.equal("Tiedoillasi ei löydy opiskeluoikeuksia")
+        expect(omattiedot.virhe()).to.equal(
+          "Tiedoillasi ei löydy opintosuorituksia eikä opiskeluoikeuksia." +
+          "Koski-palvelussa pystytään näyttämään seuraavat tiedot:" +
+          "Vuoden 2018 tammikuun jälkeen suoritetut peruskoulun, lukion ja ammattikoulun opinnot ja voimassa olevat opiskeluoikeudet." +
+          "Vuoden 1990 jälkeen suoritetut ylioppilastutkinnot." +
+          "Korkeakoulutusuoritukset ja opiskeluoikeudet ovat näkyvissä pääsääntöisesti vuodesta 1995 eteenpäin, mutta tässä voi olla korkeakoulukohtaisia poikkeuksia." +
+          "Mikäli tiedoistasi puuttuu opintosuorituksia tai opiskeluoikeuksia, joiden kuuluisi ylläolevien tietojen perusteella näkyä Koski-palvelussa, voit ilmoittaa asiasta oppilaitoksellesi.")
       })
     })
   })


### PR DESCRIPTION
Näytetään parempi selitysteksti kirjautuneelle kansalaiselle, kun opiskeluoikeuksia ei löydy.