### PR TITLE
Lukiosuoritusten koulutustyypit

### DIFF
--- a/src/main/resources/mockdata/koodisto/koodit/koskikoulutustendiaarinumerot.json
+++ b/src/main/resources/mockdata/koodisto/koodit/koskikoulutustendiaarinumerot.json
@@ -301,7 +301,7 @@
   } ],
   "versio" : 1,
   "withinCodeElements" : [ {
-    "codeElementUri" : "koulutustyyppi_2",
+    "codeElementUri" : "koulutustyyppi_14",
     "codeElementVersion" : 2,
     "passive" : false
   } ]
@@ -480,7 +480,7 @@
   } ],
   "versio" : 1,
   "withinCodeElements" : [ {
-    "codeElementUri" : "koulutustyyppi_2",
+    "codeElementUri" : "koulutustyyppi_14",
     "codeElementVersion" : 2,
     "passive" : false
   } ]

--- a/src/main/scala/fi/oph/koski/tutkinto/TutkinnonPerusteetServlet.scala
+++ b/src/main/scala/fi/oph/koski/tutkinto/TutkinnonPerusteetServlet.scala
@@ -15,9 +15,11 @@ class TutkinnonPerusteetServlet(implicit val application: KoskiApplication) exte
    })
   }
 
-  get("/diaarinumerot/koulutustyyppi/:koulutustyyppi") {
-    val koulutusTyyppi = params("koulutustyyppi")
-    application.koodistoViitePalvelu.getSisältyvätKoodiViitteet(application.koodistoViitePalvelu.getLatestVersion("koskikoulutustendiaarinumerot").get, Koodistokoodiviite(koulutusTyyppi, "koulutustyyppi"))
+  get("/diaarinumerot/koulutustyyppi/:koulutustyypit") {
+    val koulutustyypit = params("koulutustyypit").split(",").toSet
+    koulutustyypit.flatMap(koulutusTyyppi =>
+      application.koodistoViitePalvelu.getSisältyvätKoodiViitteet(application.koodistoViitePalvelu.getLatestVersion("koskikoulutustendiaarinumerot").get, Koodistokoodiviite(koulutusTyyppi, "koulutustyyppi"))
+    ).flatten.toList
   }
 
   get("/tutkinnonosat/:diaari") {

--- a/web/app/suoritus/PerusteDropdown.jsx
+++ b/web/app/suoritus/PerusteDropdown.jsx
@@ -4,7 +4,7 @@ import Bacon from 'baconjs'
 import Dropdown from '../components/Dropdown'
 import {elementWithLoadingIndicator} from '../components/AjaxLoadingIndicator'
 import {t} from '../i18n/i18n'
-import {koulutustyyppiKoodi} from './Suoritus'
+import {koulutustyyppiKoodit} from './Suoritus'
 
 const preferred = ['OPH-1280-2017', '104/011/2014']
 
@@ -36,8 +36,10 @@ export const PerusteDropdown = ({suoritusTyyppiP, perusteAtom}) => {
 }
 
 export const diaarinumerot = suoritusTyyppi => {
-  let koulutustyyppi = suoritusTyyppi && koulutustyyppiKoodi(suoritusTyyppi.koodiarvo)
-  return koulutustyyppi ? Http.cachedGet(`/koski/api/tutkinnonperusteet/diaarinumerot/koulutustyyppi/${koulutustyyppi}`) : []
+  const koulutustyypit = suoritusTyyppi && koulutustyyppiKoodit(suoritusTyyppi.koodiarvo)
+  return koulutustyypit
+    ? Http.cachedGet(`/koski/api/tutkinnonperusteet/diaarinumerot/koulutustyyppi/${koulutustyypit.join()}`)
+    : []
 }
 
 export const setPeruste = (perusteAtom, suoritusTyyppi) => {

--- a/web/app/suoritus/Suoritus.js
+++ b/web/app/suoritus/Suoritus.js
@@ -90,7 +90,7 @@ export const koulutustyyppiKoodi = suoritustyyppiKoodi => {
     return '5'
   }
   if (suoritustyyppiKoodi == 'lukionoppimaara' || suoritustyyppiKoodi == 'lukionoppiaineenoppimaara') {
-    return '2'
+    return ['2', '14']
   }
 }
 

--- a/web/app/suoritus/Suoritus.js
+++ b/web/app/suoritus/Suoritus.js
@@ -67,27 +67,27 @@ export const perusopetuksenOppiaineenOppimääränSuoritus = opiskeluoikeudenSuo
 export const näyttötutkintoonValmistavanKoulutuksenSuoritus = opiskeluoikeudenSuoritusByTyyppi('nayttotutkintoonvalmistavakoulutus')
 export const ammatillisenTutkinnonSuoritus = opiskeluoikeudenSuoritusByTyyppi('ammatillinentutkinto')
 
-export const koulutustyyppiKoodi = suoritustyyppiKoodi => {
+export const koulutustyyppiKoodit = suoritustyyppiKoodi => {
   if (suoritustyyppiKoodi == 'perusopetuksenoppimaara' || suoritustyyppiKoodi == 'perusopetuksenvuosiluokka') {
-    return '16'
+    return ['16']
   }
   if (suoritustyyppiKoodi == 'aikuistenperusopetuksenoppimaara' || suoritustyyppiKoodi == 'perusopetuksenoppiaineenoppimaara' || suoritustyyppiKoodi == 'aikuistenperusopetuksenoppimaaranalkuvaihe'){
-    return '17'
+    return ['17']
   }
   if (suoritustyyppiKoodi == 'perusopetuksenlisaopetus') {
-    return '6'
+    return ['6']
   }
   if (suoritustyyppiKoodi == 'perusopetukseenvalmistavaopetus') {
-    return '22'
+    return ['22']
   }
   if (suoritustyyppiKoodi == 'esiopetuksensuoritus') {
-    return '15'
+    return ['15']
   }
   if (suoritustyyppiKoodi == 'valma') {
-    return '18'
+    return ['18']
   }
   if (suoritustyyppiKoodi == 'telma') {
-    return '5'
+    return ['5']
   }
   if (suoritustyyppiKoodi == 'lukionoppimaara' || suoritustyyppiKoodi == 'lukionoppiaineenoppimaara') {
     return ['2', '14']


### PR DESCRIPTION
Erotetaan lukiokoulutukseen ja aikuisten lukiokoulutukseen kuuluvat diaarinumerot toisistaan.

Koskessa sekä nuorten että aikuisten lukiokoulutus on "Lukion opiskeluoikeus", jonka määrittää tarkemmin Lukion oppimäärän (tai oppiaineen oppimäärän) suorituksen tieto "oppimäärä". Muutetaan koulutustyyppi -> diaarinumerot -rajapintaa siten, että usean koulutustyypin sisältämät diaarinumerot voidaan hakea yhdellä kyselyllä: näin voidaan hakea samalla kertaa sekä lukiokoulutuksen että aikuisten lukiokoulutuksen mahdolliset perusteet (diaarinumerot).