### PR TITLE
Paranna valtakunnallisten lukion kurssien lisäystä

### DIFF
--- a/src/main/scala/fi/oph/koski/editor/EditorServlet.scala
+++ b/src/main/scala/fi/oph/koski/editor/EditorServlet.scala
@@ -112,7 +112,7 @@ class EditorServlet(implicit val application: KoskiApplication) extends ApiServl
 
     val ePerusteetRakenne = oppimääränDiaarinumero.flatMap(application.ePerusteet.findRakenne)
 
-    def ePerusteidenMukaisetKurssit = {
+    val ePerusteidenMukaisetKurssit = {
       val oppiaine = for {
         rakenne <- ePerusteetRakenne
         lukiokoulutus <- rakenne.lukiokoulutus
@@ -140,7 +140,7 @@ class EditorServlet(implicit val application: KoskiApplication) extends ApiServl
       case _ => oppiaineeseenSisältyvätKurssit
     }
     toKoodistoEnumValues(oppiaineeseenJaKieleenSisältyvätKurssit match {
-      case Nil if ePerusteetRakenne.isDefined => koodistojenKoodit(kurssiKoodistot)
+      case Nil if ePerusteidenMukaisetKurssit.nonEmpty => koodistojenKoodit(kurssiKoodistot)
         .filter(k => ePerusteidenMukaisetKurssit.map(_.koodiArvo).contains(k.koodiarvo))
       case Nil => koodistojenKoodit(kurssiKoodistot)
       case _ => oppiaineeseenJaKieleenSisältyvätKurssit


### PR DESCRIPTION
Mahdollistetaan valtakunnallisten kurssien koodien palautus, vaikka
hakuparametreilla ei löytyisikään kursseja ePerusteista. Esimerkiksi
A1-englannin tunniste- ja kieli-koodit eivät Kosken mallissa vastaa ePerusteiden
oppiainetta ja oppimäärää, joten nämä rajautuivat pois palautetuista vaihtoehdoista.

Palautetaan nyt kaikki valtakunnalliset kurssit, mikäli haku
ePerusteista ei tuota kurssituloksia (vaikka diaarinumeron mukainen
rakenne löytyisikin).