### PR TITLE
Language-kenttää ei aina välitetä ytr-datassa

### DIFF
--- a/src/main/resources/mockdata/ytr/120674-064R.json
+++ b/src/main/resources/mockdata/ytr/120674-064R.json
@@ -87,6 +87,5 @@
       "points": 83,
       "sections": []
     }
-  ],
-  "language": "fi"
+  ]
 }

--- a/src/main/scala/fi/oph/koski/ytr/YtrOppija.scala
+++ b/src/main/scala/fi/oph/koski/ytr/YtrOppija.scala
@@ -12,7 +12,7 @@ case class YtrOppija(
   graduationSchoolOphOid: Option[String],
   graduationSchoolYtlNumber: Option[Int],
   hasCompletedMandatoryExams: Boolean,
-  language: String
+  language: Option[String]
 )
 case class YtrExam(
   period: String, // Esim 2013S, TODO: tää pitäis palastella ja kielistää

--- a/web/test/spec/ylioppilastutkintoSpec.js
+++ b/web/test/spec/ylioppilastutkintoSpec.js
@@ -115,4 +115,23 @@ describe('Ylioppilastutkinto', function( ){
     })
   })
 
+  describe('Kieli puuttuu oppilastiedoista', function() {
+    before(page.openPage, page.oppijaHaku.searchAndSelect('120674-064R'))
+    before(opinnot.expandAll)
+
+    it('kaikki osasuoritukset näkyvissä', function() {
+      expect(extractAsText(S('.ylioppilastutkinnonsuoritus .osasuoritukset'))).to.equal(
+        'Tutkintokerta Koe Arvosana\n' +
+        '1996 kevät Reaali, elämänkatsomustiedon kysymykset Improbatur\n' +
+        '1996 syksy Englanninkielinen kypsyyskoe Cum laude approbatur\n' +
+        '1996 syksy Matematiikan koe, lyhyt oppimäärä Improbatur\n' +
+        '1996 syksy Reaali, elämänkatsomustiedon kysymykset Improbatur\n' +
+        '1997 kevät Suomi, lyhyt oppimäärä Improbatur\n' +
+        '1997 kevät Matematiikan koe, lyhyt oppimäärä Approbatur\n' +
+        '1997 kevät Reaali, elämänkatsomustiedon kysymykset Approbatur\n' +
+        '1997 syksy Suomi, lyhyt oppimäärä Improbatur\n' +
+        '1998 kevät Suomi, lyhyt oppimäärä Improbatur'
+      )
+    })
+  })
 })


### PR DESCRIPTION
Kansalainen ei näe tietojaan, tulee virheitä lokiin tyyliin _java.lang.RuntimeException: Validation error while de-serializing as fi.oph.koski.ytr.YtrOppija: List(ValidationError(language,JNothing,MissingProperty(missingProperty)))_
