### PR TITLE
Älä näytä lisää-painiketta uuden oppiaineen opiskeluoikeuden lisäyksessä

### DIFF
--- a/web/app/oppiaine/UusiOppiaineDropdown.jsx
+++ b/web/app/oppiaine/UusiOppiaineDropdown.jsx
@@ -10,7 +10,7 @@ import {fetchAlternativesBasedOnPrototypes} from '../editor/EnumEditor'
 import {elementWithLoadingIndicator} from '../components/AjaxLoadingIndicator'
 import {t} from '../i18n/i18n'
 
-export const UusiOppiaineDropdown = ({suoritukset = [], organisaatioOid, oppiaineenSuoritus, pakollinen, selected = Bacon.constant(undefined), resultCallback, placeholder, enableFilter=true}) => {
+export const UusiOppiaineDropdown = ({suoritukset = [], organisaatioOid, oppiaineenSuoritus, pakollinen, selected = Bacon.constant(undefined), resultCallback, placeholder, enableFilter=true, allowPaikallinen = true}) => {
   if (!oppiaineenSuoritus || !oppiaineenSuoritus.context.edit) return null
   let käytössäolevatKoodiarvot = suoritukset.map(s => modelData(s, 'koulutusmoduuli')).filter(k => !k.kieli).map(k => k.tunniste.koodiarvo)
 
@@ -40,7 +40,7 @@ export const UusiOppiaineDropdown = ({suoritukset = [], organisaatioOid, oppiain
           displayValue={oppiaine => isUusi(oppiaine) ? 'Lisää...' : modelLookup(oppiaine, 'tunniste').value.title}
           onSelectionChanged={resultCallback}
           selectionText={placeholder}
-          newItem={paikallinenProto}
+          newItem={allowPaikallinen && paikallinenProto}
           enableFilter={enableFilter}
           selected={selected}
           isRemovable={isPaikallinen}

--- a/web/app/uusioppija/Oppiaine.jsx
+++ b/web/app/uusioppija/Oppiaine.jsx
@@ -54,6 +54,7 @@ export default ({suoritusPrototypeP, oppiaineenSuoritusAtom, perusteAtom, oppila
               resultCallback={s => oppiainePrototypeAtom.set(s)}
               pakollinen={true}
               enableFilter={false}
+              allowPaikallinen={false}
               />
           </label>
           { suoritusModelP.map(model =>


### PR DESCRIPTION
- Ennen: uuden paikallisen oppiaineen lisäys-painike ei toimi, sillä
uuden opiskeluoikeuden lisäykseen ei ole liitetty uuden paikallisen
oppiaineen lisäyskäyttöliittymää
- Nyt: poistetaan painike