### PR TITLE
Korjaa organisaation preferenceistä haetun oppiaineen lisäys

### DIFF
--- a/web/app/ib/UusiIBOppiaineDropdown.jsx
+++ b/web/app/ib/UusiIBOppiaineDropdown.jsx
@@ -14,7 +14,11 @@ export const UusiIBOppiaineDropdown = ({model, aineryhmä}) => {
     const nimi = t(modelData(oppiaine, 'tunniste.nimi'))
     const oppiaineWithTitle = modelSetTitle(oppiaine, nimi)
     const oppiaineWithAineryhmä = modelSetData(oppiaineWithTitle, aineryhmä, 'ryhmä')
-    const suoritusUudellaOppiaineella = modelSet(oppiaine.parent, oppiaineWithAineryhmä, 'koulutusmoduuli')
+    const suoritusUudellaOppiaineella = modelSet(
+      oppiaine.parent || createOppiaineenSuoritus(model),
+      oppiaineWithAineryhmä,
+      'koulutusmoduuli'
+    )
     pushModel(suoritusUudellaOppiaineella, model.context.changeBus)
     ensureArrayKey(suoritusUudellaOppiaineella)
   }

--- a/web/app/lukio/UusiLukionOppiaineDropdown.jsx
+++ b/web/app/lukio/UusiLukionOppiaineDropdown.jsx
@@ -10,7 +10,11 @@ export const UusiLukionOppiaineDropdown = ({model, oppiaineenSuoritusClass}) => 
   const addOppiaine = oppiaine => {
     const nimi = t(modelData(oppiaine, 'tunniste.nimi'))
     const oppiaineWithTitle = modelSetTitle(oppiaine, nimi)
-    const suoritusUudellaOppiaineella = modelSet(oppiaine.parent, oppiaineWithTitle, 'koulutusmoduuli')
+    const suoritusUudellaOppiaineella = modelSet(
+      oppiaine.parent || createOppiaineenSuoritus(model),
+      oppiaineWithTitle,
+      'koulutusmoduuli'
+    )
     pushModel(suoritusUudellaOppiaineella, model.context.changeBus)
     ensureArrayKey(suoritusUudellaOppiaineella)
   }

--- a/web/test/spec/lukioSpec.js
+++ b/web/test/spec/lukioSpec.js
@@ -250,6 +250,23 @@ describe('Lukiokoulutus', function( ){
               it('tallettuu organisaation preferenceihin', function() {
                 expect(uusiOppiaine.getOptions()).to.contain('Paikallinen oppiaine')
               })
+
+              after(editor.cancelChanges)
+            })
+
+            describe('Organisaation preferenceistä löytyvä aine', function() {
+              describe('Lisääminen', function () {
+                before(
+                  editor.edit,
+                  uusiOppiaine.selectValue('Paikallinen oppiaine'),
+                  paikallinen.propertyBySelector('.arvosana').selectValue(9),
+                  editor.saveChanges
+                )
+
+                it('toimii', function () {
+                  expect(extractAsText(S('.oppiaineet'))).to.contain('Paikallinen oppiaine')
+                })
+              })
             })
           })
 


### PR DESCRIPTION
- Organisaation preferencejen kautta haetulla paikallisella oppiaineella
ei ole parent-tietoa. Luodaan tässä tapauksessa uusi oppiaineen
suoritus.