### PR TITLE
Päivitä IB-koodit

### DIFF
--- a/src/main/resources/localization/default-texts.json
+++ b/src/main/resources/localization/default-texts.json
@@ -151,7 +151,7 @@
   "lisää ammatillisen tutkinnon suoritus": "lisää ammatillisen tutkinnon suoritus",
   "lisää näyttötutkintoon valmistavan koulutuksen suoritus": "lisää näyttötutkintoon valmistavan koulutuksen suoritus",
   "lisää IB-tutkinnon suoritus": "lisää IB-tutkinnon suoritus",
-  "lisää pre-IB-luokan oppimäärän suoritus": "lisää pre-IB-luokan oppimäärän suoritus",
+  "lisää pre-IB-suoritus": "lisää pre-IB-suoritus",
   "Suoritus valmis": "Suoritus valmis",
   "Arvosana vaaditaan, koska päätason suoritus on merkitty valmiiksi.": "Arvosana vaaditaan, koska päätason suoritus on merkitty valmiiksi.",
   "Suoritus valmis, mutta arvosana puuttuu": "Suoritus valmis, mutta arvosana puuttuu",

--- a/src/main/resources/mockdata/koodisto/koodit/suorituksentyyppi.json
+++ b/src/main/resources/mockdata/koodisto/koodit/suorituksentyyppi.json
@@ -208,10 +208,10 @@
   "koodiUri" : "suorituksentyyppi_ibtutkinto",
   "koodiArvo" : "ibtutkinto",
   "metadata" : [ {
-    "nimi" : "Lärokurs i IB-gymnasium",
+    "nimi" : "IB-examen",
     "kieli" : "SV"
   }, {
-    "nimi" : "IB-lukion oppimäärä",
+    "nimi" : "IB-tutkinto",
     "kieli" : "FI"
   } ],
   "versio" : 1,
@@ -541,10 +541,10 @@
   "koodiUri" : "suorituksentyyppi_preiboppimaara",
   "koodiArvo" : "preiboppimaara",
   "metadata" : [ {
-    "nimi" : "Lärokurs i Pre-IB-klass",
+    "nimi" : "Pre-IB",
     "kieli" : "SV"
   }, {
-    "nimi" : "Pre-IB luokan oppimäärä",
+    "nimi" : "Pre-IB",
     "kieli" : "FI"
   } ],
   "versio" : 1,

--- a/src/main/scala/fi/oph/koski/editor/OppijaEditorModel.scala
+++ b/src/main/scala/fi/oph/koski/editor/OppijaEditorModel.scala
@@ -61,6 +61,7 @@ object OppijaEditorModel extends Timing {
       case oo: AikuistenPerusopetuksenOpiskeluoikeus => oo.copy(suoritukset = oo.suoritukset.sortBy(aikuistenPerusopetuksenSuoritustenJärjestysKriteeri))
       case oo: PerusopetuksenOpiskeluoikeus => oo.copy(suoritukset = oo.suoritukset.sortBy(perusopetuksenSuoritustenJärjestysKriteeri))
       case oo: AmmatillinenOpiskeluoikeus => oo.copy(suoritukset = oo.suoritukset.sortBy(ammatillisenSuoritustenJärjestysKriteeri))
+      case oo: IBOpiskeluoikeus => oo.copy(suoritukset = oo.suoritukset.sortBy(ibSuoritustenJärjestysKriteeri))
       case oo: Any => oo
     })
   }
@@ -89,6 +90,14 @@ object OppijaEditorModel extends Timing {
 
   def ammatillisenSuoritustenJärjestysKriteeri(s: AmmatillinenPäätasonSuoritus): Int = {
     s.alkamispäivä.map(a => -a.toEpochDay.toInt).getOrElse(0)
+  }
+
+  def ibSuoritustenJärjestysKriteeri(s : IBPäätasonSuoritus): Int = {
+    s match {
+      case _: IBTutkinnonSuoritus => -1
+      case _: PreIBSuoritus => 0
+      case _ => 1
+    }
   }
 }
 

--- a/web/app/uusisuoritus/UusiIBTutkinnonSuoritus.jsx
+++ b/web/app/uusisuoritus/UusiIBTutkinnonSuoritus.jsx
@@ -25,5 +25,5 @@ export const UusiPreIBSuoritus = {
     return suoritus(toimipisteellä)
   },
   canAddSuoritus: (opiskeluoikeus) => isIBTutkinto(opiskeluoikeus) && !preIBSuoritus(opiskeluoikeus),
-  addSuoritusTitle: () => <Text name="lisää pre-IB-luokan oppimäärän suoritus"/>
+  addSuoritusTitle: () => <Text name="lisää pre-IB-suoritus"/>
 }

--- a/web/test/page/addOppijaPage.js
+++ b/web/test/page/addOppijaPage.js
@@ -59,7 +59,7 @@ function AddOppijaPage() {
       }
     },
     enterValidDataIB: function(params) {
-      params = _.merge({ oppilaitos: 'Ressun', oppimäärä: 'IB-lukion oppimäärä' }, {}, params)
+      params = _.merge({ oppilaitos: 'Ressun', oppimäärä: 'IB-tutkinto' }, {}, params)
       return function() {
         return api.enterData(params)()
           .then(api.selectOpiskeluoikeudenTyyppi('IB-tutkinto'))
@@ -67,7 +67,7 @@ function AddOppijaPage() {
       }
     },
     enterValidDataPreIB: function(params) {
-      params = _.merge({ oppilaitos: 'Ressun', oppimäärä: 'Pre-IB luokan oppimäärä' }, {}, params)
+      params = _.merge({ oppilaitos: 'Ressun', oppimäärä: 'Pre-IB' }, {}, params)
       return function() {
         return api.enterData(params)()
           .then(api.selectOpiskeluoikeudenTyyppi('IB-tutkinto'))

--- a/web/test/spec/ibSpec.js
+++ b/web/test/spec/ibSpec.js
@@ -18,10 +18,11 @@ describe('IB', function( ) {
   })
 
   describe('Pre-IB', function () {
-    before(page.openPage, page.oppijaHaku.searchAndSelect('040701-432D'))
+    before(page.openPage, page.oppijaHaku.searchAndSelect('040701-432D'), opinnot.valitseSuoritus(undefined, 'Pre-IB'))
+
     describe('Oppijan suorituksissa', function () {
       it('näytetään', function () {
-        expect(opinnot.getTutkinto()).to.equal("Pre-IB luokan oppimäärä")
+        expect(opinnot.getTutkinto()).to.equal("Pre-IB")
         expect(opinnot.getOppilaitos()).to.equal("Ressun lukio")
       })
     })
@@ -29,7 +30,7 @@ describe('IB', function( ) {
     describe('Kaikki tiedot näkyvissä', function () {
       it('näyttää suorituksen tiedot', function() {
         expect(extractAsText(S('.suoritus > .properties, .suoritus > .tila-vahvistus'))).to.equal(
-          'Koulutus Pre-IB luokan oppimäärä\n' +
+          'Koulutus Pre-IB\n' +
           'Oppilaitos / toimipiste Ressun lukio\n' +
           'Suorituskieli englanti\n' +
           'Suoritus valmis Vahvistus : 4.6.2016 Helsinki Reijo Reksi , rehtori')
@@ -63,8 +64,6 @@ describe('IB', function( ) {
     })
 
     describe('Tietojen muuttaminen', function() {
-      before(page.openPage, page.oppijaHaku.searchAndSelect('040701-432D'), opinnot.valitseSuoritus(undefined, 'Pre-IB luokan oppimäärä'))
-
       describe('Suoritusten tiedot', function() {
         describe('Oppiaine', function() {
           var uusiOppiaine = opinnot.oppiaineet.uusiOppiaine()
@@ -486,7 +485,7 @@ describe('IB', function( ) {
   })
 
   describe('IB-tutkinto', function () {
-    before(resetFixtures, page.openPage, page.oppijaHaku.searchAndSelect('040701-432D'), opinnot.valitseSuoritus(undefined, 'IB-tutkinto'))
+    before(resetFixtures, page.openPage, page.oppijaHaku.searchAndSelect('040701-432D'))
     describe('Oppijan suorituksissa', function () {
       it('näytetään', function () {
         expect(opinnot.getTutkinto()).to.equal("IB-tutkinto (International Baccalaureate)")
@@ -864,7 +863,7 @@ describe('IB', function( ) {
   })
 
   describe('Opiskeluoikeuden lisääminen', function() {
-    describe('IB-lukion oppimäärä', function() {
+    describe('IB-tutkinto', function() {
       before(
         prepareForNewOppija('kalle', '230872-7258'),
         addOppija.enterValidDataIB(),
@@ -912,7 +911,7 @@ describe('IB', function( ) {
 
         describe('Pre-IB-suorituksen lisääminen', function() {
           var lisääSuoritus = opinnot.lisääSuoritusDialog
-          var lisäysTeksti = 'lisää pre-IB-luokan oppimäärän suoritus'
+          var lisäysTeksti = 'lisää pre-IB-suoritus'
 
           describe('Kun opiskeluoikeus on tilassa VALMIS', function() {
             before(editor.edit, opinnot.avaaLisaysDialogi, opiskeluoikeus.tila().aseta('valmistunut'), opiskeluoikeus.tallenna)
@@ -941,7 +940,7 @@ describe('IB', function( ) {
               it('Näytetään myös pre-IB-suoritus', function() {
                 expect(opinnot.suoritusTabs()).to.deep.equal([
                   'IB-tutkinto (International Baccalaureate)',
-                  'Pre-IB luokan oppimäärä'
+                  'Pre-IB'
                 ])
               })
 
@@ -954,7 +953,7 @@ describe('IB', function( ) {
 
                 it('näytetään oikein', function () {
                   expect(extractAsText(S('.suoritus > .properties, .suoritus > .tila-vahvistus'))).to.equal(
-                    'Koulutus Pre-IB luokan oppimäärä\n' +
+                    'Koulutus Pre-IB\n' +
                     'Oppilaitos / toimipiste Ressun lukio\n' +
                     'Suorituskieli suomi\n' +
                     'Suoritus kesken'
@@ -967,18 +966,18 @@ describe('IB', function( ) {
       })
     })
 
-    describe('Pre-IB-oppimäärä', function() {
+    describe('Pre-IB', function() {
       before(
         prepareForNewOppija('kalle', '230872-7258'),
         addOppija.enterValidDataPreIB(),
-        addOppija.submitAndExpectSuccess('Tyhjä, Tero (230872-7258)', 'Pre-IB luokan oppimäärä')
+        addOppija.submitAndExpectSuccess('Tyhjä, Tero (230872-7258)', 'Pre-IB')
       )
 
       describe('Lisäyksen jälkeen', function () {
         describe('Opiskeluoikeuden tiedot', function() {
           it('näytetään oikein', function () {
             expect(extractAsText(S('.suoritus > .properties, .suoritus > .tila-vahvistus'))).to.equal(
-              'Koulutus Pre-IB luokan oppimäärä\n' +
+              'Koulutus Pre-IB\n' +
               'Oppilaitos / toimipiste Ressun lukio\n' +
               'Suorituskieli suomi\n' +
               'Suoritus kesken'
@@ -1017,7 +1016,7 @@ describe('IB', function( ) {
           describe('Kun opiskeluoikeus on tilassa LÄSNÄ', function() {
             describe('Ennen lisäystä', function() {
               it('Näytetään pre-IB-suoritus', function() {
-                expect(opinnot.suoritusTabs()).to.deep.equal(['Pre-IB luokan oppimäärä'])
+                expect(opinnot.suoritusTabs()).to.deep.equal(['Pre-IB'])
               })
 
               it('IB-tutkinnon suorituksen voi lisätä', function() {
@@ -1028,9 +1027,9 @@ describe('IB', function( ) {
             describe('Lisäyksen jälkeen', function() {
               before(lisääSuoritus.clickLink(lisäysTeksti))
 
-              it('Näytetään myös pre-IB-suoritus', function() {
+              it('Näytetään myös IB-tutkinnon suoritus', function() {
                 expect(opinnot.suoritusTabs()).to.deep.equal([
-                  'Pre-IB luokan oppimäärä',
+                  'Pre-IB',
                   'IB-tutkinto (International Baccalaureate)'
                 ])
               })
@@ -1040,8 +1039,7 @@ describe('IB', function( ) {
               })
 
               describe('Suorituksen tiedot', function() {
-                before(editor.saveChanges, wait.until(page.isSavedLabelShown)
-                )
+                before(editor.saveChanges, wait.until(page.isSavedLabelShown))
 
                 it('näytetään oikein', function () {
                   expect(extractAsText(S('.suoritus > .properties, .suoritus > .tila-vahvistus'))).to.equal(


### PR DESCRIPTION
Liittyy: **TOR-353**

- Päivitetään IB:n `suorituksentyyppi`-koodit
- Järjestetään päätason IB-suoritukset seuraavasti:
  1. IB-tutkinnon suoritus
  2. Pre-IB-suoritus
  - Tällöin myös opiskeluoikeuden otsakeriviin tulee oikein IB-tutkinto (jos on) ja pre-IB vain jos IB-tutkintosuoritusta ei ole