### PR TITLE
Parsitaan syntymäaika hetusta kun ei syntymäaikatietoa

### DIFF
--- a/src/main/scala/fi/oph/koski/henkilo/OpintopolkuHenkiloRepository.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/OpintopolkuHenkiloRepository.scala
@@ -45,7 +45,8 @@ case class OpintopolkuHenkilöRepository(henkilöt: OpintopolkuHenkilöFacade, k
   }
 
   private def toTäydellisetHenkilötiedot(user: OppijaHenkilö): TäydellisetHenkilötiedot = {
-    TäydellisetHenkilötiedot(user.oidHenkilo, user.hetu, user.syntymaika, user.etunimet, user.kutsumanimi, user.sukunimi, convertÄidinkieli(user.aidinkieli), convertKansalaisuus(user.kansalaisuus))
+    val syntymäpäivä = user.hetu.flatMap { hetu => Hetu.toBirthday(hetu) }
+    TäydellisetHenkilötiedot(user.oidHenkilo, user.hetu, user.syntymaika.orElse(syntymäpäivä), user.etunimet, user.kutsumanimi, user.sukunimi, convertÄidinkieli(user.aidinkieli), convertKansalaisuus(user.kansalaisuus))
   }
 
   private def convertÄidinkieli(äidinkieli: Option[String]) = äidinkieli.flatMap(äidinkieli => koodisto.getKoodistoKoodiViite("kieli", äidinkieli.toUpperCase))

--- a/web/test/spec/omatTiedotSpec.js
+++ b/web/test/spec/omatTiedotSpec.js
@@ -49,8 +49,11 @@ describe('Omat tiedot', function() {
           )
         })
 
-        it('Näytetään nimi', function() {
-          expect(omattiedot.headerNimi()).to.equal('Väinö Tõnis Kansalainen')
+        it("Näytetään nimi ja syntymäaika", function() {
+          expect(omattiedot.headerNimi()).to.equal(
+            'Väinö Tõnis Kansalainen\n' +
+            's. 3.6.1958'
+          )
         })
 
         it("Näytetään 'Mitkä tiedot palvelussa näkyvät?' -painike", function() {
@@ -112,7 +115,7 @@ describe('Omat tiedot', function() {
         })
       })
 
-      describe('Kun henkilöllä on syntymäaika', function () {
+      describe('Kun henkilöllä on syntymäaika-tieto', function () {
         before(authentication.logout, etusivu.openPage)
         before(etusivu.login(), wait.until(korhopankki.isReady), korhopankki.login('010170-9173'), wait.until(omattiedot.isVisible))
 
@@ -193,6 +196,7 @@ describe('Omat tiedot', function() {
                 expect(form.yhteystiedotTekstinä()).to.equal(
                   'Muista mainita sähköpostissa seuraavat tiedot:\n' +
                   'Nimi: Miia Monikoululainen\n' +
+                  'Syntymäaika: 18.4.1997\n' +
                   'Oppijanumero: 1.2.246.562.24.00000000009' +
                   ' ' +
                   'Kopioi'
@@ -209,6 +213,7 @@ describe('Omat tiedot', function() {
                     '———————————————————————————————\n\n' +
                     'Allaoleva teksti on luotu automaattisesti Opintopolun tiedoista. Koulu tarvitsee näitä tietoja pystyäkseen käsittelemään kysymystäsi.\n\n' +
                     'Nimi: Miia Monikoululainen\n' +
+                    'Syntymäaika: 18.4.1997\n' +
                     'Oppijanumero: 1.2.246.562.24.00000000009'
                   )
                 )
@@ -254,6 +259,7 @@ describe('Omat tiedot', function() {
                   expect(form.yhteystiedotTekstinä()).to.equal(
                     'Muista mainita sähköpostissa seuraavat tiedot:\n' +
                     'Nimi: Miia Monikoululainen\n' +
+                    'Syntymäaika: 18.4.1997\n' +
                     'Oppijanumero: 1.2.246.562.24.00000000009' +
                     ' ' +
                     'Kopioi'


### PR DESCRIPTION
Syntymäaika on oleellinen tieto, kun kansalainen raportoi suorituksissaan olevasta virheestä. Mikäli siis (optionaalinen) syntymäaika-tieto puuttuu, luodaan se hetun perusteella.

Liittyy: TOR-80