### PR TITLE
Fix error mapper not being used

### DIFF
--- a/web/app/util/http.js
+++ b/web/app/util/http.js
@@ -64,7 +64,6 @@ const http = (url, optionsForFetch, options = {}) => {
     .mapError({status: 503, url: url})
     .flatMap(parseResponseFor(url))
     .toProperty()
-  result.onEnd(reqComplete)
   if (options.errorMapper) { // errors are mapped to values or other Error events and will be handled
     result = result.flatMapError(options.errorMapper).toProperty()
   } else if (options.errorHandler) { // explicit error handler given
@@ -72,6 +71,7 @@ const http = (url, optionsForFetch, options = {}) => {
   } else if (!options.willHandleErrors) { // unless the user promises to handle errors by { willHandleErrors: true}, we'll default to showing the internal error div
     result.onError(showInternalError)
   }
+  result.onEnd(reqComplete)
   return result
 }
 


### PR DESCRIPTION
- Problem: when firing multiple consecutive http requests and taking only the last result (i.e. using flatMapLatest to fire requests), the errorMapper would not get triggered for the previous results. This causes issues with the http.cachedGet.

- Fix: attach the .onEnd subscription to the actual property that has the
error mapper (instead of the property that was composed without the
error mapper), in order to keep the property alive even when switching
to a latter request via the flatMapLatest.