### PR TITLE
Lisää IB-oppiaineelle optionaalinen effort-tieto arviointiin

### DIFF
--- a/src/main/scala/fi/oph/koski/documentation/ExamplesIB.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesIB.scala
@@ -190,7 +190,7 @@ object ExamplesIB {
   )
 
   def ibArviointi(arvosana: String, päivä: LocalDate = date(2016, 6, 4), predicted: Boolean): Some[List[IBOppiaineenArviointi]] = {
-    Some(List(IBOppiaineenArviointi(predicted = predicted, arvosana = Koodistokoodiviite(koodiarvo = arvosana, koodistoUri = "arviointiasteikkoib"), Some(päivä))))
+    Some(List(IBOppiaineenArviointi(predicted = predicted, arvosana = Koodistokoodiviite(koodiarvo = arvosana, koodistoUri = "arviointiasteikkoib"), päivä = Some(päivä))))
   }
 
   def ibCoreArviointi(arvosana: String, päivä: LocalDate = date(2016, 6, 4), predicted: Boolean): Some[List[IBCoreRequirementsArviointi]] = {

--- a/src/main/scala/fi/oph/koski/schema/IB.scala
+++ b/src/main/scala/fi/oph/koski/schema/IB.scala
@@ -160,6 +160,9 @@ case class IBOppiaineenArviointi(
   predicted: Boolean = true,
   @KoodistoUri("arviointiasteikkoib")
   arvosana: Koodistokoodiviite,
+  @Description("Effort-arvosana, kuvaa opiskelijan tunnollisuutta, aktiivisuutta ja yritteliäisyyttä. Arvosteluasteikko: A = very good, B = good, C = needs improvement")
+  @KoodistoUri("effortasteikkoib")
+  effort: Option[Koodistokoodiviite] = None,
   @Description("Arviointipäivämäärä")
   päivä: Option[LocalDate]
 ) extends IBArviointi {


### PR DESCRIPTION
Myös IB-oppiaineella (IB-kurssin lisäksi) voi arviointiin liittyä effort-tieto. Mahdollistetaan tämä lisäämällä optionaalinen kenttä.