### PR TITLE
Korvataan henkilötiedot-kysely kevyemmällä perustiedot-kyselyllä

### DIFF
--- a/src/main/resources/localization/default-texts.json
+++ b/src/main/resources/localization/default-texts.json
@@ -1001,6 +1001,8 @@
   "description:Muoto YYYY-MM-DD. Tiedon syötössä tietoa..." : "Muoto YYYY-MM-DD. Tiedon syötössä tietoa ei tarvita; tieto poimitaan tila-kentän ensimmäisestä opiskeluoikeusjaksosta.",
   "KOSKI-palvelun tietosuojaseloste (sisältää rekisteriselosteen)": "KOSKI-palvelun tietosuojaseloste (sisältää rekisteriselosteen)",
   "tooltip:Oppiaineen laajuus kursseina." : "Oppiaineen laajuus kursseina.",
-  "Opiskeluoikeuksia": "Opiskeluoikeuksia"
+  "Opiskeluoikeuksia": "Opiskeluoikeuksia",
+  "Turvakielto" : "Turvakielto",
+  "description:Henkilöllä on turvakielto" : "Henkilöllä on turvakielto"
 }
 

--- a/src/main/scala/fi/oph/koski/fixture/KoskiDatabaseFixtures.scala
+++ b/src/main/scala/fi/oph/koski/fixture/KoskiDatabaseFixtures.scala
@@ -94,7 +94,8 @@ class KoskiDatabaseFixtureCreator(application: KoskiApplication) extends KoskiDa
       (MockOppijat.ibPredicted, ExamplesIB.opiskeluoikeusPredictedGrades),
       (MockOppijat.eero, OpiskeluoikeusTestData.mitätöityOpiskeluoikeus),
       (MockOppijat.master, ExamplesPerusopetus.päättötodistus.tallennettavatOpiskeluoikeudet.head),
-      (MockOppijat.slave, ExamplesLukio.päättötodistus())
+      (MockOppijat.slave, ExamplesLukio.päättötodistus()),
+      (MockOppijat.turvakielto, ExamplesLukio.päättötodistus())
     )
   }
 }

--- a/src/main/scala/fi/oph/koski/henkilo/MockOppijat.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/MockOppijat.scala
@@ -77,7 +77,7 @@ class MockOppijat(private var oppijat: List[TäydellisetHenkilötiedotWithMaster
   val äidinkieli: Some[Koodistokoodiviite] = Some(Koodistokoodiviite("FI", None, "kieli", None))
 
   def oppija(suku: String, etu: String, hetu: String, oid: String = generateId(), kutsumanimi: Option[String] = None, turvakielto: Boolean = false): TäydellisetHenkilötiedotWithMasterInfo =
-    addOppija(TäydellisetHenkilötiedot(oid, Some(hetu), None, etu, kutsumanimi.getOrElse(etu), suku, äidinkieli, None, turvakielto))
+    addOppija(TäydellisetHenkilötiedot(oid, Some(hetu), None, etu, kutsumanimi.getOrElse(etu), suku, äidinkieli, None, Some(turvakielto)))
 
   def addOppija(oppija: TäydellisetHenkilötiedot): TäydellisetHenkilötiedotWithMasterInfo = addOppija(TäydellisetHenkilötiedotWithMasterInfo(oppija, None))
 

--- a/src/main/scala/fi/oph/koski/henkilo/MockOppijat.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/MockOppijat.scala
@@ -60,6 +60,7 @@ object MockOppijat {
   val opiskeluoikeudenOidKonflikti = oppijat.oppija("Oidkonflikti", "Oskari", "260539-745W", "1.2.246.562.24.09090909090")
   val eiKoskessa = oppijat.oppija("EiKoskessa", "Eino", "270181-5263", "1.2.246.562.24.99999555555")
   val eiKoskessaHetuton = oppijat.addOppija(TäydellisetHenkilötiedot("1.2.246.562.24.99999555556", None, None, "Eino", "Eino", "EiKoskessaHetuton", None, None))
+  val turvakielto = oppijat.oppija("Turvakielto", "Tero", "151067-2193", turvakielto = true)
 
   def defaultOppijat = oppijat.getOppijat
 
@@ -75,8 +76,8 @@ class MockOppijat(private var oppijat: List[TäydellisetHenkilötiedotWithMaster
   private var idCounter = oppijat.length
   val äidinkieli: Some[Koodistokoodiviite] = Some(Koodistokoodiviite("FI", None, "kieli", None))
 
-  def oppija(suku: String, etu: String, hetu: String, oid: String = generateId(), kutsumanimi: Option[String] = None): TäydellisetHenkilötiedotWithMasterInfo =
-    addOppija(TäydellisetHenkilötiedot(oid, Some(hetu), None, etu, kutsumanimi.getOrElse(etu), suku, äidinkieli, None))
+  def oppija(suku: String, etu: String, hetu: String, oid: String = generateId(), kutsumanimi: Option[String] = None, turvakielto: Boolean = false): TäydellisetHenkilötiedotWithMasterInfo =
+    addOppija(TäydellisetHenkilötiedot(oid, Some(hetu), None, etu, kutsumanimi.getOrElse(etu), suku, äidinkieli, None, turvakielto))
 
   def addOppija(oppija: TäydellisetHenkilötiedot): TäydellisetHenkilötiedotWithMasterInfo = addOppija(TäydellisetHenkilötiedotWithMasterInfo(oppija, None))
 

--- a/src/main/scala/fi/oph/koski/henkilo/OpintopolkuHenkiloFacade.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/OpintopolkuHenkiloFacade.scala
@@ -90,8 +90,8 @@ class RemoteOpintopolkuHenkilöFacadeWithMockOids(oppijanumeroRekisteriClient: O
         case None =>
           elasticSearch.refreshIndex
           perustiedotRepository.findHenkilöPerustiedotByHenkilöOid(oid).map { henkilö =>
-            OppijaHenkilö(henkilö.oid, henkilö.sukunimi, henkilö.etunimet, henkilö.kutsumanimi, Some("010101-123N"), None, None, None, 0)
-          }.getOrElse(OppijaHenkilö(oid, oid.substring("1.2.246.562.24.".length, oid.length), "Testihenkilö", "Testihenkilö", Some("010101-123N"), None, None, None, 0))
+            OppijaHenkilö(henkilö.oid, henkilö.sukunimi, henkilö.etunimet, henkilö.kutsumanimi, Some("010101-123N"), None, None, None, 0, false)
+          }.getOrElse(OppijaHenkilö(oid, oid.substring("1.2.246.562.24.".length, oid.length), "Testihenkilö", "Testihenkilö", Some("010101-123N"), None, None, None, 0, false))
       }
     }
   }
@@ -144,7 +144,7 @@ class MockOpintopolkuHenkilöFacade() extends OpintopolkuHenkilöFacade with Log
   }
 
   private def toOppijaHenkilö(henkilö: TäydellisetHenkilötiedot) = {
-    OppijaHenkilö(henkilö.oid, henkilö.sukunimi, henkilö.etunimet, henkilö.kutsumanimi, henkilö.hetu, henkilö.syntymäaika, Some("FI"), None, 0)
+    OppijaHenkilö(henkilö.oid, henkilö.sukunimi, henkilö.etunimet, henkilö.kutsumanimi, henkilö.hetu, henkilö.syntymäaika, Some("FI"), None, 0, henkilö.turvakielto)
   }
 
   override def findKäyttäjäByOid(oid: String): Option[KäyttäjäHenkilö] = {

--- a/src/main/scala/fi/oph/koski/henkilo/OpintopolkuHenkiloFacade.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/OpintopolkuHenkiloFacade.scala
@@ -144,7 +144,7 @@ class MockOpintopolkuHenkilöFacade() extends OpintopolkuHenkilöFacade with Log
   }
 
   private def toOppijaHenkilö(henkilö: TäydellisetHenkilötiedot) = {
-    OppijaHenkilö(henkilö.oid, henkilö.sukunimi, henkilö.etunimet, henkilö.kutsumanimi, henkilö.hetu, henkilö.syntymäaika, Some("FI"), None, 0, henkilö.turvakielto)
+    OppijaHenkilö(henkilö.oid, henkilö.sukunimi, henkilö.etunimet, henkilö.kutsumanimi, henkilö.hetu, henkilö.syntymäaika, Some("FI"), None, 0, henkilö.turvakielto.getOrElse(false))
   }
 
   override def findKäyttäjäByOid(oid: String): Option[KäyttäjäHenkilö] = {

--- a/src/main/scala/fi/oph/koski/henkilo/OpintopolkuHenkiloRepository.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/OpintopolkuHenkiloRepository.scala
@@ -46,7 +46,7 @@ case class OpintopolkuHenkilöRepository(henkilöt: OpintopolkuHenkilöFacade, k
 
   private def toTäydellisetHenkilötiedot(user: OppijaHenkilö): TäydellisetHenkilötiedot = {
     val syntymäpäivä = user.hetu.flatMap { hetu => Hetu.toBirthday(hetu) }
-    TäydellisetHenkilötiedot(user.oidHenkilo, user.hetu, user.syntymaika.orElse(syntymäpäivä), user.etunimet, user.kutsumanimi, user.sukunimi, convertÄidinkieli(user.aidinkieli), convertKansalaisuus(user.kansalaisuus))
+    TäydellisetHenkilötiedot(user.oidHenkilo, user.hetu, user.syntymaika.orElse(syntymäpäivä), user.etunimet, user.kutsumanimi, user.sukunimi, convertÄidinkieli(user.aidinkieli), convertKansalaisuus(user.kansalaisuus), user.turvakielto)
   }
 
   private def convertÄidinkieli(äidinkieli: Option[String]) = äidinkieli.flatMap(äidinkieli => koodisto.getKoodistoKoodiViite("kieli", äidinkieli.toUpperCase))

--- a/src/main/scala/fi/oph/koski/henkilo/OpintopolkuHenkiloRepository.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/OpintopolkuHenkiloRepository.scala
@@ -46,7 +46,7 @@ case class OpintopolkuHenkilöRepository(henkilöt: OpintopolkuHenkilöFacade, k
 
   private def toTäydellisetHenkilötiedot(user: OppijaHenkilö): TäydellisetHenkilötiedot = {
     val syntymäpäivä = user.hetu.flatMap { hetu => Hetu.toBirthday(hetu) }
-    TäydellisetHenkilötiedot(user.oidHenkilo, user.hetu, user.syntymaika.orElse(syntymäpäivä), user.etunimet, user.kutsumanimi, user.sukunimi, convertÄidinkieli(user.aidinkieli), convertKansalaisuus(user.kansalaisuus), user.turvakielto)
+    TäydellisetHenkilötiedot(user.oidHenkilo, user.hetu, user.syntymaika.orElse(syntymäpäivä), user.etunimet, user.kutsumanimi, user.sukunimi, convertÄidinkieli(user.aidinkieli), convertKansalaisuus(user.kansalaisuus), Some(user.turvakielto))
   }
 
   private def convertÄidinkieli(äidinkieli: Option[String]) = äidinkieli.flatMap(äidinkieli => koodisto.getKoodistoKoodiViite("kieli", äidinkieli.toUpperCase))

--- a/src/main/scala/fi/oph/koski/henkilo/oppijanumerorekisteriservice/OppijanumeroRekisteriClient.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/oppijanumerorekisteriservice/OppijanumeroRekisteriClient.scala
@@ -29,7 +29,7 @@ case class OppijanumeroRekisteriClient(config: Config) {
         .map(_.flatMap(_.yhteystiedotRyhma.flatMap(_.yhteystieto.find(_.yhteystietoTyyppi == "YHTEYSTIETO_SAHKOPOSTI").map(_.yhteystietoArvo))))
 
   def findOppijatByOids(oids: List[Oid]): Task[List[OppijaHenkilö]] =
-    oidServiceHttp.post(uri"/oppijanumerorekisteri-service/henkilo/henkilotByHenkiloOidList", oids)(json4sEncoderOf[List[String]])(Http.parseJson[List[OppijaNumerorekisteriOppija]]).map(_.map(_.toOppijaHenkilö))
+    oidServiceHttp.post(uri"/oppijanumerorekisteri-service/henkilo/henkiloPerustietosByHenkiloOidList", oids)(json4sEncoderOf[List[String]])(Http.parseJson[List[OppijaNumerorekisteriOppija]]).map(_.map(_.toOppijaHenkilö))
 
   def findChangedOppijaOids(since: Long, offset: Int, amount: Int): Task[List[Oid]] =
     oidServiceHttp.get(uri"/oppijanumerorekisteri-service/s2s/changedSince/$since?offset=$offset&amount=$amount")(Http.parseJson[List[String]])

--- a/src/main/scala/fi/oph/koski/henkilo/oppijanumerorekisteriservice/OppijanumeroRekisteriClient.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/oppijanumerorekisteriservice/OppijanumeroRekisteriClient.scala
@@ -29,7 +29,7 @@ case class OppijanumeroRekisteriClient(config: Config) {
         .map(_.flatMap(_.yhteystiedotRyhma.flatMap(_.yhteystieto.find(_.yhteystietoTyyppi == "YHTEYSTIETO_SAHKOPOSTI").map(_.yhteystietoArvo))))
 
   def findOppijatByOids(oids: List[Oid]): Task[List[OppijaHenkilö]] =
-    oidServiceHttp.post(uri"/oppijanumerorekisteri-service/henkilo/henkiloPerustietosByHenkiloOidList", oids)(json4sEncoderOf[List[String]])(Http.parseJson[List[OppijaNumerorekisteriOppija]]).map(_.map(_.toOppijaHenkilö))
+    oidServiceHttp.post(uri"/oppijanumerorekisteri-service/henkilo/henkilotByHenkiloOidList", oids)(json4sEncoderOf[List[String]])(Http.parseJson[List[OppijaNumerorekisteriOppija]]).map(_.map(_.toOppijaHenkilö))
 
   def findChangedOppijaOids(since: Long, offset: Int, amount: Int): Task[List[Oid]] =
     oidServiceHttp.get(uri"/oppijanumerorekisteri-service/s2s/changedSince/$since?offset=$offset&amount=$amount")(Http.parseJson[List[String]])
@@ -42,8 +42,8 @@ case class OppijanumeroRekisteriClient(config: Config) {
 }
 
 case class KäyttäjäHenkilö(oidHenkilo: String, sukunimi: String, etunimet: String, kutsumanimi: String, kayttajatiedot: Option[Käyttäjätiedot], asiointiKieli: Option[Kieli])
-case class OppijaNumerorekisteriOppija(oidHenkilo: String, sukunimi: String, etunimet: String, kutsumanimi: String, hetu: Option[String], syntymaaika: Option[LocalDate], aidinkieli: Option[Kieli], kansalaisuus: Option[List[Kansalaisuus]], modified: Long) {
-  def toOppijaHenkilö = OppijaHenkilö(oidHenkilo, sukunimi, etunimet, kutsumanimi, hetu, syntymaaika, aidinkieli.map(_.kieliKoodi), kansalaisuus.map(_.map(_.kansalaisuusKoodi)), modified)
+case class OppijaNumerorekisteriOppija(oidHenkilo: String, sukunimi: String, etunimet: String, kutsumanimi: String, hetu: Option[String], syntymaaika: Option[LocalDate], aidinkieli: Option[Kieli], kansalaisuus: Option[List[Kansalaisuus]], modified: Long, turvakielto: Boolean) {
+  def toOppijaHenkilö = OppijaHenkilö(oidHenkilo, sukunimi, etunimet, kutsumanimi, hetu, syntymaaika, aidinkieli.map(_.kieliKoodi), kansalaisuus.map(_.map(_.kansalaisuusKoodi)), modified, turvakielto)
 }
 case class UusiHenkilö(hetu: Option[String], sukunimi: String, etunimet: String, kutsumanimi: String, henkiloTyyppi: String, kayttajatiedot: Option[Käyttäjätiedot])
 object UusiHenkilö {
@@ -58,6 +58,6 @@ case class Yhteystieto(yhteystietoTyyppi: String, yhteystietoArvo: String)
 
 case class Kansalaisuus(kansalaisuusKoodi: String)
 case class Kieli(kieliKoodi: String)
-case class OppijaHenkilö(oidHenkilo: String, sukunimi: String, etunimet: String, kutsumanimi: String, hetu: Option[String], syntymaika: Option[LocalDate], aidinkieli: Option[String], kansalaisuus: Option[List[String]], modified: Long) {
+case class OppijaHenkilö(oidHenkilo: String, sukunimi: String, etunimet: String, kutsumanimi: String, hetu: Option[String], syntymaika: Option[LocalDate], aidinkieli: Option[String], kansalaisuus: Option[List[String]], modified: Long, turvakielto: Boolean) {
   def toTäydellisetHenkilötiedot = TäydellisetHenkilötiedot(oidHenkilo, etunimet, kutsumanimi, sukunimi)
 }

--- a/src/main/scala/fi/oph/koski/schema/Henkilo.scala
+++ b/src/main/scala/fi/oph/koski/schema/Henkilo.scala
@@ -35,7 +35,8 @@ case class TäydellisetHenkilötiedot(
   äidinkieli: Option[Koodistokoodiviite],
   @Description("Opiskelijan kansalaisuudet")
   @KoodistoUri("maatjavaltiot2")
-  kansalaisuus: Option[List[Koodistokoodiviite]]
+  kansalaisuus: Option[List[Koodistokoodiviite]],
+  turvakielto: Boolean = false
 ) extends HenkilöWithOid with Henkilötiedot {
   def toHenkilötiedotJaOid = HenkilötiedotJaOid(oid, hetu, etunimet, kutsumanimi, sukunimi)
 }

--- a/src/main/scala/fi/oph/koski/schema/Henkilo.scala
+++ b/src/main/scala/fi/oph/koski/schema/Henkilo.scala
@@ -36,7 +36,8 @@ case class TäydellisetHenkilötiedot(
   @Description("Opiskelijan kansalaisuudet")
   @KoodistoUri("maatjavaltiot2")
   kansalaisuus: Option[List[Koodistokoodiviite]],
-  turvakielto: Boolean = false
+  @Description("Henkilöllä on turvakielto")
+  turvakielto: Option[Boolean] = None
 ) extends HenkilöWithOid with Henkilötiedot {
   def toHenkilötiedotJaOid = HenkilötiedotJaOid(oid, hetu, etunimet, kutsumanimi, sukunimi)
 }

--- a/src/main/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoService.scala
+++ b/src/main/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoService.scala
@@ -309,8 +309,8 @@ class TiedonsiirtoService(
     }
 
     haetutTiedot.orElse(oidHenkilö match {
-      case Some(oidHenkilö) => validateAndExtract[TiedonsiirtoOppija](annetutHenkilötiedot.merge(JsonSerializer.serializeWithRoot(oidHenkilö))).toOption
-      case None => annetutHenkilötiedot.toOption.flatMap(validateAndExtract[TiedonsiirtoOppija](_).toOption)
+      case Some(oidHenkilö) => validateAndExtract[TiedonsiirtoOppija](annetutHenkilötiedot.merge(JsonSerializer.serializeWithRoot(oidHenkilö)), ignoreExtras = true).toOption
+      case None => annetutHenkilötiedot.toOption.flatMap(validateAndExtract[TiedonsiirtoOppija](_, ignoreExtras = true).toOption)
     })
   }
 

--- a/src/test/scala/fi/oph/koski/api/TurvakieltoSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/TurvakieltoSpec.scala
@@ -1,0 +1,15 @@
+package fi.oph.koski.api
+
+import fi.oph.koski.henkilo.MockOppijat
+import fi.oph.koski.henkilo.MockOppijat.eero
+import fi.oph.koski.schema.TäydellisetHenkilötiedot
+import org.scalatest.{FreeSpec, Matchers}
+
+class TurvakieltoSpec extends FreeSpec with Matchers with LocalJettyHttpSpecification with OpiskeluoikeusTestMethods {
+  "Turvakielto" - {
+    "Oppijan tiedoissa näkyy turvakieltotieto" in {
+      oppija(eero.oid).henkilö.asInstanceOf[TäydellisetHenkilötiedot].turvakielto should equal(false)
+      oppija(MockOppijat.turvakielto.oid).henkilö.asInstanceOf[TäydellisetHenkilötiedot].turvakielto should equal(true)
+    }
+  }
+}

--- a/src/test/scala/fi/oph/koski/api/TurvakieltoSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/TurvakieltoSpec.scala
@@ -8,8 +8,8 @@ import org.scalatest.{FreeSpec, Matchers}
 class TurvakieltoSpec extends FreeSpec with Matchers with LocalJettyHttpSpecification with OpiskeluoikeusTestMethods {
   "Turvakielto" - {
     "Oppijan tiedoissa näkyy turvakieltotieto" in {
-      oppija(eero.oid).henkilö.asInstanceOf[TäydellisetHenkilötiedot].turvakielto should equal(false)
-      oppija(MockOppijat.turvakielto.oid).henkilö.asInstanceOf[TäydellisetHenkilötiedot].turvakielto should equal(true)
+      oppija(eero.oid).henkilö.asInstanceOf[TäydellisetHenkilötiedot].turvakielto.get should equal(false)
+      oppija(MockOppijat.turvakielto.oid).henkilö.asInstanceOf[TäydellisetHenkilötiedot].turvakielto.get should equal(true)
     }
   }
 }

--- a/web/app/style/oppija.less
+++ b/web/app/style/oppija.less
@@ -93,6 +93,16 @@
     &.edit, &.dirty {
       padding-bottom: 50px;
     }
+    .turvakielto {
+      cursor: pointer;
+      &:after {
+        .FontAwesomeSymbol;
+        content: "";
+        font-size: 25px;
+        margin-left: 8px;
+        color: @color-red;
+      }
+    }
   }
 
   .opiskeluoikeus-invalidated {

--- a/web/app/virkailija/VirkailijaOppijaView.jsx
+++ b/web/app/virkailija/VirkailijaOppijaView.jsx
@@ -200,6 +200,7 @@ export class Oppija extends React.Component {
           <div className={stateP.map(state => 'oppija-content ' + state)}>
             <h2>{`${modelTitle(henkilö, 'sukunimi')}, ${modelTitle(henkilö, 'etunimet')} `}<span
               className='hetu'>{(hetu && '(' + hetu + ')') || (syntymäaika && '(' + ISO2FinnishDate(syntymäaika) + ')')}</span>
+              {modelData(henkilö, 'turvakielto') && <span title={t('Henkilöllä on turvakielto')} className="turvakielto"/>}
               <a href={`/koski/api/oppija/${modelData(henkilö, 'oid')}`}>{'JSON'}</a>
               {showHenkilöUiLink.map(show => show && <a href={`/henkilo-ui/oppija/${modelData(henkilö, 'oid')}?permissionCheckService=KOSKI`} target='_blank' title={t('OppijanumerorekisteriLinkTooltip')}><Text name="Oppijanumerorekisteri" /></a>)}
               {showVirtaXmlLink.map(show => show && <a href={`/koski/api/oppija/${modelData(henkilö, 'oid')}/virta-opintotiedot-xml`} target='_blank'>{'Virta XML'}</a>)}

--- a/web/test/spec/koskiSpec.js
+++ b/web/test/spec/koskiSpec.js
@@ -43,6 +43,14 @@ describe('Koski', function() {
       })
     })
 
+    describe('Turvakielto', function() {
+      before(Authentication().login(), page.openPage, page.openPage, page.oppijaHaku.searchAndSelect('151067-2193'))
+
+      it('Turvakieltosymboli näytetään henkilölle jolla on turvakielto', function() {
+        expect(isElementVisible(S('.turvakielto'))).to.equal(true)
+      })
+    })
+
     describe('Kun klikataan logout-linkkiä', function() {
       before(Authentication().login(), page.openPage, page.logout)
 

--- a/web/test/spec/koskiSpec.js
+++ b/web/test/spec/koskiSpec.js
@@ -44,7 +44,7 @@ describe('Koski', function() {
     })
 
     describe('Turvakielto', function() {
-      before(Authentication().login(), page.openPage, page.openPage, page.oppijaHaku.searchAndSelect('151067-2193'))
+      before(Authentication().login(), page.openPage, page.oppijaHaku.searchAndSelect('151067-2193'))
 
       it('Turvakieltosymboli näytetään henkilölle jolla on turvakielto', function() {
         expect(isElementVisible(S('.turvakielto'))).to.equal(true)


### PR DESCRIPTION
Huom. vaatii ensin tämän mergaamista: https://github.com/Opetushallitus/koski/pull/162
Lisäksi vaatimuksena on, että tämä on mergattu ja viety tuotantoon: https://github.com/Opetushallitus/oppijanumerorekisteri/pull/117