### PR TITLE
Tiedonsiirtovirheestä lähtee sähköposti

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -52,6 +52,7 @@ elasticsearch = {
 
 features = {
   shibboleth = true
+  tiedonsiirtomail = true
 }
 
 // These mock values need to be overridden. Otherwise mock data will be used.

--- a/src/main/scala/fi/oph/koski/config/Features.scala
+++ b/src/main/scala/fi/oph/koski/config/Features.scala
@@ -4,4 +4,5 @@ import com.typesafe.config.Config
 
 case class Features(config: Config) {
   def shibboleth: Boolean = config.getBoolean("features.shibboleth")
+  def tiedonsiirtomail: Boolean = config.getBoolean("features.tiedonsiirtomail")
 }

--- a/src/main/scala/fi/oph/koski/config/KoskiApplication.scala
+++ b/src/main/scala/fi/oph/koski/config/KoskiApplication.scala
@@ -76,7 +76,7 @@ class KoskiApplication(val config: Config, implicit val cacheManager: CacheManag
   lazy val sessionTimeout = SessionTimeout(config)
   lazy val koskiSessionRepository = new KoskiSessionRepository(masterDatabase.db, sessionTimeout)
   lazy val fixtureCreator = new FixtureCreator(this)
-  lazy val tiedonsiirtoService = new TiedonsiirtoService(koskiElasticSearchIndex, new TiedonsiirtoFailureMailer(config, opintopolkuHenkilöFacade), organisaatioRepository, henkilöRepository, koodistoViitePalvelu, userRepository)
+  lazy val tiedonsiirtoService = new TiedonsiirtoService(koskiElasticSearchIndex, new TiedonsiirtoFailureMailer(this), organisaatioRepository, henkilöRepository, koodistoViitePalvelu, userRepository)
   lazy val healthCheck = HealthCheck(this)
   lazy val scheduledTasks = new KoskiScheduledTasks(this)
   lazy val ipService = new IPService(masterDatabase.db)

--- a/src/main/scala/fi/oph/koski/email/EmailSender.scala
+++ b/src/main/scala/fi/oph/koski/email/EmailSender.scala
@@ -41,7 +41,7 @@ case class RyhmäsähköpostiSender(config: Config) extends EmailSender {
   val http = VirkailijaHttpClient(ServiceConfig.apply(config, "ryhmäsähköposti.virkailija"), "/ryhmasahkoposti-service")
 
   override def sendEmail(envelope: Email): Unit = {
-    http.post(uri"/ryhmasahkoposti-service/email", envelope)(json4sEncoderOf[Email])(Http.expectSuccess)
+    runTask(http.post(uri"/ryhmasahkoposti-service/email", envelope)(json4sEncoderOf[Email])(Http.expectSuccess))
   }
 }
 

--- a/src/main/scala/fi/oph/koski/henkilo/OpintopolkuHenkiloFacade.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/OpintopolkuHenkiloFacade.scala
@@ -11,7 +11,7 @@ import fi.oph.koski.henkilo.oppijanumerorekisteriservice.{KäyttäjäHenkilö, O
 import fi.oph.koski.http.Http._
 import fi.oph.koski.http.{HttpStatus, KoskiErrorCategory, _}
 import fi.oph.koski.koskiuser.KoskiSession.systemUser
-import fi.oph.koski.koskiuser.{Käyttöoikeusryhmä, Käyttöoikeusryhmät, MockUsers}
+import fi.oph.koski.koskiuser.{MockUsers, OrganisaationKäyttöoikeusryhmä}
 import fi.oph.koski.log.Logging
 import fi.oph.koski.perustiedot.OpiskeluoikeudenPerustiedotRepository
 import fi.oph.koski.schema.Henkilö.Oid
@@ -199,7 +199,10 @@ class MockOpintopolkuHenkilöFacade() extends OpintopolkuHenkilöFacade with Log
 
   override def organisaationSähköpostit(organisaatioOid: String, ryhmä: String): List[String] =
     MockUsers.users.filter(_.käyttöoikeudet.exists { case (oid, käyttöoikeusryhmä) =>
-      organisaatioOid == oid && käyttöoikeusryhmä.nimi == ryhmä
+      käyttöoikeusryhmä match {
+        case o: OrganisaationKäyttöoikeusryhmä => organisaatioOid == oid && o.tunniste == ryhmä
+        case _ => false
+      }
     }).map(_.username + "@example.com")
 
   override def findOppijaByHetu(hetu: String): Option[OppijaHenkilö] = synchronized {

--- a/src/main/scala/fi/oph/koski/henkilo/OpintopolkuHenkiloFacade.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/OpintopolkuHenkiloFacade.scala
@@ -11,7 +11,7 @@ import fi.oph.koski.henkilo.oppijanumerorekisteriservice.{KäyttäjäHenkilö, O
 import fi.oph.koski.http.Http._
 import fi.oph.koski.http.{HttpStatus, KoskiErrorCategory, _}
 import fi.oph.koski.koskiuser.KoskiSession.systemUser
-import fi.oph.koski.koskiuser.{Käyttöoikeusryhmät, MockUsers}
+import fi.oph.koski.koskiuser.{Käyttöoikeusryhmä, Käyttöoikeusryhmät, MockUsers}
 import fi.oph.koski.log.Logging
 import fi.oph.koski.perustiedot.OpiskeluoikeudenPerustiedotRepository
 import fi.oph.koski.schema.Henkilö.Oid
@@ -198,7 +198,9 @@ class MockOpintopolkuHenkilöFacade() extends OpintopolkuHenkilöFacade with Log
   }
 
   override def organisaationSähköpostit(organisaatioOid: String, ryhmä: String): List[String] =
-    MockUsers.users.filter(_.käyttöoikeudet.contains((organisaatioOid, Käyttöoikeusryhmät.vastuukäyttäjä))).map(_.username + "@example.com")
+    MockUsers.users.filter(_.käyttöoikeudet.exists { case (oid, käyttöoikeusryhmä) =>
+      organisaatioOid == oid && käyttöoikeusryhmä.nimi == ryhmä
+    }).map(_.username + "@example.com")
 
   override def findOppijaByHetu(hetu: String): Option[OppijaHenkilö] = synchronized {
     oppijat.getOppijat.find(_.hetu.contains(hetu)).map(h => h.master.map(toOppijaHenkilö).getOrElse(toOppijaHenkilö(h.henkilö)))

--- a/src/main/scala/fi/oph/koski/koskiuser/KayttooikeusRyhmat.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/KayttooikeusRyhmat.scala
@@ -5,11 +5,11 @@ import fi.oph.koski.koskiuser.Rooli._
 object Käyttöoikeusryhmät {
   private var ryhmät: List[Käyttöoikeusryhmä] = Nil
 
-  val oppilaitosKatselija = add(OrganisaationKäyttöoikeusryhmä("KOSKI-katselija", "oman organisaation suoritus- ja opiskeluoikeustietojen katselu", List(Palvelurooli(READ), Palvelurooli(LUOTTAMUKSELLINEN))))
-  val oppilaitosTallentaja = add(OrganisaationKäyttöoikeusryhmä("KOSKI-tallentaja", "tietojen muokkaaminen (suoritus ja opiskelijatietojen tallentaja, oppilaitos: lisäys, muokkaus) käyttöliittymässä", List(Palvelurooli(READ), Palvelurooli(READ_UPDATE), Palvelurooli(LUOTTAMUKSELLINEN))))
-  val oppilaitosPalvelukäyttäjä = add(OrganisaationKäyttöoikeusryhmä("KOSKI-palvelukäyttäjä", "palvelutunnus tiedonsiirroissa: tietojen muokkaaminen (suoritus ja opiskelijatietojen tallentaja, oppilaitos: lisäys, muokkaus, passivointi)", List(Palvelurooli(READ), Palvelurooli(READ_UPDATE), Palvelurooli(TIEDONSIIRTO), Palvelurooli(LUOTTAMUKSELLINEN))))
-  val oppilaitosPääkäyttäjä = add(OrganisaationKäyttöoikeusryhmä("KOSKI-pääkäyttäjä", "tietojen katselu ja mitätöinti käyttöliittymässä", List(Palvelurooli(READ), Palvelurooli(TIEDONSIIRRON_MITATOINTI), Palvelurooli(LUOTTAMUKSELLINEN))))
-  val vastuukäyttäjä = add(OrganisaationKäyttöoikeusryhmä("Vastuukayttajat", "organisaation vastuukäyttäjä, jolle Koski lähettää tiedonsiirtojen virhe-sähköpostit", List(Palvelurooli(READ))))
+  val oppilaitosKatselija = add(OrganisaationKäyttöoikeusryhmä("KOSKI-katselija", "koski-oppilaitos-katselija_1477661680227", "oman organisaation suoritus- ja opiskeluoikeustietojen katselu", List(Palvelurooli(READ), Palvelurooli(LUOTTAMUKSELLINEN))))
+  val oppilaitosTallentaja = add(OrganisaationKäyttöoikeusryhmä("KOSKI-tallentaja", "koski-oppilaitos-tallentaja_1477661680083", "tietojen muokkaaminen (suoritus ja opiskelijatietojen tallentaja, oppilaitos: lisäys, muokkaus) käyttöliittymässä", List(Palvelurooli(READ), Palvelurooli(READ_UPDATE), Palvelurooli(LUOTTAMUKSELLINEN))))
+  val oppilaitosPalvelukäyttäjä = add(OrganisaationKäyttöoikeusryhmä("KOSKI-palvelukäyttäjä", "koski-oppilaitos-palvelukäyttäjä_1477661679970", "palvelutunnus tiedonsiirroissa: tietojen muokkaaminen (suoritus ja opiskelijatietojen tallentaja, oppilaitos: lisäys, muokkaus, passivointi)", List(Palvelurooli(READ), Palvelurooli(READ_UPDATE), Palvelurooli(TIEDONSIIRTO), Palvelurooli(LUOTTAMUKSELLINEN))))
+  val oppilaitosPääkäyttäjä = add(OrganisaationKäyttöoikeusryhmä("KOSKI-pääkäyttäjä", "koski-oppilaitos-pääkäyttäjä_1494486198456", "tietojen katselu ja mitätöinti käyttöliittymässä", List(Palvelurooli(READ), Palvelurooli(TIEDONSIIRRON_MITATOINTI), Palvelurooli(LUOTTAMUKSELLINEN))))
+  val vastuukäyttäjä = add(OrganisaationKäyttöoikeusryhmä("Vastuukayttajat", "Vastuukayttajat", "organisaation vastuukäyttäjä, jolle Koski lähettää tiedonsiirtojen virhe-sähköpostit", List(Palvelurooli(READ))))
 
   val ophPääkäyttäjä = add(GlobaaliKäyttöoikeusryhmä("koski-oph-pääkäyttäjä", "CRUP-oikeudet (lisäys, muokkaus, passivointi) Koskessa", List(Palvelurooli(OPHPAAKAYTTAJA), Palvelurooli(YLLAPITAJA), Palvelurooli(LUOTTAMUKSELLINEN))))
   val ophKatselija = add(GlobaaliKäyttöoikeusryhmä("koski-oph-katselija", "näkee kaikki Koski-tiedot", List(Palvelurooli(OPHKATSELIJA), Palvelurooli(LUOTTAMUKSELLINEN))))

--- a/src/main/scala/fi/oph/koski/koskiuser/KayttooikeusRyhmat.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/KayttooikeusRyhmat.scala
@@ -5,11 +5,10 @@ import fi.oph.koski.koskiuser.Rooli._
 object Käyttöoikeusryhmät {
   private var ryhmät: List[Käyttöoikeusryhmä] = Nil
 
-  val oppilaitosKatselija = add(OrganisaationKäyttöoikeusryhmä("koski-oppilaitos-katselija", "oman organisaation suoritus- ja opiskeluoikeustietojen katselu", List(Palvelurooli(READ), Palvelurooli(LUOTTAMUKSELLINEN))))
-  val oppilaitosTodistuksenMyöntäjä = add(OrganisaationKäyttöoikeusryhmä("koski-oppilaitos-todistuksen-myöntäjä", "Tietojen hyväksyntä (tutkinnon myöntäjä, ts. todistuksen myöntäjä (tutkinnon/tutkinnon osan)) Tutkinto/tutkinnon osa vahvistetaan. Tämän jälkeen tutkintoa/tutkinnon osaa ei voida muokata rajapinnan/kälin kautta.", List(Palvelurooli(READ))))
-  val oppilaitosTallentaja = add(OrganisaationKäyttöoikeusryhmä("koski-oppilaitos-tallentaja", "tietojen muokkaaminen (suoritus ja opiskelijatietojen tallentaja, oppilaitos: lisäys, muokkaus) käyttöliittymässä", List(Palvelurooli(READ), Palvelurooli(READ_UPDATE), Palvelurooli(LUOTTAMUKSELLINEN))))
-  val oppilaitosPalvelukäyttäjä = add(OrganisaationKäyttöoikeusryhmä("koski-oppilaitos-palvelukäyttäjä", "palvelutunnus tiedonsiirroissa: tietojen muokkaaminen (suoritus ja opiskelijatietojen tallentaja, oppilaitos: lisäys, muokkaus, passivointi)", List(Palvelurooli(READ), Palvelurooli(READ_UPDATE), Palvelurooli(TIEDONSIIRTO), Palvelurooli(LUOTTAMUKSELLINEN))))
-  val oppilaitosPääkäyttäjä = add(OrganisaationKäyttöoikeusryhmä("koski-oppilaitos-pääkäyttäjä", "tietojen katselu ja mitätöinti käyttöliittymässä", List(Palvelurooli(READ), Palvelurooli(TIEDONSIIRRON_MITATOINTI), Palvelurooli(LUOTTAMUKSELLINEN))))
+  val oppilaitosKatselija = add(OrganisaationKäyttöoikeusryhmä("KOSKI-katselija", "oman organisaation suoritus- ja opiskeluoikeustietojen katselu", List(Palvelurooli(READ), Palvelurooli(LUOTTAMUKSELLINEN))))
+  val oppilaitosTallentaja = add(OrganisaationKäyttöoikeusryhmä("KOSKI-tallentaja", "tietojen muokkaaminen (suoritus ja opiskelijatietojen tallentaja, oppilaitos: lisäys, muokkaus) käyttöliittymässä", List(Palvelurooli(READ), Palvelurooli(READ_UPDATE), Palvelurooli(LUOTTAMUKSELLINEN))))
+  val oppilaitosPalvelukäyttäjä = add(OrganisaationKäyttöoikeusryhmä("KOSKI-palvelukäyttäjä", "palvelutunnus tiedonsiirroissa: tietojen muokkaaminen (suoritus ja opiskelijatietojen tallentaja, oppilaitos: lisäys, muokkaus, passivointi)", List(Palvelurooli(READ), Palvelurooli(READ_UPDATE), Palvelurooli(TIEDONSIIRTO), Palvelurooli(LUOTTAMUKSELLINEN))))
+  val oppilaitosPääkäyttäjä = add(OrganisaationKäyttöoikeusryhmä("KOSKI-pääkäyttäjä", "tietojen katselu ja mitätöinti käyttöliittymässä", List(Palvelurooli(READ), Palvelurooli(TIEDONSIIRRON_MITATOINTI), Palvelurooli(LUOTTAMUKSELLINEN))))
   val vastuukäyttäjä = add(OrganisaationKäyttöoikeusryhmä("Vastuukayttajat", "organisaation vastuukäyttäjä, jolle Koski lähettää tiedonsiirtojen virhe-sähköpostit", List(Palvelurooli(READ))))
 
   val ophPääkäyttäjä = add(GlobaaliKäyttöoikeusryhmä("koski-oph-pääkäyttäjä", "CRUP-oikeudet (lisäys, muokkaus, passivointi) Koskessa", List(Palvelurooli(OPHPAAKAYTTAJA), Palvelurooli(YLLAPITAJA), Palvelurooli(LUOTTAMUKSELLINEN))))

--- a/src/main/scala/fi/oph/koski/koskiuser/Kayttooikeusryhma.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/Kayttooikeusryhma.scala
@@ -8,6 +8,6 @@ sealed trait Käyttöoikeusryhmä {
   override def toString = "Käyttöoikeusryhmä " + nimi
 }
 
-case class OrganisaationKäyttöoikeusryhmä private[koskiuser](val nimi: String, val kuvaus: String, val palveluroolit: List[Palvelurooli] = Nil) extends Käyttöoikeusryhmä
+case class OrganisaationKäyttöoikeusryhmä private[koskiuser](nimi: String, tunniste: String, kuvaus: String, palveluroolit: List[Palvelurooli] = Nil) extends Käyttöoikeusryhmä
 
-case class GlobaaliKäyttöoikeusryhmä private[koskiuser](val nimi: String, val kuvaus: String, val palveluroolit: List[Palvelurooli] = Nil) extends Käyttöoikeusryhmä
+case class GlobaaliKäyttöoikeusryhmä private[koskiuser](nimi: String, kuvaus: String, palveluroolit: List[Palvelurooli] = Nil) extends Käyttöoikeusryhmä

--- a/src/main/scala/fi/oph/koski/koskiuser/MockUsers.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/MockUsers.scala
@@ -29,12 +29,15 @@ object MockUsers {
   val helsinginKaupunkiPalvelukäyttäjä = MockUser("stadin-palvelu", "stadin-palvelu", "1.2.246.562.24.99999999994", Set((MockOrganisaatiot.helsinginKaupunki, oppilaitosPalvelukäyttäjä)))
   val stadinAmmattiopistoTallentaja = MockUser("tallentaja", "tallentaja", "1.2.246.562.24.99999999995", Set((MockOrganisaatiot.stadinAmmattiopisto, oppilaitosTallentaja)))
   val stadinAmmattiopistoKatselija = MockUser("katselija", "katselija", "1.2.246.562.24.99999999985", Set((MockOrganisaatiot.stadinAmmattiopisto, oppilaitosKatselija)))
+  val stadinAmmattiopistoPääkäyttäjä = MockUser("stadinammattiopisto-admin", "stadinammattiopisto-admin", "1.2.246.562.24.99999999986", Set((MockOrganisaatiot.stadinAmmattiopisto, oppilaitosPääkäyttäjä)))
   val stadinVastuukäyttäjä = MockUser("stadin-vastuu", "stadin-vastuu", "1.2.246.562.24.99999999996", Set((MockOrganisaatiot.helsinginKaupunki, vastuukäyttäjä)))
   val stadinPääkäyttäjä = MockUser("stadin-pää", "stadin-pää", "1.2.246.562.24.99999999997", Set((MockOrganisaatiot.helsinginKaupunki, oppilaitosPääkäyttäjä)))
   val hkiTallentaja = MockUser("hki-tallentaja", "hki-tallentaja", "1.2.246.562.24.99999999977", Set((MockOrganisaatiot.helsinginKaupunki, oppilaitosTallentaja)))
   val kahdenOrganisaatioPalvelukäyttäjä = MockUser("palvelu2", "palvelu2", "1.2.246.562.24.99999999998", Set((MockOrganisaatiot.helsinginKaupunki, oppilaitosPalvelukäyttäjä), (MockOrganisaatiot.omnia, oppilaitosPalvelukäyttäjä)))
   val omattiedot = MockUser("Oppija", "Oili", "1.2.246.562.24.99999999999", Set((omnia, oppilaitosTallentaja)))
   val eiOikkia = MockUser("EiOikkia", "Otto", "1.2.246.562.24.99999999902", Set())
+  val jyväskylänNormaalikoulunPalvelukäyttäjä = MockUser("jyväs-palvelu", "jyväs-palvelu", "1.2.246.562.24.99999999777", Set((MockOrganisaatiot.jyväskylänNormaalikoulu, oppilaitosPalvelukäyttäjä)))
+  val jyväskylänYliopistonVastuukäyttäjä = MockUser("jyväs-vastuu", "jyväs-vastuu", "1.2.246.562.24.99999997777", Set((MockOrganisaatiot.jyväskylänYliopisto, vastuukäyttäjä)))
 
   val users = List(
     kalle,
@@ -46,6 +49,7 @@ object MockUsers {
     paakayttaja,
     viranomainen,
     helsinginKaupunkiPalvelukäyttäjä,
+    stadinAmmattiopistoPääkäyttäjä,
     stadinAmmattiopistoTallentaja,
     stadinAmmattiopistoKatselija,
     kahdenOrganisaatioPalvelukäyttäjä,
@@ -54,7 +58,9 @@ object MockUsers {
     stadinPääkäyttäjä,
     tallentajaEiLuottamuksellinen,
     hkiTallentaja,
-    eiOikkia
+    eiOikkia,
+    jyväskylänNormaalikoulunPalvelukäyttäjä,
+    jyväskylänYliopistonVastuukäyttäjä
   )
 }
 

--- a/src/main/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoFailureMailer.scala
+++ b/src/main/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoFailureMailer.scala
@@ -12,7 +12,7 @@ import fi.oph.koski.schema.OrganisaatioWithOid
 class TiedonsiirtoFailureMailer(config: Config, authenticationServiceClient: OpintopolkuHenkilöFacade) extends Logging {
   private val sendTimes = scala.collection.mutable.Map[String, LocalDateTime]()
   private val sender = EmailSender(config)
-  private val koskiPääkäyttäjät = "KOSKI-pääkäyttäjä"
+  private val koskiPääkäyttäjät = "koski-oppilaitos-pääkäyttäjä_1494486198456"
   private val vastuukayttajat = "Vastuukayttajat"
 
   def sendMail(rootOrg: OrganisaatioWithOid, oppilaitos: Option[OrganisaatioWithOid]): Unit = try {

--- a/src/main/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoFailureMailer.scala
+++ b/src/main/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoFailureMailer.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.Config
 import fi.oph.koski.email._
 import fi.oph.koski.henkilo.OpintopolkuHenkilöFacade
 import fi.oph.koski.log.Logging
-import fi.oph.koski.schema.{Koulutustoimija, Oppilaitos, OrganisaatioWithOid}
+import fi.oph.koski.schema.OrganisaatioWithOid
 
 class TiedonsiirtoFailureMailer(config: Config, authenticationServiceClient: OpintopolkuHenkilöFacade) extends Logging {
   private val sendTimes = scala.collection.mutable.Map[String, LocalDateTime]()
@@ -15,14 +15,17 @@ class TiedonsiirtoFailureMailer(config: Config, authenticationServiceClient: Opi
   private val koskiPääkäyttäjät = "KOSKI-pääkäyttäjä"
   private val vastuukayttajat = "Vastuukayttajat"
 
-  def sendMail(rootOrg: OrganisaatioWithOid, oppilaitokset: List[OrganisaatioWithOid]): Unit = {
-    val emails = oppilaitokset.flatMap(oppilaitosSähköpostit) match {
+  def sendMail(rootOrg: OrganisaatioWithOid, oppilaitos: Option[OrganisaatioWithOid]): Unit = {
+    if (!shouldSendMail(rootOrg, oppilaitos)) {
+      return
+    }
+    val emails = oppilaitosSähköpostit(oppilaitos) match {
       case Nil => rootOrgSähköpostit(rootOrg)
       case emailAddresses => emailAddresses
     }
 
     emails.distinct match {
-      case Nil => logger.info(s"Organisaatioille ${(rootOrg :: oppilaitokset).map(_.oid).mkString(", ")} ei löydy sähköpostiosoitetta")
+      case Nil => logger.info(s"Organisaatioille ${(rootOrg.oid +: oppilaitos.toList.map(_.oid)).mkString(" ja ")} ei löydy sähköpostiosoitetta")
       case emailAddresses =>
         val mail: Email = Email(EmailContent(
           "no-reply@opintopolku.fi",
@@ -35,32 +38,24 @@ class TiedonsiirtoFailureMailer(config: Config, authenticationServiceClient: Opi
     }
   }
 
-  private def shouldSendMail(organisaatio: String) = sendTimes.synchronized {
+  private def shouldSendMail(rootOrg: OrganisaatioWithOid, organisaatio: Option[OrganisaatioWithOid]) = sendTimes.synchronized {
     val limit = now().minusHours(24)
-    if (!sendTimes.getOrElse(organisaatio, limit).isAfter(limit)) {
-      sendTimes.put(organisaatio, now())
+    val key = rootOrg.oid + organisaatio.map(_.oid).getOrElse("")
+    if (!sendTimes.getOrElse(key, limit).isAfter(limit)) {
+      sendTimes.put(key, now())
       true
     } else {
       false
     }
   }
 
-  private def rootOrgSähköpostit(k: OrganisaatioWithOid): List[String] = {
-    if (!shouldSendMail(k.oid)) {
-      return Nil
-    }
-    organisaatioSähköpostit(k.oid, koskiPääkäyttäjät) match {
-      case Nil => organisaatioSähköpostit(k.oid, vastuukayttajat)
-      case emails => emails
-    }
+  private def rootOrgSähköpostit(k: OrganisaatioWithOid) = organisaatioSähköpostit(k.oid, koskiPääkäyttäjät) match {
+    case Nil => organisaatioSähköpostit(k.oid, vastuukayttajat)
+    case emails => emails
   }
 
-  private def oppilaitosSähköpostit(org: OrganisaatioWithOid): List[String] = {
-    if (!shouldSendMail(org.oid)) {
-      return Nil
-    }
-    organisaatioSähköpostit(org.oid, koskiPääkäyttäjät)
-  }
+  private def oppilaitosSähköpostit(org: Option[OrganisaatioWithOid]) =
+    org.toList.flatMap(o => organisaatioSähköpostit(o.oid, koskiPääkäyttäjät))
 
   private def organisaatioSähköpostit(oid: String, ryhmä: String): List[String] = {
     authenticationServiceClient.organisaationSähköpostit(oid, ryhmä)

--- a/src/main/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoFailureMailer.scala
+++ b/src/main/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoFailureMailer.scala
@@ -7,31 +7,35 @@ import com.typesafe.config.Config
 import fi.oph.koski.email._
 import fi.oph.koski.henkilo.OpintopolkuHenkilöFacade
 import fi.oph.koski.log.Logging
+import fi.oph.koski.schema.{Koulutustoimija, Oppilaitos, OrganisaatioWithOid}
 
 class TiedonsiirtoFailureMailer(config: Config, authenticationServiceClient: OpintopolkuHenkilöFacade) extends Logging {
-  val sendTimes = scala.collection.mutable.Map[String, LocalDateTime]()
-  val sender = EmailSender(config)
-  val ryhmä = "Vastuukayttajat"
+  private val sendTimes = scala.collection.mutable.Map[String, LocalDateTime]()
+  private val sender = EmailSender(config)
+  private val koskiPääkäyttäjät = "KOSKI-pääkäyttäjä"
+  private val vastuukayttajat = "Vastuukayttajat"
 
-  def sendMail(organisaatioOid: String): Unit = {
-    val emailAddresses: List[String] = authenticationServiceClient.organisaationSähköpostit(organisaatioOid, ryhmä)
+  def sendMail(rootOrg: OrganisaatioWithOid, oppilaitokset: List[OrganisaatioWithOid]): Unit = {
+    val emails = oppilaitokset.flatMap(oppilaitosSähköpostit) match {
+      case Nil => rootOrgSähköpostit(rootOrg)
+      case emailAddresses => emailAddresses
+    }
 
-    emailAddresses match {
-      case Nil => logger.info("Organisaatiolle " + organisaatioOid + " ei löydy sähköpostiosoitetta henkilöille jotka kuuluvat ryhmään " + ryhmä)
-      case _ =>
-        if (shouldSendMail(organisaatioOid)) {
-          val mail: Email = Email(EmailContent(
-            "no-reply@opintopolku.fi",
-            "Virheellinen Koski-tiedonsiirto",
-            "<p>Automaattisessa tiedonsiirrossa tapahtui virhe.</p><p>Käykää ystävällisesti tarkistamassa tapahtuneet tiedonsiirrot osoitteessa: " + config.getString("koski.root.url") + "/tiedonsiirrot</p>",
-            html = true
-          ), emailAddresses.map(EmailRecipient))
-          sender.sendEmail(mail)
-        }
+    emails.distinct match {
+      case Nil => logger.info(s"Organisaatioille ${(rootOrg :: oppilaitokset).map(_.oid).mkString(", ")} ei löydy sähköpostiosoitetta")
+      case emailAddresses =>
+        val mail: Email = Email(EmailContent(
+          "no-reply@opintopolku.fi",
+          "Virheellinen Koski-tiedonsiirto",
+          "<p>Automaattisessa tiedonsiirrossa tapahtui virhe.</p><p>Käykää ystävällisesti tarkistamassa tapahtuneet tiedonsiirrot osoitteessa: " + config.getString("koski.root.url") + "/tiedonsiirrot</p>",
+          html = true
+        ), emailAddresses.map(EmailRecipient))
+        logger.debug(s"Sending failure mail to ${emailAddresses.mkString(",")}")
+        sender.sendEmail(mail)
     }
   }
 
-  def shouldSendMail(organisaatio: String) = sendTimes.synchronized {
+  private def shouldSendMail(organisaatio: String) = sendTimes.synchronized {
     val limit = now().minusHours(24)
     if (!sendTimes.getOrElse(organisaatio, limit).isAfter(limit)) {
       sendTimes.put(organisaatio, now())
@@ -39,5 +43,26 @@ class TiedonsiirtoFailureMailer(config: Config, authenticationServiceClient: Opi
     } else {
       false
     }
+  }
+
+  private def rootOrgSähköpostit(k: OrganisaatioWithOid): List[String] = {
+    if (!shouldSendMail(k.oid)) {
+      return Nil
+    }
+    organisaatioSähköpostit(k.oid, koskiPääkäyttäjät) match {
+      case Nil => organisaatioSähköpostit(k.oid, vastuukayttajat)
+      case emails => emails
+    }
+  }
+
+  private def oppilaitosSähköpostit(org: OrganisaatioWithOid): List[String] = {
+    if (!shouldSendMail(org.oid)) {
+      return Nil
+    }
+    organisaatioSähköpostit(org.oid, koskiPääkäyttäjät)
+  }
+
+  private def organisaatioSähköpostit(oid: String, ryhmä: String): List[String] = {
+    authenticationServiceClient.organisaationSähköpostit(oid, ryhmä)
   }
 }

--- a/src/main/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoService.scala
+++ b/src/main/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoService.scala
@@ -136,7 +136,7 @@ class TiedonsiirtoService(
 
       if (error.isDefined) {
         tiedonSiirtoVirheet.inc
-        mailer.sendMail(org.oid)
+        mailer.sendMail(org, oppilaitokset.toList.flatten)
       }
     })
   }

--- a/src/main/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoService.scala
+++ b/src/main/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoService.scala
@@ -136,7 +136,10 @@ class TiedonsiirtoService(
 
       if (error.isDefined) {
         tiedonSiirtoVirheet.inc
-        mailer.sendMail(org, oppilaitokset.toList.flatten)
+        oppilaitokset.toList.flatten match {
+          case Nil => mailer.sendMail(org, None)
+          case orgs => orgs.foreach(o => mailer.sendMail(org, Some(o)))
+        }
       }
     })
   }

--- a/src/test/scala/fi/oph/koski/api/TiedonsiirtoSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/TiedonsiirtoSpec.scala
@@ -43,7 +43,7 @@ class TiedonsiirtoSpec extends FreeSpec with LocalJettyHttpSpecification with Op
             "Virheellinen Koski-tiedonsiirto",
             "<p>Automaattisessa tiedonsiirrossa tapahtui virhe.</p><p>Käykää ystävällisesti tarkistamassa tapahtuneet tiedonsiirrot osoitteessa: http://localhost:7021/koski/tiedonsiirrot</p>",
             true),
-          List(EmailRecipient("stadin-vastuu@example.com")))))
+          List(EmailRecipient("stadinammattiopisto-admin@example.com")))))
       }
 
       "toisesta peräkkäisestä epäonnistuneesta tiedonsiirrosta ei lähetetä emailia" in {

--- a/src/test/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoFailureMailerSpec.scala
+++ b/src/test/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoFailureMailerSpec.scala
@@ -7,7 +7,7 @@ import fi.oph.koski.schema.OidOrganisaatio
 import org.scalatest.{BeforeAndAfterEach, FreeSpec, Matchers}
 
 class TiedonsiirtoFailureMailerSpec extends FreeSpec with Matchers with BeforeAndAfterEach {
-  private val mailer = new TiedonsiirtoFailureMailer(KoskiApplicationForTests.config, KoskiApplicationForTests.opintopolkuHenkilöFacade)
+  private val mailer = new TiedonsiirtoFailureMailer(KoskiApplicationForTests)
   "Lähettää sähköpostia" - {
     "oppilaitoksen KOSKI-pääkäyttäjä:lle jos mahdollista" in {
       mailer.sendMail(OidOrganisaatio(helsinginKaupunki), Some(OidOrganisaatio(stadinAmmattiopisto)))

--- a/src/test/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoFailureMailerSpec.scala
+++ b/src/test/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoFailureMailerSpec.scala
@@ -10,17 +10,17 @@ class TiedonsiirtoFailureMailerSpec extends FreeSpec with Assertions with Matche
   private val mailer = new TiedonsiirtoFailureMailer(KoskiApplicationForTests.config, KoskiApplicationForTests.opintopolkuHenkilöFacade)
   "Lähettää sähköpostia" - {
     "oppilaitoksen KOSKI-pääkäyttäjä:lle jos mahdollista" in {
-      mailer.sendMail(OidOrganisaatio(helsinginKaupunki), List(OidOrganisaatio(stadinAmmattiopisto)))
+      mailer.sendMail(OidOrganisaatio(helsinginKaupunki), Some(OidOrganisaatio(stadinAmmattiopisto)))
       MockEmailSender.checkMail should equal(List(expectedEmail("stadinammattiopisto-admin@example.com")))
     }
 
     "sitten juuriorganisaation KOSKI-pääkäyttäjä:lle jos mahdollista" in {
-      mailer.sendMail(OidOrganisaatio(helsinginKaupunki), List(OidOrganisaatio(omnia)))
+      mailer.sendMail(OidOrganisaatio(helsinginKaupunki), Some(OidOrganisaatio(omnia)))
       MockEmailSender.checkMail should equal(List(expectedEmail("stadin-pää@example.com")))
     }
 
     "viimeiseksi juuriorganisaation Vastuukayttaja:lle" in {
-      mailer.sendMail(OidOrganisaatio(jyväskylänYliopisto), List(OidOrganisaatio(jyväskylänNormaalikoulu)))
+      mailer.sendMail(OidOrganisaatio(jyväskylänYliopisto), Some(OidOrganisaatio(jyväskylänNormaalikoulu)))
       MockEmailSender.checkMail should equal(List(expectedEmail("jyväs-vastuu@example.com")))
     }
   }

--- a/src/test/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoFailureMailerSpec.scala
+++ b/src/test/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoFailureMailerSpec.scala
@@ -4,9 +4,9 @@ import fi.oph.koski.KoskiApplicationForTests
 import fi.oph.koski.email.{Email, EmailContent, EmailRecipient, MockEmailSender}
 import fi.oph.koski.organisaatio.MockOrganisaatiot._
 import fi.oph.koski.schema.OidOrganisaatio
-import org.scalatest.{Assertions, FreeSpec, Matchers}
+import org.scalatest.{BeforeAndAfterEach, FreeSpec, Matchers}
 
-class TiedonsiirtoFailureMailerSpec extends FreeSpec with Assertions with Matchers {
+class TiedonsiirtoFailureMailerSpec extends FreeSpec with Matchers with BeforeAndAfterEach {
   private val mailer = new TiedonsiirtoFailureMailer(KoskiApplicationForTests.config, KoskiApplicationForTests.opintopolkuHenkilöFacade)
   "Lähettää sähköpostia" - {
     "oppilaitoksen KOSKI-pääkäyttäjä:lle jos mahdollista" in {
@@ -24,6 +24,8 @@ class TiedonsiirtoFailureMailerSpec extends FreeSpec with Assertions with Matche
       MockEmailSender.checkMail should equal(List(expectedEmail("jyväs-vastuu@example.com")))
     }
   }
+
+  override def beforeEach = MockEmailSender.checkMail
 
   private def expectedEmail(emailAddress: String) = Email(
     EmailContent(

--- a/src/test/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoFailureMailerSpec.scala
+++ b/src/test/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoFailureMailerSpec.scala
@@ -1,0 +1,35 @@
+package fi.oph.koski.tiedonsiirto
+
+import fi.oph.koski.KoskiApplicationForTests
+import fi.oph.koski.email.{Email, EmailContent, EmailRecipient, MockEmailSender}
+import fi.oph.koski.organisaatio.MockOrganisaatiot._
+import fi.oph.koski.schema.OidOrganisaatio
+import org.scalatest.{Assertions, FreeSpec, Matchers}
+
+class TiedonsiirtoFailureMailerSpec extends FreeSpec with Assertions with Matchers {
+  private val mailer = new TiedonsiirtoFailureMailer(KoskiApplicationForTests.config, KoskiApplicationForTests.opintopolkuHenkilöFacade)
+  "Lähettää sähköpostia" - {
+    "oppilaitoksen KOSKI-pääkäyttäjä:lle jos mahdollista" in {
+      mailer.sendMail(OidOrganisaatio(helsinginKaupunki), List(OidOrganisaatio(stadinAmmattiopisto)))
+      MockEmailSender.checkMail should equal(List(expectedEmail("stadinammattiopisto-admin@example.com")))
+    }
+
+    "sitten juuriorganisaation KOSKI-pääkäyttäjä:lle jos mahdollista" in {
+      mailer.sendMail(OidOrganisaatio(helsinginKaupunki), List(OidOrganisaatio(omnia)))
+      MockEmailSender.checkMail should equal(List(expectedEmail("stadin-pää@example.com")))
+    }
+
+    "viimeiseksi juuriorganisaation Vastuukayttaja:lle" in {
+      mailer.sendMail(OidOrganisaatio(jyväskylänYliopisto), List(OidOrganisaatio(jyväskylänNormaalikoulu)))
+      MockEmailSender.checkMail should equal(List(expectedEmail("jyväs-vastuu@example.com")))
+    }
+  }
+
+  private def expectedEmail(emailAddress: String) = Email(
+    EmailContent(
+      "no-reply@opintopolku.fi",
+      "Virheellinen Koski-tiedonsiirto",
+      "<p>Automaattisessa tiedonsiirrossa tapahtui virhe.</p><p>Käykää ystävällisesti tarkistamassa tapahtuneet tiedonsiirrot osoitteessa: http://localhost:7021/koski/tiedonsiirrot</p>",
+      html = true),
+    List(EmailRecipient(emailAddress)))
+}

--- a/web/test/spec/raporttiSpec.js
+++ b/web/test/spec/raporttiSpec.js
@@ -98,11 +98,11 @@ describe('Raportti', function() {
     })
 
     it('palvelukäyttäjäoikeuksien määrä', function () {
-      expect(page.metric('käyttöoikeusien-määrä-koski-oppilaitos-palvelukäyttäjä').value() >= 0).to.equal(true)
+      expect(page.metric('käyttöoikeusien-määrä-KOSKI-palvelukäyttäjä').value() >= 0).to.equal(true)
     })
 
     it('tallentajaoikeuksien määrä', function () {
-      expect(page.metric('käyttöoikeusien-määrä-koski-oppilaitos-tallentaja').value() >= 0).to.equal(true)
+      expect(page.metric('käyttöoikeusien-määrä-KOSKI-tallentaja').value() >= 0).to.equal(true)
     })
 
     it('pääkäyttäjien määrä', function () {
@@ -114,7 +114,7 @@ describe('Raportti', function() {
     })
 
     it('oppilaitoskatselijaoikeuksien määrä', function () {
-      expect(page.metric('käyttöoikeusien-määrä-koski-oppilaitos-katselija').value() >= 0).to.equal(true)
+      expect(page.metric('käyttöoikeusien-määrä-KOSKI-katselija').value() >= 0).to.equal(true)
     })
 
     it('vastuukäyttäjien määrä', function () {


### PR DESCRIPTION
Disabloitu kaikissa ympäristöissä konffivivulla (https://github.com/Opetushallitus/koski-env/commit/8f03ecd83ebee7a30e4f7dcee8f8af67a9453d96), otetaan käyttöön vasta kun oppilashallintajärjestelmät ottavat automaattisen tiedonsiiirron käyttöön.