### PR TITLE
Fix JavaScript Date parsing/formatting if system time zone is west of UTC

### DIFF
--- a/web/app/date/date.js
+++ b/web/app/date/date.js
@@ -1,14 +1,14 @@
 import fecha from 'fecha'
 
 const finnishDateRE = /([0-3]?\d)\.([0-2]?\d)\.(\d\d\d\d)/
-export const formatISODate = (date) => date.toISOString().substring(0, 10)
+export const formatISODate = (date) => format(date, 'YYYY-MM-DD')
 export const parseFinnishDate = (dateStr) => {
   let match = dateStr.match(finnishDateRE)
   if (match) {
     let year = parseInt(match[3], 10)
     let month = parseInt(match[2], 10) - 1
     let day = parseInt(match[1], 10)
-    var date = new Date(Date.UTC(year, month, day))
+    var date = new Date(year, month, day)
     if (date && date.getDate() === day && date.getMonth() === month) {
       return date
     }
@@ -20,9 +20,8 @@ export const ISO2FinnishDateTime = (date) => formatFinnishDateTime(parseISODateT
 export const parseISODate = (date) => fecha.parse(date, 'YYYY-MM-DD')
 export const formatFinnishDate = (date) => format(date, 'D.M.YYYY')
 export const yearFromIsoDateString = dateString => {
-  const year = dateString && new Date(dateString).getFullYear()
-  if (Number.isNaN(year)) return ''
-  return year
+  const date = parseISODate(dateString)
+  return (date && date.getFullYear()) || ''
 }
 
 export const ISO2FinnishDate = (date) => date && formatFinnishDate(parseISODate(date))

--- a/web/app/opiskeluoikeus/OpiskeluoikeudenTilaEditor.jsx
+++ b/web/app/opiskeluoikeus/OpiskeluoikeudenTilaEditor.jsx
@@ -40,7 +40,7 @@ export const OpiskeluoikeudenTilaEditor = ({model, alkuChangeBus}) => {
   }
 
   let showLisaaTila = wrappedModel.context.edit && !onLopputilassa(wrappedModel)
-  let edellisenTilanAlkupäivä = modelData(items[0], 'alku') && new Date(modelData(items[0], 'alku'))
+  let edellisenTilanAlkupäivä = modelData(items[0], 'alku') && parseISODate(modelData(items[0], 'alku'))
 
   return (
       <div>


### PR DESCRIPTION
Tilanne tällä hetkellä:

- `formatISODate` olettaa inputtina JavaScript Date:n, joka on ko. päivämäärän keskiyö UTC:ssä (ja toimii väärin, jos selaimen aikavyöhyke on UTC:stä länteen)
- `parseFinnishDate` palauttaa ko. päivämäärän keskiyön UTC:ssä jos selaimen aikavyöhyke on UTC:stä itään, ja on rikki jos selaimen aikavyöhyke on länteen.
- `parseISODate` (samassa tiedossa) palauttaa JavaScript Date:n, joka on ko. päivämäärän keskiyö selaimen aikavyöhykkeessä

En ole 100% varma mikä olisi paras mahdollinen ratkaisu (varmaankin erillinen tietotyyppi ala LocalDate, mutta se on isompi muutos), mutta tämä pullari korjaa tilanteen niin, että käytetään aina ko. päivämäärän keskiyötä selaimen aikavyöhykkeessä.

Nyt nämä funkkarit joihin on koskettu pitäisi toimia oikein riippumatta onko selaimen aikavyöhyke itään vai länteen UTC:stä, toivottavasti missään muualla ei ole koodia joka olettaa jotain... 
