### PR TITLE
Korjaa kansalaiselle välähtävä 'Ei suorituksia'

### DIFF
--- a/web/app/EiSuorituksia.jsx
+++ b/web/app/EiSuorituksia.jsx
@@ -1,20 +1,12 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import './style/main.less'
-import {TiedotPalvelussa} from './omattiedot/TiedotPalvelussa'
-
-export const EiSuorituksia = () => (
-  <div className='ei-suorituksia'>
-    <h2>{'Tiedoillasi ei löydy opintosuorituksia eikä opiskeluoikeuksia.'}</h2>
-    <TiedotPalvelussa/>
-    <p>{'Mikäli tiedoistasi puuttuu opintosuorituksia tai opiskeluoikeuksia, joiden kuuluisi ylläolevien tietojen perusteella näkyä Koski-palvelussa, voit ilmoittaa asiasta oppilaitoksellesi.'}</p>
-  </div>
-)
+import {EiSuorituksiaInfo} from './omattiedot/EiSuorituksiaInfo'
 
 ReactDOM.render((
   <div>
     <div className='koski-heading'><h1>{'KOSKI'}</h1></div>
-    <EiSuorituksia/>
+    <EiSuorituksiaInfo/>
   </div>
 ), document.getElementById('content'))
 

--- a/web/app/OmatTiedot.jsx
+++ b/web/app/OmatTiedot.jsx
@@ -13,8 +13,8 @@ import editorMapping from './oppija/editors'
 import {userP} from './util/user'
 import {addContext, modelData} from './editor/EditorModel'
 import {locationP} from './util/location'
-import {EiSuorituksia} from './EiSuorituksia'
 import {Header} from './omattiedot/header/Header'
+import {EiSuorituksiaInfo} from './omattiedot/EiSuorituksiaInfo'
 
 const omatTiedotP = () => Bacon.combineWith(
   Http.cachedGet('/koski/api/omattiedot/editor', { errorMapper: (e) => e.httpStatus === 404 ? null : new Bacon.Error(e)}).toProperty(),
@@ -29,7 +29,7 @@ const topBarP = userP.map(user => <OmatTiedotTopBar user={user}/>)
 const contentP = locationP.flatMapLatest(() => omatTiedotP().map(oppija =>
     oppija
       ? <div className="main-content oppija"><Oppija oppija={Editor.setupContext(oppija, {editorMapping})} stateP={Bacon.constant('viewing')}/></div>
-      : <div className="main-content"><EiSuorituksia/></div>
+      : <div className="main-content"><EiSuorituksiaInfo/></div>
     )
 ).toProperty().startWith(<div className="main-content ajax-indicator-bg"><Text name="Ladataan..."/></div>)
 

--- a/web/app/omattiedot/EiSuorituksiaInfo.jsx
+++ b/web/app/omattiedot/EiSuorituksiaInfo.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import {TiedotPalvelussa} from './TiedotPalvelussa'
+
+export const EiSuorituksiaInfo = () => (
+  <div className='ei-suorituksia'>
+    <h2>{'Tiedoillasi ei löydy opintosuorituksia eikä opiskeluoikeuksia.'}</h2>
+    <TiedotPalvelussa/>
+    <p>{'Mikäli tiedoistasi puuttuu opintosuorituksia tai opiskeluoikeuksia, joiden kuuluisi ylläolevien tietojen perusteella näkyä Koski-palvelussa, voit ilmoittaa asiasta oppilaitoksellesi.'}</p>
+  </div>
+)


### PR DESCRIPTION
Kansalaiselle näytetään lyhyen aikaa "ei suorituksia" -ilmoitus avattaessa omat tiedot -sivua. Korjataan tämä virheellinen näyttäminen.