### PR TITLE
Fix faulty redirects when user session has expired

### DIFF
--- a/src/main/scala/fi/oph/koski/IndexServlet.scala
+++ b/src/main/scala/fi/oph/koski/IndexServlet.scala
@@ -2,7 +2,7 @@ package fi.oph.koski
 
 import fi.oph.koski.config.{Environment, KoskiApplication}
 import fi.oph.koski.http.KoskiErrorCategory
-import fi.oph.koski.koskiuser.AuthenticationSupport
+import fi.oph.koski.koskiuser.{AuthenticationSupport, SessionStatusExpiredKansalainen}
 import fi.oph.koski.servlet.HtmlServlet
 import fi.oph.koski.sso.SSOSupport
 import org.scalatra.ScalatraServlet
@@ -10,6 +10,13 @@ import org.scalatra.ScalatraServlet
 import scala.xml.Unparsed
 
 class IndexServlet(implicit val application: KoskiApplication) extends ScalatraServlet with HtmlServlet with AuthenticationSupport {
+  before("/omattiedot") {
+    sessionOrStatus match {
+      case Left(_) => redirectToFrontpage
+      case Right(_) =>
+    }
+  }
+
   before("/.+".r) {
     if (!isAuthenticated) {
       redirectToLogin

--- a/src/main/scala/fi/oph/koski/koskiuser/KoskiSessionStatus.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/KoskiSessionStatus.scala
@@ -1,0 +1,7 @@
+package fi.oph.koski.koskiuser
+
+trait KoskiSessionStatus
+
+case object SessionStatusExpiredKansalainen extends KoskiSessionStatus
+case object SessionStatusExpiredVirkailija extends KoskiSessionStatus
+case object SessionStatusNoSession extends KoskiSessionStatus

--- a/src/main/scala/fi/oph/koski/koskiuser/LogoutServlet.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/LogoutServlet.scala
@@ -8,7 +8,11 @@ class LogoutServlet(implicit val application: KoskiApplication) extends HtmlServ
   get("/") {
     logger.info("Logged out")
     getUser.right.toOption.flatMap(_.serviceTicket).foreach(application.koskiSessionRepository.removeSessionByTicket)
-    val kansalainen = koskiSessionOption.exists(_.user.kansalainen)
+    val kansalainen = sessionOrStatus match {
+      case Right(session) if session.user.kansalainen => true
+      case Left(SessionStatusExpiredKansalainen) => true
+      case Right(_) | Left(_) => false
+    }
     removeUserCookie
     if (kansalainen) {
       kansalaisLogout


### PR DESCRIPTION
TOR-435

Käyttäjän session vanhennuttua tulisi käyttäjä uudelleenohjata eri
paikkoihin riippuen siitä, onko kyseessä kansalais- vai
virkailijakäyttäjä. Aiemmin kuitenkaan tätä tietoa ei tässä vaiheessa
enää ollut, sillä käyttäjän sessio oli jo poistettu. Kaikki käyttäjät
ohjattiin tässä tilanteessa virkailijan osoitteeseen.

Fix:

- Tarkistetaan vanhentuneesta sessiosta ennen sessiotiedon hävittämistä,
oliko kyseessä kansalais- vai virkailijakäyttäjä. Ohjataan tämän
perusteella käyttäjä oikeaan paikkaan.