### PR TITLE
[WIP] TOR-436 erityisopetuksen toteutuspaikka

### DIFF
--- a/src/main/resources/localization/default-texts.json
+++ b/src/main/resources/localization/default-texts.json
@@ -249,6 +249,7 @@
   "Oppiaineet": "Oppiaineet",
   "Titteli": "Titteli",
   "Opiskelee erityisryhmässä": "Opiskelee erityisryhmässä",
+  "Toteutuspaikka": "Toteutuspaikka",
   "Organisaatio": "Organisaatio",
   "organisaatio": "organisaatio",
   "Arvioitu päättymispäivä": "Arvioitu päättymispäivä",

--- a/src/main/resources/mockdata/koodisto/koodistot/erityisopetuksentoteutuspaikka.json
+++ b/src/main/resources/mockdata/koodisto/koodistot/erityisopetuksentoteutuspaikka.json
@@ -1,0 +1,15 @@
+{
+  "koodistoUri" : "erityisopetuksentoteutuspaikka",
+  "versio" : 1,
+  "metadata" : [ {
+    "kieli" : "FI",
+    "nimi" : "Erityisopetuksen toteutuspaikka",
+    "kuvaus" : "Erityisopetuksen toteutuspaikka"
+  } ],
+  "codesGroupUri" : "http://koski",
+  "voimassaAlkuPvm" : "2018-05-02",
+  "organisaatioOid" : "1.2.246.562.10.00000000001",
+  "withinCodes" : [ ],
+  "tila" : "LUONNOS",
+  "version" : 1
+}

--- a/src/main/resources/mockdata/koodisto/koodit/erityisopetuksentoteutuspaikka.json
+++ b/src/main/resources/mockdata/koodisto/koodit/erityisopetuksentoteutuspaikka.json
@@ -11,7 +11,7 @@
   "koodiUri" : "erityisopetuksentoteutuspaikka_2",
   "koodiArvo" : "2",
   "metadata" : [ {
-    "nimi" : "Opetuksesta 1-49 % on yleisopetuksen ryhmissä",
+    "nimi" : "Opetuksesta 1-19 % on yleisopetuksen ryhmissä",
     "kieli" : "FI"
   } ],
   "versio" : 1,
@@ -20,7 +20,7 @@
   "koodiUri" : "erityisopetuksentoteutuspaikka_3",
   "koodiArvo" : "3",
   "metadata" : [ {
-    "nimi" : "Opetuksesta 50-79 % on yleisopetuksen ryhmissä",
+    "nimi" : "Opetuksesta 20-49 % on yleisopetuksen ryhmissä",
     "kieli" : "FI"
   } ],
   "versio" : 1,
@@ -28,6 +28,15 @@
 }, {
   "koodiUri" : "erityisopetuksentoteutuspaikka_4",
   "koodiArvo" : "4",
+  "metadata" : [ {
+    "nimi" : "Opetuksesta 50-79 % on yleisopetuksen ryhmissä",
+    "kieli" : "FI"
+  } ],
+  "versio" : 1,
+  "withinCodeElements" : [ ]
+}, {
+  "koodiUri" : "erityisopetuksentoteutuspaikka_5",
+  "koodiArvo" : "5",
   "metadata" : [ {
     "nimi" : "Opetuksesta 80-100 % on yleisopetuksen ryhmissä",
     "kieli" : "FI"

--- a/src/main/resources/mockdata/koodisto/koodit/erityisopetuksentoteutuspaikka.json
+++ b/src/main/resources/mockdata/koodisto/koodit/erityisopetuksentoteutuspaikka.json
@@ -1,0 +1,37 @@
+[ {
+  "koodiUri" : "erityisopetuksentoteutuspaikka_1",
+  "koodiArvo" : "1",
+  "metadata" : [ {
+    "nimi" : "Opetus on kokonaan erityisryhmissä tai -luokassa",
+    "kieli" : "FI"
+  } ],
+  "versio" : 1,
+  "withinCodeElements" : [ ]
+}, {
+  "koodiUri" : "erityisopetuksentoteutuspaikka_2",
+  "koodiArvo" : "2",
+  "metadata" : [ {
+    "nimi" : "Opetuksesta 1-49 % on yleisopetuksen ryhmissä",
+    "kieli" : "FI"
+  } ],
+  "versio" : 1,
+  "withinCodeElements" : [ ]
+}, {
+  "koodiUri" : "erityisopetuksentoteutuspaikka_3",
+  "koodiArvo" : "3",
+  "metadata" : [ {
+    "nimi" : "Opetuksesta 50-79 % on yleisopetuksen ryhmissä",
+    "kieli" : "FI"
+  } ],
+  "versio" : 1,
+  "withinCodeElements" : [ ]
+}, {
+  "koodiUri" : "erityisopetuksentoteutuspaikka_4",
+  "koodiArvo" : "4",
+  "metadata" : [ {
+    "nimi" : "Opetuksesta 80-100 % on yleisopetuksen ryhmissä",
+    "kieli" : "FI"
+  } ],
+  "versio" : 1,
+  "withinCodeElements" : [ ]
+} ]

--- a/src/main/scala/fi/oph/koski/koodisto/Koodistot.scala
+++ b/src/main/scala/fi/oph/koski/koodisto/Koodistot.scala
@@ -26,6 +26,7 @@ object Koodistot {
     KoodistoAsetus("arviointiasteikkoyleissivistava"),
     KoodistoAsetus("effortasteikkoib", vaadiSuomenkielinenNimi = false, vaadiRuotsinkielinenNimi = false),
     KoodistoAsetus("erityinenkoulutustehtava"),
+    KoodistoAsetus("erityisopetuksentoteutuspaikka"),
     KoodistoAsetus("koskikoulutustendiaarinumerot"),
     KoodistoAsetus("koskiopiskeluoikeudentila"),
     KoodistoAsetus("koskioppiaineetyleissivistava"),

--- a/src/main/scala/fi/oph/koski/schema/Esiopetus.scala
+++ b/src/main/scala/fi/oph/koski/schema/Esiopetus.scala
@@ -38,7 +38,12 @@ case class EsiopetuksenOpiskeluoikeudenLisätiedot(
   @Description("Tieto mahdollisesta pidennetystä oppivelvollisuudesta alkamis- ja päättymispäivineen.")
   @SensitiveData
   @OksaUri("tmpOKSAID517", "pidennetty oppivelvollisuus")
-  pidennettyOppivelvollisuus: Option[Päätösjakso] = None
+  pidennettyOppivelvollisuus: Option[Päätösjakso] = None,
+  @Description("Erityisen tuen päätös alkamis- ja päättymispäivineen. Kentän puuttuminen tai null-arvo tulkitaan siten, että päätöstä ei ole tehty. Rahoituksen laskennassa käytettävä tieto.")
+  @Tooltip("Mahdollisen erityisen tuen päätöksen alkamis- ja päättymispäivät. Rahoituksen laskennassa käytettävä tieto.")
+  @SensitiveData
+  @OksaUri("tmpOKSAID281", "henkilökohtainen opetuksen järjestämistä koskeva suunnitelma")
+  erityisenTuenPäätös: Option[ErityisenTuenPäätös] = None
 ) extends OpiskeluoikeudenLisätiedot
 
 case class EsiopetuksenSuoritus(

--- a/src/main/scala/fi/oph/koski/schema/NuortenPerusopetus.scala
+++ b/src/main/scala/fi/oph/koski/schema/NuortenPerusopetus.scala
@@ -159,7 +159,9 @@ Huom: toiminta-alue arviointeineen on kuvattu oppiaineen suorituksessa.""")
   @Tooltip("Suorittaako erityisoppilas koulutusta omassa erityisryhmässään vai inklusiivisesti opetuksen mukana.")
   @OksaUri("tmpOKSAID444", "opetusryhmä")
   @Title("Opiskelee erityisryhmässä")
-  erityisryhmässä: Boolean
+  erityisryhmässä: Boolean,
+  @KoodistoUri("erityisopetuksentoteutuspaikka")
+  toteutuspaikka: Option[Koodistokoodiviite] = None
 )
 
 trait PerusopetuksenPäätasonSuoritus extends KoskeenTallennettavaPäätasonSuoritus with Toimipisteellinen with MonikielinenSuoritus with Suorituskielellinen


### PR DESCRIPTION
TOR-436

- Mallinnetaan perusopetukseen ja perusopetuksen lisäopetukseen "eritysen tuen päätös" -tiedon osaksi uusi kenttä "toteutuspaikka", jolla on 4 eri mahdollista arvoa
- Lisätään arvoja varten uusi koodisto "erityisopetuksen toteutuspaikka"
- Lisätään koko erityisen tuen päätös -rakenne tässä muodossa myös esiopetukselle