### PR TITLE
Piilotetaan opiskeluoikeusoid ja versiohistoria

### DIFF
--- a/web/app/opiskeluoikeus/OpiskeluoikeusEditor.jsx
+++ b/web/app/opiskeluoikeus/OpiskeluoikeusEditor.jsx
@@ -105,7 +105,8 @@ const OpiskeluoikeudenId = ({opiskeluoikeus}) => {
     sel.removeAllRanges()
     sel.addRange(range)
   }
-  return <span className="id"><Text name="Opiskeluoikeuden oid"/>{': '}<span className="value" onClick={selectAllText}>{modelData(opiskeluoikeus, 'oid')}</span></span>
+  const opiskeluoikeusOid = modelData(opiskeluoikeus, 'oid')
+  return opiskeluoikeusOid ? <span className="id"><Text name="Opiskeluoikeuden oid"/>{': '}<span className="value" onClick={selectAllText}>{opiskeluoikeusOid}</span></span> : null
 }
 
 const OpiskeluoikeudenVoimassaoloaika = ({opiskeluoikeus}) => {

--- a/web/app/opiskeluoikeus/Versiohistoria.jsx
+++ b/web/app/opiskeluoikeus/Versiohistoria.jsx
@@ -24,7 +24,7 @@ export default class Versiohistoria extends BaconComponent {
     }
     let selectedVersion = this.versionumero() || history.length
     return (
-      <div className={'versiohistoria'+(showHistory?' open':'')}>
+      opiskeluoikeusOid ? <div className={'versiohistoria'+(showHistory?' open':'')}>
         <a onClick={() => toggle()}><Text name="Versiohistoria"/></a>
         {showHistory && (
           <div className="modal">
@@ -41,7 +41,7 @@ export default class Versiohistoria extends BaconComponent {
             }</ol>
           </div>
         )}
-      </div>
+      </div> : null
     )
   }
   componentWillMount() {


### PR DESCRIPTION
Opiskeluoikeuksilla, joita ei tallenneta Koskeen, ei ole opiskeluoikeusoid:a eikä versiohistoriaa.
Piilotetaan nämä käyttäliittymästä, jos opiskeluoikeudella ei ole oidia