### PR TITLE
Properties editor ei printtaa tyhjiä tauluja

### DIFF
--- a/web/app/editor/PropertiesEditor.jsx
+++ b/web/app/editor/PropertiesEditor.jsx
@@ -53,11 +53,12 @@ export class PropertiesEditor extends React.Component {
       }
     }
 
-    return (<div className={ buildClassNames(['properties', className]) }>
+    const tableContents = flatMapArray(properties.filter(shouldShow), munch(''));
+    return (tableContents && tableContents.length > 0 ? <div className={ buildClassNames(['properties', className]) }>
       <table><tbody>
-      { flatMapArray(properties.filter(shouldShow), munch('')) }
+      { tableContents }
       </tbody></table>
-    </div>)
+    </div> : null)
   }
 }
 PropertiesEditor.canShowInline = () => false


### PR DESCRIPTION
Properties editor printtaa tyhjiä tauluja joissain tilanteissa, ks esim gäppiä Järjestämismuotojen ja Ryhmätietojen välillä opiskeluoikeudessa: https://dev.koski.opintopolku.fi/koski/oppija/1.2.246.562.24.56145616714?1.2.246.562.15.75706369487.suoritus=Autoalan%20perustutkinto
