### PR TITLE
Kohdennetaan kansalaisen ylioppilastutkintovirheraportoinnit YTL:lle

### DIFF
--- a/src/main/resources/mockdata/ytr/080698-967F.json
+++ b/src/main/resources/mockdata/ytr/080698-967F.json
@@ -1,0 +1,106 @@
+{
+  "graduationSchoolOphOid": "1.2.246.562.10.14613773812",
+  "graduationSchoolYtlNumber": 1648,
+  "ssn": "080698-967F",
+  "lastname": "Ylioppilas",
+  "firstnames": "Ynjevi",
+  "graduationDate": "2012-06-02",
+  "graduationPeriod": "2012K",
+  "hasCompletedMandatoryExams": true,
+  "language" : "fi",
+  "exams" : [ {
+    "period" : "2012K",
+    "examId" : "A",
+    "examRoleLegacy" : "11",
+    "examRoleShort" : "mother-tongue",
+    "grade" : "B",
+    "points" : 46,
+    "sections" : [ {
+      "sectionPoints" : 25,
+      "sectionId" : "T001"
+    }, {
+      "sectionPoints" : 21,
+      "sectionId" : "T002"
+    } ]
+  }, {
+    "period" : "2012K",
+    "examId" : "BB",
+    "examRoleLegacy" : null,
+    "examRoleShort" : "optional-subject",
+    "grade" : "C",
+    "points" : 166,
+    "sections" : [ {
+      "sectionPoints" : 33,
+      "sectionId" : "HM02"
+    }, {
+      "sectionPoints" : 9,
+      "sectionId" : "HT01"
+    }, {
+      "sectionPoints" : 34,
+      "sectionId" : "LM02"
+    }, {
+      "sectionPoints" : 12,
+      "sectionId" : "LT02"
+    }, {
+      "sectionPoints" : 17,
+      "sectionId" : "RM01"
+    }, {
+      "sectionPoints" : 4,
+      "sectionId" : "RT01"
+    }, {
+      "sectionPoints" : 57,
+      "sectionId" : "KK01"
+    } ]
+  }, {
+    "period" : "2012K",
+    "examId" : "EA",
+    "examRoleLegacy" : "31",
+    "examRoleShort" : "mandatory-subject",
+    "grade" : "C",
+    "points" : 210,
+    "sections" : [ {
+      "sectionPoints" : 37,
+      "sectionId" : "HM02"
+    }, {
+      "sectionPoints" : 18,
+      "sectionId" : "HT01"
+    }, {
+      "sectionPoints" : 34,
+      "sectionId" : "LM02"
+    }, {
+      "sectionPoints" : 14,
+      "sectionId" : "LT02"
+    }, {
+      "sectionPoints" : 21,
+      "sectionId" : "RM01"
+    }, {
+      "sectionPoints" : 8,
+      "sectionId" : "RT03"
+    }, {
+      "sectionPoints" : 78,
+      "sectionId" : "KK01"
+    } ]
+  }, {
+    "period" : "2012K",
+    "examId" : "GE",
+    "examRoleLegacy" : "41",
+    "examRoleShort" : "mandatory-subject",
+    "grade" : "M",
+    "points" : 26,
+    "sections" : [ {
+      "sectionPoints" : 26,
+      "sectionId" : "T000"
+    } ]
+  }, {
+    "period" : "2012K",
+    "examId" : "N",
+    "examRoleLegacy" : null,
+    "examRoleShort" : "mandatory-subject",
+    "grade" : "L",
+    "points" : 59,
+    "sections" : [ {
+      "sectionPoints" : 59,
+      "sectionId" : "T000"
+    } ]
+  }
+]}

--- a/src/main/scala/fi/oph/koski/fixture/KoskiDatabaseFixtures.scala
+++ b/src/main/scala/fi/oph/koski/fixture/KoskiDatabaseFixtures.scala
@@ -107,6 +107,7 @@ class KoskiDatabaseFixtureCreator(application: KoskiApplication) extends KoskiDa
       (MockOppijat.liiketalous, OpiskeluoikeusTestData.opiskeluoikeus(MockOrganisaatiot.stadinAmmattiopisto, koulutusKoodi = 331101, diaariNumero = "59/011/2014")),
       (MockOppijat.valma, ExamplesValma.valmaTodistus.tallennettavatOpiskeluoikeudet.head),
       (MockOppijat.telma, ExamplesTelma.telmaTodistus.tallennettavatOpiskeluoikeudet.head),
+      (MockOppijat.ylioppilasLukiolainen, ExamplesLukio.päättötodistus()),
       (MockOppijat.erikoisammattitutkinto, AmmattitutkintoExample.opiskeluoikeus),
       (MockOppijat.reformitutkinto, ReforminMukainenErikoisammattitutkintoExample.opiskeluoikeus),
       (MockOppijat.osittainenammattitutkinto, AmmatillinenPerustutkintoExample.osittainenPerustutkintoOpiskeluoikeus),

--- a/src/main/scala/fi/oph/koski/henkilo/MockOppijat.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/MockOppijat.scala
@@ -44,6 +44,7 @@ object MockOppijat {
   val luva = oppijat.oppija("Lukioonvalmistautuja", "Luke", "211007-442N")
   val valma = oppijat.oppija("Amikseenvalmistautuja", "Anneli", "130404-054C")
   val ylioppilas = oppijat.oppija("Ylioppilas", "Ynjevi", "210244-374K")
+  val ylioppilasLukiolainen = oppijat.oppija("Ylioppilaslukiolainen", "Ynjevi", "080698-967F")
   val ylioppilasEiOppilaitosta = oppijat.oppija("Ylioppilas", "Yrjänä", "240775-720P")
   val toimintaAlueittainOpiskelija = oppijat.oppija("Toiminta", "Tommi", "031112-020J")
   val telma = oppijat.oppija("Telmanen", "Tuula", "021080-725C")

--- a/src/main/scala/fi/oph/koski/organisaatio/MockOrganisaatioRepository.scala
+++ b/src/main/scala/fi/oph/koski/organisaatio/MockOrganisaatioRepository.scala
@@ -96,6 +96,8 @@ object MockOrganisaatioRepository extends JsonOrganisaatioRepository(MockKoodist
   override def findSähköpostiVirheidenRaportointiin(oid: String): Option[SähköpostiVirheidenRaportointiin] = {
     if (oid == MockOrganisaatiot.kulosaarenAlaAste) {
       None
+    } else if (oid == MockOrganisaatiot.ytl) {
+      getOrganisaatioHierarkia(oid).map(h => SähköpostiVirheidenRaportointiin(h.oid, h.nimi, "ytl.ytl@example.com"))
     } else {
       getOrganisaatioHierarkia(oid).map(h => SähköpostiVirheidenRaportointiin(h.oid, h.nimi, "joku.osoite@example.com"))
     }

--- a/web/app/omattiedot/virheraportointi/RadioOption.jsx
+++ b/web/app/omattiedot/virheraportointi/RadioOption.jsx
@@ -23,7 +23,7 @@ const RadioOption = ({selectedOppilaitosA, label, value, styleModifier, checked}
 const OppilaitosOption = ({oppilaitos, selectedOppilaitosA}) => (
   <RadioOption
     selectedOppilaitosA={selectedOppilaitosA}
-    label={t(oppilaitos.nimi)}
+    label={t(oppilaitos.nimi) + (oppilaitos.suoritus ? ` (${oppilaitos.suoritus.toLowerCase()})` : '')}
     value={oppilaitos.oid}
   />
 )

--- a/web/app/omattiedot/virheraportointi/RaportoiVirheestaForm.jsx
+++ b/web/app/omattiedot/virheraportointi/RaportoiVirheestaForm.jsx
@@ -6,7 +6,7 @@ import Http from '../../util/http'
 import {PuuttuvatTiedot} from './PuuttuvatTiedot'
 import Text from '../../i18n/Text'
 import {t} from '../../i18n/i18n'
-import {modelData, modelItems} from '../../editor/EditorModel'
+import {modelData, modelItems, modelTitle} from '../../editor/EditorModel'
 import {flatMapArray, ift} from '../../util/util'
 import {Yhteystiedot} from './Yhteystiedot'
 import OrganisaatioPicker from '../../virkailija/OrganisaatioPicker'
@@ -15,7 +15,7 @@ import {trackEvent} from '../../tracking/piwikTracking'
 
 const resolveResponsibleOrganization = opiskeluoikeus =>
   modelData(opiskeluoikeus, 'tyyppi.koodiarvo') === 'ylioppilastutkinto'
-    ? modelData(opiskeluoikeus, 'koulutustoimija')
+    ? R.assoc('suoritus', modelTitle(opiskeluoikeus, 'suoritukset.0.tyyppi'), modelData(opiskeluoikeus, 'koulutustoimija'))
     : modelData(opiskeluoikeus, 'oppilaitos')
 
 const OppilaitosPicker = ({oppilaitosAtom}) => {

--- a/web/test/spec/omatTiedotSpec.js
+++ b/web/test/spec/omatTiedotSpec.js
@@ -215,9 +215,58 @@ describe('Omat tiedot', function() {
             })
           })
         })
+
+        describe('Ylioppilastutkinnoille', () => {
+          var form = omattiedot.virheraportointiForm
+
+          describe('kun ei lukiosuorituksia', () => {
+            before(authentication.logout, etusivu.openPage)
+            before(etusivu.login(), wait.until(korhopankki.isReady), korhopankki.login('210244-374K'), wait.until(omattiedot.isVisible))
+            before(click(omattiedot.virheraportointiButton), form.acceptDisclaimer)
+
+            it('näytetään oppilaitoksissa ylioppilastutkintolautakunta, ei lukiota, lisäksi suorituksen tyyppi (ylioppilastutkinto)', () => {
+              expect(form.oppilaitosNames()).to.deep.equal([
+                'Ylioppilastutkintolautakunta (ylioppilastutkinto)',
+                'Muu'
+              ])
+            })
+
+            it('ylioppilastutkintolautakunnalla on oikea OID', function () {
+              expect(form.oppilaitosOids()).to.deep.equal([
+                '1.2.246.562.10.43628088406',
+                'other'
+              ])
+            })
+          })
+
+          describe('kun myös lukiosuorituksia', () => {
+            before(authentication.logout, etusivu.openPage)
+            before(etusivu.login(), wait.until(korhopankki.isReady), korhopankki.login('080698-967F'), wait.until(omattiedot.isVisible))
+            before(click(omattiedot.virheraportointiButton), form.acceptDisclaimer)
+
+            it('näytetään oppilaitoksissa ylioppilastutkintolautakunta ja lukio', () => {
+              expect(form.oppilaitosNames()).to.deep.equal([
+                'Ylioppilastutkintolautakunta (ylioppilastutkinto)',
+                'Jyväskylän normaalikoulu',
+                'Muu'
+              ])
+            })
+
+            it('oppilaitoksilla on oikeat OIDit', function () {
+              expect(form.oppilaitosOids()).to.deep.equal([
+                '1.2.246.562.10.43628088406',
+                '1.2.246.562.10.14613773812',
+                'other'
+              ])
+            })
+          })
+        })
       })
 
       describe('Suoritusjako', function() {
+        before(authentication.logout, etusivu.openPage)
+        before(etusivu.login(), wait.until(korhopankki.isReady), korhopankki.login('180497-112F'), wait.until(omattiedot.isVisible))
+
         var form = omattiedot.suoritusjakoForm
         window.secrets = {}
 


### PR DESCRIPTION
TOR-495

Selvityksessä: 

- [x] Lisätään mahdollisesti Koski-kenttä YTL-organisaatiotietoihin (nyt käytetään YTL-sähköpostitietoa)

Näytetään kansalaisen virheraportointilomakkeessa ylioppilastutkintojen osalta "oppilaitoksena" YTL eikä lukiota. Näytetään kuitenkin lisäksi lukio, mikäli myös lukion suorituksia.