### PR TITLE
Eronnut-tila pois ammatillisen kälistä

### DIFF
--- a/web/app/opiskeluoikeus/OpiskeluoikeudenUusiTilaPopup.jsx
+++ b/web/app/opiskeluoikeus/OpiskeluoikeudenUusiTilaPopup.jsx
@@ -2,7 +2,7 @@ import React from 'baret'
 import Bacon from 'baconjs'
 import {
   accumulateModelStateAndValidity,
-  contextualizeSubModel,
+  contextualizeSubModel, modelData,
   modelItems,
   modelLookup,
   modelLookupRequired
@@ -49,6 +49,13 @@ export const OpiskeluoikeudenUusiTilaPopup = ({edellisenTilanAlkupäivä, suorit
   </ModalDialog>)
 }
 
-const fetchTilat = model => {
-  return EnumEditor.fetchAlternatives(model).map(alts => alts.filter(a => a.data.koodiarvo !== 'mitatoity'))
-}
+const fetchTilat = model => EnumEditor.fetchAlternatives(model).map(alts => alts
+  .filter(a => {
+    const opiskeluoikeudenTyyppi = modelData(model.context.opiskeluoikeus, 'tyyppi.koodiarvo')
+    const excludedValues = opiskeluoikeudenTyyppi === 'ammatillinenkoulutus'
+      ? ['mitatoity', 'eronnut']
+      : ['mitatoity']
+
+    return !excludedValues.includes(a.data.koodiarvo)
+  })
+)

--- a/web/app/uusioppija/UusiOpiskeluoikeus.jsx
+++ b/web/app/uusioppija/UusiOpiskeluoikeus.jsx
@@ -45,7 +45,11 @@ export default ({opiskeluoikeusAtom}) => {
   suorituskieletP.onValue(kielet => suorituskieliAtom.set(kielet[0]))
 
   const tilatP = koodistoValues('koskiopiskeluoikeudentila/lasna,valmistunut,eronnut,katsotaaneronneeksi,valiaikaisestikeskeytynyt,peruutettu,loma')
-  const opiskeluoikeudenTilatP = Bacon.combineAsArray(tilatP, tyyppiAtom.map('.koodiarvo')).map(([tilat,tyyppi]) => tyyppi === 'ammatillinenkoulutus' ? tilat : tilat.filter(tila => tila.koodiarvo !== 'loma'))
+  const opiskeluoikeudenTilatP = Bacon.combineAsArray(tilatP, tyyppiAtom.map('.koodiarvo')).map(([tilat,tyyppi]) =>
+    tyyppi === 'ammatillinenkoulutus'
+      ? tilat.filter(tila => tila.koodiarvo !== 'eronnut')
+      : tilat.filter(tila => tila.koodiarvo !== 'loma')
+  )
   const rahoituksetP = koodistoValues('opintojenrahoitus').map(R.sortBy(R.compose(parseInt, R.prop('koodiarvo'))))
   const hasRahoituksetAvailable = tyyppiAtom.map(koodiarvoMatch('ammatillinenkoulutus', 'lukiokoulutus'))
 

--- a/web/test/page/addOppijaPage.js
+++ b/web/test/page/addOppijaPage.js
@@ -182,6 +182,9 @@ function AddOppijaPage() {
         ? selectFromDropdown('.opintojenrahoitus .dropdown', rahoitus)
         : function() {}
     },
+    opiskeluoikeudenTilat: function() {
+      return pageApi.getInputOptions('.opiskeluoikeudentila .dropdown')
+    },
     selectPeruste: function(peruste) {
       return selectFromDropdown('.peruste .dropdown', peruste)
     },

--- a/web/test/spec/ammatillinenSpec.js
+++ b/web/test/spec/ammatillinenSpec.js
@@ -61,6 +61,17 @@ describe('Ammatillinen koulutus', function() {
             'Työvoimakoulutus (OKM rahoitus)'
           ])
         })
+
+        it('Näytetään tilavaihtoehdoissa loma-tila, mutta ei eronnut-tilaa', function() {
+          expect(addOppija.opiskeluoikeudenTilat()).to.deep.equal([
+            'Katsotaan eronneeksi',
+            'Loma',
+            'Läsnä',
+            'Peruutettu',
+            'Valmistunut',
+            'Väliaikaisesti keskeytynyt'
+          ])
+        })
       })
 
       describe('Kun lisätään oppija', function() {

--- a/web/test/spec/ammatillinenSpec.js
+++ b/web/test/spec/ammatillinenSpec.js
@@ -537,10 +537,9 @@ describe('Ammatillinen koulutus', function() {
 
     describe('Ammatillisen koulutuksen tilat', function () {
       before(editor.edit, opinnot.avaaLisaysDialogi)
-      it('Sisältää loma-tilan', function () {
+      it('Sisältää loma-tilan, mutta ei eronnut-tilaa', function () {
         expect(OpiskeluoikeusDialog().tilat()).to.deep.equal(
             [
-              'koskiopiskeluoikeudentila_eronnut',
               'koskiopiskeluoikeudentila_katsotaaneronneeksi',
               'koskiopiskeluoikeudentila_loma',
               'koskiopiskeluoikeudentila_lasna',

--- a/web/test/spec/perusopetusSpec.js
+++ b/web/test/spec/perusopetusSpec.js
@@ -1666,6 +1666,17 @@ describe('Perusopetus', function() {
           it('Ei näytetä opintojen rahoitus -kenttää', function() {
             expect(addOppija.rahoitusIsVisible()).to.equal(false)
           })
+
+          it('Oikeat tilat tilavaihtoehtoina', function() {
+            expect(addOppija.opiskeluoikeudenTilat()).to.deep.equal([
+              'Eronnut',
+              'Katsotaan eronneeksi',
+              'Läsnä',
+              'Peruutettu',
+              'Valmistunut',
+              'Väliaikaisesti keskeytynyt'
+            ])
+          })
         })
 
         describe('Kun painetaan Lisää-nappia', function() {


### PR DESCRIPTION
TOR-496

Poistetaan ammatillisen syöttökälistä tila "eronnut". Arvo kuitenkin näytetään mikäli se on opiskeluoikeudelle välitetty. "Eronnut" on terminä uuden laindääsännön myötä vanhentunut, ja oppilaitosten tulee käyttää tilaa "katsotaan eronneeksi".