### PR TITLE
Tiedonsiirrot-sivulle tutkintotiedot

### DIFF
--- a/src/main/scala/fi/oph/koski/tiedonsiirto/ExamplesTiedonsiirto.scala
+++ b/src/main/scala/fi/oph/koski/tiedonsiirto/ExamplesTiedonsiirto.scala
@@ -1,20 +1,25 @@
 package fi.oph.koski.tiedonsiirto
 
 import fi.oph.koski.documentation.AmmatillinenExampleData._
-import fi.oph.koski.documentation.{AmmatillinenExampleData, Example}
+import fi.oph.koski.documentation.{AmmatillinenExampleData, AmmatillinenPerustutkintoExample, Example}
 import fi.oph.koski.henkilo.MockOppijat
 import fi.oph.koski.henkilo.MockOppijat.asUusiOppija
 import fi.oph.koski.organisaatio.MockOrganisaatiot
-import fi.oph.koski.schema.{AmmatillinenOpiskeluoikeus, Oppija, Oppilaitos}
+import fi.oph.koski.schema.{AmmatillinenOpiskeluoikeus, Oppija, Oppilaitos, TäydellisetHenkilötiedot}
 
 object ExamplesTiedonsiirto {
   val opiskeluoikeus: AmmatillinenOpiskeluoikeus = AmmatillinenExampleData.opiskeluoikeus().copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId))
   val failingOpiskeluoikeus: AmmatillinenOpiskeluoikeus = opiskeluoikeus.copy(oppilaitos = Some(Oppilaitos(MockOrganisaatiot.aaltoYliopisto)))
+  val epävalidiHenkilö: TäydellisetHenkilötiedot = MockOppijat.tiedonsiirto.henkilö.copy(hetu = Some("epävalidiHetu"))
+  val failingTutkinnonosaOpiskeluoikeus: AmmatillinenOpiskeluoikeus = AmmatillinenPerustutkintoExample.osittainenPerustutkintoOpiskeluoikeus.copy(
+    lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId)
+  )
 
   val examples: List[Example] = List(
     Example("tiedonsiirto - onnistunut", "Onnistunut tiedonsiirto", Oppija(asUusiOppija(MockOppijat.tiedonsiirto.henkilö), List(opiskeluoikeus)), 403),
     Example("tiedonsiirto - vain syntymäaika", "Onnistunut tiedonsiirto", Oppija(MockOppijat.hetuton.henkilö, List(opiskeluoikeus)), 403),
     Example("tiedonsiirto - epäonnistunut", "Epäonnistunut tiedonsiirto", Oppija(asUusiOppija(MockOppijat.tiedonsiirto.henkilö), List(failingOpiskeluoikeus)), 403),
-    Example("tiedonsiirto - epäonnistunut 2", "Onnistunut tiedonsiirto", Oppija(asUusiOppija(MockOppijat.ammattilainen.henkilö), List(failingOpiskeluoikeus)), 403)
+    Example("tiedonsiirto - epäonnistunut 2", "Onnistunut tiedonsiirto", Oppija(asUusiOppija(MockOppijat.ammattilainen.henkilö), List(failingOpiskeluoikeus)), 403),
+    Example("tiedonsiirto - epäonnistunut 3", "Epäonnistunut tiedonsiirto", Oppija(asUusiOppija(epävalidiHenkilö), List(failingTutkinnonosaOpiskeluoikeus)), 403)
   )
 }

--- a/web/app/style/tiedonsiirrot.less
+++ b/web/app/style/tiedonsiirrot.less
@@ -1,15 +1,17 @@
 .content-area.tiedonsiirrot {
-  display: table;
+  display: flex;
 
   .sidebar {
-    display: table-cell;
-    width: @sidebar-width;
+    flex-grow: 1;
+    max-width: @sidebar-width;
     padding-top: 35px;
     vertical-align: top;
   }
 
   .main-content {
-    display: table-cell;
+    flex-grow: 1;
+    flex-basis: 80%;
+    max-width: @max-content-width - @sidebar-width;
     padding-left: 60px;
     padding-right: 20px;
     vertical-align: top;
@@ -33,10 +35,6 @@
   }
 }
 
-.sidebar.tiedonsiirrot-navi {
-  width: ~"calc(50px + (100vw - 1200px) / 2)";
-}
-
 .tiedonsiirrot-content {
   position: relative;
   button.update-content {
@@ -56,13 +54,8 @@
     margin-top: 20px;
     font-size: 0.80em;
     width: 100%;
-    .tila { width: 5em; }
-    .aika { width: 10em; }
     .hetu { padding-right: 10px; }
     .tiedot { padding-right: 5px; }
-    .oppilaitos { width: 14em;}
-    .opiskeluoikeudet, .siirretyt, .virheelliset { width: 7em;}
-    .lahdejarjestelma { width: 5em;}
     .tiedonsiirto-errors {
       list-style: none;
       padding: 0;
@@ -71,6 +64,12 @@
     }
     td {
       position: relative;
+
+      ul.cell-listing {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
     }
     .group {
       .expand, .collapse {
@@ -100,7 +99,7 @@
       max-width: 500px;
     }
     .status {
-      margin-left: 10px;
+      margin-left: 5px;
       &.fail {
         color: red;
       }

--- a/web/app/style/topbar.less
+++ b/web/app/style/topbar.less
@@ -3,7 +3,7 @@
 @import "constants";
 @import "colors";
 
-@sidebar-width: 300px;
+@sidebar-width: 200px;
 @topbar-height: 93px;
 
 #content[data-inraamit='oppija'] #topbar {

--- a/web/app/tiedonsiirrot/Tiedonsiirtotaulukko.jsx
+++ b/web/app/tiedonsiirrot/Tiedonsiirtotaulukko.jsx
@@ -20,6 +20,7 @@ export class Tiedonsiirtotaulukko extends React.Component {
           <th className="hetu"><Text name="Henkilötunnus / Syntymäaika"/></th>
           <th className="nimi"><Text name="Nimi"/></th>
           <th className="oppilaitos"><Text name="Oppilaitos"/></th>
+          <th className="tutkinto"><Text name="Tutkinto / osaamisala / nimike"/></th>
           <th className="virhe"><Text name="Virhe"/></th>
           <th className="tiedot"><Text name="Tiedot"/></th>
           { selected && showSelected && <th className="valitse"></th> }
@@ -108,6 +109,15 @@ class Lokirivi extends React.Component {
           <Link key={i} href={'/koski/tiedonsiirrot' + (showError ? '/virheet' : '') + '?oppilaitos=' + oppilaitos.oid}>{oppilaitos && oppilaitos.nimi && t(oppilaitos.nimi)}</Link>
         )
       }</td>
+      <td className="tutkinto">{ row.suoritustiedot.map((suoritus, j) => (
+          <ul className="cell-listing" key={j}>
+            <li className="koulutusmoduuli">{t(suoritus.koulutusmoduuli.nimi)}</li>
+            {(suoritus.osaamisalat || []).map((osaamisala, k) => <li className="osaamisala" key={k}>{t(osaamisala.nimi)}</li>)}
+            {(suoritus.tutkintonimike || []).map((nimike, k) => <li className="tutkintonimike" key={k}>{t(nimike.nimi)}</li>)}
+          </ul>
+        )
+      )}
+      </td>
       <td className="virhe">{row.virhe.length > 0 && <span>{errorDetails(row.virhe)}</span>}</td>
       <td className="tiedot">
         {!!row.inputData && dataLink()}

--- a/web/test/spec/tiedonsiirrotSpec.js
+++ b/web/test/spec/tiedonsiirrotSpec.js
@@ -23,10 +23,10 @@ describe('Tiedonsiirrot', function() {
 
     it('Näytetään', function() {
       expect(tiedonsiirrot.tiedot().sort(sortByName)).to.deep.equal([
-        ['280618-402H', 'Ammattilainen, Aarne', 'Aalto-yliopisto', 'virhe', 'tiedot'],
-        ['24.2.1977', 'Hetuton, Heikki', 'Stadin ammattiopisto', '', ''],
-        ['270303-281N', 'Tiedonsiirto, Tiina', 'Stadin ammattiopisto', '', ''],
-        ['', '', '', 'virhe', 'tiedot']
+        ['280618-402H', 'Ammattilainen, Aarne', 'Aalto-yliopisto', '', 'virhe', 'tiedot'],
+        ['24.2.1977', 'Hetuton, Heikki', 'Stadin ammattiopisto', 'Autoalan perustutkinto', '', ''],
+        ['270303-281N', 'Tiedonsiirto, Tiina', 'Stadin ammattiopisto', 'Autoalan perustutkinto', '', ''],
+        ['', '', '', '', 'virhe', 'tiedot']
       ].sort(sortByName))
     })
   })
@@ -44,8 +44,8 @@ describe('Tiedonsiirrot', function() {
 
     it('Näytetään', function() {
       expect(tiedonsiirrot.tiedot()).to.deep.equal([
-        ['280618-402H', 'Ammattilainen, Aarne', 'Aalto-yliopisto', 'Ei oikeuksia organisatioon 1.2.246.562.10.56753942459virhe', 'tiedot'],
-        ['', '', '', 'Viesti ei ole skeeman mukainen (notAnyOf henkilö)virhe', 'tiedot']
+        ['280618-402H', 'Ammattilainen, Aarne', 'Aalto-yliopisto', '', 'Ei oikeuksia organisatioon 1.2.246.562.10.56753942459virhe', 'tiedot'],
+        ['', '', '', '', 'Viesti ei ole skeeman mukainen (notAnyOf henkilö)virhe', 'tiedot']
       ])
     })
 
@@ -97,7 +97,7 @@ describe('Tiedonsiirrot', function() {
         )
         it('Se poistuu listauksesta', function() {
           expect(tiedonsiirrot.tiedot()).to.deep.equal([
-            ['280618-402H', 'Ammattilainen, Aarne', 'Aalto-yliopisto', 'Ei oikeuksia organisatioon 1.2.246.562.10.56753942459virhe', 'tiedot']
+            ['280618-402H', 'Ammattilainen, Aarne', 'Aalto-yliopisto', '', 'Ei oikeuksia organisatioon 1.2.246.562.10.56753942459virhe', 'tiedot']
           ])
         })
         it('Poista valitut nappi on disabloitu', function () {

--- a/web/test/spec/tiedonsiirrotSpec.js
+++ b/web/test/spec/tiedonsiirrotSpec.js
@@ -12,6 +12,7 @@ describe('Tiedonsiirrot', function() {
     insertExample('tiedonsiirto - onnistunut.json'),
     insertExample('tiedonsiirto - epäonnistunut 2.json'),
     insertExample('tiedonsiirto - vain syntymäaika.json'),
+    insertExample('tiedonsiirto - epäonnistunut 3.json'),
     syncTiedonsiirrot,
     tiedonsiirrot.openPage
   )
@@ -23,6 +24,7 @@ describe('Tiedonsiirrot', function() {
 
     it('Näytetään', function() {
       expect(tiedonsiirrot.tiedot().sort(sortByName)).to.deep.equal([
+        ['epävalidiHetu', 'Tiedonsiirto, Tiina', 'Stadin ammattiopisto', 'Luonto- ja ympäristöalan perustutkintoAutokorinkorjauksen osaamisalaAutokorinkorjaaja', 'virhe', 'tiedot'],
         ['280618-402H', 'Ammattilainen, Aarne', 'Aalto-yliopisto', '', 'virhe', 'tiedot'],
         ['24.2.1977', 'Hetuton, Heikki', 'Stadin ammattiopisto', 'Autoalan perustutkinto', '', ''],
         ['270303-281N', 'Tiedonsiirto, Tiina', 'Stadin ammattiopisto', 'Autoalan perustutkinto', '', ''],
@@ -44,6 +46,7 @@ describe('Tiedonsiirrot', function() {
 
     it('Näytetään', function() {
       expect(tiedonsiirrot.tiedot()).to.deep.equal([
+        ['epävalidiHetu', 'Tiedonsiirto, Tiina', 'Stadin ammattiopisto', 'Luonto- ja ympäristöalan perustutkintoAutokorinkorjauksen osaamisalaAutokorinkorjaaja', 'Virheellinen muoto hetulla: epävalidiHetuvirhe', 'tiedot'],
         ['280618-402H', 'Ammattilainen, Aarne', 'Aalto-yliopisto', '', 'Ei oikeuksia organisatioon 1.2.246.562.10.56753942459virhe', 'tiedot'],
         ['', '', '', '', 'Viesti ei ole skeeman mukainen (notAnyOf henkilö)virhe', 'tiedot']
       ])
@@ -97,6 +100,7 @@ describe('Tiedonsiirrot', function() {
         )
         it('Se poistuu listauksesta', function() {
           expect(tiedonsiirrot.tiedot()).to.deep.equal([
+            ['epävalidiHetu', 'Tiedonsiirto, Tiina', 'Stadin ammattiopisto', 'Luonto- ja ympäristöalan perustutkintoAutokorinkorjauksen osaamisalaAutokorinkorjaaja', 'Virheellinen muoto hetulla: epävalidiHetuvirhe', 'tiedot'],
             ['280618-402H', 'Ammattilainen, Aarne', 'Aalto-yliopisto', '', 'Ei oikeuksia organisatioon 1.2.246.562.10.56753942459virhe', 'tiedot']
           ])
         })


### PR DESCRIPTION
TOR-395

Lisätään tiedonsiirrot-sivulle (tiedonsiirtoloki- ja virheet-taulukoihin) "tutkinto / osaamisala / nimike" -sarake.