### PR TITLE
[WIP] Add additional highly more specific specifier for font

### DIFF
--- a/web/app/style/main.less
+++ b/web/app/style/main.less
@@ -50,7 +50,8 @@ body {
   background-color: @color-lightgray;
 }
 
-button, input, optgroup, select, textarea {
+button, input, optgroup, select, textarea,
+#content.koski-content[data-inraamit="virkailija"] {
   font-family: 'Source Sans Pro', sans-serif;
 }
 


### PR DESCRIPTION
- Virkailija raamit defines font for HTML body, which differs from the
font used for Koski and overrides it. Fix this and use correct font
(Source Sans Pro) by adding an additional more specific CSS selector for
virkailija.