### PR TITLE
Mount modal directly on body

### DIFF
--- a/web/app/components/ModalMount.jsx
+++ b/web/app/components/ModalMount.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+const root = document.body
+const contentRoot = document.getElementById('content')
+
+export default class ModalMount extends React.Component {
+  constructor(props) {
+    super(props)
+    this.container = document.createElement('div')
+    this.container.classList.add('koski-modal')
+  }
+
+  componentDidMount() {
+    root.appendChild(this.container)
+    contentRoot.setAttribute('aria-hidden', true)
+  }
+
+  componentWillUnmount() {
+    root.removeChild(this.container)
+    contentRoot.removeAttribute('aria-hidden')
+  }
+
+  render() {
+    return ReactDOM.createPortal(
+      this.props.children,
+      this.container
+    )
+  }
+}

--- a/web/app/editor/ModalDialog.jsx
+++ b/web/app/editor/ModalDialog.jsx
@@ -14,7 +14,7 @@ export default ({className, onDismiss, onSubmit, children, submitOnEnterKey, okT
     if (e.keyCode == 27) onDismiss()
     if (e.keyCode == 13 && submitOnEnterKey) onSubmit()
   }
-  let classNameP = submittedAtom.map(submitted => (className ? className : '') + ' modal' + (submitted ? ' submitted' : '') + (fullscreen ? ' fullscreen' : ''))
+  let classNameP = submittedAtom.map(submitted => (className ? className : '') + ' modal' + (submitted ? ' submitted' : '') + (fullscreen ? ' fullscreen textstyle-body' : ''))
 
   const Modal = () => (
     <div className={classNameP} role='dialog' aria-modal={true} aria-describedby='modal-main-content'>

--- a/web/app/omattiedot/suoritusjako/SuoritusjakoLink.jsx
+++ b/web/app/omattiedot/suoritusjako/SuoritusjakoLink.jsx
@@ -7,6 +7,7 @@ import {formatISODate, ISO2FinnishDateTime, parseISODate} from '../../date/date'
 import Http from '../../util/http'
 import ModalDialog from '../../editor/ModalDialog'
 import {DateInputFeedback} from './DateInputFeedback'
+import ModalMount from '../../components/ModalMount'
 
 const ApiBaseUrl = '/koski/api/suoritusjako'
 
@@ -142,16 +143,18 @@ export class SuoritusjakoLink extends React.Component {
               </button>
 
               {showDeleteConfirmation && (
-                <ModalDialog
-                  fullscreen={true}
-                  onDismiss={this.cancelConfimDelete.bind(this)}
-                  onSubmit={this.deleteSelf.bind(this)}
-                  submitOnEnterKey={false}
-                  okTextKey='Kyllä, poista linkki käytöstä'
-                  cancelTextKey='Älä poista linkkiä'
-                >
-                  <Text name='Linkin poistamisen jälkeen kukaan ei pääse katsomaan opintosuorituksiasi, vaikka olisit jakanut tämän linkin heille.'/>
-                </ModalDialog>
+                <ModalMount>
+                  <ModalDialog
+                    fullscreen={true}
+                    onDismiss={this.cancelConfimDelete.bind(this)}
+                    onSubmit={this.deleteSelf.bind(this)}
+                    submitOnEnterKey={false}
+                    okTextKey='Kyllä, poista linkki käytöstä'
+                    cancelTextKey='Älä poista linkkiä'
+                  >
+                    <Text name='Linkin poistamisen jälkeen kukaan ei pääse katsomaan opintosuorituksiasi, vaikka olisit jakanut tämän linkin heille.'/>
+                  </ModalDialog>
+                </ModalMount>
               )}
             </div>
           </div>

--- a/web/app/style/global.less
+++ b/web/app/style/global.less
@@ -1,5 +1,5 @@
 // Scope Koski-global styles (separate from raamit)
-.koski-content {
+.koski-content, .koski-modal {
   .koski-button {
     .BaseButton;
 


### PR DESCRIPTION
This makes it practical to add aria-hidden to other content and will therefore prevent screen readers from escaping the modal contents. Similar case for traditional displays is already handled within the modal dialog with focus trapping.

This only applies to kansalainen (suoritusjako confirmation).