### PR TITLE
Korjaa näkymien virheellinen pinoamisjärjestys

### DIFF
--- a/web/app/style/oppija.less
+++ b/web/app/style/oppija.less
@@ -173,6 +173,7 @@
     position: fixed;
     bottom: -60px;
     opacity: 0;
+    z-index: @z-index-edit-bar;
     transition: bottom 1s, opacity 1s;
     &.visible {
       bottom: 0;
@@ -188,7 +189,6 @@
     padding-bottom: 8px;
     background: white;
     box-shadow: 0 -2px 5px #eeeeee;
-    z-index: @z-index-edit-bar;
     .cancel {
       margin-left: 20px;
     }


### PR DESCRIPTION
Bug: virkailijan näkymässä suoritus-välilehdet menivät edit-palkin
päälle.

Cause: edit-palkin pinotaso oli määritelty suhteessa edit-palkin omaan
pinokontekstiin, jonka taso puolestaan oli alempi kuin välilehtien.

Fix: määritellään edit-palkin kontekstin taso korkeammaksi kuin
välilehtien.