### PR TITLE
less explicit error messages: don't leak username to 3rd parties

### DIFF
--- a/src/main/scala/fi/oph/koski/koskiuser/AuthenticationSupport.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/AuthenticationSupport.scala
@@ -88,7 +88,7 @@ trait AuthenticationSupport extends KoskiBaseServlet with SSOSupport with Loggin
 
   def tryLogin(username: String, password: String): Either[HttpStatus, AuthenticationUser] = {
     // prevent brute-force login by blocking incorrect logins with progressive delay
-    lazy val loginFail = Left(KoskiErrorCategory.unauthorized.loginFail(s"Sisäänkirjautuminen käyttäjätunnuksella $username epäonnistui."))
+    lazy val loginFail = Left(KoskiErrorCategory.unauthorized.loginFail(s"Sisäänkirjautuminen epäonnistui, väärä käyttäjätunnus tai salasana."))
     val blockedUntil = application.basicAuthSecurity.getLoginBlocked(username)
     if (blockedUntil.isDefined) {
       logger(LogUserContext(request)).warn(s"Too many failed login attempts for username ${username}, blocking login until ${blockedUntil.get}")

--- a/src/test/scala/fi/oph/koski/koskiuser/AuthenticationSpec.scala
+++ b/src/test/scala/fi/oph/koski/koskiuser/AuthenticationSpec.scala
@@ -18,12 +18,12 @@ class AuthenticationSpec extends FreeSpec with Matchers with LocalJettyHttpSpeci
     }
     "Invalid credentials" in {
       post("user/login", JsonSerializer.writeWithRoot(Login("kalle", "asdf")), headers = jsonContent) {
-        verifyResponseStatus(401, KoskiErrorCategory.unauthorized.loginFail("Sisäänkirjautuminen käyttäjätunnuksella kalle epäonnistui."))
+        verifyResponseStatus(401, KoskiErrorCategory.unauthorized.loginFail("Sisäänkirjautuminen epäonnistui, väärä käyttäjätunnus tai salasana."))
       }
 
       // blocking because of too many login attempts
       post("user/login", JsonSerializer.writeWithRoot(Login("kalle", "kalle")), headers = jsonContent) {
-        verifyResponseStatus(401, KoskiErrorCategory.unauthorized.loginFail("Sisäänkirjautuminen käyttäjätunnuksella kalle epäonnistui."))
+        verifyResponseStatus(401, KoskiErrorCategory.unauthorized.loginFail("Sisäänkirjautuminen epäonnistui, väärä käyttäjätunnus tai salasana."))
       }
 
       sleep(1000)


### PR DESCRIPTION
When 3rd party apps call My Data APIs via Palveluväylä, all error messages are passed to the caller. Removed username from failed authentication error message so it won't leak to 3rd parties. 