### PR TITLE
Upgrade react-dom from 16.3.2 to 16.3.3

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9171,9 +9171,9 @@
       }
     },
     "react-dom": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.2.tgz",
-      "integrity": "sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==",
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.3.tgz",
+      "integrity": "sha512-ALCp7ZbSGkqRDtQoZozKVNgwXMxbxf/IGOUMC2A0yF6JHeZrS8e2cOotPT87Vf4b7PKCuUVKU4/RDEXxToA/yA==",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",

--- a/web/package.json
+++ b/web/package.json
@@ -23,7 +23,7 @@
     "ramda": "^0.25.0",
     "react": "^16.3.2",
     "react-day-picker": "^7.1.8",
-    "react-dom": "^16.3.2",
+    "react-dom": "^16.3.3",
     "react-focus-lock": "^1.11.1",
     "react-highlight": "^0.12.0",
     "react-highlighter": "github:Dentosal/react-highlighter#fa9392a55bacb418ef1b5327dba922f3829941ca",


### PR DESCRIPTION
 (to avoid warning about CVE-2018-6341; the vulnerability itself doesn't affect us)