### PR TITLE
Korjaa väärä kieli suoritusjakojen katselussa

### DIFF
--- a/src/main/scala/fi/oph/koski/koskiuser/KoskiSession.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/KoskiSession.scala
@@ -78,6 +78,6 @@ object KoskiSession {
 
   val untrustedUser = new KoskiSession(AuthenticationUser(UNTRUSTED_SYSTEM_USER, UNTRUSTED_SYSTEM_USER, UNTRUSTED_SYSTEM_USER, None), "fi", InetAddress.getLoopbackAddress, "", Set())
 
-  def suoritusjakoKatsominenUser(request: RichRequest) = new KoskiSession(AuthenticationUser(SUORITUSJAKO_KATSOMINEN_USER, SUORITUSJAKO_KATSOMINEN_USER, SUORITUSJAKO_KATSOMINEN_USER, None), "fi",  LogUserContext.clientIpFromRequest(request), LogUserContext.userAgent(request), Set(KäyttöoikeusGlobal(List(Palvelurooli(OPHKATSELIJA)))))
+  def suoritusjakoKatsominenUser(request: RichRequest) = new KoskiSession(AuthenticationUser(SUORITUSJAKO_KATSOMINEN_USER, SUORITUSJAKO_KATSOMINEN_USER, SUORITUSJAKO_KATSOMINEN_USER, None), KoskiUserLanguage.getLanguageFromCookie(request), LogUserContext.clientIpFromRequest(request), LogUserContext.userAgent(request), Set(KäyttöoikeusGlobal(List(Palvelurooli(OPHKATSELIJA)))))
 }
 

--- a/src/test/scala/fi/oph/koski/api/SuoritusjakoTestMethods.scala
+++ b/src/test/scala/fi/oph/koski/api/SuoritusjakoTestMethods.scala
@@ -19,6 +19,7 @@ trait SuoritusjakoTestMethods extends LocalJettyHttpSpecification with Opiskeluo
     val request = mock(classOf[RichRequest])
     when(request.header("User-Agent")).thenReturn(Some("MockUserAgent/1.0"))
     when(request.header("HTTP_X_FORWARDED_FOR")).thenReturn(Some("10.1.2.3"))
+    when(request.cookies).thenReturn(Map[String, String]())
     KoskiSession.suoritusjakoKatsominenUser(request)
   }
 


### PR DESCRIPTION
- Osa suoritusjaon sisällöstä näytettiin suomeksi vaikka kieleksi olisi
valittu ruotsi