### PR TITLE
Päätason suorituksen mitätöinti

### DIFF
--- a/src/main/resources/localization/default-texts.json
+++ b/src/main/resources/localization/default-texts.json
@@ -1110,6 +1110,10 @@
   "Peru lupa": "Peru lupa",
   "Et ole tällä hetkellä antanut millekään palveluntarjoajalle lupaa nähdä opintotietojasi Oma Opintopolusta. Luvan myöntäminen tapahtuu kyseisen palvelutarjoajan sivun kautta.": "Et ole tällä hetkellä antanut millekään palveluntarjoajalle lupaa nähdä opintotietojasi Oma Opintopolusta. Luvan myöntäminen tapahtuu kyseisen palvelutarjoajan sivun kautta.",
   "Kyllä, poista lupa": "Kyllä, poista lupa",
-  "Älä poista lupaa": "Älä poista lupaa"
+  "Älä poista lupaa": "Älä poista lupaa",
+  "Suoritus poistettu": "Suoritus poistettu",
+  "Poista suoritus": "Poista suoritus",
+  "Vahvista poisto, operaatiota ei voi peruuttaa": "Vahvista poisto, operaatiota ei voi peruuttaa",
+  "Peruuta poisto": "Peruuta poisto"
 }
 

--- a/src/main/scala/fi/oph/koski/documentation/PerusopetusExampleData.scala
+++ b/src/main/scala/fi/oph/koski/documentation/PerusopetusExampleData.scala
@@ -103,6 +103,11 @@ object PerusopetusExampleData {
       perusopetuksenOppimääränSuoritus.copy(toimipiste = toimipiste))
   )
 
+  def vuosiluokanOpiskeluoikeus(oppilaitos: Oppilaitos = jyväskylänNormaalikoulu, toimipiste: OrganisaatioWithOid = jyväskylänNormaalikoulu,  luokka: String = "C") = opiskeluoikeus(
+    oppilaitos = oppilaitos,
+    suoritukset = List(seitsemännenLuokanSuoritus.copy(toimipiste = toimipiste, luokka = "7A"))
+  )
+
   val kahdeksannenLuokanSuoritus = PerusopetuksenVuosiluokanSuoritus(
     koulutusmoduuli = PerusopetuksenLuokkaAste(8, perusopetuksenDiaarinumero), luokka = "8C", alkamispäivä = Some(date(2014, 8, 15)),
     toimipiste = jyväskylänNormaalikoulu,

--- a/src/main/scala/fi/oph/koski/editor/EditorModelBuilder.scala
+++ b/src/main/scala/fi/oph/koski/editor/EditorModelBuilder.scala
@@ -349,10 +349,19 @@ case class ObjectModelBuilder(schema: ClassSchema)(implicit context: ModelBuilde
       case _ => false
     }
     val editable = context.editable && !lähdejärjestelmällinen && orgWriteAccess
+
     val invalidatable = obj match {
       case o: Opiskeluoikeus => context.invalidatable && OpiskeluoikeusAccessChecker.isInvalidatable(o, context.user)
-      case _ => context.invalidatable // currently this flag is only used for Opiskeluoikeus
+      /*
+      In case of properties (such as Päätason suoritukset), context is relative to containing object (Opiskeluoikeus, in this case).
+      Here, we have already resolved invalidatability for Opiskeluoikeus, so we can 'inherit' the invalidatability for these Päätason suoritukset.
+      For other Päätason suoritukset, we explicitly mark invalidatability as false (which may be in contrast to their Opiskeluoikeus).
+       */
+      case _: PerusopetuksenPäätasonSuoritus | _: AikuistenPerusopetuksenPäätasonSuoritus => context.invalidatable
+      case _: PäätasonSuoritus => false
+      case _ => context.invalidatable
     }
+
     context.copy(editable = editable, invalidatable = invalidatable, root = false, prototypesBeingCreated = SchemaSet.empty)(context.user, context.koodisto, context.localizationRepository)
   }
 }

--- a/src/main/scala/fi/oph/koski/fixture/KoskiDatabaseFixtures.scala
+++ b/src/main/scala/fi/oph/koski/fixture/KoskiDatabaseFixtures.scala
@@ -92,6 +92,7 @@ class KoskiDatabaseFixtureCreator(application: KoskiApplication) extends KoskiDa
       (MockOppijat.koululainen, PerusopetusExampleData.päättötodistusOpiskeluoikeus()),
       (MockOppijat.koululainen, ExamplesPerusopetukseenValmistavaOpetus.perusopetukseenValmistavaOpiskeluoikeus),
       (MockOppijat.luokallejäänyt, PerusopetusExampleData.päättötodistusLuokanTuplauksellaOpiskeluoikeus()),
+      (MockOppijat.vuosiluokkalainen, PerusopetusExampleData.vuosiluokanOpiskeluoikeus()),
       (MockOppijat.toimintaAlueittainOpiskelija, ExamplesPerusopetus.toimintaAlueittainOpiskelija.tallennettavatOpiskeluoikeudet.head),
       (MockOppijat.oppiaineenKorottaja, ExamplesAikuistenPerusopetus.aineopiskelija.tallennettavatOpiskeluoikeudet.head),
       (MockOppijat.aikuisOpiskelija, ExamplesAikuistenPerusopetus.aikuistenPerusopetuksenOpiskeluoikeusAlkuvaiheineen),

--- a/src/main/scala/fi/oph/koski/fixture/KoskiDatabaseFixtures.scala
+++ b/src/main/scala/fi/oph/koski/fixture/KoskiDatabaseFixtures.scala
@@ -79,11 +79,11 @@ class KoskiDatabaseFixtureCreator(application: KoskiApplication) extends KoskiDa
 
   private def defaultOpiskeluOikeudet: List[(TäydellisetHenkilötiedotWithMasterInfo, KoskeenTallennettavaOpiskeluoikeus)] = {
     List(
-      (MockOppijat.eero, OpiskeluoikeusTestData.opiskeluoikeus(MockOrganisaatiot.stadinAmmattiopisto)),
-      (MockOppijat.eerola, OpiskeluoikeusTestData.opiskeluoikeus(MockOrganisaatiot.stadinAmmattiopisto)),
-      (MockOppijat.teija, OpiskeluoikeusTestData.opiskeluoikeus(MockOrganisaatiot.stadinAmmattiopisto)),
-      (MockOppijat.syntymäajallinen, OpiskeluoikeusTestData.opiskeluoikeus(MockOrganisaatiot.stadinAmmattiopisto)),
-      (MockOppijat.markkanen, OpiskeluoikeusTestData.opiskeluoikeus(MockOrganisaatiot.omnia)),
+      (MockOppijat.eero, AmmatillinenOpiskeluoikeusTestData.opiskeluoikeus(MockOrganisaatiot.stadinAmmattiopisto)),
+      (MockOppijat.eerola, AmmatillinenOpiskeluoikeusTestData.opiskeluoikeus(MockOrganisaatiot.stadinAmmattiopisto)),
+      (MockOppijat.teija, AmmatillinenOpiskeluoikeusTestData.opiskeluoikeus(MockOrganisaatiot.stadinAmmattiopisto)),
+      (MockOppijat.syntymäajallinen, AmmatillinenOpiskeluoikeusTestData.opiskeluoikeus(MockOrganisaatiot.stadinAmmattiopisto)),
+      (MockOppijat.markkanen, AmmatillinenOpiskeluoikeusTestData.opiskeluoikeus(MockOrganisaatiot.omnia)),
       (MockOppijat.eskari, ExamplesEsiopetus.esioppilas.tallennettavatOpiskeluoikeudet.head),
       (MockOppijat.ysiluokkalainen, ysinOpiskeluoikeusKesken),
       (MockOppijat.hetuton, ysinOpiskeluoikeusKesken),
@@ -103,7 +103,7 @@ class KoskiDatabaseFixtureCreator(application: KoskiApplication) extends KoskiDa
       (MockOppijat.luva, ExamplesLukioonValmistavaKoulutus.luvaTodistus.tallennettavatOpiskeluoikeudet.head),
       (MockOppijat.ammattilainen, AmmatillinenExampleData.perustutkintoOpiskeluoikeusValmis()),
       (MockOppijat.amis, AmmatillinenExampleData.perustutkintoOpiskeluoikeusKesken()),
-      (MockOppijat.liiketalous, OpiskeluoikeusTestData.opiskeluoikeus(MockOrganisaatiot.stadinAmmattiopisto, koulutusKoodi = 331101, diaariNumero = "59/011/2014")),
+      (MockOppijat.liiketalous, AmmatillinenOpiskeluoikeusTestData.opiskeluoikeus(MockOrganisaatiot.stadinAmmattiopisto, koulutusKoodi = 331101, diaariNumero = "59/011/2014")),
       (MockOppijat.valma, ExamplesValma.valmaTodistus.tallennettavatOpiskeluoikeudet.head),
       (MockOppijat.telma, ExamplesTelma.telmaTodistus.tallennettavatOpiskeluoikeudet.head),
       (MockOppijat.ylioppilasLukiolainen, ExamplesLukio.päättötodistus()),
@@ -111,22 +111,23 @@ class KoskiDatabaseFixtureCreator(application: KoskiApplication) extends KoskiDa
       (MockOppijat.reformitutkinto, ReforminMukainenErikoisammattitutkintoExample.opiskeluoikeus),
       (MockOppijat.osittainenammattitutkinto, AmmatillinenPerustutkintoExample.osittainenPerustutkintoOpiskeluoikeus),
       (MockOppijat.paikallinenTunnustettu, AmmatillinenPerustutkintoExample.tunnustettuPaikallinenTutkinnonOsaOpiskeluoikeus),
-      (MockOppijat.tiedonsiirto, OpiskeluoikeusTestData.lähdejärjestelmällinenOpiskeluoikeus),
+      (MockOppijat.tiedonsiirto, AmmatillinenOpiskeluoikeusTestData.lähdejärjestelmällinenOpiskeluoikeus),
+      (MockOppijat.perusopetuksenTiedonsiirto, PerusopetuksenOpiskeluoikeusTestData.lähdejärjestelmällinenOpiskeluoikeus),
       (MockOppijat.omattiedot, PerusopetusExampleData.päättötodistusOpiskeluoikeus(luokka = "D")),
       (MockOppijat.omattiedot, ExamplesLukio.päättötodistus()),
       (MockOppijat.omattiedotSlave, AmmatillinenOldExamples.uusi.tallennettavatOpiskeluoikeudet(0)),
       (MockOppijat.ibFinal, ExamplesIB.opiskeluoikeus),
       (MockOppijat.ibPredicted, ExamplesIB.opiskeluoikeusPredictedGrades),
-      (MockOppijat.eero, OpiskeluoikeusTestData.mitätöityOpiskeluoikeus),
+      (MockOppijat.eero, AmmatillinenOpiskeluoikeusTestData.mitätöityOpiskeluoikeus),
       (MockOppijat.master, ExamplesPerusopetus.päättötodistus.tallennettavatOpiskeluoikeudet.head),
       (MockOppijat.slave, ExamplesLukio.päättötodistus()),
       (MockOppijat.turvakielto, ExamplesLukio.päättötodistus()),
-      (MockOppijat.erkkiEiperusteissa, OpiskeluoikeusTestData.opiskeluoikeus(MockOrganisaatiot.stadinAmmattiopisto, koulutusKoodi = 334117, diaariNumero = "22/011/2004"))
+      (MockOppijat.erkkiEiperusteissa, AmmatillinenOpiskeluoikeusTestData.opiskeluoikeus(MockOrganisaatiot.stadinAmmattiopisto, koulutusKoodi = 334117, diaariNumero = "22/011/2004"))
     )
   }
 }
 
-object OpiskeluoikeusTestData {
+object AmmatillinenOpiskeluoikeusTestData {
   def opiskeluoikeus(oppilaitosId: String, koulutusKoodi: Int = 351301, diaariNumero: String = "39/011/2014"): AmmatillinenOpiskeluoikeus = {
     val oppilaitos: Oppilaitos = Oppilaitos(oppilaitosId, None, None)
     val koulutusKoodiViite = Koodistokoodiviite(koulutusKoodi.toString, None, "koulutus", None)
@@ -156,4 +157,11 @@ object OpiskeluoikeusTestData {
 
   lazy val lähdejärjestelmällinenOpiskeluoikeus: AmmatillinenOpiskeluoikeus =
     opiskeluoikeus(MockOrganisaatiot.stadinAmmattiopisto).copy(lähdejärjestelmänId = Some(AmmatillinenExampleData.winnovaLähdejärjestelmäId))
+}
+
+object PerusopetuksenOpiskeluoikeusTestData {
+  lazy val lähdejärjestelmällinenOpiskeluoikeus: PerusopetuksenOpiskeluoikeus =
+    PerusopetusExampleData.päättötodistusOpiskeluoikeus(oppilaitos = Oppilaitos(MockOrganisaatiot.stadinAmmattiopisto, None, None)).copy(
+      lähdejärjestelmänId = Some(AmmatillinenExampleData.primusLähdejärjestelmäId)
+    )
 }

--- a/src/main/scala/fi/oph/koski/henkilo/MockOppijat.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/MockOppijat.scala
@@ -23,6 +23,7 @@ object MockOppijat {
   val koululainen = oppijat.oppija("Koululainen", "Kaisa", "220109-784L")
   val luokallejäänyt = oppijat.oppija("Luokallejäänyt", "Lasse", "170186-6520")
   val ysiluokkalainen = oppijat.oppija("Ysiluokkalainen", "Ylermi", "160932-311V")
+  val vuosiluokkalainen = oppijat.oppija("Vuosiluokkalainen", "Ville", "010100-325X")
   val monessaKoulussaOllut = oppijat.oppija("Monikoululainen", "Miia", "180497-112F")
   val lukiolainen = oppijat.oppija("Lukiolainen", "Liisa", "020655-2479")
   val lukioKesken = oppijat.oppija("Lukiokesken", "Leila", "190363-279X")

--- a/src/main/scala/fi/oph/koski/henkilo/MockOppijat.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/MockOppijat.scala
@@ -53,6 +53,7 @@ object MockOppijat {
   val osittainenammattitutkinto = oppijat.oppija("Osittainen", "Outi", "230297-6448")
   val paikallinenTunnustettu = oppijat.oppija("Tunnustettu", "Teuvo", "140176-449X")
   val tiedonsiirto = oppijat.oppija("Tiedonsiirto", "Tiina", "270303-281N")
+  val perusopetuksenTiedonsiirto = oppijat.oppija("Perusopetuksensiirto", "Pertti", "010100-071R")
   val omattiedot = oppijat.oppija(MockUsers.omattiedot.ldapUser.sukunimi, MockUsers.omattiedot.ldapUser.etunimet, "190751-739W", MockUsers.omattiedot.ldapUser.oid)
   val ibFinal = oppijat.oppija("IB-final", "Iina", "040701-432D")
   val ibPredicted = oppijat.oppija("IB-predicted", "Petteri", "071096-317K")

--- a/src/main/scala/fi/oph/koski/http/KoskiErrorCategory.scala
+++ b/src/main/scala/fi/oph/koski/http/KoskiErrorCategory.scala
@@ -136,6 +136,7 @@ object KoskiErrorCategory {
   object forbidden extends ErrorCategory("forbidden", 403, "Käyttäjällä ei ole oikeuksia annetun organisaation tietoihin.") {
     val organisaatio = subcategory("organisaatio", "Käyttäjällä ei oikeuksia annettuun organisaatioon (esimerkiksi oppilaitokseen).")
     val kiellettyMuutos = subcategory("kiellettyMuutos", "Yritetty muuttaa opiskeluoikeuden perustietoja (oppilaitos, tyyppi...)")
+    val ainoanPäätasonSuorituksenPoisto = subcategory("ainoanPäätasonSuorituksenPoisto", "Yritetty poistaa opiskeluoikeuden ainoaa päätason suoritusta")
     val lähdejärjestelmäIdPuuttuu = subcategory("lähdejärjestelmäIdPuuttuu", "Käyttäjä on palvelukäyttäjä mutta lähdejärjestelmää ei ole määritelty")
     val lähdejärjestelmäIdEiSallittu = subcategory("lähdejärjestelmäIdEiSallittu", "Lähdejärjestelmä määritelty, mutta käyttäjä ei ole palvelukäyttäjä")
     val juuriorganisaatioPuuttuu = subcategory("juuriorganisaatioPuuttuu", "Automaattisen tiedonsiirron palvelukäyttäjällä ei yksiselitteistä juuriorganisaatiota")

--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/CompositeOpiskeluoikeusRepository.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/CompositeOpiskeluoikeusRepository.scala
@@ -28,8 +28,8 @@ class CompositeOpiskeluoikeusRepository(main: KoskiOpiskeluoikeusRepository, vir
   def findByOid(oid: String)(implicit user: KoskiSession): Either[HttpStatus, OpiskeluoikeusRow] =
     main.findByOid(oid)
 
-  def createOrUpdate(oppijaOid: PossiblyUnverifiedHenkilöOid, opiskeluoikeus: KoskeenTallennettavaOpiskeluoikeus, allowUpdate: Boolean)(implicit user: KoskiSession): Either[HttpStatus, CreateOrUpdateResult] =
-    main.createOrUpdate(oppijaOid, opiskeluoikeus, allowUpdate)
+  def createOrUpdate(oppijaOid: PossiblyUnverifiedHenkilöOid, opiskeluoikeus: KoskeenTallennettavaOpiskeluoikeus, allowUpdate: Boolean, allowDeleteCompleted: Boolean = false)(implicit user: KoskiSession): Either[HttpStatus, CreateOrUpdateResult] =
+    main.createOrUpdate(oppijaOid, opiskeluoikeus, allowUpdate, allowDeleteCompleted)
 
   def mapFailureToVirtaUnavailable(result: Try[Seq[Opiskeluoikeus]], oid: String): Try[WithWarnings[Seq[Opiskeluoikeus]]] = {
     result match {

--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/KoskiOpiskeluoikeusRepository.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/KoskiOpiskeluoikeusRepository.scala
@@ -11,7 +11,7 @@ import org.json4s.JValue
 trait KoskiOpiskeluoikeusRepository extends AuxiliaryOpiskeluoikeusRepository {
   def findByOid(oid: String)(implicit user: KoskiSession): Either[HttpStatus, OpiskeluoikeusRow]
   def getOppijaOidsForOpiskeluoikeus(opiskeluoikeusOid: String)(implicit user: KoskiSession): Either[HttpStatus, List[Henkilö.Oid]]
-  def createOrUpdate(oppijaOid: PossiblyUnverifiedHenkilöOid, opiskeluoikeus: KoskeenTallennettavaOpiskeluoikeus, allowUpdate: Boolean)(implicit user: KoskiSession): Either[HttpStatus, CreateOrUpdateResult]
+  def createOrUpdate(oppijaOid: PossiblyUnverifiedHenkilöOid, opiskeluoikeus: KoskeenTallennettavaOpiskeluoikeus, allowUpdate: Boolean, allowDeleteComplete: Boolean = false)(implicit user: KoskiSession): Either[HttpStatus, CreateOrUpdateResult]
   def filterOppijat(oppijat: List[HenkilötiedotJaOid])(implicit user: KoskiSession): List[HenkilötiedotJaOid]
   def findByOppijaOid(oid: String)(implicit user: KoskiSession): Seq[Opiskeluoikeus]
   def findByUserOid(oid: String)(implicit user: KoskiSession): Seq[Opiskeluoikeus]

--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/OpiskeluoikeusServlet.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/OpiskeluoikeusServlet.scala
@@ -18,6 +18,12 @@ class OpiskeluoikeusServlet(implicit val application: KoskiApplication) extends 
     renderEither[KoskeenTallennettavaOpiskeluoikeus](result.map(_.toOpiskeluoikeus))
   }
 
+  delete("/:oid/:index") {
+    val result = application.oppijaFacade.invalidatePäätasonSuoritus(getStringParam("oid"), getIntegerParam("index"))
+    result.foreach(_ => application.elasticSearch.refreshIndex)
+    renderEither[HenkilönOpiskeluoikeusVersiot](result)
+  }
+
   delete("/:oid") {
     val result = application.oppijaFacade.invalidateOpiskeluoikeus(getStringParam("oid"))
     result.foreach(_ => application.elasticSearch.refreshIndex)

--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/OpiskeluoikeusServlet.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/OpiskeluoikeusServlet.scala
@@ -18,8 +18,13 @@ class OpiskeluoikeusServlet(implicit val application: KoskiApplication) extends 
     renderEither[KoskeenTallennettavaOpiskeluoikeus](result.map(_.toOpiskeluoikeus))
   }
 
-  delete("/:oid/:index") {
-    val result = application.oppijaFacade.invalidatePäätasonSuoritus(getStringParam("oid"), getIntegerParam("index"))
+  delete("/:oid/:versionumero/:index") {
+    val result = application.oppijaFacade.invalidatePäätasonSuoritus(
+      getStringParam("oid"),
+      getIntegerParam("index"),
+      getIntegerParam("versionumero")
+    )
+
     result.foreach(_ => application.elasticSearch.refreshIndex)
     renderEither[HenkilönOpiskeluoikeusVersiot](result)
   }

--- a/src/main/scala/fi/oph/koski/oppija/KoskiOppijaFacade.scala
+++ b/src/main/scala/fi/oph/koski/oppija/KoskiOppijaFacade.scala
@@ -147,7 +147,7 @@ class KoskiOppijaFacade(henkilöRepository: HenkilöRepository, henkilöCache: K
         case v: Option[Int] if v.isDefined => Left(KoskiErrorCategory.conflict.versionumero())
         case _ => Left(KoskiErrorCategory.badRequest())
       })
-      .flatMap(invalidatedPäätasonSuoritus(päätasonSuoritusIndex))
+      .flatMap(withoutPäätasonSuoritus(päätasonSuoritusIndex))
       .map(oo => oppija.copy(opiskeluoikeudet = List(oo)))
   }
 
@@ -166,7 +166,7 @@ class KoskiOppijaFacade(henkilöRepository: HenkilöRepository, henkilöCache: K
     }).map(oo.withTila).map(_.withPäättymispäivä(now))
   }
 
-  private def invalidatedPäätasonSuoritus(päätasonSuoritusIndex: Int)(oo: KoskeenTallennettavaOpiskeluoikeus): Either[HttpStatus, Opiskeluoikeus] = {
+  private def withoutPäätasonSuoritus(päätasonSuoritusIndex: Int)(oo: KoskeenTallennettavaOpiskeluoikeus): Either[HttpStatus, Opiskeluoikeus] = {
     if (oo.suoritukset.length == 1) {
       Left(KoskiErrorCategory.forbidden.ainoanPäätasonSuorituksenPoisto())
     } else {

--- a/src/main/scala/fi/oph/koski/oppija/KoskiOppijaFacade.scala
+++ b/src/main/scala/fi/oph/koski/oppija/KoskiOppijaFacade.scala
@@ -173,7 +173,9 @@ class KoskiOppijaFacade(henkilöRepository: HenkilöRepository, henkilöCache: K
       oo match {
         case _: PerusopetuksenOpiskeluoikeus | _: AikuistenPerusopetuksenOpiskeluoikeus =>
           val poistetullaSuorituksella = oo.suoritukset.filterNot(_ == päätasonSuoritus)
-          if (poistetullaSuorituksella.length != (oo.suoritukset.length - 1)) {
+          if (poistetullaSuorituksella.length == oo.suoritukset.length) {
+            Left(KoskiErrorCategory.notFound())
+          } else if (poistetullaSuorituksella.length != oo.suoritukset.length - 1) {
             Left(KoskiErrorCategory.internalError())
           } else {
             Right(oo.withSuoritukset(poistetullaSuorituksella))

--- a/src/main/scala/fi/oph/koski/oppija/KoskiOppijaFacade.scala
+++ b/src/main/scala/fi/oph/koski/oppija/KoskiOppijaFacade.scala
@@ -165,8 +165,12 @@ class KoskiOppijaFacade(henkilöRepository: HenkilöRepository, henkilöCache: K
     if (oo.suoritukset.length == 1) {
       Left(KoskiErrorCategory.forbidden.ainoanPäätasonSuorituksenPoisto())
     } else {
-      val (l, r) = oo.suoritukset.splitAt(päätasonSuoritusIndex)
-      Right(oo.withSuoritukset(l ::: r.drop(1)))
+      oo match {
+        case _: PerusopetuksenOpiskeluoikeus | _: AikuistenPerusopetuksenOpiskeluoikeus =>
+          val (l, r) = oo.suoritukset.splitAt(päätasonSuoritusIndex)
+          Right(oo.withSuoritukset(l ::: r.drop(1)))
+        case _ => Left(KoskiErrorCategory.badRequest())
+      }
     }
   }
 

--- a/src/main/scala/fi/oph/koski/oppija/KoskiOppijaFacade.scala
+++ b/src/main/scala/fi/oph/koski/oppija/KoskiOppijaFacade.scala
@@ -143,8 +143,8 @@ class KoskiOppijaFacade(henkilöRepository: HenkilöRepository, henkilöCache: K
     oppija.tallennettavatOpiskeluoikeudet.find(_.oid.exists(_ == opiskeluoikeusOid))
       .toRight(KoskiErrorCategory.notFound())
       .flatMap(oo => oo.versionumero match {
-        case v: Option[Int] if v.contains(versionumero) => Right(oo)
-        case v: Option[Int] if v.isDefined => Left(KoskiErrorCategory.conflict.versionumero())
+        case Some(v) if v == versionumero => Right(oo)
+        case Some(_) => Left(KoskiErrorCategory.conflict.versionumero())
         case _ => Left(KoskiErrorCategory.badRequest())
       })
       .flatMap(withoutPäätasonSuoritus(päätasonSuoritus))

--- a/src/test/scala/fi/oph/koski/api/PaatasonSuoritusInvalidateSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/PaatasonSuoritusInvalidateSpec.scala
@@ -122,8 +122,8 @@ class PaatasonSuoritusInvalidateSpec extends FreeSpec with Matchers with LocalJe
         val oo = oppija(MockOppijat.koululainen.oid).tallennettavatOpiskeluoikeudet.head
         val suoritus = oppija(MockOppijat.ysiluokkalainen.oid).tallennettavatOpiskeluoikeudet.head.suoritukset.head
 
-        deletePäätasonSuoritus(oo.oid.get, 3, suoritus) {
-          verifyResponseStatus(500, KoskiErrorCategory.internalError())
+        deletePäätasonSuoritus(oo.oid.get, oo.versionumero.get, suoritus) {
+          verifyResponseStatus(404, KoskiErrorCategory.notFound())
         }
       }
     }

--- a/src/test/scala/fi/oph/koski/api/PaatasonSuoritusInvalidateSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/PaatasonSuoritusInvalidateSpec.scala
@@ -1,0 +1,131 @@
+package fi.oph.koski.api
+
+import fi.oph.koski.henkilo.MockOppijat
+import fi.oph.koski.http.{ErrorMatcher, HttpTester, KoskiErrorCategory}
+import fi.oph.koski.schema.PerusopetuksenVuosiluokanSuoritus
+import org.scalatest.{FreeSpec, Matchers}
+
+class PaatasonSuoritusInvalidateSpec extends FreeSpec with Matchers with LocalJettyHttpSpecification with PaatasonSuoritusTestMethods with HttpTester {
+  resetFixtures
+
+  "Päätason suorituksen poistaminen" - {
+    "onnistuu" - {
+      "kun useampi nuorten perusopetuksen päätason suoritus" in {
+        val oid = MockOppijat.koululainen.oid
+        val oo = oppija(oid).tallennettavatOpiskeluoikeudet.head
+
+        deletePäätasonSuoritus(oo.oid.get, 1, oo.suoritukset.head) {
+          verifyResponseStatusOk()
+        }
+      }
+
+      "kun useampi aikuisten perusopetuksen päätason suoritus" in {
+        val oo = oppija(MockOppijat.aikuisOpiskelija.oid).tallennettavatOpiskeluoikeudet.head
+
+        deletePäätasonSuoritus(oo.oid.get, 1, oo.suoritukset.head) {
+          verifyResponseStatusOk()
+        }
+      }
+
+      "kun suoritus on valmis" in {
+        val oo = oppija(MockOppijat.koululainen.oid).tallennettavatOpiskeluoikeudet.head
+        val suoritus = oo.suoritukset.head
+
+        assert(suoritus.valmis)
+
+        deletePäätasonSuoritus(oo.oid.get, 2, suoritus) {
+          verifyResponseStatusOk()
+        }
+      }
+
+      "kun suoritus on kesken" in {
+        val oo = oppija(MockOppijat.ysiluokkalainen.oid).tallennettavatOpiskeluoikeudet.head
+        val suoritus = oo.suoritukset.head
+
+        assert(!suoritus.valmis)
+
+        deletePäätasonSuoritus(oo.oid.get, 1, suoritus) {
+          verifyResponseStatusOk()
+        }
+      }
+
+      "kun kaksi saman vuosiluokan suoritusta" in {
+        val oo = oppija(MockOppijat.luokallejäänyt.oid).tallennettavatOpiskeluoikeudet.head
+        val suoritus = oo.suoritukset
+          .collect { case s: PerusopetuksenVuosiluokanSuoritus => s }
+          .find(_.luokka == "7A")
+          .get
+
+        deletePäätasonSuoritus(oo.oid.get, 1, suoritus) {
+          verifyResponseStatusOk()
+        }
+
+        val updated = getOpiskeluoikeus(MockOppijat.luokallejäänyt.oid, "perusopetus")
+
+        val poistettuVuosiluokanSuoritus = updated.suoritukset
+          .collect { case s: PerusopetuksenVuosiluokanSuoritus => s }
+          .filter(_.luokka == "7A")
+
+        val jäljelläOlevaVuosiluokanSuoritus = updated.suoritukset
+          .collect { case s: PerusopetuksenVuosiluokanSuoritus => s }
+          .filter(_.luokka == "7C")
+
+        assert(poistettuVuosiluokanSuoritus.isEmpty)
+        assert(jäljelläOlevaVuosiluokanSuoritus.length == 1)
+      }
+    }
+
+    "epäonnistuu" - {
+      "kun suoritus on ainoa päätason suoritus" in {
+        val oo = oppija(MockOppijat.aikuisOpiskelija.oid).tallennettavatOpiskeluoikeudet.head
+
+        assert(oo.suoritukset.length == 1)
+
+        deletePäätasonSuoritus(oo.oid.get, 2, oo.suoritukset.head) {
+          verifyResponseStatus(403, KoskiErrorCategory.forbidden.ainoanPäätasonSuorituksenPoisto())
+        }
+      }
+
+      "kun suoritus on muu päätason suoritus kuin perusopetuksen päätason suoritus" in {
+        val oo = oppija(MockOppijat.ammattilainen.oid).tallennettavatOpiskeluoikeudet.head
+
+        deletePäätasonSuoritus(oo.oid.get, 1, oo.suoritukset.head) {
+          verifyResponseStatus(403, KoskiErrorCategory.forbidden.ainoanPäätasonSuorituksenPoisto())
+        }
+      }
+
+      "vanhalla versionumerolla" in {
+        val oo = oppija(MockOppijat.koululainen.oid).tallennettavatOpiskeluoikeudet.head
+
+        deletePäätasonSuoritus(oo.oid.get, 1, oo.suoritukset.head) {
+          verifyResponseStatus(409, KoskiErrorCategory.conflict.versionumero())
+        }
+      }
+
+      "olemattomalla versionumerolla" in {
+        val oo = oppija(MockOppijat.koululainen.oid).tallennettavatOpiskeluoikeudet.head
+
+        deletePäätasonSuoritus(oo.oid.get, 4, oo.suoritukset.head) {
+          verifyResponseStatus(409, KoskiErrorCategory.conflict.versionumero())
+        }
+      }
+
+      "virheellisellä oid:lla" in {
+        val oo = oppija(MockOppijat.koululainen.oid).tallennettavatOpiskeluoikeudet.head
+
+        deletePäätasonSuoritus("1.2.246.562.24.99999999999", 1, oo.suoritukset.head) {
+          verifyResponseStatus(400, ErrorMatcher.regex(KoskiErrorCategory.badRequest.queryParam.virheellinenOpiskeluoikeusOid, ".*Virheellinen oid.*".r))
+        }
+      }
+
+      "suorituksella, jota ei löydy" in {
+        val oo = oppija(MockOppijat.koululainen.oid).tallennettavatOpiskeluoikeudet.head
+        val suoritus = oppija(MockOppijat.ysiluokkalainen.oid).tallennettavatOpiskeluoikeudet.head.suoritukset.head
+
+        deletePäätasonSuoritus(oo.oid.get, 3, suoritus) {
+          verifyResponseStatus(500, KoskiErrorCategory.internalError())
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/fi/oph/koski/api/PaatasonSuoritusTestMethods.scala
+++ b/src/test/scala/fi/oph/koski/api/PaatasonSuoritusTestMethods.scala
@@ -1,0 +1,16 @@
+package fi.oph.koski.api
+
+import fi.oph.koski.json.JsonSerializer
+import fi.oph.koski.schema.Suoritus
+import fi.oph.koski.koskiuser.MockUsers.paakayttaja
+
+trait PaatasonSuoritusTestMethods extends LocalJettyHttpSpecification with OpiskeluoikeusTestMethods {
+  def deletePäätasonSuoritus[A](opiskeluoikeusOid: String, versionumero: Int, suoritus: Suoritus)(f: => A): A = {
+    val suoritusBody = JsonSerializer.writeWithRoot(suoritus)
+
+    post(s"api/opiskeluoikeus/$opiskeluoikeusOid/$versionumero/delete-paatason-suoritus",
+      body = suoritusBody,
+      headers = authHeaders(paakayttaja) ++ jsonContent
+    )(f)
+  }
+}

--- a/web/app/components/ButtonWithConfirmation.jsx
+++ b/web/app/components/ButtonWithConfirmation.jsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import Text from '../i18n/Text'
+
+class ButtonWithConfirmation extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { isActionRequested: false }
+  }
+
+  render() {
+    const { text, confirmationText, cancelText, action, className, confirmationClassName } = this.props
+
+    const isActionRequested = this.state.isActionRequested
+
+    return isActionRequested
+      ? (
+        <div className={className}>
+          <a onClick={() => this.setState({ isActionRequested: false })}>
+            <Text name={cancelText}/>
+          </a>
+
+          <button className={`koski-button ${(confirmationClassName ? confirmationClassName : '')}`} onClick={action}>
+            <Text name={confirmationText}/>
+          </button>
+        </div>
+      )
+      : (
+        <a className={className} onClick={() => this.setState({ isActionRequested: true })}>
+          <Text name={text} />
+        </a>
+      )
+  }
+}
+
+export default ButtonWithConfirmation

--- a/web/app/components/InvalidationNotification.jsx
+++ b/web/app/components/InvalidationNotification.jsx
@@ -1,0 +1,24 @@
+import React from 'baret'
+import Bacon from 'baconjs'
+import Text from '../i18n/Text'
+
+// use session storage for notification status to persist over page reload
+const NOTIFICATION_STORAGE_KEY = 'invalidationCompleted'
+
+export const setInvalidationNotification = messageKey => sessionStorage.setItem(NOTIFICATION_STORAGE_KEY, messageKey)
+export const resetInvalidationNotification = () => sessionStorage.removeItem(NOTIFICATION_STORAGE_KEY)
+
+export const InvalidationNotification = ({location}) => {
+  if (!location || location.path !== '/koski/virkailija' || !sessionStorage.getItem(NOTIFICATION_STORAGE_KEY)) {
+    return null
+  }
+  let hideBus = Bacon.Bus()
+  let later = Bacon.later(5000)
+  let hideP = hideBus.merge(later).map('hide').toProperty('')
+  hideP.filter(e => e === 'hide').onValue(resetInvalidationNotification)
+  return (<div id="invalidated" className={hideP.map(hideClass => 'opiskeluoikeus-invalidated ' + hideClass)}>
+    <Text name="Opiskeluoikeus mitätöity"/><a onClick={() => hideBus.push()} className="hide-invalidated-message"/>
+  </div>)
+}
+
+export default InvalidationNotification

--- a/web/app/components/InvalidationNotification.jsx
+++ b/web/app/components/InvalidationNotification.jsx
@@ -10,16 +10,19 @@ export const resetInvalidationNotification = () => sessionStorage.removeItem(NOT
 
 export class InvalidationNotification extends React.PureComponent {
   render() {
-    if (!sessionStorage.getItem(NOTIFICATION_STORAGE_KEY)) {
-      return null
-    }
-    let hideBus = Bacon.Bus()
-    let later = Bacon.later(5000)
-    let hideP = hideBus.merge(later).map('hide').toProperty('')
+    if (!sessionStorage.getItem(NOTIFICATION_STORAGE_KEY)) return null
+
+    const hideBus = Bacon.Bus()
+    const later = Bacon.later(5000)
+    const hideP = hideBus.merge(later).map('hide').toProperty('')
     hideP.filter(e => e === 'hide').onValue(resetInvalidationNotification)
-    return (<div id="invalidated" className={hideP.map(hideClass => 'opiskeluoikeus-invalidated ' + hideClass)}>
-      <Text name="Opiskeluoikeus mitätöity"/><a onClick={() => hideBus.push()} className="hide-invalidated-message"/>
-    </div>)
+
+    return (
+      <div id="invalidated" className={hideP.map(hideClass => 'opiskeluoikeus-invalidated ' + hideClass)}>
+        <Text name="Opiskeluoikeus mitätöity"/>
+        <a onClick={() => hideBus.push()} className="hide-invalidated-message"/>
+      </div>
+    )
   }
 }
 

--- a/web/app/components/InvalidationNotification.jsx
+++ b/web/app/components/InvalidationNotification.jsx
@@ -19,9 +19,9 @@ export class InvalidationNotification extends React.PureComponent {
     hideP.filter(e => e === 'hide').onValue(resetInvalidationNotification)
 
     return (
-      <div id="invalidated" className={hideP.map(hideClass => 'opiskeluoikeus-invalidated ' + hideClass)}>
+      <div id="invalidated" className={hideP.map(hideClass => 'invalidation-notification ' + hideClass)}>
         <Text name={notification}/>
-        <a onClick={() => hideBus.push()} className="hide-invalidated-message"/>
+        <a onClick={() => hideBus.push()} className="hide-invalidation-notification"/>
       </div>
     )
   }

--- a/web/app/components/InvalidationNotification.jsx
+++ b/web/app/components/InvalidationNotification.jsx
@@ -10,7 +10,8 @@ export const resetInvalidationNotification = () => sessionStorage.removeItem(NOT
 
 export class InvalidationNotification extends React.PureComponent {
   render() {
-    if (!sessionStorage.getItem(NOTIFICATION_STORAGE_KEY)) return null
+    const notification = sessionStorage.getItem(NOTIFICATION_STORAGE_KEY)
+    if (!notification) return null
 
     const hideBus = Bacon.Bus()
     const later = Bacon.later(5000)
@@ -19,7 +20,7 @@ export class InvalidationNotification extends React.PureComponent {
 
     return (
       <div id="invalidated" className={hideP.map(hideClass => 'opiskeluoikeus-invalidated ' + hideClass)}>
-        <Text name="Opiskeluoikeus mitätöity"/>
+        <Text name={notification}/>
         <a onClick={() => hideBus.push()} className="hide-invalidated-message"/>
       </div>
     )

--- a/web/app/components/InvalidationNotification.jsx
+++ b/web/app/components/InvalidationNotification.jsx
@@ -8,17 +8,19 @@ const NOTIFICATION_STORAGE_KEY = 'invalidationCompleted'
 export const setInvalidationNotification = messageKey => sessionStorage.setItem(NOTIFICATION_STORAGE_KEY, messageKey)
 export const resetInvalidationNotification = () => sessionStorage.removeItem(NOTIFICATION_STORAGE_KEY)
 
-export const InvalidationNotification = ({location}) => {
-  if (!location || location.path !== '/koski/virkailija' || !sessionStorage.getItem(NOTIFICATION_STORAGE_KEY)) {
-    return null
+export class InvalidationNotification extends React.PureComponent {
+  render() {
+    if (!sessionStorage.getItem(NOTIFICATION_STORAGE_KEY)) {
+      return null
+    }
+    let hideBus = Bacon.Bus()
+    let later = Bacon.later(5000)
+    let hideP = hideBus.merge(later).map('hide').toProperty('')
+    hideP.filter(e => e === 'hide').onValue(resetInvalidationNotification)
+    return (<div id="invalidated" className={hideP.map(hideClass => 'opiskeluoikeus-invalidated ' + hideClass)}>
+      <Text name="Opiskeluoikeus mitätöity"/><a onClick={() => hideBus.push()} className="hide-invalidated-message"/>
+    </div>)
   }
-  let hideBus = Bacon.Bus()
-  let later = Bacon.later(5000)
-  let hideP = hideBus.merge(later).map('hide').toProperty('')
-  hideP.filter(e => e === 'hide').onValue(resetInvalidationNotification)
-  return (<div id="invalidated" className={hideP.map(hideClass => 'opiskeluoikeus-invalidated ' + hideClass)}>
-    <Text name="Opiskeluoikeus mitätöity"/><a onClick={() => hideBus.push()} className="hide-invalidated-message"/>
-  </div>)
 }
 
 export default InvalidationNotification

--- a/web/app/editor/TogglableEditor.jsx
+++ b/web/app/editor/TogglableEditor.jsx
@@ -4,7 +4,7 @@ import {contextualizeModel} from './EditorModel.js'
 import {currentLocation} from '../util/location'
 import Text from '../i18n/Text'
 import {modelData} from './EditorModel'
-import {InvalidateOpiskeluoikeusButton} from '../opiskeluoikeus/OpiskeluoikeusInvalidation'
+import InvalidateOpiskeluoikeusButton from '../opiskeluoikeus/InvalidateOpiskeluoikeusButton'
 
 export class TogglableEditor extends React.Component {
   render() {

--- a/web/app/opiskeluoikeus/InvalidateOpiskeluoikeusButton.jsx
+++ b/web/app/opiskeluoikeus/InvalidateOpiskeluoikeusButton.jsx
@@ -3,7 +3,7 @@ import {modelData} from '../editor/EditorModel'
 import {invalidateOpiskeluoikeus} from '../virkailija/VirkailijaOppijaView'
 import ButtonWithConfirmation from '../components/ButtonWithConfirmation'
 
-export const InvalidateOpiskeluoikeusButton = ({opiskeluoikeus}) => (
+export default ({opiskeluoikeus}) => (
   <ButtonWithConfirmation
     text='Mitätöi opiskeluoikeus'
     confirmationText='Vahvista mitätöinti, operaatiota ei voi peruuttaa'

--- a/web/app/opiskeluoikeus/InvalidateOpiskeluoikeusButton.jsx
+++ b/web/app/opiskeluoikeus/InvalidateOpiskeluoikeusButton.jsx
@@ -9,7 +9,7 @@ export default ({opiskeluoikeus}) => (
     confirmationText='Vahvista mitätöinti, operaatiota ei voi peruuttaa'
     cancelText='Peruuta mitätöinti'
     action={() => invalidateOpiskeluoikeus(modelData(opiskeluoikeus, 'oid'))}
-    className='invalidate'
-    confirmationClassName='confirm-invalidate'
+    className='invalidate invalidate-opiskeluoikeus'
+    confirmationClassName='confirm-invalidate invalidate-opiskeluoikeus__confirm'
   />
 )

--- a/web/app/opiskeluoikeus/OpiskeluoikeusInvalidation.jsx
+++ b/web/app/opiskeluoikeus/OpiskeluoikeusInvalidation.jsx
@@ -3,6 +3,7 @@ import Bacon from 'baconjs'
 import Text from '../i18n/Text'
 import {modelData} from '../editor/EditorModel'
 import {invalidateOpiskeluoikeus} from '../virkailija/VirkailijaOppijaView'
+import ButtonWithConfirmation from '../components/ButtonWithConfirmation'
 
 export const setOpiskeluoikeusInvalidated = () => sessionStorage.setItem('opiskeluoikeusInvalidated', true)
 export const resetOpiskeluoikeusInvalidated = () => sessionStorage.removeItem('opiskeluoikeusInvalidated')
@@ -20,17 +21,14 @@ export const OpiskeluoikeusInvalidatedMessage = ({location}) => {
   </div>)
 }
 
-export class InvalidateOpiskeluoikeusButton extends React.Component {
-  render() {
-    let { opiskeluoikeus } = this.props
-    let deleteRequested = this.state && this.state.deleteRequested
-
-    return deleteRequested
-      ? (<div className="invalidate">
-        <a onClick={() => this.setState({deleteRequested: false})}><Text name="Peruuta mitätöinti" /></a>
-        <button className="koski-button confirm-invalidate" onClick={() => invalidateOpiskeluoikeus(modelData(opiskeluoikeus, 'oid'))}><Text name="Vahvista mitätöinti, operaatiota ei voi peruuttaa" /></button>
-      </div>)
-      : <a className="invalidate" onClick={() => this.setState({deleteRequested: true})}><Text name="Mitätöi opiskeluoikeus" /></a>
-  }
-}
+export const InvalidateOpiskeluoikeusButton = ({opiskeluoikeus}) => (
+  <ButtonWithConfirmation
+    text='Mitätöi opiskeluoikeus'
+    confirmationText='Vahvista mitätöinti, operaatiota ei voi peruuttaa'
+    cancelText='Peruuta mitätöinti'
+    action={() => invalidateOpiskeluoikeus(modelData(opiskeluoikeus, 'oid'))}
+    className='invalidate'
+    confirmationClassName='confirm-invalidate'
+  />
+)
 

--- a/web/app/opiskeluoikeus/OpiskeluoikeusInvalidation.jsx
+++ b/web/app/opiskeluoikeus/OpiskeluoikeusInvalidation.jsx
@@ -1,25 +1,7 @@
-import React from 'baret'
-import Bacon from 'baconjs'
-import Text from '../i18n/Text'
+import React from 'react'
 import {modelData} from '../editor/EditorModel'
 import {invalidateOpiskeluoikeus} from '../virkailija/VirkailijaOppijaView'
 import ButtonWithConfirmation from '../components/ButtonWithConfirmation'
-
-export const setOpiskeluoikeusInvalidated = () => sessionStorage.setItem('opiskeluoikeusInvalidated', true)
-export const resetOpiskeluoikeusInvalidated = () => sessionStorage.removeItem('opiskeluoikeusInvalidated')
-
-export const OpiskeluoikeusInvalidatedMessage = ({location}) => {
-  if (!location || location.path !== '/koski/virkailija' || !sessionStorage.getItem('opiskeluoikeusInvalidated')) {
-    return null
-  }
-  let hideBus = Bacon.Bus()
-  let later = Bacon.later(5000)
-  let hideP = hideBus.merge(later).map('hide').toProperty('')
-  hideP.filter(e => e === 'hide').onValue(resetOpiskeluoikeusInvalidated)
-  return (<div id="invalidated" className={hideP.map(hideClass => 'opiskeluoikeus-invalidated ' + hideClass)}>
-    <Text name="Opiskeluoikeus mitätöity"/><a onClick={() => hideBus.push()} className="hide-invalidated-message"/>
-  </div>)
-}
 
 export const InvalidateOpiskeluoikeusButton = ({opiskeluoikeus}) => (
   <ButtonWithConfirmation
@@ -31,4 +13,3 @@ export const InvalidateOpiskeluoikeusButton = ({opiskeluoikeus}) => (
     confirmationClassName='confirm-invalidate'
   />
 )
-

--- a/web/app/style/opiskeluoikeus.less
+++ b/web/app/style/opiskeluoikeus.less
@@ -13,8 +13,24 @@
       }
     }
 
-    .suoritus > .properties .dropdown {
-      width: 300px;
+    .suoritus {
+      &  > .properties .dropdown {
+        width: 300px;
+      }
+
+      & > .delete-paatason-suoritus-container {
+        margin-top: -25px;
+        height: 40px;
+        text-align: right;
+
+        & > .delete-paatason-suoritus {
+          position: relative;
+        }
+
+        & > a.delete-paatason-suoritus {
+          top: 10px;
+        }
+      }
     }
 
     .text-like-input, .dropdown {

--- a/web/app/style/opiskeluoikeus.less
+++ b/web/app/style/opiskeluoikeus.less
@@ -607,6 +607,8 @@
       a.todistus {
         opacity: 0;
         .OverlayLink;
+        top: inherit;
+        bottom: 0;
       }
 
       .properties {

--- a/web/app/style/oppija.less
+++ b/web/app/style/oppija.less
@@ -105,7 +105,7 @@
     }
   }
 
-  .opiskeluoikeus-invalidated {
+  .invalidation-notification {
     text-align: center;
     z-index: 1;
     position: absolute;

--- a/web/app/style/topbar.less
+++ b/web/app/style/topbar.less
@@ -92,7 +92,7 @@
       line-height: 50px;
       vertical-align: middle;
     }
-    .hide-invalidated-message {
+    .hide-invalidation-notification {
       float: right;
       .RemoveSymbol;
     }

--- a/web/app/style/topbar.less
+++ b/web/app/style/topbar.less
@@ -81,7 +81,7 @@
     color: white;
   }
 
-  .opiskeluoikeus-invalidated {
+  .invalidation-notification {
     text-align: center;
     height: 50px;
     background: @color-topbar-message-background;

--- a/web/app/suoritus/DeletePaatasonSuoritusButton.jsx
+++ b/web/app/suoritus/DeletePaatasonSuoritusButton.jsx
@@ -3,12 +3,14 @@ import {deletePäätasonSuoritus} from '../virkailija/VirkailijaOppijaView'
 import ButtonWithConfirmation from '../components/ButtonWithConfirmation'
 
 export default ({opiskeluoikeus, päätasonSuoritus}) => (
-  <ButtonWithConfirmation
-    text='Poista suoritus'
-    confirmationText='Vahvista poisto, operaatiota ei voi peruuttaa'
-    cancelText='Peruuta poisto'
-    action={() => deletePäätasonSuoritus(opiskeluoikeus, päätasonSuoritus)}
-    className='invalidate delete-paatason-suoritus'
-    confirmationClassName='confirm-invalidate delete-paatason-suoritus__confirm'
-  />
+  <div className='delete-paatason-suoritus-container'>
+    <ButtonWithConfirmation
+      text='Poista suoritus'
+      confirmationText='Vahvista poisto, operaatiota ei voi peruuttaa'
+      cancelText='Peruuta poisto'
+      action={() => deletePäätasonSuoritus(opiskeluoikeus, päätasonSuoritus)}
+      className='invalidate delete-paatason-suoritus'
+      confirmationClassName='confirm-invalidate delete-paatason-suoritus__confirm'
+    />
+  </div>
 )

--- a/web/app/suoritus/DeletePaatasonSuoritusButton.jsx
+++ b/web/app/suoritus/DeletePaatasonSuoritusButton.jsx
@@ -8,7 +8,7 @@ export default ({opiskeluoikeus, päätasonSuoritus}) => (
     confirmationText='Vahvista poisto, operaatiota ei voi peruuttaa'
     cancelText='Peruuta poisto'
     action={() => deletePäätasonSuoritus(opiskeluoikeus, päätasonSuoritus)}
-    className='invalidate'
-    confirmationClassName='confirm-invalidate'
+    className='invalidate delete-paatason-suoritus'
+    confirmationClassName='confirm-invalidate delete-paatason-suoritus__confirm'
   />
 )

--- a/web/app/suoritus/DeletePaatasonSuoritusButton.jsx
+++ b/web/app/suoritus/DeletePaatasonSuoritusButton.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import {deletePäätasonSuoritus} from '../virkailija/VirkailijaOppijaView'
+import ButtonWithConfirmation from '../components/ButtonWithConfirmation'
+
+export default ({opiskeluoikeus, päätasonSuoritus}) => (
+  <ButtonWithConfirmation
+    text='Poista suoritus'
+    confirmationText='Vahvista poisto, operaatiota ei voi peruuttaa'
+    cancelText='Peruuta poisto'
+    action={() => deletePäätasonSuoritus(opiskeluoikeus, päätasonSuoritus)}
+    className='invalidate'
+    confirmationClassName='confirm-invalidate'
+  />
+)

--- a/web/app/suoritus/SuoritusEditor.jsx
+++ b/web/app/suoritus/SuoritusEditor.jsx
@@ -1,4 +1,4 @@
-import {addContext, modelData, modelLookup, removeCommonPath} from '../editor/EditorModel'
+import {addContext, modelData, modelItems, modelLookup, removeCommonPath} from '../editor/EditorModel'
 import React from 'baret'
 import {PropertiesEditor} from '../editor/PropertiesEditor'
 import {Editor} from '../editor/Editor'
@@ -16,7 +16,8 @@ export class SuoritusEditor extends React.Component {
 
     const editingAny = !!currentLocation().params.edit
     const showEditLink = model.editable && !editingAny
-    const showDeleteLink = model.invalidatable && !showEditLink
+    const isSingleSuoritus = modelItems(model.context.opiskeluoikeus, 'suoritukset').length == 1
+    const showDeleteLink = model.invalidatable && !showEditLink && !isSingleSuoritus
 
     return showDeleteLink && (
       <DeletePaatasonSuoritusButton

--- a/web/app/suoritus/SuoritusEditor.jsx
+++ b/web/app/suoritus/SuoritusEditor.jsx
@@ -8,8 +8,24 @@ import Text from '../i18n/Text'
 import {resolveOsasuorituksetEditor, resolvePropertyEditor} from './suoritusEditorMapping'
 import {flatMapArray} from '../util/util'
 import DeletePaatasonSuoritusButton from './DeletePaatasonSuoritusButton'
+import {currentLocation} from '../util/location'
 
 export class SuoritusEditor extends React.Component {
+  showDeleteButtonIfAllowed() {
+    const {model} = this.props
+
+    const editingAny = !!currentLocation().params.edit
+    const showEditLink = model.editable && !editingAny
+    const showDeleteLink = model.invalidatable && !showEditLink
+
+    return showDeleteLink && (
+      <DeletePaatasonSuoritusButton
+        opiskeluoikeus={model.context.opiskeluoikeus}
+        päätasonSuoritus={model}
+      />
+    )
+  }
+
   render() {
     const excludedProperties = ['osasuoritukset', 'käyttäytymisenArvio', 'vahvistus', 'jääLuokalle', 'pakollinen']
 
@@ -21,10 +37,7 @@ export class SuoritusEditor extends React.Component {
 
     return (
       <div className={className}>
-        <DeletePaatasonSuoritusButton
-          opiskeluoikeus={model.context.opiskeluoikeus}
-          päätasonSuoritus={model}
-        />
+        {this.showDeleteButtonIfAllowed()}
         <TodistusLink suoritus={model} />
         <PropertiesEditor
           model={model}

--- a/web/app/suoritus/SuoritusEditor.jsx
+++ b/web/app/suoritus/SuoritusEditor.jsx
@@ -7,6 +7,7 @@ import {arviointiPuuttuu, osasuoritukset, suoritusKesken, suoritusValmis} from '
 import Text from '../i18n/Text'
 import {resolveOsasuorituksetEditor, resolvePropertyEditor} from './suoritusEditorMapping'
 import {flatMapArray} from '../util/util'
+import DeletePaatasonSuoritusButton from './DeletePaatasonSuoritusButton'
 
 export class SuoritusEditor extends React.Component {
   render() {
@@ -20,6 +21,10 @@ export class SuoritusEditor extends React.Component {
 
     return (
       <div className={className}>
+        <DeletePaatasonSuoritusButton
+          opiskeluoikeus={model.context.opiskeluoikeus}
+          päätasonSuoritus={model}
+        />
         <TodistusLink suoritus={model} />
         <PropertiesEditor
           model={model}

--- a/web/app/topbar/LocalTopBar.jsx
+++ b/web/app/topbar/LocalTopBar.jsx
@@ -17,7 +17,7 @@ export default ({location, user, titleKey}) => {
       {(user !== null) &&
       <div className='topbarnav'>
         <NavList location={location} user={user}/>
-        <InvalidationNotification location={location} />
+        <InvalidationNotification/>
       </div>
       }
     </header>

--- a/web/app/topbar/LocalTopBar.jsx
+++ b/web/app/topbar/LocalTopBar.jsx
@@ -3,7 +3,7 @@ import {UserInfo} from './UserInfo'
 import Link from '../components/Link'
 import Text from '../i18n/Text'
 import NavList from './NavList'
-import {OpiskeluoikeusInvalidatedMessage} from '../opiskeluoikeus/OpiskeluoikeusInvalidation'
+import InvalidationNotification from '../components/InvalidationNotification'
 
 export default ({location, user, titleKey}) => {
   return (
@@ -17,7 +17,7 @@ export default ({location, user, titleKey}) => {
       {(user !== null) &&
       <div className='topbarnav'>
         <NavList location={location} user={user}/>
-        <OpiskeluoikeusInvalidatedMessage location={location} />
+        <InvalidationNotification location={location} />
       </div>
       }
     </header>

--- a/web/app/topbar/TopBar.jsx
+++ b/web/app/topbar/TopBar.jsx
@@ -1,7 +1,7 @@
 import React from 'baret'
-import {OpiskeluoikeusInvalidatedMessage} from '../opiskeluoikeus/OpiskeluoikeusInvalidation'
 import LocalTopBar from './LocalTopBar'
 import NavList from './NavList'
+import InvalidationNotification from '../components/InvalidationNotification'
 
 export const TopBar = ({user, titleKey, inRaamit, location}) => {
   return (inRaamit
@@ -13,6 +13,6 @@ export const TopBar = ({user, titleKey, inRaamit, location}) => {
 const RaamitTopBar = ({location, user}) => {
   return (<header id="topbar" className="inraamit topbarnav">
     <NavList location={location} user={user}/>
-    <OpiskeluoikeusInvalidatedMessage location={location} />
+    <InvalidationNotification location={location} />
   </header>)
 }

--- a/web/app/topbar/TopBar.jsx
+++ b/web/app/topbar/TopBar.jsx
@@ -13,6 +13,6 @@ export const TopBar = ({user, titleKey, inRaamit, location}) => {
 const RaamitTopBar = ({location, user}) => {
   return (<header id="topbar" className="inraamit topbarnav">
     <NavList location={location} user={user}/>
-    <InvalidationNotification location={location} />
+    <InvalidationNotification/>
   </header>)
 }

--- a/web/app/virkailija/VirkailijaOppijaView.jsx
+++ b/web/app/virkailija/VirkailijaOppijaView.jsx
@@ -27,7 +27,7 @@ import {doActionWhileMounted, flatMapArray} from '../util/util'
 import Text from '../i18n/Text'
 import {t} from '../i18n/i18n'
 import {EditLocalizationsLink} from '../i18n/EditLocalizationsLink'
-import {setOpiskeluoikeusInvalidated} from '../opiskeluoikeus/OpiskeluoikeusInvalidation'
+import {setInvalidationNotification} from '../components/InvalidationNotification'
 import {userP} from '../util/user'
 import {Varoitukset} from '../util/Varoitukset'
 
@@ -254,6 +254,6 @@ const EditBar = ({stateP, saveChangesBus, cancelChangesBus, oppija}) => {
 }
 
 const opiskeluoikeusInvalidated = () => {
-  setOpiskeluoikeusInvalidated()
+  setInvalidationNotification('Opiskeluoikeus mitätöity')
   window.location = '/koski/virkailija'
 }

--- a/web/test/page/koskiPage.js
+++ b/web/test/page/koskiPage.js
@@ -190,7 +190,14 @@ function KoskiPage() {
       return S('.user-info .name').text()
     },
     isOpiskeluoikeusInvalidatedMessageShown: function() {
-      return isElementVisible(S(".opiskeluoikeus-invalidated")) && !isElementVisible(S(".opiskeluoikeus-invalidated.hide"));
+      return isElementVisible(S(".invalidation-notification")) &&
+        !isElementVisible(S(".invalidation-notification.hide")) &&
+        S(".invalidation-notification").text() == "Opiskeluoikeus mitätöity";
+    },
+    isPäätasonSuoritusDeletedMessageShown: function() {
+      return isElementVisible(S(".invalidation-notification")) &&
+        !isElementVisible(S(".invalidation-notification.hide")) &&
+        S(".invalidation-notification").text() == "Suoritus poistettu";
     }
   }
 

--- a/web/test/page/opinnotPage.js
+++ b/web/test/page/opinnotPage.js
@@ -167,14 +167,22 @@ function OpinnotPage() {
       }
     },
     invalidateOpiskeluoikeusIsShown: function() {
-      return isElementVisible(findSingle('.invalidate'))
+      return isElementVisible(findSingle('.invalidate.invalidate-opiskeluoikeus'))
     },
     confirmInvalidateOpiskeluoikeusIsShown: function() {
-      return isElementVisible(findSingle('.confirm-invalidate'))
+      return isElementVisible(findSingle('.confirm-invalidate.invalidate-opiskeluoikeus__confirm'))
     },
-    invalidateOpiskeluoikeus: click(findSingle('.invalidate')),
-    confirmInvalidateOpiskeluoikeus: click(findSingle('.confirm-invalidate')),
+    deletePäätasonSuoritusIsShown: function() {
+      return isElementVisible(findSingle('.invalidate.delete-paatason-suoritus'))
+    },
+    confirmDeletePäätasonSuoritusIsShown: function() {
+      return isElementVisible(findSingle('.confirm-invalidate.delete-paatason-suoritus__confirm'))
+    },
+    invalidateOpiskeluoikeus: click(findSingle('.invalidate.invalidate-opiskeluoikeus')),
+    confirmInvalidateOpiskeluoikeus: click(findSingle('.confirm-invalidate.invalidate-opiskeluoikeus__confirm')),
     hideInvalidateMessage: click(findSingle('.hide-invalidated-message')),
+    deletePäätasonSuoritus: click(findSingle('.invalidate.delete-paatason-suoritus')),
+    confirmDeletePäätasonSuoritus: click(findSingle('.confirm-invalidate.delete-paatason-suoritus__confirm')),
     backToList: click(findSingle('.back-link'))
   }
 

--- a/web/test/page/opinnotPage.js
+++ b/web/test/page/opinnotPage.js
@@ -180,7 +180,7 @@ function OpinnotPage() {
     },
     invalidateOpiskeluoikeus: click(findSingle('.invalidate.invalidate-opiskeluoikeus')),
     confirmInvalidateOpiskeluoikeus: click(findSingle('.confirm-invalidate.invalidate-opiskeluoikeus__confirm')),
-    hideInvalidateMessage: click(findSingle('.hide-invalidated-message')),
+    hideInvalidateMessage: click(findSingle('.hide-invalidation-notification')),
     deletePäätasonSuoritus: click(findSingle('.invalidate.delete-paatason-suoritus')),
     confirmDeletePäätasonSuoritus: click(findSingle('.confirm-invalidate.delete-paatason-suoritus__confirm')),
     backToList: click(findSingle('.back-link'))

--- a/web/test/spec/ammatillinenSpec.js
+++ b/web/test/spec/ammatillinenSpec.js
@@ -1389,6 +1389,16 @@ describe('Ammatillinen koulutus', function() {
         })
       })
     })
+
+    describe('Päätason suorituksen poistaminen', function() {
+      before(editor.edit)
+
+      describe('Mitätöintilinkki', function() {
+        it('Ei näytetä', function() {
+          expect(opinnot.deletePäätasonSuoritusIsShown()).to.equal(false)
+        })
+      })
+    })
   })
 
   describe('Ammatillinen perustutkinto', function() {

--- a/web/test/spec/esiopetusSpec.js
+++ b/web/test/spec/esiopetusSpec.js
@@ -71,6 +71,15 @@ describe('Esiopetus', function() {
       })
     })
 
+    describe('Päätason suorituksen poistaminen', function() {
+      before(editor.edit)
+
+      describe('Mitätöintilinkki', function() {
+        it('Ei näytetä', function() {
+          expect(opinnot.deletePäätasonSuoritusIsShown()).to.equal(false)
+        })
+      })
+    })
   })
 
   describe('Aloituspäivä', function() {

--- a/web/test/spec/ibSpec.js
+++ b/web/test/spec/ibSpec.js
@@ -484,6 +484,16 @@ describe('IB', function( ) {
 
         })
       })
+
+      describe('Päätason suorituksen poistaminen', function() {
+        before(editor.edit)
+
+        describe('Mitätöintilinkki', function() {
+          it('Ei näytetä', function() {
+            expect(opinnot.deletePäätasonSuoritusIsShown()).to.equal(false)
+          })
+        })
+      })
     })
   })
 
@@ -1002,6 +1012,16 @@ describe('IB', function( ) {
                 expect(extractAsText(S('.oppiaineet .A'))).to.not.contain('PAIK')
               })
             })
+          })
+        })
+      })
+
+      describe('Päätason suorituksen poistaminen', function() {
+        before(editor.edit)
+
+        describe('Mitätöintilinkki', function() {
+          it('Ei näytetä', function() {
+            expect(opinnot.deletePäätasonSuoritusIsShown()).to.equal(false)
           })
         })
       })

--- a/web/test/spec/lukioSpec.js
+++ b/web/test/spec/lukioSpec.js
@@ -386,6 +386,16 @@ describe('Lukiokoulutus', function( ){
           })
         })
       })
+
+      describe('Päätason suorituksen poistaminen', function() {
+        before(editor.edit)
+
+        describe('Mitätöintilinkki', function() {
+          it('Ei näytetä', function() {
+            expect(opinnot.deletePäätasonSuoritusIsShown()).to.equal(false)
+          })
+        })
+      })
     })
   })
 

--- a/web/test/spec/omatTiedotSpec.js
+++ b/web/test/spec/omatTiedotSpec.js
@@ -141,7 +141,7 @@ describe('Omat tiedot', function() {
                   'Muista mainita sähköpostissa seuraavat tiedot:\n' +
                   'Nimi: Miia Monikoululainen\n' +
                   'Syntymäaika: 18.4.1997\n' +
-                  'Oppijanumero: 1.2.246.562.24.00000000010' +
+                  'Oppijanumero: 1.2.246.562.24.00000000011' +
                   ' ' +
                   'Kopioi'
                 )
@@ -158,7 +158,7 @@ describe('Omat tiedot', function() {
                     'Allaoleva teksti on luotu automaattisesti Opintopolun tiedoista. Koulu tarvitsee näitä tietoja pystyäkseen käsittelemään kysymystäsi.\n\n' +
                     'Nimi: Miia Monikoululainen\n' +
                     'Syntymäaika: 18.4.1997\n' +
-                    'Oppijanumero: 1.2.246.562.24.00000000010'
+                    'Oppijanumero: 1.2.246.562.24.00000000011'
                   )
                 )
               })
@@ -202,7 +202,7 @@ describe('Omat tiedot', function() {
                     'Muista mainita sähköpostissa seuraavat tiedot:\n' +
                     'Nimi: Miia Monikoululainen\n' +
                     'Syntymäaika: 18.4.1997\n' +
-                    'Oppijanumero: 1.2.246.562.24.00000000010' +
+                    'Oppijanumero: 1.2.246.562.24.00000000011' +
                     ' ' +
                     'Kopioi'
                   )

--- a/web/test/spec/oppijataulukkoSpec.js
+++ b/web/test/spec/oppijataulukkoSpec.js
@@ -143,11 +143,11 @@ describe('Oppijataulukko', function() {
       )
 
       it('Oletusjärjestys nouseva nimen mukaan', function() {
-        expect(page.oppijataulukko.names()).to.deep.equal([ 'Hetuton, Heikki', 'Koululainen, Kaisa', 'Lukiolainen, Liisa', 'Luokallejäänyt, Lasse', 'Monikoululainen, Miia', 'Monikoululainen, Miia', 'Oppija, Oili', 'Toiminta, Tommi', 'Ysiluokkalainen, Ylermi', 'of Puppets, Master' ])
+        expect(page.oppijataulukko.names()).to.deep.equal([ 'Hetuton, Heikki', 'Koululainen, Kaisa', 'Lukiolainen, Liisa', 'Luokallejäänyt, Lasse', 'Monikoululainen, Miia', 'Monikoululainen, Miia', 'Oppija, Oili', 'Perusopetuksensiirto, Pertti', 'Toiminta, Tommi', 'Vuosiluokkalainen, Ville', 'Ysiluokkalainen, Ylermi', 'of Puppets, Master' ])
       })
       it('Laskeva järjestys klikkaamalla', function() {
         return page.oppijataulukko.sortBy('nimi')().then(function() {
-          expect(page.oppijataulukko.names()).to.deep.equal([ 'of Puppets, Master', 'Ysiluokkalainen, Ylermi', 'Toiminta, Tommi', 'Oppija, Oili', 'Monikoululainen, Miia', 'Monikoululainen, Miia', 'Luokallejäänyt, Lasse', 'Lukiolainen, Liisa', 'Koululainen, Kaisa', 'Hetuton, Heikki' ])
+          expect(page.oppijataulukko.names()).to.deep.equal([ 'of Puppets, Master', 'Ysiluokkalainen, Ylermi', 'Vuosiluokkalainen, Ville', 'Toiminta, Tommi', 'Perusopetuksensiirto, Pertti', 'Oppija, Oili', 'Monikoululainen, Miia', 'Monikoululainen, Miia', 'Luokallejäänyt, Lasse', 'Lukiolainen, Liisa', 'Koululainen, Kaisa', 'Hetuton, Heikki' ])
         })
       })
     })
@@ -184,12 +184,12 @@ describe('Oppijataulukko', function() {
       before(page.oppijataulukko.filterBy('tyyppi'), page.oppijataulukko.filterBy('tutkinto'), page.oppijataulukko.filterBy('nimi'), page.oppijataulukko.filterBy('luokka', '9'))
       it('Nouseva järjestys', function() {
         return page.oppijataulukko.sortBy('luokka')().then(function() {
-          expect(page.oppijataulukko.data().map(function(row) { return row[8]})).to.deep.equal([ '9B', '9C', '9C', '9C', '9C', '9C', '9C', '9D' ])
+          expect(page.oppijataulukko.data().map(function(row) { return row[8]})).to.deep.equal([ '9B', '9C', '9C', '9C', '9C', '9C', '9C', '9C', '9D' ])
         })
       })
       it('Laskeva järjestys', function() {
         return page.oppijataulukko.sortBy('luokka')().then(function() {
-          expect(page.oppijataulukko.data().map(function(row) { return row[8]})).to.deep.equal([ '9D', '9C', '9C', '9C', '9C', '9C', '9C', '9B' ])
+          expect(page.oppijataulukko.data().map(function(row) { return row[8]})).to.deep.equal([ '9D', '9C', '9C', '9C', '9C', '9C', '9C', '9C', '9B' ])
         })
       })
     })

--- a/web/test/spec/perusopetusSpec.js
+++ b/web/test/spec/perusopetusSpec.js
@@ -1543,7 +1543,16 @@ describe('Perusopetus', function() {
           it('Näytetään', function () {
             expect(opinnot.deletePäätasonSuoritusIsShown()).to.equal(true)
           })
+
+          describe('Vahvistusviestin', function() {
+            before(opinnot.hideInvalidateMessage, wait.untilFalse(page.isOpiskeluoikeusInvalidatedMessageShown))
+            it('Voi piilottaa', function () {
+              expect(page.isOpiskeluoikeusInvalidatedMessageShown()).to.equal(false)
+            })
+          })
         })
+
+        after(resetFixtures)
       })
     })
 

--- a/web/test/spec/perusopetusSpec.js
+++ b/web/test/spec/perusopetusSpec.js
@@ -1511,6 +1511,14 @@ describe('Perusopetus', function() {
           })
         })
 
+        describe('Opiskeluoikeudelle, jossa on vain yksi päätason suoritus', function() {
+          before(Authentication().logout, Authentication().login(), page.openPage, page.oppijaHaku.searchAndSelect('010100-325X'), editor.edit)
+
+          it('Ei näytetä', function() {
+            expect(opinnot.confirmDeletePäätasonSuoritusIsShown()).to.equal(false)
+          })
+        })
+
         describe('Opiskeluoikeudelle, joka on peräisin ulkoisesta järjestelmästä', function() {
           describe('Kun kirjautunut oppilaitoksen tallentajana', function() {
             before(Authentication().logout, Authentication().login(), page.openPage, page.oppijaHaku.searchAndSelect('010100-071R'))

--- a/web/test/spec/perusopetusSpec.js
+++ b/web/test/spec/perusopetusSpec.js
@@ -1480,47 +1480,59 @@ describe('Perusopetus', function() {
     })
 
     describe('Päätason suorituksen poistaminen', function() {
-      before(editor.edit)
+      describe('Nuorten perusopetus', function() {
+        before(editor.edit)
 
-      describe('Mitätöintilinkki', function() {
-        it('Näytetään', function() {
-          expect(opinnot.deletePäätasonSuoritusIsShown()).to.equal(true)
-        })
-
-        describe('Painettaessa', function() {
-          before(opinnot.deletePäätasonSuoritus)
-          it('Pyydetään vahvistus', function() {
-            expect(opinnot.confirmDeletePäätasonSuoritusIsShown()).to.equal(true)
+        describe('Mitätöintilinkki', function() {
+          it('Näytetään', function() {
+            expect(opinnot.deletePäätasonSuoritusIsShown()).to.equal(true)
           })
 
-          describe('Painettaessa uudestaan', function() {
-            before(opinnot.confirmDeletePäätasonSuoritus, wait.until(page.isPäätasonSuoritusDeletedMessageShown))
-            it('Päätason suoritus poistetaan', function() {
-              expect(page.isPäätasonSuoritusDeletedMessageShown()).to.equal(true)
+          describe('Painettaessa', function() {
+            before(opinnot.deletePäätasonSuoritus)
+            it('Pyydetään vahvistus', function() {
+              expect(opinnot.confirmDeletePäätasonSuoritusIsShown()).to.equal(true)
             })
 
-            describe('Poistettua päätason suoritusta', function() {
-              before(wait.until(page.isReady), opinnot.opiskeluoikeudet.valitseOpiskeluoikeudenTyyppi('perusopetus'))
-
-              it('Ei näytetä', function () {
-                expect(opinnot.suoritusTabs()).to.deep.equal([ '9. vuosiluokka', '8. vuosiluokka', '7. vuosiluokka' ])
+            describe('Painettaessa uudestaan', function() {
+              before(opinnot.confirmDeletePäätasonSuoritus, wait.until(page.isPäätasonSuoritusDeletedMessageShown))
+              it('Päätason suoritus poistetaan', function() {
+                expect(page.isPäätasonSuoritusDeletedMessageShown()).to.equal(true)
               })
+
+              describe('Poistettua päätason suoritusta', function() {
+                before(wait.until(page.isReady), opinnot.opiskeluoikeudet.valitseOpiskeluoikeudenTyyppi('perusopetus'))
+
+                it('Ei näytetä', function () {
+                  expect(opinnot.suoritusTabs()).to.deep.equal([ '9. vuosiluokka', '8. vuosiluokka', '7. vuosiluokka' ])
+                })
+              })
+            })
+          })
+        })
+
+        describe('Opiskeluoikeudelle, joka on peräisin ulkoisesta järjestelmästä', function() {
+          describe('Kun kirjautunut oppilaitoksen tallentajana', function() {
+            before(Authentication().logout, Authentication().login(), page.openPage, page.oppijaHaku.searchAndSelect('010100-071R'))
+            it('Ei näytetä poistopainiketta', function() {
+              expect(opinnot.deletePäätasonSuoritusIsShown()).to.equal(false)
+            })
+          })
+
+          describe('Kun kirjautunut oppilaitoksen pääkäyttäjänä', function() {
+            before(Authentication().logout, Authentication().login('stadin-pää'), page.openPage, page.oppijaHaku.searchAndSelect('010100-071R'))
+            it('Näytetään poistopainike', function() {
+              expect(opinnot.deletePäätasonSuoritusIsShown()).to.equal(true)
             })
           })
         })
       })
 
-      describe('Opiskeluoikeudelle, joka on peräisin ulkoisesta järjestelmästä', function() {
-        describe('Kun kirjautunut oppilaitoksen tallentajana', function() {
-          before(Authentication().logout, Authentication().login(), page.openPage, page.oppijaHaku.searchAndSelect('010100-071R'))
-          it('Ei näytetä poistopainiketta', function() {
-            expect(opinnot.deletePäätasonSuoritusIsShown()).to.equal(false)
-          })
-        })
+      describe('Aikuisten perusopetus', function() {
+        before(Authentication().logout, Authentication().login(), page.openPage, page.oppijaHaku.searchAndSelect('280598-2415'), editor.edit)
 
-        describe('Kun kirjautunut oppilaitoksen pääkäyttäjänä', function() {
-          before(Authentication().logout, Authentication().login('stadin-pää'), page.openPage, page.oppijaHaku.searchAndSelect('010100-071R'))
-          it('Näytetään poistopainike', function() {
+        describe('Mitätöintilinkki', function () {
+          it('Näytetään', function () {
             expect(opinnot.deletePäätasonSuoritusIsShown()).to.equal(true)
           })
         })

--- a/web/test/spec/perusopetusSpec.js
+++ b/web/test/spec/perusopetusSpec.js
@@ -1479,6 +1479,54 @@ describe('Perusopetus', function() {
       })
     })
 
+    describe('Päätason suorituksen poistaminen', function() {
+      before(editor.edit)
+
+      describe('Mitätöintilinkki', function() {
+        it('Näytetään', function() {
+          expect(opinnot.deletePäätasonSuoritusIsShown()).to.equal(true)
+        })
+
+        describe('Painettaessa', function() {
+          before(opinnot.deletePäätasonSuoritus)
+          it('Pyydetään vahvistus', function() {
+            expect(opinnot.confirmDeletePäätasonSuoritusIsShown()).to.equal(true)
+          })
+
+          describe('Painettaessa uudestaan', function() {
+            before(opinnot.confirmDeletePäätasonSuoritus, wait.until(page.isPäätasonSuoritusDeletedMessageShown))
+            it('Päätason suoritus poistetaan', function() {
+              expect(page.isPäätasonSuoritusDeletedMessageShown()).to.equal(true)
+            })
+
+            describe('Poistettua päätason suoritusta', function() {
+              before(wait.until(page.isReady), opinnot.opiskeluoikeudet.valitseOpiskeluoikeudenTyyppi('perusopetus'))
+
+              it('Ei näytetä', function () {
+                expect(opinnot.suoritusTabs()).to.deep.equal([ '9. vuosiluokka', '8. vuosiluokka', '7. vuosiluokka' ])
+              })
+            })
+          })
+        })
+      })
+
+      describe('Opiskeluoikeudelle, joka on peräisin ulkoisesta järjestelmästä', function() {
+        describe('Kun kirjautunut oppilaitoksen tallentajana', function() {
+          before(Authentication().logout, Authentication().login(), page.openPage, page.oppijaHaku.searchAndSelect('010100-071R'))
+          it('Ei näytetä poistopainiketta', function() {
+            expect(opinnot.deletePäätasonSuoritusIsShown()).to.equal(false)
+          })
+        })
+
+        describe('Kun kirjautunut oppilaitoksen pääkäyttäjänä', function() {
+          before(Authentication().logout, Authentication().login('stadin-pää'), page.openPage, page.oppijaHaku.searchAndSelect('010100-071R'))
+          it('Näytetään poistopainike', function() {
+            expect(opinnot.deletePäätasonSuoritusIsShown()).to.equal(true)
+          })
+        })
+      })
+    })
+
     describe('Navigointi pois sivulta', function() {
       describe('Kun ei ole tallentamattomia muutoksia', function() {
         before(editor.edit, page.oppijaHaku.searchAndSelect('280618-402H'))
@@ -1516,6 +1564,7 @@ describe('Perusopetus', function() {
         })
       })
     })
+
     describe('Virhetilanteet', function() {
       describe('Kun tallennus epäonnistuu', function() {
         before(
@@ -2672,6 +2721,7 @@ describe('Perusopetus', function() {
       })
     })
   })
+
   describe('Perusopetuksen oppiaineen oppimäärän suoritus', function() {
     before(Authentication().login(), page.openPage, page.oppijaHaku.searchAndSelect('110738-839L'))
     describe('Kaikki tiedot näkyvissä', function() {


### PR DESCRIPTION
**TOR-492**

Mahdollistetaan päätason suorituksen poisto (mitätöinti) perusopetuksessa ja aikuisten perusopetuksessa. Mahdollista vain, jos useampi kuin yksi päätason suoritus.