### PR TITLE
[WIP] Tee vahvistus-painikkeesta turvallisempi käyttää

### DIFF
--- a/web/app/components/ButtonWithConfirmation.jsx
+++ b/web/app/components/ButtonWithConfirmation.jsx
@@ -15,13 +15,13 @@ class ButtonWithConfirmation extends React.Component {
     return isActionRequested
       ? (
         <div className={className}>
-          <a onClick={() => this.setState({ isActionRequested: false })}>
-            <Text name={cancelText}/>
-          </a>
-
           <button className={`koski-button ${(confirmationClassName ? confirmationClassName : '')}`} onClick={action}>
             <Text name={confirmationText}/>
           </button>
+
+          <a onClick={() => this.setState({ isActionRequested: false })}>
+            <Text name={cancelText}/>
+          </a>
         </div>
       )
       : (

--- a/web/app/style/opiskeluoikeus.less
+++ b/web/app/style/opiskeluoikeus.less
@@ -867,7 +867,7 @@
 
     button.confirm-invalidate {
       background-color: @color-delete;
-      margin-left: 10px;
+      margin-right: 10px;
     }
 
     .OverlayLink {


### PR DESCRIPTION
Opiskeluoikeuden mitätöinnissä ja päätason suoritusten poistossa on
käytössä kaksivaiheinen painike, jossa toisena vaiheena vahvistetaan
haluttu toimenpide. Vaihdetaan toisen vaiheen peruutus- ja
hyväksymispainikkeiden paikkaa siten, että vahingossa hyväksyminen
(esim. tuplaklikkauksella) ei ole niin helposti tehtävissä.