### PR TITLE
Merkitse vanhentuneet kentät skeema-dokumentaatioon

### DIFF
--- a/src/main/scala/fi/oph/koski/documentation/KoskiSchemaDocumentHtml.scala
+++ b/src/main/scala/fi/oph/koski/documentation/KoskiSchemaDocumentHtml.scala
@@ -166,7 +166,7 @@ object KoskiSchemaDocumentHtml {
     case Description(desc) => Some(<span class="description">{formatDescription(desc)}</span>)
     case ReadOnly(desc) => Some(<div class="readonly">{formatDescription(desc)}</div>)
     case _ => None
-  }) ++ onlyWhenHtml(metadata) ++ sensitiveDataHtml(metadata)
+  }) ++ onlyWhenHtml(metadata) ++ sensitiveDataHtml(metadata) ++ deprecatedHtml(metadata)
 
   private def onlyWhenHtml(metadata: List[Metadata]): List[Elem] = metadata.collect { case o: OnlyWhen => o } match {
     case Nil => Nil
@@ -175,6 +175,10 @@ object KoskiSchemaDocumentHtml {
 
   private def sensitiveDataHtml(metadata: List[Metadata]): List[Elem] = metadata.collect {
     case s: SensitiveData => <div class="sensitive">Arkaluontoinen tieto.</div>
+  }
+
+  private def deprecatedHtml(metadata: List[Metadata]): List[Elem] = metadata.collect {
+    case s: Deprecated => <div class="deprecated">Vanhentunut kenttä.</div>
   }
 
   def intersperse[E](x: E, xs:Seq[E]): Seq[E] = (x, xs) match {

--- a/src/main/scala/fi/oph/koski/schema/annotation/Deprecated.scala
+++ b/src/main/scala/fi/oph/koski/schema/annotation/Deprecated.scala
@@ -1,9 +1,11 @@
 package fi.oph.koski.schema.annotation
 
 import fi.oph.scalaschema.Metadata
-import org.json4s.JsonAST.JObject
+import org.json4s.JsonAST.{JBool, JObject}
 
 // When field is deprecated it is hidden from the UI when it doesn't contain data
 case class Deprecated(msg: String) extends Metadata {
-  override def appendMetadataToJsonSchema(obj: JObject): JObject = obj
+  def descriptionWithStyle: String = <b>Vanhentunut kenttä: </b> + msg
+  def wrapInParentheses(description: String) = s"($description)"
+  override def appendMetadataToJsonSchema(obj: JObject) = appendToDescription(obj.merge(JObject("deprecated" -> JBool(true))), wrapInParentheses(descriptionWithStyle))
 }

--- a/web/static/css/schema-printable.css
+++ b/web/static/css/schema-printable.css
@@ -69,6 +69,7 @@ td.kuvaus .description {
     display: block;
 }
 
-.sensitive {
+.sensitive,
+.deprecated {
   font-weight: bold;
 }

--- a/web/static/css/schema-printable.css
+++ b/web/static/css/schema-printable.css
@@ -73,3 +73,8 @@ td.kuvaus .description {
 .deprecated {
   font-weight: bold;
 }
+
+.deprecated__message {
+  font-weight: normal;
+  display: block;
+}


### PR DESCRIPTION
Näytetään vanhentuneet kentät HTML-dokumentaatiossa:
- kentän nimen kohdalla "Vanhentunut kenttä"
- kentän kuvauksen kohdalla myös deprecated-metadatan viesti

Näytetään vanhentuneet kentät JSON-skeemakatselijassa:
- näytetään vanhentuneet kentät katselijan oranssilla deprecated-merkkivärillä
- näytetään kentän kuvauksessa myös deprecated-metadatan viesti