### PR TITLE
Encode callback parameter

### DIFF
--- a/src/main/scala/fi/oph/koski/servlet/MyDataSupport.scala
+++ b/src/main/scala/fi/oph/koski/servlet/MyDataSupport.scala
@@ -13,9 +13,11 @@ trait MyDataSupport extends ScalatraServlet with MyDataConfig {
   override def getConfigForMember(id: String = memberCodeParam): TypeSafeConfig
   def mydataLoginServletURL: String = conf.getString("login.servlet")
 
+  def urlEncode(str: String): String = URLEncoder.encode(str, "UTF-8")
+
   def getLoginURL(target: String = getCurrentURL, encode: Boolean = false): String = {
     if (encode) {
-      URLEncoder.encode(s"${mydataLoginServletURL}?onSuccess=${target}", "UTF-8")
+      urlEncode(s"${mydataLoginServletURL}?onSuccess=${urlEncode(target)}")
     } else {
       s"${mydataLoginServletURL}?onSuccess=${target}"
     }
@@ -29,7 +31,7 @@ trait MyDataSupport extends ScalatraServlet with MyDataConfig {
 
   def getKorhopankkiRedirectURLParameter(target: String): String = {
     if(application.config.getString("shibboleth.security") == "mock") {
-      s"&redirect=${URLEncoder.encode(target, "UTF-8")}"
+      s"&redirect=${urlEncode(target)}"
     } else {
       ""
     }

--- a/src/test/scala/fi/oph/koski/mydata/MyDataSupportTest.scala
+++ b/src/test/scala/fi/oph/koski/mydata/MyDataSupportTest.scala
@@ -33,7 +33,7 @@ class MyDataSupportTest extends FreeSpec with Matchers with MockFactory {
       (mockRequest.getRequestURI _).expects().returning("/koski/omadata/valtuutus/hsl")
 
       support(mockRequest).getShibbolethLoginURL(lang = lang) should
-        equal("/koski/login/shibboleth?login=%2Fkoski%2Fuser%2Fshibbolethlogin%3FonSuccess%3D%2Fkoski%2Fomadata%2Fvaltuutus%2Fhsl%3Fcallback%3Dhttp%3A%2F%2Fwww.hsl.fi&redirect=%2Fkoski%2Fomadata%2Fvaltuutus%2Fhsl%3Fcallback%3Dhttp%3A%2F%2Fwww.hsl.fi")
+        equal("/koski/login/shibboleth?login=%2Fkoski%2Fuser%2Fshibbolethlogin%3FonSuccess%3D%252Fkoski%252Fomadata%252Fvaltuutus%252Fhsl%253Fcallback%253Dhttp%253A%252F%252Fwww.hsl.fi&redirect=%2Fkoski%2Fomadata%2Fvaltuutus%2Fhsl%3Fcallback%3Dhttp%3A%2F%2Fwww.hsl.fi")
     }
     "Palauttaa oikean URL:n sisään loganneille" in {
       val mockRequest = mock[HttpServletRequest]

--- a/web/app/omadata/HyvaksyntaLanding.jsx
+++ b/web/app/omadata/HyvaksyntaLanding.jsx
@@ -72,7 +72,7 @@ class HyvaksyntaLanding extends React.Component {
   }
 
   getLogoutURL() {
-    return `/koski/user/logout?target=${this.state.callback}`
+    return `/koski/user/logout?target=${encodeURIComponent(this.state.callback)}`
   }
 
   parseCallbackURL() {

--- a/web/test/page/myDataPage.js
+++ b/web/test/page/myDataPage.js
@@ -1,10 +1,10 @@
 function MyDataPage() {
 
-  var callbackURL = window.location.origin + "/koski/pulssi"
+  var callbackURL = window.location.origin + "/koski/pulssi#linkki"
 
   var api = {
     openPage: function() {
-      return openPage("/koski/omadata/valtuutus/hsl?callback=" + callbackURL, function() { return true  })()
+      return openPage("/koski/omadata/valtuutus/hsl?callback=" + encodeURIComponent(callbackURL), function() { return true  })()
     },
     callbackURL: callbackURL,
     go: function() {


### PR DESCRIPTION
URL-encode the callback parameter so it won't get messed up in login redirects