### PR TITLE
[WIP] Massahaku API:n muutoksia

### DIFF
--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/OpiskeluoikeusQueryFilter.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/OpiskeluoikeusQueryFilter.scala
@@ -32,6 +32,7 @@ object OpiskeluoikeusQueryFilter {
   case class OppijaOidHaku(oids: Seq[String]) extends OpiskeluoikeusQueryFilter
   case class MuuttunutEnnen(aikaleima: Instant) extends OpiskeluoikeusQueryFilter
   case class MuuttunutJälkeen(aikaleima: Instant) extends OpiskeluoikeusQueryFilter
+  case class OneOfOpiskeluoikeudenTyypit(opiskeluoikeudenTyypit: List[OpiskeluoikeudenTyyppi]) extends OpiskeluoikeusQueryFilter
 
   def parse(params: List[(String, String)])(implicit koodisto: KoodistoViitePalvelu, organisaatiot: OrganisaatioRepository, session: KoskiSession): Either[HttpStatus, List[OpiskeluoikeusQueryFilter]] = OpiskeluoikeusQueryFilterParser.parse(params)
 }
@@ -87,7 +88,7 @@ private object OpiskeluoikeusQueryFilterParser {
       case (p, v) if (p == "muuttunutEnnen") => dateTimeParam((p, v)).right.map(MuuttunutEnnen(_))
       case (p, v) if (p == "muuttunutJälkeen") => dateTimeParam((p, v)).right.map(MuuttunutJälkeen(_))
       case (p, _) => Left(KoskiErrorCategory.badRequest.queryParam.unknown("Unsupported query parameter: " + p))
-      // IdHaku, OppijaOidHaku missing from here (intentionally)
+      // IdHaku, OppijaOidHaku, OneOfOpiskeluoikeudenTyypit missing from here (intentionally)
     }
 
     queryFilters.partition(_.isLeft) match {

--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/OpiskeluoikeusQueryService.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/OpiskeluoikeusQueryService.scala
@@ -72,6 +72,7 @@ class OpiskeluoikeusQueryService(val db: DB) extends DatabaseExecutionContext wi
       case (query, SuoritusJsonHaku(json)) => query.filter(_._1.data.+>("suoritukset").@>(json))
       case (query, MuuttunutEnnen(aikaleima)) => query.filter(_._1.aikaleima < Timestamp.from(aikaleima))
       case (query, MuuttunutJälkeen(aikaleima)) => query.filter(_._1.aikaleima >= Timestamp.from(aikaleima))
+      case (query, OneOfOpiskeluoikeudenTyypit(tyypit)) => query.filter(_._1.data.#>>(List("tyyppi", "koodiarvo")) inSet (tyypit.map(_.tyyppi.koodiarvo)))
       case (query, filter) => throw new InvalidRequestException(KoskiErrorCategory.internalError("Hakua ei ole toteutettu: " + filter))
     }
 

--- a/src/test/scala/fi/oph/koski/luovutuspalvelu/LuovutuspalveluSpec.scala
+++ b/src/test/scala/fi/oph/koski/luovutuspalvelu/LuovutuspalveluSpec.scala
@@ -78,6 +78,26 @@ class LuovutuspalveluSpec extends FreeSpec with LocalJettyHttpSpecification with
      }
    }
 
+   "Palauttaa valitut opiskeluoikeudenTyypit" in {
+     val henkilot = Set(MockOppijat.amis, MockOppijat.lukiolainen, MockOppijat.ysiluokkalainen)
+     val opiskeluoikeudenTyypit = Set("ammatillinenkoulutus", "lukiokoulutus", "perusopetus")
+     postHetut(henkilot.map(_.hetu.get).toList, opiskeluoikeudenTyypit.toList) {
+       verifyResponseStatusOk()
+       val resp = JsonSerializer.parse[Seq[HetuResponseV1]](body)
+       val actualOpiskeluoikeudenTyypit = resp.flatMap(_.opiskeluoikeudet.map(_.tyyppi.koodiarvo)).toSet
+       actualOpiskeluoikeudenTyypit should equal (opiskeluoikeudenTyypit)
+     }
+   }
+
+   "Palauttaa valitun opiskeluoikeudenTyypin" in {
+     val opiskeluoikeudenTyyppi = Set("ammatillinenkoulutus")
+     postHetut(List(MockOppijat.amis.hetu.get), opiskeluoikeudenTyyppi.toList) {
+       verifyResponseStatusOk()
+       val resp = JsonSerializer.parse[Seq[HetuResponseV1]](body)
+       resp.flatMap(_.opiskeluoikeudet.map(_.tyyppi.koodiarvo)).toSet should equal (opiskeluoikeudenTyyppi)
+     }
+   }
+
    "Palauttaa 400 jos liian monta hetua" in {
      val hetut = List.range(0, 1001).map(_.toString)
      hetut.length should be > 1000


### PR DESCRIPTION
- Lisää mahdollisuuden luoda kantakyselyn jossa opiskeluoikeuksia voi rajata monen opiskeluoikeustyypin perusteella
- Korjaa bugin jossa monen opiskeluoikeustyypin määrittäminen rajasi toisensa pois, tuloksena tyhjä vastaus