### PR TITLE
Poista surefire-plugin käytöstä

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -385,6 +385,14 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
         <version>1.0</version>


### PR DESCRIPTION
Asetettu skipTests = true, kuten ohjeistettu täällä http://www.scalatest.org/user_guide/using_the_scalatest_maven_plugin

surefire ei toimi uusimmalla JDK:lla: build 1.8.0_181-8u181-b13-1ubuntu0.18.04.1-b13

https://issues.apache.org/jira/browse/SUREFIRE-1588