### PR TITLE
Poistaa logoutin tietojen käyttö sivulta

### DIFF
--- a/web/app/omadata/Header.jsx
+++ b/web/app/omadata/Header.jsx
@@ -1,10 +1,7 @@
 import React from 'baret'
-import Atom from 'bacon.atom'
 import Text from '../i18n/Text'
-import Logout from './fragments/Logout'
 import {lang, setLang} from '../i18n/i18n'
 
-const menuOpened = Atom(false)
 
 const ChangeLang = () =>
   (<span className='change-lang' onClick={() => lang === 'sv' ? setLang('fi') : setLang('sv')}>
@@ -12,11 +9,8 @@ const ChangeLang = () =>
   </span>)
 
 
-export default ({ logoutURL }) => (
+export default () => (
   <div className='header'>
-    <button id='header-mobile-menu-button' onClick={() => menuOpened.modify(x => !x)}>
-      <img src='/koski/images/baseline-menu-24px.svg' />
-    </button>
     <div className='title'>
       <img src='/koski/images/opintopolku_logo.svg' alt='' />
       <h1><Text name='Oma Opintopolku'/></h1>
@@ -26,16 +20,5 @@ export default ({ logoutURL }) => (
       <ChangeLang />
     </div>
 
-    <div>
-      <div className='user'>
-        <Logout logoutURL={logoutURL} />
-      </div>
-
-      <div id='header-mobile-menu' className={menuOpened.map(opened => opened ? 'menu-open' : 'menu-closed')}>
-        <div className='top'>
-          <Logout logoutURL={logoutURL} />
-        </div>
-      </div>
-    </div>
   </div>
 )

--- a/web/app/omadata/HyvaksyntaAnnettu.jsx
+++ b/web/app/omadata/HyvaksyntaAnnettu.jsx
@@ -7,7 +7,7 @@ export default class HyvaksyntaAnnettu extends React.Component {
     super(props)
     this.state = {
       logoutURL: this.props.logoutURL,
-      timeout: this.props.timeout || 3000
+      timeout: this.props.timeout || 6000
     }
 
     this.moveToCallbackURL = this.moveToCallbackURL.bind(this)

--- a/web/app/omadata/HyvaksyntaLanding.jsx
+++ b/web/app/omadata/HyvaksyntaLanding.jsx
@@ -88,7 +88,7 @@ class HyvaksyntaLanding extends React.Component {
 
     return (
       <div>
-        <Header logoutURL={this.getLogoutURL()} />
+        <Header />
         {error}
 
         {

--- a/web/app/style/omadata.less
+++ b/web/app/style/omadata.less
@@ -36,68 +36,6 @@
       }
     }
 
-    #header-mobile-menu-button {
-      display: none;
-      border-width: 0;
-      padding: 0;
-      margin-left: @margin-mobile-left;
-
-      @media @media-phone {
-        display: flex;
-      }
-
-      img {
-        height: 40px;
-        width: 40px;
-        margin: 0;
-        background-color: @color-link-blue;
-      }
-    }
-
-    #header-mobile-menu {
-      display: none;
-      -webkit-box-orient: vertical;
-      -webkit-box-direction: normal;
-      flex-direction: column;
-      position: absolute;
-      font-family: 'Source Sans Pro', sans-serif;
-      background-color: #06526b;
-      z-index: 1;
-      left: 0;
-      top: @element-header-height;
-      height: 0;
-      width: 250px;
-      overflow: hidden;
-
-      @media @media-phone {
-        display: flex;
-      }
-
-      .username {
-        display: flex;
-        justify-content: center;
-      }
-
-      &.menu-open {
-        height: calc(100% - @element-header-height);
-        -webkit-transition: height 300ms ease-out;
-      }
-
-      &.menu-closed {
-        height: 0;
-        -webkit-transition: height 300ms ease-out;
-      }
-
-      .top {
-        min-height: 130px;
-        padding-top: 10px;
-        background-color: @color-link-blue;
-        display: flex;
-        justify-content: center;
-        text-align: center;
-        flex-direction: column;
-      }
-    }
     .title {
       display: flex;
       margin-left: 8.1%;
@@ -138,18 +76,6 @@
       margin-right: 20px;
     }
 
-    .logout > a > span {
-      display: block;
-      font-size: 12px;
-      text-decoration: underline;
-      text-align: right;
-      color: @color-white;
-
-      @media @media-phone {
-        text-align: center;
-        margin-top: 10px;
-      }
-    }
   }
   .acceptance-container {
     margin-left: 8.1%;

--- a/web/app/style/omadata.less
+++ b/web/app/style/omadata.less
@@ -13,7 +13,7 @@
     height: @element-header-height;
     background-color: @color-link-blue;
     color: @color-white;
-    justify-content: space-around;
+    justify-content: space-between;
     align-items: center;
 
     font-style: normal;
@@ -29,6 +29,7 @@
     .lang {
       font-weight: 900;
       cursor: pointer;
+      margin-right: 8.1%;
 
       @media @media-phone {
         margin-right: auto;
@@ -97,9 +98,9 @@
         flex-direction: column;
       }
     }
-
     .title {
       display: flex;
+      margin-left: 8.1%;
       align-items: center;
       font-size: 24px;
       font-weight: bold;

--- a/web/test/spec/myDataSpec.js
+++ b/web/test/spec/myDataSpec.js
@@ -90,16 +90,6 @@ describe('MyData', function() {
     })
   })
 
-  describe('Kun klikataan logout-nappia', function() {
-    before.apply(null, login('fi'))
-    before(mydata.clickLogout)
-    before(wait.until(function() { return isElementVisible(S('.statistics-wrapper')) }))
-
-    it('Päädytään oikealle sivulle', function() {
-      expect(document.getElementById('testframe').contentWindow.document.URL).to.equal(mydata.callbackURL)
-    })
-  })
-
   describe('Kun klikataan peruuta-nappia', function() {
     before.apply(null, login('fi'))
     before(mydata.clickCancel)


### PR DESCRIPTION
- Poistaa logout napin yläpalkista
- Poistaa mobiilimenun (Täältä aikaisemmin löytyi logout nappi mobiililla)
- Siirtyy palveluntarjoajan sivulle hitaammin hyväksynnän jälkeen