### PR TITLE
Update MyData documentation (link to WSDL)

### DIFF
--- a/src/main/resources/documentation/rajapinnat_palveluvayla_omadata.md
+++ b/src/main/resources/documentation/rajapinnat_palveluvayla_omadata.md
@@ -20,7 +20,7 @@ Mikäli halutaan, että käyttäjän selain palaa luvan antamisen jälkeen tiety
 ### Kansalaisen opintotietojen hakeminen
 
 Kun kansalainen on myöntänyt luvan tietojen hakemiseen, voidaan tietoja hakea Suomi.fi-palveluväylän kautta.
-Tiedot haetaan kumppanin omalta liityntäpalvelimelta SOAP-requestilla, joka on kuvattu [täällä](https://sp.omadata.opintopolku.fi/?wsdl=true).
+Tiedot haetaan kumppanin omalta liityntäpalvelimelta SOAP-requestilla, joka on kuvattu [palveluväylän liityntäkatalogissa](https://liityntakatalogi.suomi.fi/dataset/koski).
 
 Esimerkkipyyntö:
 


### PR DESCRIPTION
WSDL link on MyData documentation now points to Suomi.fi liityntäkatalogi instead of Koski-sovitinpalvelu URL.