### PR TITLE
Mahdollista uuden DIA-oppijan lisäys kälissä

### DIFF
--- a/src/main/scala/fi/oph/koski/oppilaitos/OppilaitosServlet.scala
+++ b/src/main/scala/fi/oph/koski/oppilaitos/OppilaitosServlet.scala
@@ -15,6 +15,7 @@ class OppilaitosServlet(implicit val application: KoskiApplication) extends ApiS
   val esiopetuksenTyypit = List(OpiskeluoikeudenTyyppi.esiopetus)
   val ammatillisenTyypit = List(OpiskeluoikeudenTyyppi.ammatillinenkoulutus)
   val lukionTyypit = List(OpiskeluoikeudenTyyppi.lukiokoulutus, OpiskeluoikeudenTyyppi.ibtutkinto)
+  val saksalaisenKoulunTyypit = List(OpiskeluoikeudenTyyppi.diatutkinto)
 
   get("/opiskeluoikeustyypit/:oid") {
     val oppilaitostyypit: List[String] = application.organisaatioRepository.getOrganisaatioHierarkia(params("oid")).toList.flatMap(_.oppilaitostyyppi)
@@ -22,7 +23,7 @@ class OppilaitosServlet(implicit val application: KoskiApplication) extends ApiS
       case tyyppi if List(peruskoulut, peruskouluasteenErityiskoulut).contains(tyyppi) => perusopetuksenTyypit ++ esiopetuksenTyypit
       case tyyppi if List(ammatillisetOppilaitokset, ammatillisetErityisoppilaitokset, ammatillisetErikoisoppilaitokset, ammatillisetAikuiskoulutusKeskukset).contains(tyyppi) => perusopetuksenTyypit ++ ammatillisenTyypit
       case tyyppi if List(lukio).contains(tyyppi) => perusopetuksenTyypit ++ lukionTyypit
-      case tyyppi if List(perusJaLukioasteenKoulut).contains(tyyppi) => perusopetuksenTyypit ++ esiopetuksenTyypit ++ lukionTyypit
+      case tyyppi if List(perusJaLukioasteenKoulut).contains(tyyppi) => perusopetuksenTyypit ++ esiopetuksenTyypit ++ lukionTyypit ++ saksalaisenKoulunTyypit
       case _ => perusopetuksenTyypit ++ ammatillisenTyypit
     }.map(_.koodiarvo).flatMap(application.koodistoViitePalvelu.validate("opiskeluoikeudentyyppi", _))
   }

--- a/web/app/suoritus/Suoritus.js
+++ b/web/app/suoritus/Suoritus.js
@@ -73,6 +73,8 @@ export const näyttötutkintoonValmistavanKoulutuksenSuoritus = opiskeluoikeuden
 export const ammatillisenTutkinnonSuoritus = opiskeluoikeudenSuoritusByTyyppi('ammatillinentutkinto')
 export const preIBSuoritus = opiskeluoikeudenSuoritusByTyyppi('preiboppimaara')
 export const ibTutkinnonSuoritus = opiskeluoikeudenSuoritusByTyyppi('ibtutkinto')
+export const valmistavanDIAVaiheenSuoritus = opiskeluoikeudenSuoritusByTyyppi('diavalmistavavaihe')
+export const diaTutkinnonSuoritus = opiskeluoikeudenSuoritusByTyyppi('diatutkintovaihe')
 
 export const koulutustyyppiKoodit = suoritustyyppiKoodi => {
   if (suoritustyyppiKoodi == 'perusopetuksenoppimaara' || suoritustyyppiKoodi == 'perusopetuksenvuosiluokka' || suoritustyyppiKoodi == 'nuortenperusopetuksenoppiaineenoppimaara') {

--- a/web/app/uusioppija/UusiDIASuoritus.jsx
+++ b/web/app/uusioppija/UusiDIASuoritus.jsx
@@ -1,0 +1,22 @@
+import React from 'baret'
+import Bacon from 'baconjs'
+import Atom from 'bacon.atom'
+import {koodiarvoMatch, koodistoValues} from './koodisto'
+import {makeSuoritus} from './diaSuoritus'
+import Suoritustyyppi from './Suoritustyyppi'
+
+export default ({suoritusAtom, oppilaitosAtom, suorituskieliAtom}) => {
+  const suoritustyyppiAtom = Atom()
+
+  const suoritustyypitP = koodistoValues('suorituksentyyppi/diavalmistavavaihe,diatutkintovaihe')
+  suoritustyypitP.onValue(tyypit => suoritustyyppiAtom.set(tyypit.find(koodiarvoMatch('diatutkintovaihe'))))
+
+  Bacon.combineWith(
+    oppilaitosAtom, suoritustyyppiAtom, suorituskieliAtom,
+    makeSuoritus
+  ).onValue(suoritus => suoritusAtom.set(suoritus))
+
+  return (
+    <Suoritustyyppi suoritustyyppiAtom={suoritustyyppiAtom} suoritustyypitP={suoritustyypitP} title="Oppimäärä"/>
+  )
+}

--- a/web/app/uusioppija/UusiOpiskeluoikeus.jsx
+++ b/web/app/uusioppija/UusiOpiskeluoikeus.jsx
@@ -21,6 +21,7 @@ import UusiAikuistenPerusopetuksenSuoritus from './UusiAikuistenPerusopetuksenSu
 import UusiLukionSuoritus from './UusiLukionSuoritus'
 import {sallitutRahoituskoodiarvot} from '../lukio/lukio'
 import UusiIBSuoritus from './UusiIBSuoritus'
+import UusiDIASuoritus from './UusiDIASuoritus'
 
 export default ({opiskeluoikeusAtom}) => {
   const dateAtom = Atom(new Date())
@@ -74,6 +75,7 @@ export default ({opiskeluoikeusAtom}) => {
         if (tyyppi == 'perusopetuksenlisaopetus') return <UusiPerusopetuksenLisaopetuksenSuoritus suoritusAtom={suoritusAtom} oppilaitosAtom={oppilaitosAtom} suorituskieliAtom={suorituskieliAtom} />
         if (tyyppi == 'lukiokoulutus') return <UusiLukionSuoritus suoritusAtom={suoritusAtom} oppilaitosAtom={oppilaitosAtom} suorituskieliAtom={suorituskieliAtom} />
         if (tyyppi == 'ibtutkinto') return <UusiIBSuoritus suoritusAtom={suoritusAtom} oppilaitosAtom={oppilaitosAtom} suorituskieliAtom={suorituskieliAtom} />
+        if (tyyppi == 'diatutkinto') return <UusiDIASuoritus suoritusAtom={suoritusAtom} oppilaitosAtom={oppilaitosAtom} suorituskieliAtom={suorituskieliAtom} />
       })
     }
     <Aloituspäivä dateAtom={dateAtom} />

--- a/web/app/uusioppija/diaSuoritus.js
+++ b/web/app/uusioppija/diaSuoritus.js
@@ -1,0 +1,31 @@
+export const makeSuoritus = (oppilaitos, suoritustyyppi, suorituskieli) => {
+  if (!oppilaitos || !suoritustyyppi || ! suorituskieli) return null
+
+  switch (suoritustyyppi.koodiarvo) {
+    case 'diatutkintovaihe':
+      return {
+        suorituskieli : suorituskieli,
+        koulutusmoduuli: {
+          tunniste: {
+            koodiarvo: '301103',
+            koodistoUri: 'koulutus'
+          }
+        },
+        toimipiste: oppilaitos,
+        tyyppi: suoritustyyppi
+      }
+
+    case 'diavalmistavavaihe':
+      return {
+        suorituskieli : suorituskieli,
+        koulutusmoduuli: {
+          tunniste: {
+            koodiarvo: 'diavalmistavavaihe',
+            koodistoUri: 'suorituksentyyppi'
+          }
+        },
+        toimipiste: oppilaitos,
+        tyyppi: suoritustyyppi
+      }
+  }
+}

--- a/web/app/uusisuoritus/UusiDIATutkinnonSuoritus.jsx
+++ b/web/app/uusisuoritus/UusiDIATutkinnonSuoritus.jsx
@@ -1,0 +1,32 @@
+import React from 'baret'
+import Bacon from 'baconjs'
+import {
+  copyToimipiste,
+  newSuoritusProto,
+  diaTutkinnonSuoritus,
+  valmistavanDIAVaiheenSuoritus
+} from '../suoritus/Suoritus'
+import {modelData} from '../editor/EditorModel'
+import Text from '../i18n/Text'
+
+const isDIATutkinto = opiskeluoikeus => modelData(opiskeluoikeus, 'tyyppi.koodiarvo') === 'diatutkinto'
+
+export const UusiDIATutkinnonSuoritus = {
+  createSuoritus: (opiskeluoikeus) => {
+    const proto = newSuoritusProto(opiskeluoikeus, 'diatutkinnonsuoritus')
+    const toimipisteellä = copyToimipiste(valmistavanDIAVaiheenSuoritus(opiskeluoikeus), proto)
+    return Bacon.once(toimipisteellä)
+  },
+  canAddSuoritus: (opiskeluoikeus) => isDIATutkinto(opiskeluoikeus) && !diaTutkinnonSuoritus(opiskeluoikeus),
+  addSuoritusTitle: () => <Text name="lisää DIA-tutkinnon suoritus"/>
+}
+
+export const UusiValmistavanDIAVaiheenSuoritus = {
+  createSuoritus: (opiskeluoikeus) => {
+    const proto = newSuoritusProto(opiskeluoikeus, 'diavalmistavanvaiheensuoritus')
+    const toimipisteellä = copyToimipiste(diaTutkinnonSuoritus(opiskeluoikeus), proto)
+    return Bacon.once(toimipisteellä)
+  },
+  canAddSuoritus: (opiskeluoikeus) => isDIATutkinto(opiskeluoikeus) && !valmistavanDIAVaiheenSuoritus(opiskeluoikeus),
+  addSuoritusTitle: () => <Text name="lisää valmistavan DIA-vaiheen suoritus"/>
+}

--- a/web/app/uusisuoritus/UusiSuoritusLink.jsx
+++ b/web/app/uusisuoritus/UusiSuoritusLink.jsx
@@ -13,6 +13,10 @@ import {
   UusiIBTutkinnonSuoritus,
   UusiPreIBSuoritus
 } from './UusiIBTutkinnonSuoritus'
+import {
+  UusiDIATutkinnonSuoritus,
+  UusiValmistavanDIAVaiheenSuoritus
+} from './UusiDIATutkinnonSuoritus'
 
 export default ({opiskeluoikeus, callback}) => {
   return (<span className="add-suoritus tab">{
@@ -56,7 +60,9 @@ const popups = [
   UusiAmmatillisenTutkinnonSuoritus,
   UusiNäyttötutkintoonValmistavanKoulutuksenSuoritus,
   UusiIBTutkinnonSuoritus,
-  UusiPreIBSuoritus
+  UusiPreIBSuoritus,
+  UusiDIATutkinnonSuoritus,
+  UusiValmistavanDIAVaiheenSuoritus
 ]
 
 const findPopUps = (opiskeluoikeus) => popups.filter(popup => popup.canAddSuoritus(opiskeluoikeus))

--- a/web/test/page/addOppijaPage.js
+++ b/web/test/page/addOppijaPage.js
@@ -85,6 +85,22 @@ function AddOppijaPage() {
           .then(api.selectOppimäärä(params.oppimäärä))
       }
     },
+    enterValidDataDIA: function(params) {
+      params = _.merge({ oppilaitos: 'Helsingin', oppimäärä: 'DIA-tutkinto' }, {}, params)
+      return function() {
+        return api.enterData(params)()
+          .then(api.selectOpiskeluoikeudenTyyppi('DIA-tutkinto'))
+          .then(api.selectOppimäärä(params.oppimäärä))
+      }
+    },
+    enterValidDataDIAValmistavaVaihe: function(params) {
+      params = _.merge({ oppilaitos: 'Helsingin', oppimäärä: 'Valmistava DIA-vaihe' }, {}, params)
+      return function() {
+        return api.enterData(params)()
+          .then(api.selectOpiskeluoikeudenTyyppi('DIA-tutkinto'))
+          .then(api.selectOppimäärä(params.oppimäärä))
+      }
+    },
     enterData: function(params) {
       return function() {
         return api.enterHenkilötiedot(params)()

--- a/web/test/spec/diaSpec.js
+++ b/web/test/spec/diaSpec.js
@@ -2,6 +2,9 @@ describe('DIA', function( ) {
   var page = KoskiPage()
   var opinnot = OpinnotPage()
   var editor = opinnot.opiskeluoikeusEditor()
+  var opiskeluoikeus = OpiskeluoikeusDialog()
+  var addOppija = AddOppijaPage()
+
   before(Authentication().login(), resetFixtures)
 
   describe('Opiskeluoikeuden tiedot', function () {
@@ -650,6 +653,109 @@ describe('DIA', function( ) {
 
             it('poistaa oppiaineen', function () {
               expect(extractAsText(S('.oppiaineet'))).to.not.contain('Lakitieto')
+            })
+          })
+        })
+      })
+    })
+  })
+
+  describe('Opiskeluoikeuden lisääminen', function () {
+    describe('DIA-tutkinto', function () {
+      before(
+        prepareForNewOppija('kalle', '020782-5339'),
+        addOppija.enterValidDataDIA({etunimet: 'Doris', kutsumanimi: 'Doris', sukunimi: 'Dia'}),
+        addOppija.submitAndExpectSuccess('Dia, Doris (020782-5339)', 'Deutsche Internationale Abitur')
+      )
+
+      describe('Lisäyksen jälkeen', function () {
+        describe('Opiskeluoikeuden tiedot', function () {
+          it('näytetään oikein', function () {
+            expect(extractAsText(S('.suoritus > .properties, .suoritus > .tila-vahvistus'))).to.equal(
+              'Koulutus Deutsche Internationale Abitur; Reifeprüfung\n' +
+              'Oppilaitos / toimipiste Helsingin Saksalainen koulu\n' +
+              'Suorituskieli suomi\n' +
+              'Suoritus kesken'
+            )
+          })
+        })
+
+        describe('Oppiaineita', function () {
+          it('ei esitäytetä', function () {
+            expect(extractAsText(S('.oppiaineet'))).to.equal('Oppiaine Laajuus (vuosiviikkotuntia)')
+          })
+        })
+
+        describe('Muokattaessa', function () {
+          before(editor.edit)
+
+          it('näytetään tyhjät(kin) osa-alueet sekä Lisäaineet-ryhmä', function () {
+            expect(extractAsText(S('.oppiaineet .aineryhmä'))).to.equal('' +
+              'Kielet, kirjallisuus, taide\n\n' +
+              'Matematiikka ja luonnontieteet\n\n' +
+              'Yhteiskuntatieteet\n\n' +
+              'Lisäaineet'
+            )
+          })
+
+          it('näytetään jokaiselle osa-alueelle ja Lisäaineille uuden oppiaineen lisäys-dropdown', function () {
+            expect(S('.oppiaineet .aineryhmä + .uusi-oppiaine .dropdown').length).to.equal(4)
+          })
+
+          after(editor.cancelChanges)
+        })
+
+        describe('Valmistavan DIA-vaiheen suorituksen lisääminen', function () {
+          var lisääSuoritus = opinnot.lisääSuoritusDialog
+          var lisäysTeksti = 'lisää valmistavan DIA-vaiheen suoritus'
+
+          describe('Kun opiskeluoikeus on tilassa VALMIS', function () {
+            before(editor.edit, opinnot.avaaLisaysDialogi, opiskeluoikeus.tila().aseta('valmistunut'), opiskeluoikeus.tallenna)
+
+            it('Valmistavaa DIA-vaihetta ei voi lisätä', function () {
+              expect(lisääSuoritus.isLinkVisible(lisäysTeksti)).to.equal(false)
+            })
+
+            after(editor.property('tila').removeItem(0))
+          })
+
+          describe('Kun opiskeluoikeus on tilassa LÄSNÄ', function () {
+            describe('Ennen lisäystä', function () {
+              it('Näytetään DIA-tutkinto', function () {
+                expect(opinnot.suoritusTabs()).to.deep.equal(['Deutsche Internationale Abitur'])
+              })
+
+              it('Valmistavan DIA-vaiheen voi lisätä', function () {
+                expect(lisääSuoritus.isLinkVisible(lisäysTeksti)).to.equal(true)
+              })
+            })
+
+            describe('Lisäyksen jälkeen', function () {
+              before(lisääSuoritus.clickLink(lisäysTeksti))
+
+              it('Näytetään myös valmistavan DIA-vaiheen suoritus', function () {
+                expect(opinnot.suoritusTabs()).to.deep.equal([
+                  'Deutsche Internationale Abitur',
+                  'Valmistava DIA-vaihe'
+                ])
+              })
+
+              it('Valmistavaa vaihetta ei voi enää lisätä', function () {
+                expect(lisääSuoritus.isLinkVisible(lisäysTeksti)).to.equal(false)
+              })
+
+              describe('Suorituksen tiedot', function () {
+                before(editor.saveChanges, wait.until(page.isSavedLabelShown))
+
+                it('näytetään oikein', function () {
+                  expect(extractAsText(S('.suoritus > .properties, .suoritus > .tila-vahvistus'))).to.equal(
+                    'Koulutus Valmistava DIA-vaihe\n' +
+                    'Oppilaitos / toimipiste Helsingin Saksalainen koulu\n' +
+                    'Suorituskieli suomi\n' +
+                    'Suoritus kesken'
+                  )
+                })
+              })
             })
           })
         })

--- a/web/test/spec/diaSpec.js
+++ b/web/test/spec/diaSpec.js
@@ -761,5 +761,106 @@ describe('DIA', function( ) {
         })
       })
     })
+
+    describe('Valmistava DIA-vaihe', function() {
+      before(
+        prepareForNewOppija('kalle', '020782-5339'),
+        addOppija.enterValidDataDIAValmistavaVaihe({etunimet: 'Doris', kutsumanimi: 'Doris', sukunimi: 'Dia'}),
+        addOppija.submitAndExpectSuccess('Dia, Doris (020782-5339)', 'Valmistava DIA-vaihe')
+      )
+
+      describe('Lisäyksen jälkeen', function () {
+        describe('Opiskeluoikeuden tiedot', function() {
+          it('näytetään oikein', function () {
+            expect(extractAsText(S('.suoritus > .properties, .suoritus > .tila-vahvistus'))).to.equal(
+              'Koulutus Valmistava DIA-vaihe\n' +
+              'Oppilaitos / toimipiste Helsingin Saksalainen koulu\n' +
+              'Suorituskieli suomi\n' +
+              'Suoritus kesken'
+            )
+          })
+        })
+
+        describe('Oppiaineita', function () {
+          it('ei esitäytetä', function () {
+            expect(extractAsText(S('.oppiaineet'))).to.equal('Oppiaine Laajuus (vuosiviikkotuntia)')
+          })
+        })
+
+        describe('Muokattaessa', function() {
+          before(editor.edit)
+
+          it('näytetään tyhjät(kin) osa-alueet sekä Lisäaineet-ryhmä', function () {
+            expect(extractAsText(S('.oppiaineet .aineryhmä'))).to.equal('' +
+              'Kielet, kirjallisuus, taide\n\n' +
+              'Matematiikka ja luonnontieteet\n\n' +
+              'Yhteiskuntatieteet\n\n' +
+              'Lisäaineet'
+            )
+          })
+
+          it('näytetään jokaiselle osa-alueelle uuden oppiaineen lisäys-dropdown', function () {
+            expect(S('.oppiaineet .aineryhmä + .uusi-oppiaine .dropdown').length).to.equal(4)
+          })
+
+          after(editor.cancelChanges)
+        })
+
+        describe('DIA-tutkinnon suorituksen lisääminen', function() {
+          var lisääSuoritus = opinnot.lisääSuoritusDialog
+          var lisäysTeksti = 'lisää DIA-tutkinnon suoritus'
+
+          describe('Kun opiskeluoikeus on tilassa VALMIS', function() {
+            before(editor.edit, opinnot.avaaLisaysDialogi, opiskeluoikeus.tila().aseta('valmistunut'), opiskeluoikeus.tallenna)
+
+            it('DIA-tutkinnon suoritusta ei voi lisätä', function() {
+              expect(lisääSuoritus.isLinkVisible(lisäysTeksti)).to.equal(false)
+            })
+
+            after(editor.property('tila').removeItem(0))
+          })
+
+          describe('kun opiskeluoikeus on tilassa läsnä', function() {
+            describe('Ennen lisäystä', function() {
+              it('Näytetään valmistavan DIA-vaiheen suoritus', function() {
+                expect(opinnot.suoritusTabs()).to.deep.equal(['Valmistava DIA-vaihe'])
+              })
+
+              it('DIA-tutkinnon suorituksen voi lisätä', function() {
+                expect(lisääSuoritus.isLinkVisible(lisäysTeksti)).to.equal(true)
+              })
+            })
+
+            describe('Lisäyksen jälkeen', function() {
+              before(lisääSuoritus.clickLink(lisäysTeksti))
+
+              it('Näytetään myös DIA-tutkinnon suoritus', function() {
+                expect(opinnot.suoritusTabs()).to.deep.equal([
+                  'Valmistava DIA-vaihe',
+                  'Deutsche Internationale Abitur'
+                ])
+              })
+
+              it('DIA-tutkinnon suoritusta ei voi enää lisätä', function() {
+                expect(lisääSuoritus.isLinkVisible(lisäysTeksti)).to.equal(false)
+              })
+
+              describe('Suorituksen tiedot', function() {
+                before(editor.saveChanges, wait.until(page.isSavedLabelShown))
+
+                it('näytetään oikein', function () {
+                  expect(extractAsText(S('.suoritus > .properties, .suoritus > .tila-vahvistus'))).to.equal(
+                    'Koulutus Deutsche Internationale Abitur; Reifeprüfung\n' +
+                    'Oppilaitos / toimipiste Helsingin Saksalainen koulu\n' +
+                    'Suorituskieli suomi\n' +
+                    'Suoritus kesken'
+                  )
+                })
+              })
+            })
+          })
+        })
+      })
+    })
   })
 })


### PR DESCRIPTION
Mahdollistetaan kälissä
- uuden DIA-opiskeluoikeuden lisääminen
  - valmistavalla vaiheella tai
  - tutkintovaiheella
- olemassa olevaan DIA-opiskeluoikeuteen
  - valmistavan vaiheen lisääminen, jos ei ole mutta on tutkintovaihe
  - tutkintovaiheen lisääminen, jos ei ole mutta on valmistava vaihe