### PR TITLE
Muuta Oppijanumerorekisteri-nappulan käyttöoikeudet

### DIFF
--- a/src/main/scala/fi/oph/koski/koskiuser/KoskiSession.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/KoskiSession.scala
@@ -46,10 +46,10 @@ class KoskiSession(val user: AuthenticationUser, val lang: String, val clientIp:
   lazy val sensitiveDataAllowed = hasRole(LUOTTAMUKSELLINEN)
 
   // Note: keep in sync with PermissionCheckServlet's hasSufficientRoles function. See PermissionCheckServlet for more comments.
-  private val HenkilonhallintaCrud = Palvelurooli("HENKILONHALLINTA", "CRUD")
-  private val HenkilonhallintaReadUpdate = Palvelurooli("HENKILONHALLINTA", "READ_UPDATE")
-  def hasHenkiloUiWriteAccess = globalKäyttöoikeudet.exists(ko => ko.globalPalveluroolit.contains(HenkilonhallintaCrud) || ko.globalPalveluroolit.contains(HenkilonhallintaReadUpdate)) ||
-    orgKäyttöoikeudet.exists(ko => ko.organisaatiokohtaisetPalveluroolit.contains(HenkilonhallintaCrud) || ko.organisaatiokohtaisetPalveluroolit.contains(HenkilonhallintaReadUpdate))
+  private val OppijanumerorekisteriRekisterinpitäjä = Palvelurooli("OPPIJANUMEROREKISTERI", "REKISTERINPITAJA")
+  private val OppijanumerorekisteriReadUpdate = Palvelurooli("OPPIJANUMEROREKISTERI", "HENKILON_RU")
+  def hasHenkiloUiWriteAccess = globalKäyttöoikeudet.exists(ko => ko.globalPalveluroolit.contains(OppijanumerorekisteriRekisterinpitäjä) || ko.globalPalveluroolit.contains(OppijanumerorekisteriReadUpdate)) ||
+    orgKäyttöoikeudet.exists(ko => ko.organisaatiokohtaisetPalveluroolit.contains(OppijanumerorekisteriRekisterinpitäjä) || ko.organisaatiokohtaisetPalveluroolit.contains(OppijanumerorekisteriReadUpdate))
 
   def hasRole(role: String): Boolean = {
     val palveluRooli = Palvelurooli("KOSKI", role)

--- a/src/main/scala/fi/oph/koski/koskiuser/MockUsers.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/MockUsers.scala
@@ -23,7 +23,7 @@ object MockUsers {
   val omniaTallentaja = MockUser("käyttäjä", "omnia-tallentaja", "1.2.246.562.24.99999999991", Set(oppilaitosTallentaja(omnia)))
   val omniaPääkäyttäjä = MockUser("omnia-pää", "omnia-pää", "1.2.246.562.24.99999977777", Set(oppilaitosPääkäyttäjä(MockOrganisaatiot.omnia)))
   val tallentajaEiLuottamuksellinen = MockUser("epäluotettava-tallentaja", "epäluotettava-tallentaja", "1.2.246.562.24.99999999997", Set(ilmanLuottamuksellisiaTietoja(omnia), ilmanLuottamuksellisiaTietoja(jyväskylänNormaalikoulu)))
-  val paakayttaja = MockUser("käyttäjä", "pää", "1.2.246.562.24.99999999992", Set(ophPääkäyttäjä, localizationAdmin, KäyttöoikeusGlobal(List(Palvelurooli("HENKILONHALLINTA", "CRUD")))))
+  val paakayttaja = MockUser("käyttäjä", "pää", "1.2.246.562.24.99999999992", Set(ophPääkäyttäjä, localizationAdmin, KäyttöoikeusGlobal(List(Palvelurooli("OPPIJANUMEROREKISTERI", "REKISTERINPITAJA")))))
   val viranomainen = MockUser("käyttäjä", "viranomais", "1.2.246.562.24.99999999993", Set(viranomaisKatselija))
   val helsinginKaupunkiPalvelukäyttäjä = MockUser("stadin-palvelu", "stadin-palvelu", "1.2.246.562.24.99999999994", Set(oppilaitosPalvelukäyttäjä(MockOrganisaatiot.helsinginKaupunki)))
   val stadinAmmattiopistoTallentaja = MockUser("tallentaja", "tallentaja", "1.2.246.562.24.99999999995", Set(oppilaitosTallentaja(MockOrganisaatiot.stadinAmmattiopisto)))

--- a/src/main/scala/fi/oph/koski/permission/PermissionCheckServlet.scala
+++ b/src/main/scala/fi/oph/koski/permission/PermissionCheckServlet.scala
@@ -40,6 +40,6 @@ class PermissionCheckServlet(implicit val application: KoskiApplication) extends
   // Note 1: keep in sync with KoskiSession's hasHenkiloUiWriteAccess function
   // Note 2: Tämä logiikka saattaa kaivata päivitystä jos käyttöoikeusryhmien sisältö muuttuu.
   private def hasSufficientRoles(roles: List[String]): Boolean = {
-    roles.contains("ROLE_APP_KOSKI") && (roles.contains("ROLE_APP_HENKILONHALLINTA_CRUD") || roles.contains("ROLE_APP_HENKILONHALLINTA_READ_UPDATE"))
+    roles.contains("ROLE_APP_KOSKI") && (roles.contains("ROLE_APP_OPPIJANUMEROREKISTERI_REKISTERINPITAJA") || roles.contains("ROLE_APP_OPPIJANUMEROREKISTERI_HENKILON_RU"))
   }
 }

--- a/src/test/scala/fi/oph/koski/api/PermissionCheckSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/PermissionCheckSpec.scala
@@ -38,7 +38,7 @@ class PermissionCheckSpec extends FreeSpec with LocalJettyHttpSpecification with
 
   import fi.oph.koski.schema.KoskiSchema.deserializationContext
 
-  def permissionCheck(personOidsForSamePerson: List[Henkilö.Oid], organisationOids: List[Organisaatio.Oid], loggedInUserRoles: List[String] = List("ROLE_APP_KOSKI", "ROLE_APP_HENKILONHALLINTA_CRUD")): Boolean = {
+  def permissionCheck(personOidsForSamePerson: List[Henkilö.Oid], organisationOids: List[Organisaatio.Oid], loggedInUserRoles: List[String] = List("ROLE_APP_KOSKI", "ROLE_APP_OPPIJANUMEROREKISTERI_HENKILON_RU")): Boolean = {
     post(
       "api/permission/checkpermission",
       JsonSerializer.writeWithRoot(PermissionCheckRequest(


### PR DESCRIPTION
HENKILONHALLINTA-oikeudet ovat deprekoituneet.
OPPIJANUMEROREKISTERI-oikeudet korvaavat nämä.