### PR TITLE
Näytä pelkkä nimi saksalaisen koulun käyttöliittymän osasuoritus-dropdownissa

### DIFF
--- a/web/app/kurssi/UusiKurssiDropdown.jsx
+++ b/web/app/kurssi/UusiKurssiDropdown.jsx
@@ -5,7 +5,7 @@ import Atom from 'bacon.atom'
 import DropDown from '../components/Dropdown'
 import {modelData, modelLookup, modelSetValue, modelTitle} from '../editor/EditorModel'
 import {deleteOrganizationalPreference, getOrganizationalPreferences} from '../virkailija/organizationalPreferences'
-import {isPaikallinen, isUusi} from '../suoritus/Koulutusmoduuli'
+import {isPaikallinen, isUusi, isDiaKurssi} from '../suoritus/Koulutusmoduuli'
 import {elementWithLoadingIndicator} from '../components/AjaxLoadingIndicator'
 import {t} from '../i18n/i18n'
 import Http from '../util/http'
@@ -34,7 +34,13 @@ export const UusiKurssiDropdown = (
     getOrganizationalPreferences(organisaatioOid, paikallinenKurssiProto.value.classes[0]).onValue(setPaikallisetKurssit)
   }
 
-  let displayValue = (kurssi) => modelData(kurssi, 'tunniste.koodiarvo') + ' ' + modelTitle(kurssi, 'tunniste')
+  let displayValue = (kurssi) => {
+    if (isDiaKurssi(kurssi)) {
+      return modelTitle(kurssi, 'tunniste')
+    } else {
+      return modelData(kurssi, 'tunniste.koodiarvo') + ' ' + modelTitle(kurssi, 'tunniste')
+    }
+  }
   let kurssit = Bacon.combineWith(paikallisetKurssit, valtakunnallisetKurssit, (x,y) => x.concat(y))
     .map(aineet => aineet.filter(kurssi => !käytössäolevatKoodiarvot.includes(modelData(kurssi, 'tunniste').koodiarvo)))
     .map(R.sortBy(displayValue))

--- a/web/app/suoritus/Koulutusmoduuli.js
+++ b/web/app/suoritus/Koulutusmoduuli.js
@@ -9,6 +9,7 @@ export const isUusi = (oppiaine) => {
 export const isIBOppiaine = (m) => m && m.value.classes.includes('iboppiaine')
 export const isLukionKurssi = (m) => m && m.value.classes.includes('lukionkurssi')
 export const isPreIBKurssi = (m) => m && m.value.classes.includes('preibkurssi')
+export const isDiaKurssi = (m) => m && m.value.classes.includes('diaoppiaineenosasuoritus')
 export const isLukioonValmistavanKoulutuksenKurssi = (m) => m && m.value.classes.includes('lukioonvalmistavankoulutuksenkurssi')
 export const isLukionMatematiikka = (m) => m && m.value.classes.includes('lukionmatematiikka')
 export const koulutusModuuliprototypes = (suoritus) => oneOfPrototypes(modelLookup(suoritus, 'koulutusmoduuli'))

--- a/web/test/spec/diaSpec.js
+++ b/web/test/spec/diaSpec.js
@@ -236,7 +236,7 @@ describe('DIA', function( ) {
               before(
                 editor.edit,
                 aine.avaaLisääKurssiDialog,
-                dialog.valitseKurssi('2 10/II'),
+                dialog.valitseKurssi('10/II'),
                 dialog.lisääKurssi,
                 aine.kurssi('10/II').arvosana.selectValue(2),
                 editor.saveChanges,
@@ -488,7 +488,7 @@ describe('DIA', function( ) {
               before(
                 editor.edit,
                 aine.avaaLisääKurssiDialog,
-                dialog.valitseKurssi('6 12/II'),
+                dialog.valitseKurssi('12/II'),
                 dialog.lisääKurssi,
                 aine.kurssi('12/II').arvosana.selectValue(4),
                 editor.saveChanges,
@@ -544,9 +544,9 @@ describe('DIA', function( ) {
 
               it('voi lisätä enää kirjallisen tai suullisen kokeen tai näyttötutkinnon', function() {
                 expect(dialog.kurssit()).to.deep.equal([
-                  'kirjallinenkoe Kirjallinen koe',
-                  'nayttotutkinto Erityisosaamisen näyttötutkinto',
-                  'suullinenkoe Suullinen koe'
+                  'Erityisosaamisen näyttötutkinto',
+                  'Kirjallinen koe',
+                  'Suullinen koe'
                 ])
               })
 
@@ -557,7 +557,7 @@ describe('DIA', function( ) {
             })
 
             describe('Päättökokeet', function() {
-              function testaaPäättökokeenLisäysJaPoisto(koodi, nimi, arvosana) {
+              function testaaPäättökokeenLisäysJaPoisto(nimi, arvosana) {
                 describe(nimi, function() {
                   var dialog = aine.lisääKurssiDialog
 
@@ -565,7 +565,7 @@ describe('DIA', function( ) {
                     before(
                       editor.edit,
                       aine.avaaLisääKurssiDialog,
-                      dialog.valitseKurssi(koodi + ' ' + nimi),
+                      dialog.valitseKurssi(nimi),
                       dialog.lisääKurssi,
                       aine.kurssi(nimi).arvosana.selectValue(arvosana),
                       aine.kurssi(nimi).toggleDetails,
@@ -595,9 +595,9 @@ describe('DIA', function( ) {
                 })
               }
 
-              testaaPäättökokeenLisäysJaPoisto('kirjallinenkoe', 'Kirjallinen koe', 10)
-              testaaPäättökokeenLisäysJaPoisto('suullinenkoe', 'Suullinen koe', 9)
-              testaaPäättökokeenLisäysJaPoisto('nayttotutkinto', 'Erityisosaamisen näyttötutkinto', 11)
+              testaaPäättökokeenLisäysJaPoisto('Kirjallinen koe', 10)
+              testaaPäättökokeenLisäysJaPoisto('Suullinen koe', 9)
+              testaaPäättökokeenLisäysJaPoisto('Erityisosaamisen näyttötutkinto', 11)
             })
 
             describe('Poistaminen', function() {


### PR DESCRIPTION
Saksalaisen koulun käyttöliittymässä, uutta kurssia valittaessa, näytetään dropdownin sisältönä nyt ainoastaan kurssin nimi, eikä kurssin koodi sekä nimi.