### PR TITLE
DIA-laajuudet

### DIFF
--- a/src/main/scala/fi/oph/koski/documentation/DIAExampleData.scala
+++ b/src/main/scala/fi/oph/koski/documentation/DIAExampleData.scala
@@ -1,9 +1,82 @@
 package fi.oph.koski.documentation
 
+import java.time.LocalDate
+import java.time.LocalDate.{of => date}
+
 import fi.oph.koski.localization.LocalizedStringImplicits._
 import fi.oph.koski.organisaatio.MockOrganisaatiot
 import fi.oph.koski.schema._
 
 object DIAExampleData {
   lazy val saksalainenKoulu: Oppilaitos = Oppilaitos(MockOrganisaatiot.saksalainenKoulu, Some(Koodistokoodiviite("00085", None, "oppilaitosnumero", None)), Some("Helsingin Saksalainen koulu"))
+
+  def laajuus(laajuus: Float, yksikkö: String = "3"): Some[LaajuusVuosiviikkotunneissa] = Some(LaajuusVuosiviikkotunneissa(laajuus, Koodistokoodiviite(koodistoUri = "opintojenlaajuusyksikko", koodiarvo = yksikkö)))
+
+  def diaValmistavaVaiheAineSuoritus(oppiaine: DIAOppiaine, lukukaudet: Option[List[(DIAOppiaineenValmistavanVaiheenLukukausi, String)]] = None) = DIAOppiaineenValmistavanVaiheenSuoritus(
+    koulutusmoduuli = oppiaine,
+    osasuoritukset = lukukaudet.map(_.map { case (lukukausi, arvosana) =>
+      DIAOppiaineenValmistavanVaiheenLukukaudenSuoritus(
+        koulutusmoduuli = lukukausi,
+        arviointi = diaValmistavaVaiheArviointi(arvosana)
+      )
+    })
+  )
+
+  def diaTutkintoAineSuoritus(oppiaine: DIAOppiaine, lukukaudet: Option[List[(DIAOppiaineenTutkintovaiheenLukukausi, String)]] = None, suorituskieli: Option[String] = None) = DIAOppiaineenTutkintovaiheenSuoritus(
+    koulutusmoduuli = oppiaine,
+    suorituskieli = suorituskieli.map(k => Koodistokoodiviite(koodiarvo = k, koodistoUri = "kieli")),
+    osasuoritukset = lukukaudet.map(_.map { case (lukukausi, arvosana) =>
+      DIAOppiaineenTutkintovaiheenOsasuorituksenSuoritus(
+        koulutusmoduuli = lukukausi,
+        arviointi = diaTutkintovaiheenArviointi(arvosana)
+      )
+    })
+  )
+
+  def diaOppiaineMuu(aine: String, osaAlue: String, laajuus: Option[LaajuusVuosiviikkotunneissa] = None) = DIAOppiaineMuu(
+    tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = aine),
+    laajuus = laajuus,
+    osaAlue = Koodistokoodiviite(koodiarvo = osaAlue, koodistoUri = "diaosaalue")
+  )
+
+  def diaOppiaineKieliaine(taso: String, kieli: String, laajuus: Option[LaajuusVuosiviikkotunneissa] = None) = DIAOppiaineKieli(
+    tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = taso),
+    kieli = Koodistokoodiviite(koodistoUri = "kielivalikoima", koodiarvo = kieli),
+    laajuus = laajuus
+  )
+
+  def diaOppiaineÄidinkieli(kieli: String, laajuus: Option[LaajuusVuosiviikkotunneissa] = None) = DIAOppiaineÄidinkieli(
+    tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = "AI"),
+    kieli = Koodistokoodiviite(koodistoUri = "oppiainediaaidinkieli", koodiarvo = kieli),
+    laajuus = laajuus
+  )
+
+  def diaOppiaineLisäaine(aine: String, laajuus: Option[LaajuusVuosiviikkotunneissa] = None) = DIAOppiaineLisäaine(
+    tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = aine),
+    laajuus = laajuus
+  )
+
+  def diaOppiaineLisäaineKieli(taso: String, kieli: String, laajuus: Option[LaajuusVuosiviikkotunneissa] = None) = DIAOppiaineLisäaineKieli(
+    tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = taso),
+    kieli = Koodistokoodiviite(koodistoUri = "kielivalikoima", koodiarvo = kieli),
+    laajuus = laajuus
+  )
+
+  def diaTutkintovaiheenArviointi(arvosana: String, päivä: LocalDate = date(2016, 6, 4)): Some[List[DIAOppiaineenTutkintovaiheenNumeerinenArviointi]] = {
+    Some(List(DIAOppiaineenTutkintovaiheenNumeerinenArviointi(arvosana = Koodistokoodiviite(koodiarvo = arvosana, koodistoUri = "arviointiasteikkodiatutkinto"), päivä = Some(päivä))))
+  }
+
+  def diaValmistavaVaiheArviointi(arvosana: String, päivä: LocalDate = date(2016, 6, 4)): Some[List[DIAOppiaineenValmistavanVaiheenLukukaudenArviointi]] = {
+    Some(List(DIAOppiaineenValmistavanVaiheenLukukaudenArviointi(arvosana = Koodistokoodiviite(koodiarvo = arvosana, koodistoUri = "arviointiasteikkodiavalmistava"), päivä = Some(päivä))))
+  }
+
+  def diaValmistavaLukukausi(lukukausi: String = "1", laajuus: Option[LaajuusVuosiviikkotunneissa] = None) = DIAOppiaineenValmistavanVaiheenLukukausi(
+    tunniste = Koodistokoodiviite(koodiarvo = lukukausi, koodistoUri = "dialukukausi"),
+    laajuus = laajuus
+  )
+
+  def diaTutkintoLukukausi(lukukausi: String = "3", laajuus: Option[LaajuusVuosiviikkotunneissa] = None) = DIAOppiaineenTutkintovaiheenLukukausi(
+    tunniste = Koodistokoodiviite(koodiarvo = lukukausi, koodistoUri = "dialukukausi"),
+    laajuus = laajuus
+  )
 }

--- a/src/main/scala/fi/oph/koski/documentation/ExamplesDIA.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesDIA.scala
@@ -19,7 +19,7 @@ object ExamplesDIA {
       (diaValmistavaLukukausi("2", laajuus(2)), "3")
     ))),
     diaValmistavaVaiheAineSuoritus(diaOppiaineKieliaine("A", "EN", laajuus(3)), Some(List(
-      (diaValmistavaLukukausi("1", laajuus(3)), "3")
+      (diaValmistavaLukukausi(), "3")
     ))),
     diaValmistavaVaiheAineSuoritus(diaOppiaineKieliaine("B1", "SV", laajuus(3)), Some(List(
       (diaValmistavaLukukausi("1", laajuus(1)), "2"),
@@ -85,9 +85,9 @@ object ExamplesDIA {
       (diaTutkintoLukukausi("6", laajuus(2)), "3")
     ))),
     diaTutkintoAineSuoritus(diaOppiaineKieliaine("A", "EN", laajuus(6)), Some(List(
-      (diaTutkintoLukukausi("3", laajuus(2)), "2"),
-      (diaTutkintoLukukausi("4", laajuus(2)), "3"),
-      (diaTutkintoLukukausi("5", laajuus(2)), "2")
+      (diaTutkintoLukukausi("3"), "2"),
+      (diaTutkintoLukukausi("4"), "3"),
+      (diaTutkintoLukukausi("5"), "2")
     ))),
     diaTutkintoAineSuoritus(diaOppiaineKieliaine("B1", "SV", laajuus(6)), Some(List(
       (diaTutkintoLukukausi("3", laajuus(1)), "2"),

--- a/src/main/scala/fi/oph/koski/documentation/ExamplesDIA.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesDIA.scala
@@ -12,165 +12,165 @@ import fi.oph.koski.schema._
 object ExamplesDIA {
   def osasuorituksetValmistavaVaihe: List[DIAOppiaineenValmistavanVaiheenSuoritus] = List(
     diaValmistavaVaiheAineSuoritus(diaÄidinkieli("DE", laajuus = 3), List(
-      (diaValmistavaLukukausi("1"), "3"),
-      (diaValmistavaLukukausi("2"), "5")
+      (diaValmistavaLukukausi("1", 1), "3"),
+      (diaValmistavaLukukausi("2", 2), "5")
     )),
     diaValmistavaVaiheAineSuoritus(diaÄidinkieli("FI", laajuus = 3), List(
-      (diaValmistavaLukukausi("1"), "2"),
-      (diaValmistavaLukukausi("2"), "3")
+      (diaValmistavaLukukausi("1", 1), "2"),
+      (diaValmistavaLukukausi("2", 2), "3")
     )),
     diaValmistavaVaiheAineSuoritus(diaKieliaine("A", "EN", laajuus = 3), List(
-      (diaValmistavaLukukausi("1"), "3")
+      (diaValmistavaLukukausi("1", 3), "3")
     )),
     diaValmistavaVaiheAineSuoritus(diaKieliaine("B1", "SV", laajuus = 3), List(
-      (diaValmistavaLukukausi("1"), "2"),
-      (diaValmistavaLukukausi("2"), "2")
+      (diaValmistavaLukukausi("1", 1), "2"),
+      (diaValmistavaLukukausi("2", 2), "2")
     )),
     diaValmistavaVaiheAineSuoritus(diaLisäaineKieli("B2", "LA", laajuus = 2), List(
-      (diaValmistavaLukukausi("1"), "4"),
-      (diaValmistavaLukukausi("2"), "4")
+      (diaValmistavaLukukausi("1", 1), "4"),
+      (diaValmistavaLukukausi("2", 1), "4")
     )),
     diaValmistavaVaiheAineSuoritus(diaKieliaine("B3", "RU", laajuus = 3), List(
-      (diaValmistavaLukukausi("1"), "4"),
-      (diaValmistavaLukukausi("2"), "3")
+      (diaValmistavaLukukausi("1", 1), "4"),
+      (diaValmistavaLukukausi("2", 2), "3")
     )),
     diaValmistavaVaiheAineSuoritus(diaOppiaine("KU", "1", laajuus = 2), List(
-      (diaValmistavaLukukausi("1"), "4"),
-      (diaValmistavaLukukausi("2"), "5")
+      (diaValmistavaLukukausi("1", 1), "4"),
+      (diaValmistavaLukukausi("2", 1), "5")
     )),
     diaValmistavaVaiheAineSuoritus(diaOppiaine("MA", "2", laajuus = 4), List(
-      (diaValmistavaLukukausi("1"), "3"),
-      (diaValmistavaLukukausi("2"), "1")
+      (diaValmistavaLukukausi("1", 2), "3"),
+      (diaValmistavaLukukausi("2", 2), "1")
     )),
     diaValmistavaVaiheAineSuoritus(diaOppiaine("FY", "2", laajuus = 2), List(
-      (diaValmistavaLukukausi("1"), "3"),
-      (diaValmistavaLukukausi("2"), "2")
+      (diaValmistavaLukukausi("1", 1), "3"),
+      (diaValmistavaLukukausi("2", 1), "2")
     )),
     diaValmistavaVaiheAineSuoritus(diaOppiaine("KE", "2", laajuus = 2), List(
-      (diaValmistavaLukukausi("1"), "2"),
-      (diaValmistavaLukukausi("2"), "4")
+      (diaValmistavaLukukausi("1", 1), "2"),
+      (diaValmistavaLukukausi("2", 1), "4")
     )),
     diaValmistavaVaiheAineSuoritus(diaOppiaine("TI", "2", laajuus = 2), List(
-      (diaValmistavaLukukausi("1"), "1"),
-      (diaValmistavaLukukausi("2"), "2")
+      (diaValmistavaLukukausi("1", 1), "1"),
+      (diaValmistavaLukukausi("2", 1), "2")
     )),
     diaValmistavaVaiheAineSuoritus(diaOppiaine("HI", "3", laajuus = 2), List(
-      (diaValmistavaLukukausi("1"), "3"),
-      (diaValmistavaLukukausi("2"), "4")
+      (diaValmistavaLukukausi("1", 1), "3"),
+      (diaValmistavaLukukausi("2", 1), "4")
     )),
     diaValmistavaVaiheAineSuoritus(diaOppiaine("TA", "3", laajuus = 2), List(
-      (diaValmistavaLukukausi("1"), "5"),
-      (diaValmistavaLukukausi("2"), "3")
+      (diaValmistavaLukukausi("1", 1), "5"),
+      (diaValmistavaLukukausi("2", 1), "3")
     )),
     diaValmistavaVaiheAineSuoritus(diaOppiaine("MAA", "3", laajuus = 2), List(
-      (diaValmistavaLukukausi("1"), "3"),
-      (diaValmistavaLukukausi("2"), "3")
+      (diaValmistavaLukukausi("1", 1), "3"),
+      (diaValmistavaLukukausi("2", 1), "3")
     )),
     diaValmistavaVaiheAineSuoritus(diaOppiaine("FI", "3", laajuus = 2), List(
-      (diaValmistavaLukukausi("1"), "1"),
-      (diaValmistavaLukukausi("2"), "1")
+      (diaValmistavaLukukausi("1", 1), "1"),
+      (diaValmistavaLukukausi("2", 1), "1")
     ))
   )
 
   def osasuorituksetTutkintovaihe: List[DIAOppiaineenTutkintovaiheenSuoritus] = List(
     diaTutkintoAineSuoritus(diaÄidinkieli("DE", laajuus = 10), List(
-      (diaTutkintoLukukausi("3"), "3"),
-      (diaTutkintoLukukausi("4"), "5"),
-      (diaTutkintoLukukausi("5"), "4"),
-      (diaTutkintoLukukausi("6"), "3")
+      (diaTutkintoLukukausi("3", 2), "3"),
+      (diaTutkintoLukukausi("4", 2), "5"),
+      (diaTutkintoLukukausi("5", 2), "4"),
+      (diaTutkintoLukukausi("6", 4), "3")
     )),
     diaTutkintoAineSuoritus(diaÄidinkieli("FI", laajuus = 8), List(
-      (diaTutkintoLukukausi("3"), "2"),
-      (diaTutkintoLukukausi("4"), "3"),
-      (diaTutkintoLukukausi("5"), "3"),
-      (diaTutkintoLukukausi("6"), "3")
+      (diaTutkintoLukukausi("3", 2), "2"),
+      (diaTutkintoLukukausi("4", 2), "3"),
+      (diaTutkintoLukukausi("5", 2), "3"),
+      (diaTutkintoLukukausi("6", 2), "3")
     )),
     diaTutkintoAineSuoritus(diaKieliaine("A", "EN", laajuus = 6), List(
-      (diaTutkintoLukukausi("3"), "2"),
-      (diaTutkintoLukukausi("4"), "3"),
-      (diaTutkintoLukukausi("5"), "2")
+      (diaTutkintoLukukausi("3", 2), "2"),
+      (diaTutkintoLukukausi("4", 2), "3"),
+      (diaTutkintoLukukausi("5", 2), "2")
     )),
     diaTutkintoAineSuoritus(diaKieliaine("B1", "SV", laajuus = 6), List(
-      (diaTutkintoLukukausi("3"), "2"),
-      (diaTutkintoLukukausi("4"), "2"),
-      (diaTutkintoLukukausi("5"), "4"),
-      (diaTutkintoLukukausi("6"), "3")
+      (diaTutkintoLukukausi("3", 1), "2"),
+      (diaTutkintoLukukausi("4", 1), "2"),
+      (diaTutkintoLukukausi("5", 1), "4"),
+      (diaTutkintoLukukausi("6", 3), "3")
     )),
     diaTutkintoAineSuoritus(diaLisäaineKieli("B2", "LA", laajuus = 4), List(
-      (diaTutkintoLukukausi("3"), "3"),
-      (diaTutkintoLukukausi("4"), "3"),
-      (diaTutkintoLukukausi("5"), "2"),
-      (diaTutkintoLukukausi("6"), "2")
+      (diaTutkintoLukukausi("3", 1), "3"),
+      (diaTutkintoLukukausi("4", 1), "3"),
+      (diaTutkintoLukukausi("5", 1), "2"),
+      (diaTutkintoLukukausi("6", 1), "2")
     )),
     diaTutkintoAineSuoritus(diaKieliaine("B3", "RU", laajuus = 6), List(
-      (diaTutkintoLukukausi("3"), "4"),
-      (diaTutkintoLukukausi("4"), "3"),
-      (diaTutkintoLukukausi("5"), "4"),
-      (diaTutkintoLukukausi("6"), "3")
+      (diaTutkintoLukukausi("3", 1), "4"),
+      (diaTutkintoLukukausi("4", 1), "3"),
+      (diaTutkintoLukukausi("5", 1), "4"),
+      (diaTutkintoLukukausi("6", 3), "3")
     )),
     diaTutkintoAineSuoritus(diaOppiaine("KU", "1", laajuus = 4), List(
-      (diaTutkintoLukukausi("3"), "4"),
-      (diaTutkintoLukukausi("4"), "3"),
-      (diaTutkintoLukukausi("5"), "2"),
-      (diaTutkintoLukukausi("6"), "2")
+      (diaTutkintoLukukausi("3", 1), "4"),
+      (diaTutkintoLukukausi("4", 1), "3"),
+      (diaTutkintoLukukausi("5", 1), "2"),
+      (diaTutkintoLukukausi("6", 1), "2")
     )),
     diaTutkintoAineSuoritus(diaOppiaine("MA", "2", laajuus = 8), List(
-      (diaTutkintoLukukausi("3"), "3"),
-      (diaTutkintoLukukausi("4"), "1"),
-      (diaTutkintoLukukausi("5"), "1"),
-      (diaTutkintoLukukausi("6"), "2")
+      (diaTutkintoLukukausi("3", 2), "3"),
+      (diaTutkintoLukukausi("4", 2), "1"),
+      (diaTutkintoLukukausi("5", 2), "1"),
+      (diaTutkintoLukukausi("6", 2), "2")
     )),
     diaTutkintoAineSuoritus(diaOppiaine("FY", "2", laajuus = 6), List(
-      (diaTutkintoLukukausi("3"), "2"),
-      (diaTutkintoLukukausi("4"), "2"),
-      (diaTutkintoLukukausi("5"), "1"),
-      (diaTutkintoLukukausi("6"), "1")
+      (diaTutkintoLukukausi("3", 1), "2"),
+      (diaTutkintoLukukausi("4", 1), "2"),
+      (diaTutkintoLukukausi("5", 1), "1"),
+      (diaTutkintoLukukausi("6", 3), "1")
     )),
     diaTutkintoAineSuoritus(diaOppiaine("KE", "2", laajuus = 6), List(
-      (diaTutkintoLukukausi("3"), "3"),
-      (diaTutkintoLukukausi("4"), "2"),
-      (diaTutkintoLukukausi("5"), "1"),
-      (diaTutkintoLukukausi("6"), "2")
+      (diaTutkintoLukukausi("3", 1), "3"),
+      (diaTutkintoLukukausi("4", 1), "2"),
+      (diaTutkintoLukukausi("5", 1), "1"),
+      (diaTutkintoLukukausi("6", 3), "2")
     )),
     diaTutkintoAineSuoritus(diaOppiaine("TI", "2", laajuus = 4), List(
-      (diaTutkintoLukukausi("3"), "2"),
-      (diaTutkintoLukukausi("4"), "1"),
-      (diaTutkintoLukukausi("5"), "1"),
-      (diaTutkintoLukukausi("6"), "1")
+      (diaTutkintoLukukausi("3", 1), "2"),
+      (diaTutkintoLukukausi("4", 1), "1"),
+      (diaTutkintoLukukausi("5", 1), "1"),
+      (diaTutkintoLukukausi("6", 1), "1")
     )),
     diaTutkintoAineSuoritus(diaOppiaine("HI", "3", laajuus = 6), List(
-      (diaTutkintoLukukausi("3"), "3"),
-      (diaTutkintoLukukausi("4"), "4"),
-      (diaTutkintoLukukausi("5"), "3"),
-      (diaTutkintoLukukausi("6"), "1")
+      (diaTutkintoLukukausi("3", 1), "3"),
+      (diaTutkintoLukukausi("4", 1), "4"),
+      (diaTutkintoLukukausi("5", 1), "3"),
+      (diaTutkintoLukukausi("6", 3), "1")
     ), suorituskieli = Some("FI")),
     diaTutkintoAineSuoritus(diaOppiaine("TA", "3", laajuus = 6), List(
-      (diaTutkintoLukukausi("3"), "4"),
-      (diaTutkintoLukukausi("4"), "3"),
-      (diaTutkintoLukukausi("5"), "2"),
-      (diaTutkintoLukukausi("6"), "3")
+      (diaTutkintoLukukausi("3", 1), "4"),
+      (diaTutkintoLukukausi("4", 1), "3"),
+      (diaTutkintoLukukausi("5", 1), "2"),
+      (diaTutkintoLukukausi("6", 3), "3")
     )),
     diaTutkintoAineSuoritus(diaOppiaine("MAA", "3", laajuus = 6), List(
-      (diaTutkintoLukukausi("3"), "3"),
-      (diaTutkintoLukukausi("4"), "5"),
-      (diaTutkintoLukukausi("5"), "3"),
-      (diaTutkintoLukukausi("6"), "2")
+      (diaTutkintoLukukausi("3", 1), "3"),
+      (diaTutkintoLukukausi("4", 1), "5"),
+      (diaTutkintoLukukausi("5", 1), "3"),
+      (diaTutkintoLukukausi("6", 3), "2")
     )),
     diaTutkintoAineSuoritus(diaOppiaine("FI", "3", laajuus = 4), List(
-      (diaTutkintoLukukausi("3"), "2"),
-      (diaTutkintoLukukausi("4"), "2"),
-      (diaTutkintoLukukausi("5"), "2"),
-      (diaTutkintoLukukausi("6"), "2")
+      (diaTutkintoLukukausi("3", 1), "2"),
+      (diaTutkintoLukukausi("4", 1), "2"),
+      (diaTutkintoLukukausi("5", 1), "2"),
+      (diaTutkintoLukukausi("6", 1), "2")
     )),
     diaTutkintoAineSuoritus(diaMuuValinnainen("CCEA", laajuus = 1), List(
-      (diaTutkintoLukukausi("5"), "3"),
-      (diaTutkintoLukukausi("6"), "1")
+      (diaTutkintoLukukausi("5", 0.5f), "3"),
+      (diaTutkintoLukukausi("6", 0.5f), "1")
     )),
     diaTutkintoAineSuoritus(diaMuuValinnainen("MASY", laajuus = 2), List(
-      (diaTutkintoLukukausi("3"), "2"),
-      (diaTutkintoLukukausi("4"), "1"),
-      (diaTutkintoLukukausi("5"), "2"),
-      (diaTutkintoLukukausi("6"), "4")
+      (diaTutkintoLukukausi("3", 0.5f), "2"),
+      (diaTutkintoLukukausi("4", 0.5f), "1"),
+      (diaTutkintoLukukausi("5", 0.5f), "2"),
+      (diaTutkintoLukukausi("6", 0.5f), "4")
     ))
   )
 
@@ -239,12 +239,14 @@ object ExamplesDIA {
     laajuus = Some(LaajuusVuosiviikkotunneissa(laajuus))
   )
 
-  def diaValmistavaLukukausi(lukukausi: String) = DIAOppiaineenValmistavanVaiheenLukukausi(
-    tunniste = Koodistokoodiviite(koodiarvo = lukukausi, koodistoUri = "dialukukausi")
+  def diaValmistavaLukukausi(lukukausi: String, laajuus: Float) = DIAOppiaineenValmistavanVaiheenLukukausi(
+    tunniste = Koodistokoodiviite(koodiarvo = lukukausi, koodistoUri = "dialukukausi"),
+    laajuus = Some(LaajuusVuosiviikkotunneissa(laajuus))
   )
 
-  def diaTutkintoLukukausi(lukukausi: String) = DIAOppiaineenTutkintovaiheenLukukausi(
-    tunniste = Koodistokoodiviite(koodiarvo = lukukausi, koodistoUri = "dialukukausi")
+  def diaTutkintoLukukausi(lukukausi: String, laajuus: Float) = DIAOppiaineenTutkintovaiheenLukukausi(
+    tunniste = Koodistokoodiviite(koodiarvo = lukukausi, koodistoUri = "dialukukausi"),
+    laajuus = Some(LaajuusVuosiviikkotunneissa(laajuus))
   )
 
   def diaTutkintovaiheenArviointi(arvosana: String, päivä: LocalDate = date(2016, 6, 4)): Some[List[DIAOppiaineenTutkintovaiheenNumeerinenArviointi]] = {

--- a/src/main/scala/fi/oph/koski/documentation/ExamplesDIA.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesDIA.scala
@@ -194,7 +194,7 @@ object ExamplesDIA {
     osasuoritukset = Some(lukukaudet.map { case (lukukausi, arvosana) =>
       DIAOppiaineenValmistavanVaiheenLukukaudenSuoritus(
         koulutusmoduuli = lukukausi,
-        arviointi = diaTutkintovaiheArviointi(arvosana)
+        arviointi = diaValmistavaVaiheArviointi(arvosana)
       )
     })
   )
@@ -205,7 +205,7 @@ object ExamplesDIA {
     osasuoritukset = Some(lukukaudet.map { case (lukukausi, arvosana) =>
       DIAOppiaineenTutkintovaiheenOsasuorituksenSuoritus(
         koulutusmoduuli = lukukausi,
-        arviointi = diaValmistavaVaiheArviointi(arvosana)
+        arviointi = diaTutkintovaiheenArviointi(arvosana)
       )
     })
   )
@@ -247,11 +247,11 @@ object ExamplesDIA {
     tunniste = Koodistokoodiviite(koodiarvo = lukukausi, koodistoUri = "dialukukausi")
   )
 
-  def diaValmistavaVaiheArviointi(arvosana: String, päivä: LocalDate = date(2016, 6, 4)): Some[List[DIAOppiaineenTutkintovaiheenNumeerinenArviointi]] = {
+  def diaTutkintovaiheenArviointi(arvosana: String, päivä: LocalDate = date(2016, 6, 4)): Some[List[DIAOppiaineenTutkintovaiheenNumeerinenArviointi]] = {
     Some(List(DIAOppiaineenTutkintovaiheenNumeerinenArviointi(arvosana = Koodistokoodiviite(koodiarvo = arvosana, koodistoUri = "arviointiasteikkodiatutkinto"), päivä = Some(päivä))))
   }
 
-  def diaTutkintovaiheArviointi(arvosana: String, päivä: LocalDate = date(2016, 6, 4)): Some[List[DIAOppiaineenValmistavanVaiheenLukukaudenArviointi]] = {
+  def diaValmistavaVaiheArviointi(arvosana: String, päivä: LocalDate = date(2016, 6, 4)): Some[List[DIAOppiaineenValmistavanVaiheenLukukaudenArviointi]] = {
     Some(List(DIAOppiaineenValmistavanVaiheenLukukaudenArviointi(arvosana = Koodistokoodiviite(koodiarvo = arvosana, koodistoUri = "arviointiasteikkodiavalmistava"), päivä = Some(päivä))))
   }
 

--- a/src/main/scala/fi/oph/koski/documentation/ExamplesDIA.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesDIA.scala
@@ -1,177 +1,176 @@
 package fi.oph.koski.documentation
 
-import java.time.LocalDate
 import java.time.LocalDate.{of => date}
 
 import fi.oph.koski.documentation.ExampleData.{englanti, helsinki}
-import fi.oph.koski.documentation.DIAExampleData.saksalainenKoulu
+import fi.oph.koski.documentation.DIAExampleData._
 import fi.oph.koski.henkilo.MockOppijat
 import fi.oph.koski.henkilo.MockOppijat.asUusiOppija
 import fi.oph.koski.schema._
 
 object ExamplesDIA {
   def osasuorituksetValmistavaVaihe: List[DIAOppiaineenValmistavanVaiheenSuoritus] = List(
-    diaValmistavaVaiheAineSuoritus(diaOppiaineÄidinkieli("DE", laajuus = 3), List(
-      (diaValmistavaLukukausi("1", 1), "3"),
-      (diaValmistavaLukukausi("2", 2), "5")
-    )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaineÄidinkieli("FI", laajuus = 3), List(
-      (diaValmistavaLukukausi("1", 1), "2"),
-      (diaValmistavaLukukausi("2", 2), "3")
-    )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaineKieliaine("A", "EN", laajuus = 3), List(
-      (diaValmistavaLukukausi("1", 3), "3")
-    )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaineKieliaine("B1", "SV", laajuus = 3), List(
-      (diaValmistavaLukukausi("1", 1), "2"),
-      (diaValmistavaLukukausi("2", 2), "2")
-    )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaineLisäaineKieli("B2", "LA", laajuus = 2), List(
-      (diaValmistavaLukukausi("1", 1), "4"),
-      (diaValmistavaLukukausi("2", 1), "4")
-    )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaineKieliaine("B3", "RU", laajuus = 3), List(
-      (diaValmistavaLukukausi("1", 1), "4"),
-      (diaValmistavaLukukausi("2", 2), "3")
-    )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("KU", "1", laajuus = 2), List(
-      (diaValmistavaLukukausi("1", 1), "4"),
-      (diaValmistavaLukukausi("2", 1), "5")
-    )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("MA", "2", laajuus = 4), List(
-      (diaValmistavaLukukausi("1", 2), "3"),
-      (diaValmistavaLukukausi("2", 2), "1")
-    )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("FY", "2", laajuus = 2), List(
-      (diaValmistavaLukukausi("1", 1), "3"),
-      (diaValmistavaLukukausi("2", 1), "2")
-    )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("KE", "2", laajuus = 2), List(
-      (diaValmistavaLukukausi("1", 1), "2"),
-      (diaValmistavaLukukausi("2", 1), "4")
-    )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("TI", "2", laajuus = 2), List(
-      (diaValmistavaLukukausi("1", 1), "1"),
-      (diaValmistavaLukukausi("2", 1), "2")
-    )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("HI", "3", laajuus = 2), List(
-      (diaValmistavaLukukausi("1", 1), "3"),
-      (diaValmistavaLukukausi("2", 1), "4")
-    )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("TA", "3", laajuus = 2), List(
-      (diaValmistavaLukukausi("1", 1), "5"),
-      (diaValmistavaLukukausi("2", 1), "3")
-    )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("MAA", "3", laajuus = 2), List(
-      (diaValmistavaLukukausi("1", 1), "3"),
-      (diaValmistavaLukukausi("2", 1), "3")
-    )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("FI", "3", laajuus = 2), List(
-      (diaValmistavaLukukausi("1", 1), "1"),
-      (diaValmistavaLukukausi("2", 1), "1")
-    ))
+    diaValmistavaVaiheAineSuoritus(diaOppiaineÄidinkieli("DE", laajuus(3)), Some(List(
+      (diaValmistavaLukukausi("1", laajuus(1)), "3"),
+      (diaValmistavaLukukausi("2", laajuus(2)), "5")
+    ))),
+    diaValmistavaVaiheAineSuoritus(diaOppiaineÄidinkieli("FI", laajuus(3)), Some(List(
+      (diaValmistavaLukukausi("1", laajuus(1)), "2"),
+      (diaValmistavaLukukausi("2", laajuus(2)), "3")
+    ))),
+    diaValmistavaVaiheAineSuoritus(diaOppiaineKieliaine("A", "EN", laajuus(3)), Some(List(
+      (diaValmistavaLukukausi("1", laajuus(3)), "3")
+    ))),
+    diaValmistavaVaiheAineSuoritus(diaOppiaineKieliaine("B1", "SV", laajuus(3)), Some(List(
+      (diaValmistavaLukukausi("1", laajuus(1)), "2"),
+      (diaValmistavaLukukausi("2", laajuus(2)), "2")
+    ))),
+    diaValmistavaVaiheAineSuoritus(diaOppiaineLisäaineKieli("B2", "LA", laajuus(2)), Some(List(
+      (diaValmistavaLukukausi("1", laajuus(1)), "4"),
+      (diaValmistavaLukukausi("2", laajuus(1)), "4")
+    ))),
+    diaValmistavaVaiheAineSuoritus(diaOppiaineKieliaine("B3", "RU", laajuus(3)), Some(List(
+      (diaValmistavaLukukausi("1", laajuus(1)), "4"),
+      (diaValmistavaLukukausi("2", laajuus(2)), "3")
+    ))),
+    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("KU", "1",  laajuus(2)), Some(List(
+      (diaValmistavaLukukausi("1", laajuus(1)), "4"),
+      (diaValmistavaLukukausi("2", laajuus(1)), "5")
+    ))),
+    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("MA", "2", laajuus(4)), Some(List(
+      (diaValmistavaLukukausi("1", laajuus(2)), "3"),
+      (diaValmistavaLukukausi("2", laajuus(2)), "1")
+    ))),
+    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("FY", "2", laajuus(2)), Some(List(
+      (diaValmistavaLukukausi("1", laajuus(1)), "3"),
+      (diaValmistavaLukukausi("2", laajuus(1)), "2")
+    ))),
+    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("KE", "2", laajuus(2)), Some(List(
+      (diaValmistavaLukukausi("1", laajuus(1)), "2"),
+      (diaValmistavaLukukausi("2", laajuus(1)), "4")
+    ))),
+    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("TI", "2", laajuus(2)), Some(List(
+      (diaValmistavaLukukausi("1", laajuus(1)), "1"),
+      (diaValmistavaLukukausi("2", laajuus(1)), "2")
+    ))),
+    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("HI", "3", laajuus(2)), Some(List(
+      (diaValmistavaLukukausi("1", laajuus(1)), "3"),
+      (diaValmistavaLukukausi("2", laajuus(1)), "4")
+    ))),
+    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("TA", "3", laajuus(2)), Some(List(
+      (diaValmistavaLukukausi("1", laajuus(1)), "5"),
+      (diaValmistavaLukukausi("2", laajuus(1)), "3")
+    ))),
+    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("MAA", "3", laajuus(2)), Some(List(
+      (diaValmistavaLukukausi("1", laajuus(1)), "3"),
+      (diaValmistavaLukukausi("2", laajuus(1)), "3")
+    ))),
+    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("FI", "3", laajuus(2)), Some(List(
+      (diaValmistavaLukukausi("1", laajuus(1)), "1"),
+      (diaValmistavaLukukausi("2", laajuus(1)), "1")
+    )))
   )
 
   def osasuorituksetTutkintovaihe: List[DIAOppiaineenTutkintovaiheenSuoritus] = List(
-    diaTutkintoAineSuoritus(diaOppiaineÄidinkieli("DE", laajuus = 10), List(
-      (diaTutkintoLukukausi("3", 2), "3"),
-      (diaTutkintoLukukausi("4", 2), "5"),
-      (diaTutkintoLukukausi("5", 2), "4"),
-      (diaTutkintoLukukausi("6", 4), "3")
-    )),
-    diaTutkintoAineSuoritus(diaOppiaineÄidinkieli("FI", laajuus = 8), List(
-      (diaTutkintoLukukausi("3", 2), "2"),
-      (diaTutkintoLukukausi("4", 2), "3"),
-      (diaTutkintoLukukausi("5", 2), "3"),
-      (diaTutkintoLukukausi("6", 2), "3")
-    )),
-    diaTutkintoAineSuoritus(diaOppiaineKieliaine("A", "EN", laajuus = 6), List(
-      (diaTutkintoLukukausi("3", 2), "2"),
-      (diaTutkintoLukukausi("4", 2), "3"),
-      (diaTutkintoLukukausi("5", 2), "2")
-    )),
-    diaTutkintoAineSuoritus(diaOppiaineKieliaine("B1", "SV", laajuus = 6), List(
-      (diaTutkintoLukukausi("3", 1), "2"),
-      (diaTutkintoLukukausi("4", 1), "2"),
-      (diaTutkintoLukukausi("5", 1), "4"),
-      (diaTutkintoLukukausi("6", 3), "3")
-    )),
-    diaTutkintoAineSuoritus(diaOppiaineLisäaineKieli("B2", "LA", laajuus = 4), List(
-      (diaTutkintoLukukausi("3", 1), "3"),
-      (diaTutkintoLukukausi("4", 1), "3"),
-      (diaTutkintoLukukausi("5", 1), "2"),
-      (diaTutkintoLukukausi("6", 1), "2")
-    )),
-    diaTutkintoAineSuoritus(diaOppiaineKieliaine("B3", "RU", laajuus = 6), List(
-      (diaTutkintoLukukausi("3", 1), "4"),
-      (diaTutkintoLukukausi("4", 1), "3"),
-      (diaTutkintoLukukausi("5", 1), "4"),
-      (diaTutkintoLukukausi("6", 3), "3")
-    )),
-    diaTutkintoAineSuoritus(diaOppiaineMuu("KU", "1", laajuus = 4), List(
-      (diaTutkintoLukukausi("3", 1), "4"),
-      (diaTutkintoLukukausi("4", 1), "3"),
-      (diaTutkintoLukukausi("5", 1), "2"),
-      (diaTutkintoLukukausi("6", 1), "2")
-    )),
-    diaTutkintoAineSuoritus(diaOppiaineMuu("MA", "2", laajuus = 8), List(
-      (diaTutkintoLukukausi("3", 2), "3"),
-      (diaTutkintoLukukausi("4", 2), "1"),
-      (diaTutkintoLukukausi("5", 2), "1"),
-      (diaTutkintoLukukausi("6", 2), "2")
-    )),
-    diaTutkintoAineSuoritus(diaOppiaineMuu("FY", "2", laajuus = 6), List(
-      (diaTutkintoLukukausi("3", 1), "2"),
-      (diaTutkintoLukukausi("4", 1), "2"),
-      (diaTutkintoLukukausi("5", 1), "1"),
-      (diaTutkintoLukukausi("6", 3), "1")
-    )),
-    diaTutkintoAineSuoritus(diaOppiaineMuu("KE", "2", laajuus = 6), List(
-      (diaTutkintoLukukausi("3", 1), "3"),
-      (diaTutkintoLukukausi("4", 1), "2"),
-      (diaTutkintoLukukausi("5", 1), "1"),
-      (diaTutkintoLukukausi("6", 3), "2")
-    )),
-    diaTutkintoAineSuoritus(diaOppiaineMuu("TI", "2", laajuus = 4), List(
-      (diaTutkintoLukukausi("3", 1), "2"),
-      (diaTutkintoLukukausi("4", 1), "1"),
-      (diaTutkintoLukukausi("5", 1), "1"),
-      (diaTutkintoLukukausi("6", 1), "1")
-    )),
-    diaTutkintoAineSuoritus(diaOppiaineMuu("HI", "3", laajuus = 6), List(
-      (diaTutkintoLukukausi("3", 1), "3"),
-      (diaTutkintoLukukausi("4", 1), "4"),
-      (diaTutkintoLukukausi("5", 1), "3"),
-      (diaTutkintoLukukausi("6", 3), "1")
-    ), suorituskieli = Some("FI")),
-    diaTutkintoAineSuoritus(diaOppiaineMuu("TA", "3", laajuus = 6), List(
-      (diaTutkintoLukukausi("3", 1), "4"),
-      (diaTutkintoLukukausi("4", 1), "3"),
-      (diaTutkintoLukukausi("5", 1), "2"),
-      (diaTutkintoLukukausi("6", 3), "3")
-    )),
-    diaTutkintoAineSuoritus(diaOppiaineMuu("MAA", "3", laajuus = 6), List(
-      (diaTutkintoLukukausi("3", 1), "3"),
-      (diaTutkintoLukukausi("4", 1), "5"),
-      (diaTutkintoLukukausi("5", 1), "3"),
-      (diaTutkintoLukukausi("6", 3), "2")
-    )),
-    diaTutkintoAineSuoritus(diaOppiaineMuu("FI", "3", laajuus = 4), List(
-      (diaTutkintoLukukausi("3", 1), "2"),
-      (diaTutkintoLukukausi("4", 1), "2"),
-      (diaTutkintoLukukausi("5", 1), "2"),
-      (diaTutkintoLukukausi("6", 1), "2")
-    )),
-    diaTutkintoAineSuoritus(diaOppiaineLisäaine("CCEA", laajuus = 1), List(
-      (diaTutkintoLukukausi("5", 0.5f), "3"),
-      (diaTutkintoLukukausi("6", 0.5f), "1")
-    )),
-    diaTutkintoAineSuoritus(diaOppiaineLisäaine("MASY", laajuus = 2), List(
-      (diaTutkintoLukukausi("3", 0.5f), "2"),
-      (diaTutkintoLukukausi("4", 0.5f), "1"),
-      (diaTutkintoLukukausi("5", 0.5f), "2"),
-      (diaTutkintoLukukausi("6", 0.5f), "4")
-    ))
+    diaTutkintoAineSuoritus(diaOppiaineÄidinkieli("DE", laajuus(10)), Some(List(
+      (diaTutkintoLukukausi("3", laajuus(2)), "3"),
+      (diaTutkintoLukukausi("4", laajuus(2)), "5"),
+      (diaTutkintoLukukausi("5", laajuus(2)), "4"),
+      (diaTutkintoLukukausi("6", laajuus(4)), "3")
+    ))),
+    diaTutkintoAineSuoritus(diaOppiaineÄidinkieli("FI", laajuus(8)), Some(List(
+      (diaTutkintoLukukausi("3", laajuus(2)), "2"),
+      (diaTutkintoLukukausi("4", laajuus(2)), "3"),
+      (diaTutkintoLukukausi("5", laajuus(2)), "3"),
+      (diaTutkintoLukukausi("6", laajuus(2)), "3")
+    ))),
+    diaTutkintoAineSuoritus(diaOppiaineKieliaine("A", "EN", laajuus(6)), Some(List(
+      (diaTutkintoLukukausi("3", laajuus(2)), "2"),
+      (diaTutkintoLukukausi("4", laajuus(2)), "3"),
+      (diaTutkintoLukukausi("5", laajuus(2)), "2")
+    ))),
+    diaTutkintoAineSuoritus(diaOppiaineKieliaine("B1", "SV", laajuus(6)), Some(List(
+      (diaTutkintoLukukausi("3", laajuus(1)), "2"),
+      (diaTutkintoLukukausi("4", laajuus(1)), "2"),
+      (diaTutkintoLukukausi("5", laajuus(1)), "4"),
+      (diaTutkintoLukukausi("6", laajuus(3)), "3")
+    ))),
+    diaTutkintoAineSuoritus(diaOppiaineLisäaineKieli("B2", "LA", laajuus(4)), Some(List(
+      (diaTutkintoLukukausi("3", laajuus(1)), "3"),
+      (diaTutkintoLukukausi("4", laajuus(1)), "3"),
+      (diaTutkintoLukukausi("5", laajuus(1)), "2"),
+      (diaTutkintoLukukausi("6", laajuus(1)), "2")
+    ))),
+    diaTutkintoAineSuoritus(diaOppiaineKieliaine("B3", "RU", laajuus(6)), Some(List(
+      (diaTutkintoLukukausi("3", laajuus(1)), "4"),
+      (diaTutkintoLukukausi("4", laajuus(1)), "3"),
+      (diaTutkintoLukukausi("5", laajuus(1)), "4"),
+      (diaTutkintoLukukausi("6", laajuus(3)), "3")
+    ))),
+    diaTutkintoAineSuoritus(diaOppiaineMuu("KU", "1", laajuus(4)), Some(List(
+      (diaTutkintoLukukausi("3", laajuus(1)), "4"),
+      (diaTutkintoLukukausi("4", laajuus(1)), "3"),
+      (diaTutkintoLukukausi("5", laajuus(1)), "2"),
+      (diaTutkintoLukukausi("6", laajuus(1)), "2")
+    ))),
+    diaTutkintoAineSuoritus(diaOppiaineMuu("MA", "2", laajuus(8)), Some(List(
+      (diaTutkintoLukukausi("3", laajuus(2)), "3"),
+      (diaTutkintoLukukausi("4", laajuus(2)), "1"),
+      (diaTutkintoLukukausi("5", laajuus(2)), "1"),
+      (diaTutkintoLukukausi("6", laajuus(2)), "2")
+    ))),
+    diaTutkintoAineSuoritus(diaOppiaineMuu("FY", "2", laajuus(6)), Some(List(
+      (diaTutkintoLukukausi("3", laajuus(1)), "2"),
+      (diaTutkintoLukukausi("4", laajuus(1)), "2"),
+      (diaTutkintoLukukausi("5", laajuus(1)), "1"),
+      (diaTutkintoLukukausi("6", laajuus(3)), "1")
+    ))),
+    diaTutkintoAineSuoritus(diaOppiaineMuu("KE", "2", laajuus(6)), Some(List(
+      (diaTutkintoLukukausi("3", laajuus(1)), "3"),
+      (diaTutkintoLukukausi("4", laajuus(1)), "2"),
+      (diaTutkintoLukukausi("5", laajuus(1)), "1"),
+      (diaTutkintoLukukausi("6", laajuus(3)), "2")
+    ))),
+    diaTutkintoAineSuoritus(diaOppiaineMuu("TI", "2", laajuus(4)), Some(List(
+      (diaTutkintoLukukausi("3", laajuus(1)), "2"),
+      (diaTutkintoLukukausi("4", laajuus(1)), "1"),
+      (diaTutkintoLukukausi("5", laajuus(1)), "1"),
+      (diaTutkintoLukukausi("6", laajuus(1)), "1")
+    ))),
+    diaTutkintoAineSuoritus(diaOppiaineMuu("HI", "3", laajuus(6)), Some(List(
+      (diaTutkintoLukukausi("3", laajuus(1)), "3"),
+      (diaTutkintoLukukausi("4", laajuus(1)), "4"),
+      (diaTutkintoLukukausi("5", laajuus(1)), "3"),
+      (diaTutkintoLukukausi("6", laajuus(3)), "1")
+    )), suorituskieli = Some("FI")),
+    diaTutkintoAineSuoritus(diaOppiaineMuu("TA", "3", laajuus(6)), Some(List(
+      (diaTutkintoLukukausi("3", laajuus(1)), "4"),
+      (diaTutkintoLukukausi("4", laajuus(1)), "3"),
+      (diaTutkintoLukukausi("5", laajuus(1)), "2"),
+      (diaTutkintoLukukausi("6", laajuus(3)), "3")
+    ))),
+    diaTutkintoAineSuoritus(diaOppiaineMuu("MAA", "3", laajuus(6)), Some(List(
+      (diaTutkintoLukukausi("3", laajuus(1)), "3"),
+      (diaTutkintoLukukausi("4", laajuus(1)), "5"),
+      (diaTutkintoLukukausi("5", laajuus(1)), "3"),
+      (diaTutkintoLukukausi("6", laajuus(3)), "2")
+    ))),
+    diaTutkintoAineSuoritus(diaOppiaineMuu("FI", "3", laajuus(4)), Some(List(
+      (diaTutkintoLukukausi("3", laajuus(1)), "2"),
+      (diaTutkintoLukukausi("4", laajuus(1)), "2"),
+      (diaTutkintoLukukausi("5", laajuus(1)), "2"),
+      (diaTutkintoLukukausi("6", laajuus(1)), "2")
+    ))),
+    diaTutkintoAineSuoritus(diaOppiaineLisäaine("CCEA", laajuus(1)), Some(List(
+      (diaTutkintoLukukausi("5", laajuus(0.5f)), "3"),
+      (diaTutkintoLukukausi("6", laajuus(0.5f)), "1")
+    ))),
+    diaTutkintoAineSuoritus(diaOppiaineLisäaine("MASY", laajuus(2)), Some(List(
+      (diaTutkintoLukukausi("3", laajuus(0.5f)), "2"),
+      (diaTutkintoLukukausi("4", laajuus(0.5f)), "1"),
+      (diaTutkintoLukukausi("5", laajuus(0.5f)), "2"),
+      (diaTutkintoLukukausi("6", laajuus(0.5f)), "4")
+    )))
   )
 
   def diaValmistavanVaiheenSuoritus = DIAValmistavanVaiheenSuoritus(
@@ -188,74 +187,6 @@ object ExamplesDIA {
     kokonaispistemäärä = kokonaispistemäärä,
     osasuoritukset = Some(osasuorituksetTutkintovaihe)
   )
-
-  def diaValmistavaVaiheAineSuoritus(oppiaine: DIAOppiaine, lukukaudet: List[(DIAOppiaineenValmistavanVaiheenLukukausi, String)] = Nil) = DIAOppiaineenValmistavanVaiheenSuoritus(
-    koulutusmoduuli = oppiaine,
-    osasuoritukset = Some(lukukaudet.map { case (lukukausi, arvosana) =>
-      DIAOppiaineenValmistavanVaiheenLukukaudenSuoritus(
-        koulutusmoduuli = lukukausi,
-        arviointi = diaValmistavaVaiheArviointi(arvosana)
-      )
-    })
-  )
-
-  def diaTutkintoAineSuoritus(oppiaine: DIAOppiaine, lukukaudet: List[(DIAOppiaineenTutkintovaiheenLukukausi, String)] = Nil, suorituskieli: Option[String] = None) = DIAOppiaineenTutkintovaiheenSuoritus(
-    koulutusmoduuli = oppiaine,
-    suorituskieli = suorituskieli.map(k => Koodistokoodiviite(koodiarvo = k, koodistoUri = "kieli")),
-    osasuoritukset = Some(lukukaudet.map { case (lukukausi, arvosana) =>
-      DIAOppiaineenTutkintovaiheenOsasuorituksenSuoritus(
-        koulutusmoduuli = lukukausi,
-        arviointi = diaTutkintovaiheenArviointi(arvosana)
-      )
-    })
-  )
-
-  def diaOppiaineMuu(aine: String, osaAlue: String, laajuus: Int) = DIAOppiaineMuu(
-    tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = aine),
-    laajuus = Some(LaajuusVuosiviikkotunneissa(laajuus)),
-    osaAlue = Koodistokoodiviite(koodiarvo = osaAlue, koodistoUri = "diaosaalue")
-  )
-
-  def diaOppiaineKieliaine(taso: String, kieli: String, laajuus: Int) = DIAOppiaineKieli(
-    tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = taso),
-    kieli = Koodistokoodiviite(koodistoUri = "kielivalikoima", koodiarvo = kieli),
-    laajuus = Some(LaajuusVuosiviikkotunneissa(laajuus))
-  )
-
-  def diaOppiaineÄidinkieli(kieli: String, laajuus: Int) = DIAOppiaineÄidinkieli(
-    tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = "AI"),
-    kieli = Koodistokoodiviite(koodistoUri = "oppiainediaaidinkieli", koodiarvo = kieli),
-    laajuus = Some(LaajuusVuosiviikkotunneissa(laajuus))
-  )
-
-  def diaOppiaineLisäaine(aine: String, laajuus: Int) = DIAOppiaineLisäaine(
-    tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = aine),
-    laajuus = Some(LaajuusVuosiviikkotunneissa(laajuus))
-  )
-
-  def diaOppiaineLisäaineKieli(taso: String, kieli: String, laajuus: Int) = DIAOppiaineLisäaineKieli(
-    tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = taso),
-    kieli = Koodistokoodiviite(koodistoUri = "kielivalikoima", koodiarvo = kieli),
-    laajuus = Some(LaajuusVuosiviikkotunneissa(laajuus))
-  )
-
-  def diaValmistavaLukukausi(lukukausi: String, laajuus: Float) = DIAOppiaineenValmistavanVaiheenLukukausi(
-    tunniste = Koodistokoodiviite(koodiarvo = lukukausi, koodistoUri = "dialukukausi"),
-    laajuus = Some(LaajuusVuosiviikkotunneissa(laajuus))
-  )
-
-  def diaTutkintoLukukausi(lukukausi: String, laajuus: Float) = DIAOppiaineenTutkintovaiheenLukukausi(
-    tunniste = Koodistokoodiviite(koodiarvo = lukukausi, koodistoUri = "dialukukausi"),
-    laajuus = Some(LaajuusVuosiviikkotunneissa(laajuus))
-  )
-
-  def diaTutkintovaiheenArviointi(arvosana: String, päivä: LocalDate = date(2016, 6, 4)): Some[List[DIAOppiaineenTutkintovaiheenNumeerinenArviointi]] = {
-    Some(List(DIAOppiaineenTutkintovaiheenNumeerinenArviointi(arvosana = Koodistokoodiviite(koodiarvo = arvosana, koodistoUri = "arviointiasteikkodiatutkinto"), päivä = Some(päivä))))
-  }
-
-  def diaValmistavaVaiheArviointi(arvosana: String, päivä: LocalDate = date(2016, 6, 4)): Some[List[DIAOppiaineenValmistavanVaiheenLukukaudenArviointi]] = {
-    Some(List(DIAOppiaineenValmistavanVaiheenLukukaudenArviointi(arvosana = Koodistokoodiviite(koodiarvo = arvosana, koodistoUri = "arviointiasteikkodiavalmistava"), päivä = Some(päivä))))
-  }
 
   val opiskeluoikeus = DIAOpiskeluoikeus(
     oppilaitos = Some(saksalainenKoulu),

--- a/src/main/scala/fi/oph/koski/documentation/ExamplesDIA.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesDIA.scala
@@ -11,162 +11,162 @@ import fi.oph.koski.schema._
 
 object ExamplesDIA {
   def osasuorituksetValmistavaVaihe: List[DIAOppiaineenValmistavanVaiheenSuoritus] = List(
-    diaValmistavaVaiheAineSuoritus(diaÄidinkieli("DE", laajuus = 3), List(
+    diaValmistavaVaiheAineSuoritus(diaOppiaineÄidinkieli("DE", laajuus = 3), List(
       (diaValmistavaLukukausi("1", 1), "3"),
       (diaValmistavaLukukausi("2", 2), "5")
     )),
-    diaValmistavaVaiheAineSuoritus(diaÄidinkieli("FI", laajuus = 3), List(
+    diaValmistavaVaiheAineSuoritus(diaOppiaineÄidinkieli("FI", laajuus = 3), List(
       (diaValmistavaLukukausi("1", 1), "2"),
       (diaValmistavaLukukausi("2", 2), "3")
     )),
-    diaValmistavaVaiheAineSuoritus(diaKieliaine("A", "EN", laajuus = 3), List(
+    diaValmistavaVaiheAineSuoritus(diaOppiaineKieliaine("A", "EN", laajuus = 3), List(
       (diaValmistavaLukukausi("1", 3), "3")
     )),
-    diaValmistavaVaiheAineSuoritus(diaKieliaine("B1", "SV", laajuus = 3), List(
+    diaValmistavaVaiheAineSuoritus(diaOppiaineKieliaine("B1", "SV", laajuus = 3), List(
       (diaValmistavaLukukausi("1", 1), "2"),
       (diaValmistavaLukukausi("2", 2), "2")
     )),
-    diaValmistavaVaiheAineSuoritus(diaLisäaineKieli("B2", "LA", laajuus = 2), List(
+    diaValmistavaVaiheAineSuoritus(diaOppiaineLisäaineKieli("B2", "LA", laajuus = 2), List(
       (diaValmistavaLukukausi("1", 1), "4"),
       (diaValmistavaLukukausi("2", 1), "4")
     )),
-    diaValmistavaVaiheAineSuoritus(diaKieliaine("B3", "RU", laajuus = 3), List(
+    diaValmistavaVaiheAineSuoritus(diaOppiaineKieliaine("B3", "RU", laajuus = 3), List(
       (diaValmistavaLukukausi("1", 1), "4"),
       (diaValmistavaLukukausi("2", 2), "3")
     )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaine("KU", "1", laajuus = 2), List(
+    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("KU", "1", laajuus = 2), List(
       (diaValmistavaLukukausi("1", 1), "4"),
       (diaValmistavaLukukausi("2", 1), "5")
     )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaine("MA", "2", laajuus = 4), List(
+    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("MA", "2", laajuus = 4), List(
       (diaValmistavaLukukausi("1", 2), "3"),
       (diaValmistavaLukukausi("2", 2), "1")
     )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaine("FY", "2", laajuus = 2), List(
+    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("FY", "2", laajuus = 2), List(
       (diaValmistavaLukukausi("1", 1), "3"),
       (diaValmistavaLukukausi("2", 1), "2")
     )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaine("KE", "2", laajuus = 2), List(
+    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("KE", "2", laajuus = 2), List(
       (diaValmistavaLukukausi("1", 1), "2"),
       (diaValmistavaLukukausi("2", 1), "4")
     )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaine("TI", "2", laajuus = 2), List(
+    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("TI", "2", laajuus = 2), List(
       (diaValmistavaLukukausi("1", 1), "1"),
       (diaValmistavaLukukausi("2", 1), "2")
     )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaine("HI", "3", laajuus = 2), List(
+    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("HI", "3", laajuus = 2), List(
       (diaValmistavaLukukausi("1", 1), "3"),
       (diaValmistavaLukukausi("2", 1), "4")
     )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaine("TA", "3", laajuus = 2), List(
+    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("TA", "3", laajuus = 2), List(
       (diaValmistavaLukukausi("1", 1), "5"),
       (diaValmistavaLukukausi("2", 1), "3")
     )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaine("MAA", "3", laajuus = 2), List(
+    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("MAA", "3", laajuus = 2), List(
       (diaValmistavaLukukausi("1", 1), "3"),
       (diaValmistavaLukukausi("2", 1), "3")
     )),
-    diaValmistavaVaiheAineSuoritus(diaOppiaine("FI", "3", laajuus = 2), List(
+    diaValmistavaVaiheAineSuoritus(diaOppiaineMuu("FI", "3", laajuus = 2), List(
       (diaValmistavaLukukausi("1", 1), "1"),
       (diaValmistavaLukukausi("2", 1), "1")
     ))
   )
 
   def osasuorituksetTutkintovaihe: List[DIAOppiaineenTutkintovaiheenSuoritus] = List(
-    diaTutkintoAineSuoritus(diaÄidinkieli("DE", laajuus = 10), List(
+    diaTutkintoAineSuoritus(diaOppiaineÄidinkieli("DE", laajuus = 10), List(
       (diaTutkintoLukukausi("3", 2), "3"),
       (diaTutkintoLukukausi("4", 2), "5"),
       (diaTutkintoLukukausi("5", 2), "4"),
       (diaTutkintoLukukausi("6", 4), "3")
     )),
-    diaTutkintoAineSuoritus(diaÄidinkieli("FI", laajuus = 8), List(
+    diaTutkintoAineSuoritus(diaOppiaineÄidinkieli("FI", laajuus = 8), List(
       (diaTutkintoLukukausi("3", 2), "2"),
       (diaTutkintoLukukausi("4", 2), "3"),
       (diaTutkintoLukukausi("5", 2), "3"),
       (diaTutkintoLukukausi("6", 2), "3")
     )),
-    diaTutkintoAineSuoritus(diaKieliaine("A", "EN", laajuus = 6), List(
+    diaTutkintoAineSuoritus(diaOppiaineKieliaine("A", "EN", laajuus = 6), List(
       (diaTutkintoLukukausi("3", 2), "2"),
       (diaTutkintoLukukausi("4", 2), "3"),
       (diaTutkintoLukukausi("5", 2), "2")
     )),
-    diaTutkintoAineSuoritus(diaKieliaine("B1", "SV", laajuus = 6), List(
+    diaTutkintoAineSuoritus(diaOppiaineKieliaine("B1", "SV", laajuus = 6), List(
       (diaTutkintoLukukausi("3", 1), "2"),
       (diaTutkintoLukukausi("4", 1), "2"),
       (diaTutkintoLukukausi("5", 1), "4"),
       (diaTutkintoLukukausi("6", 3), "3")
     )),
-    diaTutkintoAineSuoritus(diaLisäaineKieli("B2", "LA", laajuus = 4), List(
+    diaTutkintoAineSuoritus(diaOppiaineLisäaineKieli("B2", "LA", laajuus = 4), List(
       (diaTutkintoLukukausi("3", 1), "3"),
       (diaTutkintoLukukausi("4", 1), "3"),
       (diaTutkintoLukukausi("5", 1), "2"),
       (diaTutkintoLukukausi("6", 1), "2")
     )),
-    diaTutkintoAineSuoritus(diaKieliaine("B3", "RU", laajuus = 6), List(
+    diaTutkintoAineSuoritus(diaOppiaineKieliaine("B3", "RU", laajuus = 6), List(
       (diaTutkintoLukukausi("3", 1), "4"),
       (diaTutkintoLukukausi("4", 1), "3"),
       (diaTutkintoLukukausi("5", 1), "4"),
       (diaTutkintoLukukausi("6", 3), "3")
     )),
-    diaTutkintoAineSuoritus(diaOppiaine("KU", "1", laajuus = 4), List(
+    diaTutkintoAineSuoritus(diaOppiaineMuu("KU", "1", laajuus = 4), List(
       (diaTutkintoLukukausi("3", 1), "4"),
       (diaTutkintoLukukausi("4", 1), "3"),
       (diaTutkintoLukukausi("5", 1), "2"),
       (diaTutkintoLukukausi("6", 1), "2")
     )),
-    diaTutkintoAineSuoritus(diaOppiaine("MA", "2", laajuus = 8), List(
+    diaTutkintoAineSuoritus(diaOppiaineMuu("MA", "2", laajuus = 8), List(
       (diaTutkintoLukukausi("3", 2), "3"),
       (diaTutkintoLukukausi("4", 2), "1"),
       (diaTutkintoLukukausi("5", 2), "1"),
       (diaTutkintoLukukausi("6", 2), "2")
     )),
-    diaTutkintoAineSuoritus(diaOppiaine("FY", "2", laajuus = 6), List(
+    diaTutkintoAineSuoritus(diaOppiaineMuu("FY", "2", laajuus = 6), List(
       (diaTutkintoLukukausi("3", 1), "2"),
       (diaTutkintoLukukausi("4", 1), "2"),
       (diaTutkintoLukukausi("5", 1), "1"),
       (diaTutkintoLukukausi("6", 3), "1")
     )),
-    diaTutkintoAineSuoritus(diaOppiaine("KE", "2", laajuus = 6), List(
+    diaTutkintoAineSuoritus(diaOppiaineMuu("KE", "2", laajuus = 6), List(
       (diaTutkintoLukukausi("3", 1), "3"),
       (diaTutkintoLukukausi("4", 1), "2"),
       (diaTutkintoLukukausi("5", 1), "1"),
       (diaTutkintoLukukausi("6", 3), "2")
     )),
-    diaTutkintoAineSuoritus(diaOppiaine("TI", "2", laajuus = 4), List(
+    diaTutkintoAineSuoritus(diaOppiaineMuu("TI", "2", laajuus = 4), List(
       (diaTutkintoLukukausi("3", 1), "2"),
       (diaTutkintoLukukausi("4", 1), "1"),
       (diaTutkintoLukukausi("5", 1), "1"),
       (diaTutkintoLukukausi("6", 1), "1")
     )),
-    diaTutkintoAineSuoritus(diaOppiaine("HI", "3", laajuus = 6), List(
+    diaTutkintoAineSuoritus(diaOppiaineMuu("HI", "3", laajuus = 6), List(
       (diaTutkintoLukukausi("3", 1), "3"),
       (diaTutkintoLukukausi("4", 1), "4"),
       (diaTutkintoLukukausi("5", 1), "3"),
       (diaTutkintoLukukausi("6", 3), "1")
     ), suorituskieli = Some("FI")),
-    diaTutkintoAineSuoritus(diaOppiaine("TA", "3", laajuus = 6), List(
+    diaTutkintoAineSuoritus(diaOppiaineMuu("TA", "3", laajuus = 6), List(
       (diaTutkintoLukukausi("3", 1), "4"),
       (diaTutkintoLukukausi("4", 1), "3"),
       (diaTutkintoLukukausi("5", 1), "2"),
       (diaTutkintoLukukausi("6", 3), "3")
     )),
-    diaTutkintoAineSuoritus(diaOppiaine("MAA", "3", laajuus = 6), List(
+    diaTutkintoAineSuoritus(diaOppiaineMuu("MAA", "3", laajuus = 6), List(
       (diaTutkintoLukukausi("3", 1), "3"),
       (diaTutkintoLukukausi("4", 1), "5"),
       (diaTutkintoLukukausi("5", 1), "3"),
       (diaTutkintoLukukausi("6", 3), "2")
     )),
-    diaTutkintoAineSuoritus(diaOppiaine("FI", "3", laajuus = 4), List(
+    diaTutkintoAineSuoritus(diaOppiaineMuu("FI", "3", laajuus = 4), List(
       (diaTutkintoLukukausi("3", 1), "2"),
       (diaTutkintoLukukausi("4", 1), "2"),
       (diaTutkintoLukukausi("5", 1), "2"),
       (diaTutkintoLukukausi("6", 1), "2")
     )),
-    diaTutkintoAineSuoritus(diaMuuValinnainen("CCEA", laajuus = 1), List(
+    diaTutkintoAineSuoritus(diaOppiaineLisäaine("CCEA", laajuus = 1), List(
       (diaTutkintoLukukausi("5", 0.5f), "3"),
       (diaTutkintoLukukausi("6", 0.5f), "1")
     )),
-    diaTutkintoAineSuoritus(diaMuuValinnainen("MASY", laajuus = 2), List(
+    diaTutkintoAineSuoritus(diaOppiaineLisäaine("MASY", laajuus = 2), List(
       (diaTutkintoLukukausi("3", 0.5f), "2"),
       (diaTutkintoLukukausi("4", 0.5f), "1"),
       (diaTutkintoLukukausi("5", 0.5f), "2"),
@@ -210,30 +210,30 @@ object ExamplesDIA {
     })
   )
 
-  def diaOppiaine(aine: String, osaAlue: String, laajuus: Int) = DIAOppiaineMuu(
+  def diaOppiaineMuu(aine: String, osaAlue: String, laajuus: Int) = DIAOppiaineMuu(
     tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = aine),
     laajuus = Some(LaajuusVuosiviikkotunneissa(laajuus)),
     osaAlue = Koodistokoodiviite(koodiarvo = osaAlue, koodistoUri = "diaosaalue")
   )
 
-  def diaKieliaine(taso: String, kieli: String, laajuus: Int) = DIAOppiaineKieli(
+  def diaOppiaineKieliaine(taso: String, kieli: String, laajuus: Int) = DIAOppiaineKieli(
     tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = taso),
     kieli = Koodistokoodiviite(koodistoUri = "kielivalikoima", koodiarvo = kieli),
     laajuus = Some(LaajuusVuosiviikkotunneissa(laajuus))
   )
 
-  def diaÄidinkieli(kieli: String, laajuus: Int) = DIAOppiaineÄidinkieli(
+  def diaOppiaineÄidinkieli(kieli: String, laajuus: Int) = DIAOppiaineÄidinkieli(
     tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = "AI"),
     kieli = Koodistokoodiviite(koodistoUri = "oppiainediaaidinkieli", koodiarvo = kieli),
     laajuus = Some(LaajuusVuosiviikkotunneissa(laajuus))
   )
 
-  def diaMuuValinnainen(aine: String, laajuus: Int) = DIAOppiaineLisäaine(
+  def diaOppiaineLisäaine(aine: String, laajuus: Int) = DIAOppiaineLisäaine(
     tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = aine),
     laajuus = Some(LaajuusVuosiviikkotunneissa(laajuus))
   )
 
-  def diaLisäaineKieli(taso: String, kieli: String, laajuus: Int) = DIAOppiaineLisäaineKieli(
+  def diaOppiaineLisäaineKieli(taso: String, kieli: String, laajuus: Int) = DIAOppiaineLisäaineKieli(
     tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = taso),
     kieli = Koodistokoodiviite(koodistoUri = "kielivalikoima", koodiarvo = kieli),
     laajuus = Some(LaajuusVuosiviikkotunneissa(laajuus))

--- a/src/main/scala/fi/oph/koski/http/KoskiErrorCategory.scala
+++ b/src/main/scala/fi/oph/koski/http/KoskiErrorCategory.scala
@@ -116,6 +116,7 @@ object KoskiErrorCategory {
       class Laajuudet extends ErrorCategory(Validation.this, "laajuudet", "Suoritusten laajuuksiin liittyvä validointivirhe") {
         val osasuorituksellaEriLaajuusyksikkö = subcategory("osasuorituksellaEriLaajuusyksikkö", "Osasuorituksella on eri laajuusyksikkö kuin ylemmän tason suorituksella")
         val osasuoritustenLaajuuksienSumma = subcategory("osasuoritustenLaajuuksienSumma", "Osasuoritusten laajuuksien summa ei täsmää")
+        val oppiaineenLaajuusPuuttuu = subcategory("oppiaineenLaajuusPuuttuu", "Oppiaineen laajuus puuttuu")
       }
       val laajuudet = new Laajuudet
 

--- a/src/main/scala/fi/oph/koski/schema/DIA.scala
+++ b/src/main/scala/fi/oph/koski/schema/DIA.scala
@@ -139,7 +139,7 @@ case class DIAOppiaineenTutkintovaiheenOsasuorituksenSuoritus(
   tyyppi: Koodistokoodiviite = Koodistokoodiviite(koodiarvo = "diaoppiaineentutkintovaiheenosasuorituksensuoritus", koodistoUri = "suorituksentyyppi")
 ) extends DIASuoritus
 
-trait DIAOppiaineenOsasuoritus extends KoodistostaLöytyväKoulutusmoduuli with Laajuudeton
+trait DIAOppiaineenOsasuoritus extends KoodistostaLöytyväKoulutusmoduuli
 
 trait DIAOppiaineenLukukausi extends DIAOppiaineenOsasuoritus {
   @KoodistoUri("dialukukausi")
@@ -153,7 +153,8 @@ trait DIAOppiaineenTutkintovaiheenOsasuoritus extends DIAOppiaineenOsasuoritus
 case class DIAOppiaineenValmistavanVaiheenLukukausi(
   @KoodistoKoodiarvo("1")
   @KoodistoKoodiarvo("2")
-  tunniste: Koodistokoodiviite
+  tunniste: Koodistokoodiviite,
+  laajuus: Option[LaajuusVuosiviikkotunneissa]
 ) extends DIAOppiaineenLukukausi
 
 @Title("DIA-oppiaineen tutkintovaiheen lukukausi")
@@ -164,6 +165,7 @@ case class DIAOppiaineenTutkintovaiheenLukukausi(
   @KoodistoKoodiarvo("5")
   @KoodistoKoodiarvo("6")
   tunniste: Koodistokoodiviite,
+  laajuus: Option[LaajuusVuosiviikkotunneissa]
 ) extends DIAOppiaineenLukukausi with DIAOppiaineenTutkintovaiheenOsasuoritus
 
 @Title("DIA-tutkinnon päättökoe")
@@ -173,7 +175,7 @@ case class DIAPäättökoe (
   @KoodistoKoodiarvo("kirjallinenkoe")
   @KoodistoKoodiarvo("suullinenkoe")
   tunniste: Koodistokoodiviite
-) extends DIAOppiaineenTutkintovaiheenOsasuoritus
+) extends DIAOppiaineenTutkintovaiheenOsasuoritus with Laajuudeton
 
 @Title("DIA-tutkinnon erityisosaamisen näyttötutkinto")
 @Description("DIA-tutkinnon erityisosaamisen näyttötutkinnon tunnistetiedot")
@@ -181,7 +183,7 @@ case class DIANäyttötutkinto (
   @KoodistoUri("diapaattokoe")
   @KoodistoKoodiarvo("nayttotutkinto")
   tunniste: Koodistokoodiviite
-) extends DIAOppiaineenTutkintovaiheenOsasuoritus
+) extends DIAOppiaineenTutkintovaiheenOsasuoritus with Laajuudeton
 
 trait DIAArviointi extends KoodistostaLöytyväArviointi {
   def arvosana: Koodistokoodiviite
@@ -247,6 +249,7 @@ trait DIAOppiaine extends KoodistostaLöytyväKoulutusmoduuli {
   @KoodistoUri("oppiaineetdia")
   @OksaUri("tmpOKSAID256", "oppiaine")
   def tunniste: Koodistokoodiviite
+  def laajuus: Option[LaajuusVuosiviikkotunneissa]
 }
 
 trait DIAOsaAlueOppiaine extends DIAOppiaine {

--- a/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
+++ b/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
@@ -21,6 +21,9 @@ import fi.oph.koski.util.Timing
 import mojave._
 import org.json4s.{JArray, JValue}
 
+// scalastyle:off line.size.limit
+// scalastyle:off number.of.methods
+
 class KoskiValidator(tutkintoRepository: TutkintoRepository, val koodistoPalvelu: KoodistoViitePalvelu, val organisaatioRepository: OrganisaatioRepository, koskiOpiskeluoikeudet: KoskiOpiskeluoikeusRepository, henkilöRepository: HenkilöRepository, ePerusteet: EPerusteetRepository) extends Timing {
   def validateAsJson(oppija: Oppija)(implicit user: KoskiSession, accessType: AccessType.Value): Either[HttpStatus, Oppija] = {
     extractAndValidateOppija(JsonSerializer.serialize(oppija))

--- a/src/test/scala/fi/oph/koski/api/OpiskeluoikeusTestMethodsDIA.scala
+++ b/src/test/scala/fi/oph/koski/api/OpiskeluoikeusTestMethodsDIA.scala
@@ -1,0 +1,44 @@
+package fi.oph.koski.api
+
+import java.time.LocalDate.{of => date}
+
+import fi.oph.koski.documentation.ExampleData._
+import fi.oph.koski.documentation.LukioExampleData
+import fi.oph.koski.documentation.DIAExampleData.saksalainenKoulu
+import fi.oph.koski.schema._
+
+trait OpiskeluoikeusTestMethodsDIA extends PutOpiskeluoikeusTestMethods[DIAOpiskeluoikeus]{
+  def tag = implicitly[reflect.runtime.universe.TypeTag[DIAOpiskeluoikeus]]
+
+  override def defaultOpiskeluoikeus = OpiskeluoikeusTestMethodsDIA.opiskeluoikeus
+  def valmisOpiskeluoikeus = OpiskeluoikeusTestMethodsDIA.opiskeluoikeusValmis
+}
+
+object OpiskeluoikeusTestMethodsDIA {
+  def tutkintoSuoritus = DIATutkinnonSuoritus(
+    toimipiste = saksalainenKoulu,
+    suorituskieli = englanti,
+    kokonaispistemäärä = Some(800),
+    osasuoritukset = None
+  )
+
+  def opiskeluoikeus = DIAOpiskeluoikeus(
+    oppilaitos = Some(saksalainenKoulu),
+    tila = LukionOpiskeluoikeudenTila(
+      List(
+        LukionOpiskeluoikeusjakso(date(2012, 9, 1), LukioExampleData.opiskeluoikeusAktiivinen)
+      )
+    ),
+    suoritukset = List(tutkintoSuoritus)
+  )
+
+  def opiskeluoikeusValmis = opiskeluoikeus.copy(
+    päättymispäivä = Some(date(2016, 6, 4)),
+    tila = LukionOpiskeluoikeudenTila(
+      List(
+        LukionOpiskeluoikeusjakso(date(2012, 9, 1), LukioExampleData.opiskeluoikeusAktiivinen),
+        LukionOpiskeluoikeusjakso(date(2016, 6, 4), LukioExampleData.opiskeluoikeusPäättynyt)
+      )
+    )
+  )
+}

--- a/src/test/scala/fi/oph/koski/api/OppijaValidationDIASpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationDIASpec.scala
@@ -1,0 +1,139 @@
+package fi.oph.koski.api
+
+import fi.oph.koski.api.OpiskeluoikeusTestMethodsDIA.tutkintoSuoritus
+import fi.oph.koski.documentation.DIAExampleData._
+import fi.oph.koski.documentation.ExampleData.{vahvistusPaikkakunnalla, helsinki}
+import fi.oph.koski.http.{ErrorMatcher, KoskiErrorCategory}
+import org.scalatest.FreeSpec
+
+class OppijaValidationDIASpec extends FreeSpec with LocalJettyHttpSpecification with OpiskeluoikeusTestMethodsDIA {
+  "Laajuudet" - {
+    """Lukukauden laajuusyksikkö muu kuin "vuosiviikkotuntia" -> HTTP 400""" in {
+      val laajuudenYksikköKurssia = "4"
+      val oo = defaultOpiskeluoikeus.copy(suoritukset = List(tutkintoSuoritus.copy(
+        osasuoritukset = Some(List(diaTutkintoAineSuoritus(diaOppiaineMuu("MA", osaAlue = "2", laajuus(8)), Some(List(
+          (diaTutkintoLukukausi("3", laajuus(8f, laajuudenYksikköKurssia)), "2"),
+        )))))
+      )))
+
+      putOpiskeluoikeus(oo) {
+        verifyResponseStatus(400, ErrorMatcher.regex(KoskiErrorCategory.badRequest.validation.jsonSchema, ".*enumValueMismatch.*".r))
+      }
+    }
+
+    "Suoritus kesken, lukukausien laajuuksien summa ei täsmää -> HTTP 400" in {
+      val oo = defaultOpiskeluoikeus.copy(suoritukset = List(tutkintoSuoritus.copy(
+        osasuoritukset = Some(List(diaTutkintoAineSuoritus(diaOppiaineMuu("MA", osaAlue = "2", laajuus(2)), Some(List(
+          (diaTutkintoLukukausi("3", laajuus(1.0f)), "2"),
+        )))))
+      )))
+
+      putOpiskeluoikeus(oo) {
+        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.laajuudet.osasuoritustenLaajuuksienSumma("Suorituksen oppiaineetdia/MA osasuoritusten laajuuksien summa 1.0 ei vastaa suorituksen laajuutta 2.0"))
+      }
+    }
+
+    "Suoritus valmis, lukukausien laajuuksien summa ei täsmää -> HTTP 400" in {
+      val oo = valmisOpiskeluoikeus.copy(suoritukset = List(tutkintoSuoritus.copy(
+        vahvistus = vahvistusPaikkakunnalla(org = saksalainenKoulu, kunta = helsinki),
+        osasuoritukset = Some(List(diaTutkintoAineSuoritus(diaOppiaineMuu("MA", osaAlue = "2", laajuus(2)), Some(List(
+          (diaTutkintoLukukausi("3", laajuus(1.0f)), "2"),
+        )))))
+      )))
+
+      putOpiskeluoikeus(oo) {
+        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.laajuudet.osasuoritustenLaajuuksienSumma("Suorituksen oppiaineetdia/MA osasuoritusten laajuuksien summa 1.0 ei vastaa suorituksen laajuutta 2.0"))
+      }
+    }
+
+    "Suoritus kesken, laajuudet täsmää pyöristyksillä -> HTTP 200" in {
+      val oo = defaultOpiskeluoikeus.copy(suoritukset = List(tutkintoSuoritus.copy(
+        osasuoritukset = Some(List(diaTutkintoAineSuoritus(diaOppiaineMuu("MA", osaAlue = "2", laajuus(1)), Some(List(
+          (diaTutkintoLukukausi("3", laajuus(0.33333f)), "2"),
+          (diaTutkintoLukukausi("4", laajuus(0.33333f)), "2"),
+          (diaTutkintoLukukausi("5", laajuus(0.33333f)), "2"),
+        )))))
+      )))
+
+      putOpiskeluoikeus(oo) {
+        verifyResponseStatusOk()
+      }
+    }
+
+    "Suoritus valmis, laajuudet täsmää pyöristyksillä -> HTTP 200" in {
+      val oo = valmisOpiskeluoikeus.copy(suoritukset = List(tutkintoSuoritus.copy(
+        vahvistus = vahvistusPaikkakunnalla(org = saksalainenKoulu, kunta = helsinki),
+        osasuoritukset = Some(List(diaTutkintoAineSuoritus(diaOppiaineMuu("MA", osaAlue = "2", laajuus(1)), Some(List(
+          (diaTutkintoLukukausi("3", laajuus(0.33333f)), "2"),
+          (diaTutkintoLukukausi("4", laajuus(0.33333f)), "2"),
+          (diaTutkintoLukukausi("5", laajuus(0.33333f)), "2"),
+        )))))
+      )))
+
+      putOpiskeluoikeus(oo) {
+        verifyResponseStatusOk()
+      }
+    }
+
+    "Suoritus kesken, oppiaineelta puuttuu laajuus -> HTTP 200" in {
+      val oo = defaultOpiskeluoikeus.copy(suoritukset = List(tutkintoSuoritus.copy(
+        osasuoritukset = Some(List(diaTutkintoAineSuoritus(diaOppiaineMuu("MA", osaAlue = "2"), Some(List(
+          (diaTutkintoLukukausi("3", laajuus(1.0f)), "2"),
+        )))))
+      )))
+
+      putOpiskeluoikeus(oo) {
+        verifyResponseStatusOk()
+      }
+    }
+
+    "Suoritus valmis, oppiaineelta puuttuu laajuus -> HTTP 400" in {
+      val oo = valmisOpiskeluoikeus.copy(suoritukset = List(tutkintoSuoritus.copy(
+        vahvistus = vahvistusPaikkakunnalla(org = saksalainenKoulu, kunta = helsinki),
+        osasuoritukset = Some(List(diaTutkintoAineSuoritus(diaOppiaineMuu("MA", osaAlue = "2"), Some(List(
+          (diaTutkintoLukukausi("3", laajuus(1.0f)), "2"),
+        )))))
+      )))
+
+      putOpiskeluoikeus(oo) {
+        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.laajuudet.oppiaineenLaajuusPuuttuu("Suoritus koulutus/301103 on merkitty valmiiksi, mutta se sisältää oppiaineen, jolta puuttuu laajuus"))
+      }
+    }
+  }
+
+  "Kaksi äidinkieltä" - {
+    "Samalla kielivalinnalla -> HTTP 400" in {
+      val oo = defaultOpiskeluoikeus.copy(suoritukset = List(tutkintoSuoritus.copy(
+        osasuoritukset = Some(List(
+          diaTutkintoAineSuoritus(diaOppiaineÄidinkieli("FI", laajuus(1)), Some(List(
+            (diaTutkintoLukukausi("3", laajuus(1.0f)), "2"),
+          ))),
+          diaTutkintoAineSuoritus(diaOppiaineÄidinkieli("FI", laajuus(1)), Some(List(
+            (diaTutkintoLukukausi("3", laajuus(1.0f)), "2"),
+          )))
+        ))
+      )))
+
+      putOpiskeluoikeus(oo) {
+        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.rakenne.duplikaattiOsasuoritus("Osasuoritus (oppiaineetdia/AI,oppiainediaaidinkieli/FI) esiintyy useammin kuin kerran"))
+      }
+    }
+
+    "Eri kielivalinnalla -> HTTP 200" in {
+      val oo = defaultOpiskeluoikeus.copy(suoritukset = List(tutkintoSuoritus.copy(
+        osasuoritukset = Some(List(
+          diaTutkintoAineSuoritus(diaOppiaineÄidinkieli("FI", laajuus(1)), Some(List(
+            (diaTutkintoLukukausi("3", laajuus(1.0f)), "2"),
+          ))),
+          diaTutkintoAineSuoritus(diaOppiaineÄidinkieli("DE", laajuus(1)), Some(List(
+            (diaTutkintoLukukausi("3", laajuus(1.0f)), "2"),
+          )))
+        ))
+      )))
+
+      putOpiskeluoikeus(oo) {
+        verifyResponseStatusOk()
+      }
+    }
+  }
+}

--- a/web/test/page/opinnotPage.js
+++ b/web/test/page/opinnotPage.js
@@ -249,6 +249,9 @@ function Oppiaine(oppiaineElem) {
     kurssi: function(identifier) {
       return Kurssi(subElement(oppiaineElem, ".kurssi:contains(" + identifier +")"))
     },
+    nthOsasuoritus: function(n) {
+      return Kurssi(subElement(oppiaineElem, ".kurssi:eq(" + n + ")"))
+    },
     errorText: function() { return extractAsText(subElement(oppiaineElem, '> .error')) },
     arvosana: editorApi.propertyBySelector('tr td.arvosana'),
     laajuus: editorApi.propertyBySelector('tr.laajuus'),
@@ -319,6 +322,7 @@ function Kurssi(elem) {
       return Editor(detailsElem)
     },
     tunnustettu: Editor(elem).propertyBySelector('.tunnustettu'),
+    laajuus: Editor(elem).propertyBySelector('tr.laajuus'),
     lisääTunnustettu: click(subElement(detailsElem, '.tunnustettu .add-value')),
     poistaTunnustettu: click(subElement(detailsElem, '.tunnustettu .remove-value')),
     poistaKurssi: click(subElement(elem, '.remove-value'))

--- a/web/test/spec/diaSpec.js
+++ b/web/test/spec/diaSpec.js
@@ -178,16 +178,46 @@ describe('DIA', function( ) {
         describe('Oppiaine', function() {
           var aine = opinnot.oppiaineet.oppiaine('oppiaine.A')
 
-          describe('Laajuuden muuttaminen', function () {
-            before(
-              editor.edit,
-              aine.laajuus.setValue(4),
-              editor.saveChanges,
-              wait.until(page.isSavedLabelShown)
-            )
+          describe('Laajuus', function () {
+            describe('Muuttaminen', () => {
+              before(
+                editor.edit,
+                aine.laajuus.setValue(4),
+                editor.saveChanges,
+                wait.until(page.isSavedLabelShown)
+              )
 
-            it('onnistuu', function () {
-              expect(findSingle('.oppiaine.A .laajuus')().text()).to.equal('4')
+              it('onnistuu', function () {
+                expect(findSingle('.oppiaine.A .laajuus')().text()).to.equal('4')
+              })
+            })
+
+            describe('Poistaminen', () => {
+              before(
+                editor.edit,
+                aine.laajuus.setValue(''),
+                editor.saveChangesAndExpectError,
+                wait.until(page.isErrorShown)
+              )
+
+              describe('Valmiissa päätason suorituksessa', () => {
+                it('ei onnistu', function () {
+                  expect(page.getErrorMessage()).to.equal('Suoritus suorituksentyyppi/diavalmistavavaihe on merkitty valmiiksi, mutta se sisältää oppiaineen, jolta puuttuu laajuus')
+                })
+              })
+
+              describe('Keskeneräisessä päätason suorituksessa', () => {
+                before(
+                  editor.property('tila').removeItem(0),
+                  opinnot.tilaJaVahvistus.merkitseKeskeneräiseksi,
+                  editor.saveChanges,
+                  wait.until(page.isSavedLabelShown)
+                )
+
+                it('onnistuu', function () {
+                  expect(findSingle('.oppiaine.A .laajuus')().text()).to.equal('')
+                })
+              })
             })
           })
 
@@ -227,6 +257,58 @@ describe('DIA', function( ) {
 
               it('onnistuu', function () {
                 expect(findFirst('.oppiaine.A .kurssi:first .arvosana')().text()).to.equal('6')
+              })
+            })
+
+            describe('Laajuuden muuttaminen', function () {
+              before(
+                editor.edit,
+                osasuoritus.toggleDetails,
+                osasuoritus.details().property('laajuus').setValue(1),
+                osasuoritus.toggleDetails,
+                editor.saveChanges,
+                wait.until(page.isSavedLabelShown)
+              )
+
+              describe('Kun oppiaineella ei ole laajuutta', function () {
+                before(
+                  osasuoritus.showDetails
+                )
+
+                it('lukukauden laajuuden muutos tallentuu ja muutos näkyy osasuorituksen tiedoissa', function () {
+                  expect(osasuoritus.laajuus.getText()).to.equal('Laajuus 1 vuosiviikkotuntia')
+                })
+              })
+
+              describe('Kun oppiaineella on laajuus', () => {
+                before(
+                  editor.edit,
+                  aine.laajuus.setValue(4),
+                  editor.saveChangesAndExpectError,
+                  wait.until(page.isErrorShown)
+                )
+
+                describe('ja osasuoritusten laajuuden summa on eri kuin oppiaineen laajuus', () => {
+                  it('muutos ei tallennu', function () {
+                    expect(page.getErrorMessage()).to.equal('Suorituksen oppiaineetdia/A osasuoritusten laajuuksien summa 1.0 ei vastaa suorituksen laajuutta 4.0')
+                  })
+                })
+
+
+                describe('ja osasuoritusten laajuuden summa on sama kuin oppiaineen laajuus', () => {
+                  before(
+                    osasuoritus.toggleDetails,
+                    osasuoritus.details().property('laajuus').setValue(4),
+                    osasuoritus.toggleDetails,
+                    editor.saveChanges,
+                    wait.until(page.isSavedLabelShown),
+                    osasuoritus.showDetails
+                  )
+
+                  it('muutos tallentuu ja muutos näkyy osasuorituksen tiedoissa', function () {
+                    expect(osasuoritus.laajuus.getText()).to.equal('Laajuus 4 vuosiviikkotuntia')
+                  })
+                })
               })
             })
 
@@ -429,16 +511,45 @@ describe('DIA', function( ) {
         describe('Oppiaine', function() {
           var aine = opinnot.oppiaineet.oppiaine('oppiaine.A')
 
-          describe('Laajuuden muuttaminen', function () {
-            before(
-              editor.edit,
-              aine.laajuus.setValue(4),
-              editor.saveChanges,
-              wait.until(page.isSavedLabelShown)
-            )
+          describe('Laajuus', function () {
+            describe('Muuttaminen', () => {
+              before(
+                editor.edit,
+                aine.laajuus.setValue(4),
+                editor.saveChanges,
+                wait.until(page.isSavedLabelShown)
+              )
 
-            it('onnistuu', function () {
-              expect(findSingle('.oppiaine.A .laajuus')().text()).to.equal('4')
+              it('onnistuu', function () {
+                expect(findSingle('.oppiaine.A .laajuus')().text()).to.equal('4')
+              })
+            })
+
+            describe('Poistaminen', () => {
+              before(
+                editor.edit,
+                aine.laajuus.setValue(''),
+                editor.saveChangesAndExpectError,
+                wait.until(page.isErrorShown)
+              )
+
+              describe('Valmiissa päätason suorituksessa', () => {
+                it('ei onnistu', function () {
+                  expect(page.getErrorMessage()).to.equal('Suoritus koulutus/301103 on merkitty valmiiksi, mutta se sisältää oppiaineen, jolta puuttuu laajuus')
+                })
+              })
+
+              describe('Keskeneräisessä päätason suorituksessa', () => {
+                before(
+                  opinnot.tilaJaVahvistus.merkitseKeskeneräiseksi,
+                  editor.saveChanges,
+                  wait.until(page.isSavedLabelShown)
+                )
+
+                it('onnistuu', function () {
+                  expect(findSingle('.oppiaine.A .laajuus')().text()).to.equal('')
+                })
+              })
             })
           })
 
@@ -458,6 +569,10 @@ describe('DIA', function( ) {
           describe('Oppiaineen osasuoritukset', function() {
             var osasuoritus = aine.propertyBySelector('.kurssi:first')
             var arvosana = osasuoritus.propertyBySelector('.arvosana')
+
+            var lukukausi_11_I = aine.nthOsasuoritus(0)
+            var lukukausi_11_II = aine.nthOsasuoritus(1)
+            var lukukausi_12_I = aine.nthOsasuoritus(2)
 
             describe('Arvosana-asteikko', function () {
               before(editor.edit)
@@ -479,6 +594,79 @@ describe('DIA', function( ) {
 
               it('onnistuu', function () {
                 expect(findFirst('.oppiaine.A .kurssi:first .arvosana')().text()).to.equal('6')
+              })
+            })
+
+            describe('Laajuuden muuttaminen', function () {
+              before(
+                editor.edit,
+                lukukausi_11_I.toggleDetails,
+                lukukausi_11_I.details().property('laajuus').setValue(2),
+                lukukausi_11_I.toggleDetails,
+                editor.saveChanges,
+                wait.until(page.isSavedLabelShown)
+              )
+
+              describe('Kun oppiaineella ei ole laajuutta', function () {
+                before(
+                  lukukausi_11_I.showDetails
+                )
+
+                it('lukukauden laajuuden muutos tallentuu ja muutos näkyy osasuorituksen tiedoissa', function () {
+                  expect(lukukausi_11_I.laajuus.getText()).to.equal('Laajuus 2 vuosiviikkotuntia')
+                })
+              })
+
+              describe('Kun oppiaineella on laajuus', () => {
+                before(
+                  editor.edit,
+                  aine.laajuus.setValue(5),
+                  editor.saveChangesAndExpectError,
+                  wait.until(page.isErrorShown)
+                )
+
+                describe('ja osasuoritusten laajuuden summa on eri kuin oppiaineen laajuus', () => {
+                  it('muutos ei tallennu', function () {
+                    expect(page.getErrorMessage()).to.equal('Suorituksen oppiaineetdia/A osasuoritusten laajuuksien summa 2.0 ei vastaa suorituksen laajuutta 5.0')
+                  })
+                })
+
+
+                describe('ja osasuoritusten laajuuden summa on sama kuin oppiaineen laajuus', () => {
+                  before(
+                    lukukausi_11_II.showDetails,
+                    lukukausi_11_II.details().property('laajuus').setValue(2),
+
+                    lukukausi_12_I.showDetails,
+                    lukukausi_12_I.details().property('laajuus').setValue(1),
+
+                    editor.saveChanges,
+                    wait.until(page.isSavedLabelShown),
+                  )
+
+                  describe('muutos tallentuu', () => {
+                    describe('Lukukaudelle 11/I', () => {
+                      before(lukukausi_11_I.showDetails)
+                      it('näkyy osasuoritusten tiedoissa', function () {
+                        expect(lukukausi_11_I.laajuus.getText()).to.equal('Laajuus 2 vuosiviikkotuntia')
+                      })
+                    })
+
+                    describe('Lukukaudelle 11/II', () => {
+                      before(lukukausi_11_II.showDetails)
+                      it('näkyy osasuoritusten tiedoissa', function () {
+                        expect(lukukausi_11_II.laajuus.getText()).to.equal('Laajuus 2 vuosiviikkotuntia')
+                      })
+                    })
+
+                    describe('Lukukaudelle 12/I', () => {
+                      before(lukukausi_12_I.showDetails)
+                      it('näkyy osasuoritusten tiedoissa', function () {
+                        expect(lukukausi_12_I.laajuus.getText()).to.equal('Laajuus 1 vuosiviikkotuntia')
+                      })
+                    })
+                  })
+                })
               })
             })
 


### PR DESCRIPTION
- Lisätään **DIA-lukukausille laajuus** (mutta ei muille osasuorituksille eli kirjalliselle/suulliselle kokeelle eikä näyttötutkinnolle).
- Pidetään laajuus myös oppiaineella
  - Oppiaineen laajuus on summa osasuorituksien laajuuksista

On jo olemassa validaatio, joka validoi, että osasuoritusten laajuus täsmää oppiaineen laajuuteen. Lisätään lisäksi validaatio, joka validoi, että valmiilla DIA-päätason suorituksella (DIA-tutkinto tai valmistava vaihe) on oltava oppiaineilla laajuudet. Näin saadaan tämä data "pakotettua" talteen talletetuksi, mutta mahdollistetaan sen muuttamatta jättäminen joka kerta, kun kesken olevaa suoritusta muokataan.