### PR TITLE
DIA-tutkinnon ja -suoritusten oletuskieleksi saksa

### DIFF
--- a/web/app/suoritus/Suoritus.js
+++ b/web/app/suoritus/Suoritus.js
@@ -62,6 +62,8 @@ export const newSuoritusProto = (opiskeluoikeus, prototypeKey) => {
   return contextualizeSubModel(selectedProto, suoritukset, indexForNewItem)
 }
 
+export const copySuorituskieli = (from, to) => modelSet(to, modelLookup(from, 'suorituskieli'), 'suorituskieli')
+
 export const copyToimipiste = (from, to) => modelSet(to, modelLookup(from, 'toimipiste'), 'toimipiste')
 
 export const opiskeluoikeudenSuoritusByTyyppi = (tyyppi) => (opiskeluoikeus) => modelItems(opiskeluoikeus, 'suoritukset').find(suoritus => suorituksenTyyppi(suoritus) == tyyppi)

--- a/web/app/uusioppija/UusiDIASuoritus.jsx
+++ b/web/app/uusioppija/UusiDIASuoritus.jsx
@@ -11,6 +11,9 @@ export default ({suoritusAtom, oppilaitosAtom, suorituskieliAtom}) => {
   const suoritustyypitP = koodistoValues('suorituksentyyppi/diavalmistavavaihe,diatutkintovaihe')
   suoritustyypitP.onValue(tyypit => suoritustyyppiAtom.set(tyypit.find(koodiarvoMatch('diatutkintovaihe'))))
 
+  const suorituskieletP = koodistoValues('kieli/DE')
+  suorituskieletP.onValue(kielet => suorituskieliAtom.set(kielet.find(koodiarvoMatch('DE'))))
+
   Bacon.combineWith(
     oppilaitosAtom, suoritustyyppiAtom, suorituskieliAtom,
     makeSuoritus

--- a/web/app/uusisuoritus/UusiDIATutkinnonSuoritus.jsx
+++ b/web/app/uusisuoritus/UusiDIATutkinnonSuoritus.jsx
@@ -1,6 +1,7 @@
 import React from 'baret'
 import Bacon from 'baconjs'
 import {
+  copySuorituskieli,
   copyToimipiste,
   newSuoritusProto,
   diaTutkinnonSuoritus,
@@ -15,7 +16,8 @@ export const UusiDIATutkinnonSuoritus = {
   createSuoritus: (opiskeluoikeus) => {
     const proto = newSuoritusProto(opiskeluoikeus, 'diatutkinnonsuoritus')
     const toimipisteellä = copyToimipiste(valmistavanDIAVaiheenSuoritus(opiskeluoikeus), proto)
-    return Bacon.once(toimipisteellä)
+    const suorituskielellä = copySuorituskieli(valmistavanDIAVaiheenSuoritus(opiskeluoikeus), toimipisteellä)
+    return Bacon.once(suorituskielellä)
   },
   canAddSuoritus: (opiskeluoikeus) => isDIATutkinto(opiskeluoikeus) && !diaTutkinnonSuoritus(opiskeluoikeus),
   addSuoritusTitle: () => <Text name="lisää DIA-tutkinnon suoritus"/>
@@ -25,7 +27,8 @@ export const UusiValmistavanDIAVaiheenSuoritus = {
   createSuoritus: (opiskeluoikeus) => {
     const proto = newSuoritusProto(opiskeluoikeus, 'diavalmistavanvaiheensuoritus')
     const toimipisteellä = copyToimipiste(diaTutkinnonSuoritus(opiskeluoikeus), proto)
-    return Bacon.once(toimipisteellä)
+    const suorituskielellä = copySuorituskieli(diaTutkinnonSuoritus(opiskeluoikeus), toimipisteellä)
+    return Bacon.once(suorituskielellä)
   },
   canAddSuoritus: (opiskeluoikeus) => isDIATutkinto(opiskeluoikeus) && !valmistavanDIAVaiheenSuoritus(opiskeluoikeus),
   addSuoritusTitle: () => <Text name="lisää valmistavan DIA-vaiheen suoritus"/>

--- a/web/test/spec/diaSpec.js
+++ b/web/test/spec/diaSpec.js
@@ -661,6 +661,19 @@ describe('DIA', function( ) {
   })
 
   describe('Opiskeluoikeuden lisääminen', function () {
+    describe('Lisäysdialogi', function() {
+      describe('DIA-tutkinnon valinta', function() {
+        before(
+          prepareForNewOppija('kalle', '020782-5339'),
+          addOppija.enterValidDataDIA({etunimet: 'Doris', kutsumanimi: 'Doris', sukunimi: 'Dia'})
+        )
+
+        it('muuttaa automaattisesti suorituskieleksi saksan', function() {
+          expect(extractAsText(S('.suorituskieli .select'))).to.equal('saksa')
+        })
+      })
+    })
+
     describe('DIA-tutkinto', function () {
       before(
         prepareForNewOppija('kalle', '020782-5339'),
@@ -674,7 +687,7 @@ describe('DIA', function( ) {
             expect(extractAsText(S('.suoritus > .properties, .suoritus > .tila-vahvistus'))).to.equal(
               'Koulutus Deutsche Internationale Abitur; Reifeprüfung\n' +
               'Oppilaitos / toimipiste Helsingin Saksalainen koulu\n' +
-              'Suorituskieli suomi\n' +
+              'Suorituskieli saksa\n' +
               'Suoritus kesken'
             )
           })
@@ -775,7 +788,7 @@ describe('DIA', function( ) {
             expect(extractAsText(S('.suoritus > .properties, .suoritus > .tila-vahvistus'))).to.equal(
               'Koulutus Valmistava DIA-vaihe\n' +
               'Oppilaitos / toimipiste Helsingin Saksalainen koulu\n' +
-              'Suorituskieli suomi\n' +
+              'Suorituskieli saksa\n' +
               'Suoritus kesken'
             )
           })

--- a/web/test/spec/diaSpec.js
+++ b/web/test/spec/diaSpec.js
@@ -764,7 +764,7 @@ describe('DIA', function( ) {
                   expect(extractAsText(S('.suoritus > .properties, .suoritus > .tila-vahvistus'))).to.equal(
                     'Koulutus Valmistava DIA-vaihe\n' +
                     'Oppilaitos / toimipiste Helsingin Saksalainen koulu\n' +
-                    'Suorituskieli suomi\n' +
+                    'Suorituskieli saksa\n' +
                     'Suoritus kesken'
                   )
                 })
@@ -865,7 +865,7 @@ describe('DIA', function( ) {
                   expect(extractAsText(S('.suoritus > .properties, .suoritus > .tila-vahvistus'))).to.equal(
                     'Koulutus Deutsche Internationale Abitur; Reifeprüfung\n' +
                     'Oppilaitos / toimipiste Helsingin Saksalainen koulu\n' +
-                    'Suorituskieli suomi\n' +
+                    'Suorituskieli saksa\n' +
                     'Suoritus kesken'
                   )
                 })


### PR DESCRIPTION
Uutta opiskeluoikeutta lisättäessä DIA-tutkinnon valinta opiskeluoikeuden tyypiksi muuttaa nyt automaattisesti suorituskieleksi saksan.

Lisättäessä uutta suoritusta DIA-tutkintoon, kopioidaan suorituskieli olemassaolevalta suoritukselta (eli käytännössä joko kopioidaan valmistavan vaiheen suorituskieli tutkintovaiheen suorituskieleksi, tai päinvastoin). Näin saadaan ensimmäiselle suoritukselle oletusarvoisesti valittu suorituskieli "saksa" automaattisesti myös toiselle suoritukselle.