### PR TITLE
DIA:n "lasketaan kokonaispisteisiin" oletusarvoksi true

### DIFF
--- a/src/main/scala/fi/oph/koski/editor/EditorModelBuilder.scala
+++ b/src/main/scala/fi/oph/koski/editor/EditorModelBuilder.scala
@@ -90,6 +90,8 @@ case class NumberModelBuilder(t: NumberSchema) extends ModelBuilderWithData[Numb
 case class BooleanModelBuilder(t: BooleanSchema) extends ModelBuilderWithData[Boolean] {
   override def buildModelForObject(x: Boolean, metadata: List[Metadata]) = BooleanModel(ValueWithData(x, classesFromMetadata(metadata)), metadata)
   override def getPrototypeData = false
+  override def buildPrototype(metadata: List[Metadata]): EditorModel = buildModelForObject(getDefaultValue(metadata), metadata)
+  def getDefaultValue(metadata: List[Metadata]): Boolean = DefaultValue.getDefaultValue(metadata).getOrElse(false)
 }
 
 case class StringModelBuilder(t: StringSchema) extends ModelBuilderWithData[String] {

--- a/src/main/scala/fi/oph/koski/schema/DIA.scala
+++ b/src/main/scala/fi/oph/koski/schema/DIA.scala
@@ -229,6 +229,7 @@ case class DIAOppiaineenTutkintovaiheenNumeerinenArviointi(
   @KoodistoKoodiarvo("15")
   arvosana: Koodistokoodiviite,
   päivä: Option[LocalDate],
+  @DefaultValue(true)
   lasketaanKokonaispistemäärään: Boolean = true
 ) extends DIATutkintovaiheenArviointi
 

--- a/web/test/page/opinnotPage.js
+++ b/web/test/page/opinnotPage.js
@@ -351,6 +351,7 @@ function Kurssi(elem) {
     },
     tunnustettu: Editor(elem).propertyBySelector('.tunnustettu'),
     laajuus: Editor(elem).propertyBySelector('tr.laajuus'),
+    lasketaanKokonaispistemäärään: Editor(elem).propertyBySelector('tr.lasketaanKokonaispistemäärään'),
     lisääTunnustettu: click(subElement(detailsElem, '.tunnustettu .add-value')),
     poistaTunnustettu: click(subElement(detailsElem, '.tunnustettu .remove-value')),
     poistaKurssi: click(subElement(elem, '.remove-value'))

--- a/web/test/spec/diaSpec.js
+++ b/web/test/spec/diaSpec.js
@@ -681,24 +681,15 @@ describe('DIA', function( ) {
               )
 
               it('lisää osasuorituksen', function () {
-                expect(extractAsText(S('.oppiaineet .A'))).to.contain('12/II *\n4')
-              })
-            })
-
-            describe('Lasketaan kokonaispistemäärään -valinnan lisääminen', function() {
-              var kurssi = aine.kurssi('12/II')
-
-              before(
-                editor.edit,
-                kurssi.toggleDetails,
-                kurssi.details().property('lasketaanKokonaispistemäärään').setValue(true),
-                kurssi.toggleDetails,
-                editor.saveChanges,
-                wait.until(page.isSavedLabelShown)
-              )
-
-              it('tallentuu ja muutos näkyy osasuorituksen tiedoissa', function () {
                 expect(extractAsText(S('.oppiaineet .A'))).to.contain('12/II\n4')
+              })
+
+              describe('Lasketaan kokonaispistemäärään -tieto', () => {
+                var kurssi = aine.kurssi('12/II')
+                before(kurssi.showDetails)
+                it('on merkitty todeksi', function () {
+                  expect(kurssi.lasketaanKokonaispistemäärään.getValue()).to.equal('kyllä')
+                })
               })
             })
 
@@ -712,10 +703,31 @@ describe('DIA', function( ) {
                 kurssi.toggleDetails,
                 editor.saveChanges,
                 wait.until(page.isSavedLabelShown),
+                aine.kurssi('12/II').showDetails
               )
 
               it('poistuu ja muutos näkyy osasuorituksen tiedoissa', function () {
+                expect(kurssi.lasketaanKokonaispistemäärään.getValue()).to.equal('ei')
                 expect(extractAsText(S('.oppiaineet .A'))).to.contain('12/II *\n4')
+              })
+            })
+
+            describe('Lasketaan kokonaispistemäärään -valinnan lisääminen', function() {
+              var kurssi = aine.kurssi('12/II')
+
+              before(
+                editor.edit,
+                kurssi.toggleDetails,
+                kurssi.details().property('lasketaanKokonaispistemäärään').setValue(true),
+                kurssi.toggleDetails,
+                editor.saveChanges,
+                wait.until(page.isSavedLabelShown),
+                aine.kurssi('12/II').showDetails
+              )
+
+              it('tallentuu ja muutos näkyy osasuorituksen tiedoissa', function () {
+                expect(kurssi.lasketaanKokonaispistemäärään.getValue()).to.equal('kyllä')
+                expect(extractAsText(S('.oppiaineet .A'))).to.contain('12/II\n4')
               })
             })
 


### PR DESCRIPTION
DIA-tutkinnossa lukukaudet lähtökohtaisesti lasketaan kokonaispistemäärään, mutta tietyt lukukausisuoritukset on mahdollista jättää laskematta. Muutetaan `lasketaanKokonaispistemäärään`-kentän toimintaa syöttökäyttöliittymässä vastaamaan tätä: kun arviointi lisätään, merkitään oletuksena, että suoritus lasketaan kokonaispistemäärään. Näin vältetään tarve kääntä flagi käsin joka lukukausisuorituksen kohdalla.