### PR TITLE
TOR-566: Eri opiskeluoikeuden tilat samalla alkupvm:llä tuottaa virheen

### DIFF
--- a/src/main/scala/fi/oph/koski/validation/DateValidation.scala
+++ b/src/main/scala/fi/oph/koski/validation/DateValidation.scala
@@ -16,7 +16,7 @@ object DateValidation {
 
   def validateJaksot(name: String, jaksot: Iterable[Alkupäivällinen], errorCategory: ErrorCategory): HttpStatus = {
     HttpStatus.fold(jaksot.zip(jaksot.drop(1)).map { case (jakso1, jakso2) =>
-      HttpStatus.validate(jakso1.alku.compareTo(jakso2.alku) <= 0)(errorCategory(s"${name}: ${jakso1.alku} oltava sama tai aiempi kuin ${jakso2.alku}"))
+      HttpStatus.validate(jakso1.alku.compareTo(jakso2.alku) < 0)(errorCategory(s"${name}: ${jakso1.alku} oltava aiempi kuin ${jakso2.alku}"))
     })
   }
 

--- a/src/test/scala/fi/oph/koski/api/OppijaValidationSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationSpec.scala
@@ -282,7 +282,7 @@ class OppijaValidationSpec extends FreeSpec with LocalJettyHttpSpecification wit
           "alkamispäivä > päättymispäivä"  in (putOpiskeluoikeus(päättymispäivällä(defaultOpiskeluoikeus, date(1999, 5, 31))) {
             verifyResponseStatus(400, List(
               exact(KoskiErrorCategory.badRequest.validation.date.päättymisPäiväEnnenAlkamispäivää, "alkamispäivä (2000-01-01) oltava sama tai aiempi kuin päättymispäivä(1999-05-31)"),
-              exact(KoskiErrorCategory.badRequest.validation.date.opiskeluoikeusjaksojenPäivämäärät, "tila.opiskeluoikeusjaksot: 2000-01-01 oltava sama tai aiempi kuin 1999-05-31"),
+              exact(KoskiErrorCategory.badRequest.validation.date.opiskeluoikeusjaksojenPäivämäärät, "tila.opiskeluoikeusjaksot: 2000-01-01 oltava aiempi kuin 1999-05-31"),
               exact(KoskiErrorCategory.badRequest.validation.date.vahvistusEnnenAlkamispäivää, "suoritus.alkamispäivä (2000-01-01) oltava sama tai aiempi kuin suoritus.vahvistus.päivä(1999-05-31)")
             ))
           })
@@ -315,6 +315,13 @@ class OppijaValidationSpec extends FreeSpec with LocalJettyHttpSpecification wit
         ) {
           verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.tila.tilaMuuttunutLopullisenTilanJälkeen("Opiskeluoikeuden tila muuttunut lopullisen tilan (valmistunut) jälkeen"))
         })
+
+        "Kaksi tilaa samalla alkupäivämäärällä -> palautetaan HTTP 400" in {
+          val oo =  lisääTila(makeOpiskeluoikeus(), date(2018, 1, 1), Koodistokoodiviite("valiaikaisestikeskeytynyt", "koskiopiskeluoikeudentila"))
+          putOpiskeluoikeus(lisääTila(oo, date(2018, 1, 1), Koodistokoodiviite("lasna", "koskiopiskeluoikeudentila"))) {
+            verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.date.opiskeluoikeusjaksojenPäivämäärät("tila.opiskeluoikeusjaksot: 2018-01-01 oltava aiempi kuin 2018-01-01"))
+          }
+        }
       }
     }
 

--- a/web/app/opiskeluoikeus/OpiskeluoikeudenUusiTilaPopup.jsx
+++ b/web/app/opiskeluoikeus/OpiskeluoikeudenUusiTilaPopup.jsx
@@ -19,7 +19,7 @@ export const OpiskeluoikeudenUusiTilaPopup = ({edellisenTilanAlkupäivä, suorit
 
   let { modelP, errorP } = accumulateModelStateAndValidity(initialModel)
 
-  let isAllowedDate = d => edellisenTilanAlkupäivä ? d >= edellisenTilanAlkupäivä : true
+  let isAllowedDate = d => edellisenTilanAlkupäivä ? d > edellisenTilanAlkupäivä : true
 
   let alkuPäiväModel = modelP.map(m => modelLookupRequired(m, 'alku'))
   let tilaModel = modelP.map(m => modelLookupRequired(m, 'tila'))

--- a/web/test/spec/perusopetusSpec.js
+++ b/web/test/spec/perusopetusSpec.js
@@ -779,7 +779,7 @@ describe('Perusopetus', function() {
             expect(opinnot.opiskeluoikeusEditor().property('päättymispäivä').isVisible()).to.equal(false)
           })
           describe('Kun lisätään', function() {
-            before(editor.edit, opinnot.avaaLisaysDialogi, opiskeluoikeus.tila().aseta('lasna'), opiskeluoikeus.tallenna, editor.saveChanges)
+            before(editor.edit, opinnot.avaaLisaysDialogi, opiskeluoikeus.alkuPaiva().setValue('26.12.2018'), opiskeluoikeus.tila().aseta('lasna'), opiskeluoikeus.tallenna, editor.saveChanges)
 
             it('Opiskeluoikeuden päättymispäivää ei aseteta', function() {
               expect(opinnot.opiskeluoikeusEditor().property('päättymispäivä').isVisible()).to.equal(false)
@@ -809,7 +809,7 @@ describe('Perusopetus', function() {
         })
 
         describe('Päivämäärän validointi', function() {
-          before(editor.edit, opinnot.avaaLisaysDialogi)
+          before(editor.edit, editor.property('tila').removeItem(0), opinnot.avaaLisaysDialogi)
           describe('Virheellinen päivämäärä', function() {
             before(opiskeluoikeus.tila().aseta('eronnut'), opiskeluoikeus.alkuPaiva().setValue('11.1.200'))
             it('Tallennus on estetty', function() {
@@ -826,6 +826,13 @@ describe('Perusopetus', function() {
 
           describe('Uusi alkupäivä on aikaisempi kuin viimeisen tilan alkupäivämäärä', function() {
             before(opiskeluoikeus.tila().aseta('eronnut'), opiskeluoikeus.alkuPaiva().setValue('14.8.2008'))
+            it('Tallennus on estetty', function() {
+              expect(opiskeluoikeus.isEnabled()).to.equal(false)
+            })
+          })
+
+          describe('Uusi alkupäivä on sama kuin viimeisen tilan alkupäivämäärä', function() {
+            before(opiskeluoikeus.tila().aseta('eronnut'), opiskeluoikeus.alkuPaiva().setValue('15.8.2008'))
             it('Tallennus on estetty', function() {
               expect(opiskeluoikeus.isEnabled()).to.equal(false)
             })
@@ -848,6 +855,7 @@ describe('Perusopetus', function() {
           describe('Kun lisätään useita tähän päivään', function() {
             before(editor.edit,
               opinnot.avaaLisaysDialogi,
+              opiskeluoikeus.alkuPaiva().setValue('1.1.2017'),
               opiskeluoikeus.tila().aseta('valiaikaisestikeskeytynyt'),
               opiskeluoikeus.tallenna,
               opinnot.avaaLisaysDialogi,
@@ -1911,7 +1919,7 @@ describe('Perusopetus', function() {
 
           describe('Toisen samanlaisen opiskeluoikeuden lisääminen kun opiskeluoikeus on päättynyt', function() {
             before(
-              editor.edit, opinnot.avaaLisaysDialogi, opiskeluoikeus.tila().aseta('eronnut'), opiskeluoikeus.tallenna, editor.saveChanges,
+              editor.edit, opinnot.avaaLisaysDialogi, opiskeluoikeus.alkuPaiva().setValue('1.1.2117'), opiskeluoikeus.tila().aseta('eronnut'), opiskeluoikeus.tallenna, editor.saveChanges,
               opinnot.opiskeluoikeudet.lisääOpiskeluoikeus,
               addOppija.selectOppilaitos('Jyväskylän normaalikoulu'),
               addOppija.submitAndExpectSuccessModal('Tyhjä, Tero (230872-7258)', 'Päättötodistus'),


### PR DESCRIPTION
Kun opiskeluoikeudelle asetetaan uutta tilaa, uuden tilan alku päivämäärän tulee olla uudempi päivämäärä kuin edellisen tilan alku päivämäärän
- Estää saman tai vanhemman alku päivämäärän asettamisen uudelle tilalle virkailijan käyttöliittymässä
- Tiedonsiirrossa palauttaa virheviestin jos kahdella tilalla on sama alkupäivä

(testeissä joissa lisäillään uusia tiloja oletettiin, että defaulttina tuleva alkupäivä on validi, joten testeihin on lisätty alkupäivän asettamisia, jotta peräkkäiset tilan lisäykset menevät läpi)