### PR TITLE
Upgrade jackson-databind because of vulnerability in current version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.7</version>
+      <version>2.9.8</version>
     </dependency>
     <dependency>
       <groupId>org.json4s</groupId>


### PR DESCRIPTION
High severity vulnerability found in com.fasterxml.jackson.core:jackson-databind
  Description: Deserialization of Untrusted Data
  Info: https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72448
  Introduced through: com.fasterxml.jackson.core:jackson-databind@2.9.7