### PR TITLE
TOR-565: Opiskelijavuosikertymän laskenta opiskelijavuositiedot-raportilla

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ Paikallisen kannan datat tulevat hakemistoon `elastic-data`.
 Jos haluat tarkastella paikallisen kehityskannan tilaa SQL-työkalulla, se onnistuu esimerkiksi Postgren omalla komentorivityökalulla `psql`:
 
 ``` shell
-psql -h localhost koski koski
-psql -h localhost koskitest koski
+psql -h localhost koski oph
+psql -h localhost koskitest oph
 ```
 
 Peruskomennot:

--- a/src/main/scala/fi/oph/koski/raportit/Opiskelijavuositiedot.scala
+++ b/src/main/scala/fi/oph/koski/raportit/Opiskelijavuositiedot.scala
@@ -224,7 +224,7 @@ object Opiskelijavuositiedot {
     aikajaksot.map(lomaPäivät).reduce((a, b) => (a._1 + b._1, a._2 + b._2))
   }
 
-  private def opiskelijavuosikertymä(aikajaksot: Seq[ROpiskeluoikeusAikajaksoRow]): Double = {
+  private[raportit] def opiskelijavuosikertymä(aikajaksot: Seq[ROpiskeluoikeusAikajaksoRow]): Double = {
     aikajaksot.map(j => (j.tila match {
       case "loma" => lomaPäivät(j)._1
       case "lasna" | "valmistunut" => j.lengthInDays

--- a/src/main/scala/fi/oph/koski/raportit/Opiskelijavuositiedot.scala
+++ b/src/main/scala/fi/oph/koski/raportit/Opiskelijavuositiedot.scala
@@ -226,9 +226,10 @@ object Opiskelijavuositiedot {
 
   private[raportit] def opiskelijavuosikertymä(aikajaksot: Seq[ROpiskeluoikeusAikajaksoRow]): Double = {
     aikajaksot.map(j => (j.tila match {
-      case "loma" => lomaPäivät(j)._1
-      case "lasna" | "valmistunut" => j.lengthInDays
+      case "loma" => lomaPäivät(j)._1 * (j.osaAikaisuus.toDouble / 100.0)
+      case "lasna" => j.lengthInDays * (j.osaAikaisuus.toDouble / 100.0)
+      case "valmistunut" => j.lengthInDays // valmistumispäivä lasketaan aina 100% läsnäolopäiväksi
       case _ => 0
-    }) * (j.osaAikaisuus.toDouble / 100.0)).sum
+    })).sum
   }
 }

--- a/src/test/scala/fi/oph/koski/raportit/RaportitSpec.scala
+++ b/src/test/scala/fi/oph/koski/raportit/RaportitSpec.scala
@@ -129,6 +129,13 @@ class RaportitSpec extends FreeSpec with LocalJettyHttpSpecification with Opiske
           ROpiskeluoikeusAikajaksoRow(oid, Date.valueOf("2016-02-01"), Date.valueOf("2016-02-10"), "loma", Date.valueOf("2016-02-01"))
         )) should equal(41)
       }
+
+      "valmistumispäivä lasketaan aina 100% läsnäolopäivänä, vaikka opinnot olisivat olleet osa-aikaisia" in {
+        Opiskelijavuositiedot.opiskelijavuosikertymä(Seq(
+          ROpiskeluoikeusAikajaksoRow(oid, Date.valueOf("2016-01-01"), Date.valueOf("2016-01-31"), "lasna", Date.valueOf("2016-01-01"), osaAikaisuus = 50),
+          ROpiskeluoikeusAikajaksoRow(oid, Date.valueOf("2016-02-01"), Date.valueOf("2016-02-01"), "valmistunut", Date.valueOf("2016-02-01"), opiskeluoikeusPäättynyt = true, osaAikaisuus = 50)
+        )) should equal(16.5)
+      }
     }
 
     "raportin lataaminen toimii (ja tuottaa audit log viestin)" in {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -6753,7 +6753,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },


### PR DESCRIPTION
Opiskelijavuositiedot-raportin opiskelijavuosikertymässä lasketaan valmistumispäivä aina 100% läsnäololla, vaikka valmistumista edeltäneet opinnot olisivat olleet osa-aikaisia.