### PR TITLE
TOR-599 Opiskeluoikeuden tilojen uusia validaatioita

### DIFF
--- a/src/main/scala/fi/oph/koski/http/KoskiErrorCategory.scala
+++ b/src/main/scala/fi/oph/koski/http/KoskiErrorCategory.scala
@@ -111,6 +111,7 @@ object KoskiErrorCategory {
         val oppiaineetPuuttuvat = subcategory("oppiaineetPuuttuvat", "Suorituksella ei ole osasuorituksena yhtään oppiainetta, vaikka sillä on vahvistus")
         val oppiaineitaEiSallita = subcategory("oppiaineitaEiSallita", "9.vuosiluokan suoritukseen ei voi syöttää oppiaineita, kun sillä on vahvistus, eikä oppilas jää luokalle")
         val tilaMuuttunutLopullisenTilanJälkeen = subcategory("tilaMuuttunutLopullisenTilanJälkeen", "Opiskeluoikeuden tilojen valmistunut, eronnut jälkeen ei voi esiintyä muita tiloja")
+        val montaPäättävääTilaa = subcategory("montaPäättäväätilaa", "Opiskeluoikeudella voi olla vain yksi opiskeluoikeuden päättävä tila")
       }
       val tila = new Tila
 

--- a/src/main/scala/fi/oph/koski/validation/DateValidation.scala
+++ b/src/main/scala/fi/oph/koski/validation/DateValidation.scala
@@ -3,7 +3,7 @@ package fi.oph.koski.validation
 import java.time.LocalDate
 
 import fi.oph.koski.http.{ErrorCategory, HttpStatus}
-import fi.oph.koski.schema.Alkupäivällinen
+import fi.oph.koski.schema.{Opiskeluoikeusjakso}
 
 object DateValidation {
   type NamedDates = (String, Iterable[LocalDate])
@@ -14,9 +14,14 @@ object DateValidation {
     })
   }
 
-  def validateJaksot(name: String, jaksot: Iterable[Alkupäivällinen], errorCategory: ErrorCategory): HttpStatus = {
+  def validateJaksotDateOrder(name: String, jaksot: Iterable[Opiskeluoikeusjakso], errorCategory: ErrorCategory): HttpStatus = {
     HttpStatus.fold(jaksot.zip(jaksot.drop(1)).map { case (jakso1, jakso2) =>
-      HttpStatus.validate(jakso1.alku.compareTo(jakso2.alku) < 0)(errorCategory(s"${name}: ${jakso1.alku} oltava aiempi kuin ${jakso2.alku}"))
+      val compared = jakso1.alku.compareTo(jakso2.alku)
+      if (compared == 0) {
+        errorCategory(s"${name}: ${jakso1.tila.koodiarvo} ${jakso1.alku} ei voi olla samalla päivämäärällä kuin ${jakso2.tila.koodiarvo} ${jakso2.alku}")
+      } else {
+        HttpStatus.validate(compared < 0)(errorCategory(s"${name}: ${jakso1.alku} on oltava aiempi kuin ${jakso2.alku}"))
+      }
     })
   }
 

--- a/src/main/scala/fi/oph/koski/validation/DateValidation.scala
+++ b/src/main/scala/fi/oph/koski/validation/DateValidation.scala
@@ -18,7 +18,7 @@ object DateValidation {
     HttpStatus.fold(jaksot.zip(jaksot.drop(1)).map { case (jakso1, jakso2) =>
       val compared = jakso1.alku.compareTo(jakso2.alku)
       if (compared == 0) {
-        errorCategory(s"${name}: ${jakso1.tila.koodiarvo} ${jakso1.alku} ei voi olla samalla päivämäärällä kuin ${jakso2.tila.koodiarvo} ${jakso2.alku}")
+        HttpStatus.validate(jakso2.tila.koodiarvo == "mitatoity")(errorCategory(s"${name}: ${jakso1.tila.koodiarvo} ${jakso1.alku} ei voi olla samalla päivämäärällä kuin ${jakso2.tila.koodiarvo} ${jakso2.alku}"))
       } else {
         HttpStatus.validate(compared < 0)(errorCategory(s"${name}: ${jakso1.alku} on oltava aiempi kuin ${jakso2.alku}"))
       }

--- a/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
+++ b/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
@@ -245,7 +245,7 @@ class KoskiValidator(tutkintoRepository: TutkintoRepository, val koodistoPalvelu
       validateDateOrder(("alkamispäivä", opiskeluoikeus.alkamispäivä), ("arvioituPäättymispäivä", opiskeluoikeus.arvioituPäättymispäivä), KoskiErrorCategory.badRequest.validation.date.arvioituPäättymisPäiväEnnenAlkamispäivää),
       HttpStatus.validate(päättäväJakso.isEmpty || päättäväJakso == viimeinenJakso)(KoskiErrorCategory.badRequest.validation.tila.tilaMuuttunutLopullisenTilanJälkeen(s"Opiskeluoikeuden tila muuttunut lopullisen tilan (${päättäväJakso.get.tila.koodiarvo}) jälkeen"))
         .onSuccess(HttpStatus.validate(opiskeluoikeus.päättymispäivä.isEmpty || opiskeluoikeus.päättymispäivä == päättävänJaksonPäivä)(KoskiErrorCategory.badRequest.validation.date.päättymispäivämäärä(s"Opiskeluoikeuden päättymispäivä (${formatOptionalDate(opiskeluoikeus.päättymispäivä)}) ei vastaa opiskeluoikeuden päättävän opiskeluoikeusjakson alkupäivää (${formatOptionalDate(päättävänJaksonPäivä)})"))),
-      DateValidation.validateJaksot("tila.opiskeluoikeusjaksot", opiskeluoikeus.tila.opiskeluoikeusjaksot, KoskiErrorCategory.badRequest.validation.date.opiskeluoikeusjaksojenPäivämäärät),
+      DateValidation.validateJaksotDateOrder("tila.opiskeluoikeusjaksot", opiskeluoikeus.tila.opiskeluoikeusjaksot, KoskiErrorCategory.badRequest.validation.date.opiskeluoikeusjaksojenPäivämäärät),
       HttpStatus.validate(opiskeluoikeus.alkamispäivä == ensimmäisenJaksonPäivä)(KoskiErrorCategory.badRequest.validation.date.alkamispäivä(s"Opiskeluoikeuden alkamispäivä (${formatOptionalDate(opiskeluoikeus.alkamispäivä)}) ei vastaa ensimmäisen opiskeluoikeusjakson alkupäivää (${formatOptionalDate(ensimmäisenJaksonPäivä)})"))
     )
   }

--- a/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
+++ b/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
@@ -232,7 +232,6 @@ class KoskiValidator(tutkintoRepository: TutkintoRepository, val koodistoPalvelu
 
   private def validatePäivämäärät(opiskeluoikeus: KoskeenTallennettavaOpiskeluoikeus): HttpStatus = {
     val ensimmäisenJaksonPäivä: Option[LocalDate] = opiskeluoikeus.tila.opiskeluoikeusjaksot.headOption.map(_.alku)
-    val viimeinenJakso = opiskeluoikeus.tila.opiskeluoikeusjaksot.lastOption
     val päättäväJakso: Option[Opiskeluoikeusjakso] = opiskeluoikeus.tila.opiskeluoikeusjaksot.filter(_.opiskeluoikeusPäättynyt).lastOption
     val päättävänJaksonPäivä: Option[LocalDate] = päättäväJakso.map(_.alku)
     def formatOptionalDate(date: Option[LocalDate]) = date match {
@@ -243,11 +242,20 @@ class KoskiValidator(tutkintoRepository: TutkintoRepository, val koodistoPalvelu
     HttpStatus.fold(
       validateDateOrder(("alkamispäivä", opiskeluoikeus.alkamispäivä), ("päättymispäivä", opiskeluoikeus.päättymispäivä), KoskiErrorCategory.badRequest.validation.date.päättymisPäiväEnnenAlkamispäivää),
       validateDateOrder(("alkamispäivä", opiskeluoikeus.alkamispäivä), ("arvioituPäättymispäivä", opiskeluoikeus.arvioituPäättymispäivä), KoskiErrorCategory.badRequest.validation.date.arvioituPäättymisPäiväEnnenAlkamispäivää),
-      HttpStatus.validate(päättäväJakso.isEmpty || päättäväJakso == viimeinenJakso)(KoskiErrorCategory.badRequest.validation.tila.tilaMuuttunutLopullisenTilanJälkeen(s"Opiskeluoikeuden tila muuttunut lopullisen tilan (${päättäväJakso.get.tila.koodiarvo}) jälkeen"))
+      validateJaksotPäättyminen(opiskeluoikeus.tila.opiskeluoikeusjaksot)
         .onSuccess(HttpStatus.validate(opiskeluoikeus.päättymispäivä.isEmpty || opiskeluoikeus.päättymispäivä == päättävänJaksonPäivä)(KoskiErrorCategory.badRequest.validation.date.päättymispäivämäärä(s"Opiskeluoikeuden päättymispäivä (${formatOptionalDate(opiskeluoikeus.päättymispäivä)}) ei vastaa opiskeluoikeuden päättävän opiskeluoikeusjakson alkupäivää (${formatOptionalDate(päättävänJaksonPäivä)})"))),
       DateValidation.validateJaksotDateOrder("tila.opiskeluoikeusjaksot", opiskeluoikeus.tila.opiskeluoikeusjaksot, KoskiErrorCategory.badRequest.validation.date.opiskeluoikeusjaksojenPäivämäärät),
       HttpStatus.validate(opiskeluoikeus.alkamispäivä == ensimmäisenJaksonPäivä)(KoskiErrorCategory.badRequest.validation.date.alkamispäivä(s"Opiskeluoikeuden alkamispäivä (${formatOptionalDate(opiskeluoikeus.alkamispäivä)}) ei vastaa ensimmäisen opiskeluoikeusjakson alkupäivää (${formatOptionalDate(ensimmäisenJaksonPäivä)})"))
     )
+  }
+
+  private def validateJaksotPäättyminen(jaksot: List[Opiskeluoikeusjakso]) = {
+    jaksot.filter(_.opiskeluoikeusPäättynyt) match {
+      case Nil => HttpStatus.ok
+      case List(päättäväJakso) => HttpStatus.validate(jaksot.last.opiskeluoikeusPäättynyt)(KoskiErrorCategory.badRequest.validation.tila.tilaMuuttunutLopullisenTilanJälkeen(s"Opiskeluoikeuden tila muuttunut lopullisen tilan (${päättäväJakso.tila.koodiarvo}) jälkeen"))
+      case List(_, _) => HttpStatus.validate(jaksot.last.tila.koodiarvo == "mitatoity")(KoskiErrorCategory.badRequest.validation.tila.montaPäättävääTilaa(s"Opiskeluoikeudella voi olla vain yksi opiskeluoikeuden päättävä tila"))
+      case _ => KoskiErrorCategory.badRequest.validation.tila.montaPäättävääTilaa(s"Opiskeluoikeudella voi olla vain yksi opiskeluoikeuden päättävä tila")
+    }
   }
 
   private def validateSuoritus(suoritus: Suoritus, opiskeluoikeus: KoskeenTallennettavaOpiskeluoikeus, parent: List[Suoritus])(implicit user: KoskiSession, accessType: AccessType.Value): HttpStatus = {

--- a/src/test/scala/fi/oph/koski/api/OpiskeluoikeusTestMethodsAmmatillinen.scala
+++ b/src/test/scala/fi/oph/koski/api/OpiskeluoikeusTestMethodsAmmatillinen.scala
@@ -34,6 +34,10 @@ trait OpiskeluoikeusTestMethodsAmmatillinen extends PutOpiskeluoikeusTestMethods
     tila = AmmatillinenOpiskeluoikeudenTila(oo.tila.opiskeluoikeusjaksot ++ List(AmmatillinenOpiskeluoikeusjakso(päivä, tila)))
   )
 
+  def lisääTiloja(opiskeluoikeus: AmmatillinenOpiskeluoikeus, jaksot: List[(LocalDate, Koodistokoodiviite)]) = {
+    jaksot.foldLeft(opiskeluoikeus) { case (oo, (päivä, tila)) => lisääTila(oo, päivä, tila)}
+  }
+
   val sukunimiPuuttuu = KoskiErrorCategory.badRequest.validation.jsonSchema(JsonErrorMessage(JArray(List(JObject(
     "path" -> JString("henkilö.sukunimi"),
     "value" -> JString(""),

--- a/src/test/scala/fi/oph/koski/api/OppijaValidationSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationSpec.scala
@@ -282,7 +282,7 @@ class OppijaValidationSpec extends FreeSpec with LocalJettyHttpSpecification wit
           "alkamispäivä > päättymispäivä"  in (putOpiskeluoikeus(päättymispäivällä(defaultOpiskeluoikeus, date(1999, 5, 31))) {
             verifyResponseStatus(400, List(
               exact(KoskiErrorCategory.badRequest.validation.date.päättymisPäiväEnnenAlkamispäivää, "alkamispäivä (2000-01-01) oltava sama tai aiempi kuin päättymispäivä(1999-05-31)"),
-              exact(KoskiErrorCategory.badRequest.validation.date.opiskeluoikeusjaksojenPäivämäärät, "tila.opiskeluoikeusjaksot: 2000-01-01 oltava aiempi kuin 1999-05-31"),
+              exact(KoskiErrorCategory.badRequest.validation.date.opiskeluoikeusjaksojenPäivämäärät, "tila.opiskeluoikeusjaksot: 2000-01-01 on oltava aiempi kuin 1999-05-31"),
               exact(KoskiErrorCategory.badRequest.validation.date.vahvistusEnnenAlkamispäivää, "suoritus.alkamispäivä (2000-01-01) oltava sama tai aiempi kuin suoritus.vahvistus.päivä(1999-05-31)")
             ))
           })
@@ -319,7 +319,7 @@ class OppijaValidationSpec extends FreeSpec with LocalJettyHttpSpecification wit
         "Kaksi tilaa samalla alkupäivämäärällä -> palautetaan HTTP 400" in {
           val oo =  lisääTila(makeOpiskeluoikeus(), date(2018, 1, 1), Koodistokoodiviite("valiaikaisestikeskeytynyt", "koskiopiskeluoikeudentila"))
           putOpiskeluoikeus(lisääTila(oo, date(2018, 1, 1), Koodistokoodiviite("lasna", "koskiopiskeluoikeudentila"))) {
-            verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.date.opiskeluoikeusjaksojenPäivämäärät("tila.opiskeluoikeusjaksot: 2018-01-01 oltava aiempi kuin 2018-01-01"))
+            verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.date.opiskeluoikeusjaksojenPäivämäärät("tila.opiskeluoikeusjaksot: valiaikaisestikeskeytynyt 2018-01-01 ei voi olla samalla päivämäärällä kuin lasna 2018-01-01"))
           }
         }
       }

--- a/src/test/scala/fi/oph/koski/api/OppijaValidationSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationSpec.scala
@@ -336,6 +336,36 @@ class OppijaValidationSpec extends FreeSpec with LocalJettyHttpSpecification wit
             }
           }
         }
+
+        "Päättävän tilan tyyppi" - {
+          "kaksi päättävää tilaa kun viimeinen on mitatoity" in {
+            val opiskeluoikeus = lisääTiloja(makeOpiskeluoikeus(), List(
+              (date(2018, 1, 1), Koodistokoodiviite("valmistunut", "koskiopiskeluoikeudentila")),
+              (date(2018, 2, 2), Koodistokoodiviite("mitatoity", "koskiopiskeluoikeudentila"))
+            ))
+            putOpiskeluoikeus(opiskeluoikeus) {
+              verifyResponseStatusOk()
+            }
+          }
+          "mitatoity tilan tulee olla viimeinen" in {
+            val opiskeluoikeus = lisääTiloja(makeOpiskeluoikeus(), List(
+              (date(2018, 1, 1), Koodistokoodiviite("mitatoity", "koskiopiskeluoikeudentila")),
+              (date(2018, 1, 2), Koodistokoodiviite("eronnut", "koskiopiskeluoikeudentila"))
+            ))
+            putOpiskeluoikeus(opiskeluoikeus) {
+              verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.tila.montaPäättävääTilaa("Opiskeluoikeudella voi olla vain yksi opiskeluoikeuden päättävä tila"))
+            }
+          }
+          "Päättäviä tiloja voi olla vain yksi" in {
+            val opiskeluoikeus = lisääTiloja(makeOpiskeluoikeus(), List(
+              (date(2017, 1, 1), Koodistokoodiviite("valmistunut", "koskiopiskeluoikeudentila")),
+              (date(2018, 1, 1), Koodistokoodiviite("eronnut", "koskiopiskeluoikeudentila"))
+            ))
+            putOpiskeluoikeus(opiskeluoikeus) {
+              verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.tila.montaPäättävääTilaa("Opiskeluoikeudella voi olla vain yksi opiskeluoikeuden päättävä tila"))
+            }
+          }
+        }
       }
     }
 

--- a/src/test/scala/fi/oph/koski/api/OppijaValidationSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationSpec.scala
@@ -316,10 +316,24 @@ class OppijaValidationSpec extends FreeSpec with LocalJettyHttpSpecification wit
           verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.tila.tilaMuuttunutLopullisenTilanJälkeen("Opiskeluoikeuden tila muuttunut lopullisen tilan (valmistunut) jälkeen"))
         })
 
-        "Kaksi tilaa samalla alkupäivämäärällä -> palautetaan HTTP 400" in {
-          val oo =  lisääTila(makeOpiskeluoikeus(), date(2018, 1, 1), Koodistokoodiviite("valiaikaisestikeskeytynyt", "koskiopiskeluoikeudentila"))
-          putOpiskeluoikeus(lisääTila(oo, date(2018, 1, 1), Koodistokoodiviite("lasna", "koskiopiskeluoikeudentila"))) {
-            verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.date.opiskeluoikeusjaksojenPäivämäärät("tila.opiskeluoikeusjaksot: valiaikaisestikeskeytynyt 2018-01-01 ei voi olla samalla päivämäärällä kuin lasna 2018-01-01"))
+        "Kaksi tilaa samalla alkupäivämäärällä" -  {
+          "palautetaan 400 jos viimeinen tila ei ole 'mitatoity'" in {
+            val opiskeluoikeus = lisääTiloja(makeOpiskeluoikeus(), List(
+              (date(2018, 1, 1), Koodistokoodiviite("valiaikaisestikeskeytynyt", "koskiopiskeluoikeudentila")),
+              (date (2018, 1, 1), Koodistokoodiviite("lasna", "koskiopiskeluoikeudentila"))
+            ))
+            putOpiskeluoikeus(opiskeluoikeus) {
+              verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.date.opiskeluoikeusjaksojenPäivämäärät("tila.opiskeluoikeusjaksot: valiaikaisestikeskeytynyt 2018-01-01 ei voi olla samalla päivämäärällä kuin lasna 2018-01-01"))
+            }
+          }
+          "mitatoity tila sallitaan viimeisenä" in {
+            val opiskeluoikeus = lisääTiloja(makeOpiskeluoikeus(), List(
+              (date(2018, 1, 1), Koodistokoodiviite("valmistunut", "koskiopiskeluoikeudentila")),
+              (date(2018, 1, 1), Koodistokoodiviite("mitatoity", "koskiopiskeluoikeudentila"))
+            ))
+            putOpiskeluoikeus(opiskeluoikeus) {
+              verifyResponseStatusOk()
+            }
           }
         }
       }


### PR DESCRIPTION
- Oma virheviesti tilanteelle jossa kaksi tilaa samalla päivämäärällä
- Jos opiskeluoikeudella on oikeuden päättävä tila, tulee sen olla viimeinen ja ainut päättävä tila
  * Kaksi päättävää tilaa sallitaan, jos viimeinen tila on 'mitatoity' 