### PR TITLE
Muu ammatillinen -tietomalli

### DIFF
--- a/src/main/resources/localization/default-texts.json
+++ b/src/main/resources/localization/default-texts.json
@@ -1175,6 +1175,17 @@
   "Perusopetus": "Perusopetus",
   "Deutsche Internationale Abitur": "Deutsche Internationale Abitur",
   "Painotettu keskiarvo": "Painotettu keskiarvo",
-  "tooltip:Ammatillisen tutkinnon osaamispistein painotettu keskiarvo.": "Ammatillisen tutkinnon osaamispistein painotettu keskiarvo."
+  "tooltip:Ammatillisen tutkinnon osaamispistein painotettu keskiarvo.": "Ammatillisen tutkinnon osaamispistein painotettu keskiarvo.",
+  "tooltip:Kuvaus koulutuksen sisällöstä osaamisena." : "Kuvaus koulutuksen sisällöstä osaamisena.",
+  "description:Kuvaus koulutuksen sisällöstä osaamisena." : "Kuvaus koulutuksen sisällöstä osaamisena.",
+  "description:Osasuoritukseen sisältyvien osasuoritusten suoritukset" : "Osasuoritukseen sisältyvien osasuoritusten suoritukset",
+  "tooltip:Osasuoritukseen kuuluvan ammattiosaamisen näytön tiedot." : "Osasuoritukseen kuuluvan ammattiosaamisen näytön tiedot.",
+  "Täydentää tutkintoa" : "Täydentää tutkintoa",
+  "Liittyy tutkinnon osaan" : "Liittyy tutkinnon osaan",
+  "description:Suoritukseen kuuluvien osasuoritusten suoritukset" : "Suoritukseen kuuluvien osasuoritusten suoritukset",
+  "description:Osasuoritukseen liittyvän näytön tiedot" : "Osasuoritukseen liittyvän näytön tiedot",
+  "Sisältyvät osasuoritukset" : "Sisältyvät osasuoritukset",
+  "description:Tutkinnon osaa pienempään kokonaisuuteen kuuluvien..." : "Tutkinnon osaa pienempään kokonaisuuteen kuuluvien osasuoritusten suoritukset",
+  "description:Osaamisen hankkimistavat eri ajanjaksoina." : "Osaamisen hankkimistavat eri ajanjaksoina."
 }
 

--- a/src/main/resources/mockdata/koodisto/koodistot/ammatilliseentehtavaanvalmistavakoulutus.json
+++ b/src/main/resources/mockdata/koodisto/koodistot/ammatilliseentehtavaanvalmistavakoulutus.json
@@ -1,0 +1,15 @@
+{
+  "koodistoUri" : "ammatilliseentehtavaanvalmistavakoulutus",
+  "versio" : 1,
+  "metadata" : [ {
+    "kieli" : "FI",
+    "nimi" : "Ammatilliseen tehtavaan valmistava koulutus",
+    "kuvaus" : ""
+  } ],
+  "codesGroupUri" : "http://koski",
+  "voimassaAlkuPvm" : "2019-05-01",
+  "organisaatioOid" : "1.2.246.562.10.00000000001",
+  "withinCodes" : [ ],
+  "tila" : "LUONNOS",
+  "version" : 0
+}

--- a/src/main/resources/mockdata/koodisto/koodit/ammatilliseentehtavaanvalmistavakoulutus.json
+++ b/src/main/resources/mockdata/koodisto/koodit/ammatilliseentehtavaanvalmistavakoulutus.json
@@ -1,0 +1,28 @@
+[ {
+  "koodiUri" : "ammatilliseentehtavaanvalmistavakoulutus_ansiojaliikennelentajankoulutus",
+  "koodiArvo" : "ansiojaliikennelentajankoulutus",
+  "metadata" : [ {
+    "nimi" : "Ansio- ja liikennelentäjän koulutus",
+    "kieli" : "FI"
+  } ],
+  "versio" : 1,
+  "withinCodeElements" : [ ]
+}, {
+  "koodiUri" : "ammatilliseentehtavaanvalmistavakoulutus_lennonjohtajankoulutus",
+  "koodiArvo" : "lennonjohtajankoulutus",
+  "metadata" : [ {
+    "nimi" : "Lennonjohtajan koulutus",
+    "kieli" : "FI"
+  } ],
+  "versio" : 1,
+  "withinCodeElements" : [ ]
+}, {
+  "koodiUri" : "ammatilliseentehtavaanvalmistavakoulutus_kaupunkiraideliikenteenkuljettajankoulutus",
+  "koodiArvo" : "kaupunkiraideliikenteenkuljettajankoulutus",
+  "metadata" : [ {
+    "nimi" : "Kaupunkiraideliikenteenkuljettajan koulutus",
+    "kieli" : "FI"
+  } ],
+  "versio" : 1,
+  "withinCodeElements" : [ ]
+} ]

--- a/src/main/resources/mockdata/koodisto/koodit/suorituksentyyppi.json
+++ b/src/main/resources/mockdata/koodisto/koodit/suorituksentyyppi.json
@@ -797,4 +797,13 @@
   } ],
   "versio" : 1,
   "withinCodeElements" : [ ]
+}, {
+  "koodiUri" : "suorituksentyyppi_muuammatillinenkoulutus",
+  "koodiArvo" : "muuammatillinenkoulutus",
+  "metadata" : [ {
+    "nimi" : "Muun ammatillisen koulutuksen suoritus",
+    "kieli" : "FI"
+  } ],
+  "versio" : 1,
+  "withinCodeElements" : [ ]
 } ]

--- a/src/main/resources/mockdata/koodisto/koodit/suorituksentyyppi.json
+++ b/src/main/resources/mockdata/koodisto/koodit/suorituksentyyppi.json
@@ -806,4 +806,13 @@
   } ],
   "versio" : 1,
   "withinCodeElements" : [ ]
+}, {
+  "koodiUri" : "suorituksentyyppi_muunammatillisenkoulutuksenosasuoritus",
+  "koodiArvo" : "muunammatillisenkoulutuksenosasuoritus",
+  "metadata" : [ {
+    "nimi" : "Muun ammatillisen koulutuksen osasuoritus",
+    "kieli" : "FI"
+  } ],
+  "versio" : 1,
+  "withinCodeElements" : [ ]
 } ]

--- a/src/main/resources/mockdata/koodisto/koodit/suorituksentyyppi.json
+++ b/src/main/resources/mockdata/koodisto/koodit/suorituksentyyppi.json
@@ -807,8 +807,26 @@
   "versio" : 1,
   "withinCodeElements" : [ ]
 }, {
+  "koodiUri" : "suorituksentyyppi_tutkinnonosaapienempikokonaisuus",
+  "koodiArvo" : "tutkinnonosaapienempikokonaisuus",
+  "metadata" : [ {
+    "nimi" : "Tutkinnon osaa pienempi kokonaisuus",
+    "kieli" : "FI"
+  } ],
+  "versio" : 1,
+  "withinCodeElements" : [ ]
+}, {
   "koodiUri" : "suorituksentyyppi_muunammatillisenkoulutuksenosasuoritus",
   "koodiArvo" : "muunammatillisenkoulutuksenosasuoritus",
+  "metadata" : [ {
+    "nimi" : "Muun ammatillisen koulutuksen osasuoritus",
+    "kieli" : "FI"
+  } ],
+  "versio" : 1,
+  "withinCodeElements" : [ ]
+}, {
+  "koodiUri" : "suorituksentyyppi_tutkinnonosaapienemmänkokonaisuudenosasuoritus",
+  "koodiArvo" : "tutkinnonosaapienemmänkokonaisuudenosasuoritus",
   "metadata" : [ {
     "nimi" : "Muun ammatillisen koulutuksen osasuoritus",
     "kieli" : "FI"

--- a/src/main/scala/fi/oph/koski/koodisto/Koodistot.scala
+++ b/src/main/scala/fi/oph/koski/koodisto/Koodistot.scala
@@ -10,6 +10,7 @@ object Koodistot {
     KoodistoAsetus("aikuistenperusopetuksenalkuvaiheenoppiaineet"),
     KoodistoAsetus("aikuistenperusopetuksenpaattovaiheenkurssit2017"),
     KoodistoAsetus("aineryhmaib", vaadiSuomenkielinenNimi = false, vaadiRuotsinkielinenNimi = false),
+    KoodistoAsetus("ammatilliseentehtavaanvalmistavakoulutus"),
     KoodistoAsetus("ammatillisennaytonarvioinnistapaattaneet"),
     KoodistoAsetus("ammatillisennaytonarviointikeskusteluunosallistuneet"),
     KoodistoAsetus("ammatillisennaytonarviointikohde"),

--- a/src/main/scala/fi/oph/koski/schema/Ammatillinen.scala
+++ b/src/main/scala/fi/oph/koski/schema/Ammatillinen.scala
@@ -1122,6 +1122,25 @@ case class MuunAmmatillisenKoulutuksenSuoritus(
   ryhmä: Option[String] = None
 ) extends AmmatillinenPäätasonSuoritus with Todistus with Toimipisteellinen with Ryhmällinen with Työssäoppimisjaksoton with Arvioinniton
 
+case class TutkinnonOsaaPienemmänKokonaisuudenSuoritus(
+  koulutusmoduuli: PaikallinenMuuAmmatillinenKoulutus,
+  täydentääTutkintoa: Option[AmmatillinenTutkintoKoulutus],
+  toimipiste: OrganisaatioWithOid,
+  override val alkamispäivä: Option[LocalDate],
+  vahvistus: Option[HenkilövahvistusValinnaisellaPaikkakunnalla] = None,
+  suorituskieli: Koodistokoodiviite,
+  @Description("Osaamisen hankkimistavat eri ajanjaksoina.")
+  @Tooltip("Osaamisen hankkimistavat (oppisopimus, koulutussopimus, oppilaitosmuotoinen koulutus) eri ajanjaksoina.")
+  osaamisenHankkimistavat: Option[List[OsaamisenHankkimistapajakso]] = None,
+  koulutussopimukset: Option[List[Koulutussopimusjakso]] = None,
+  @Description("Tutkinnon osaa pienempään kokonaisuuteen kuuluvien osasuoritusten suoritukset")
+  override val osasuoritukset: Option[List[TutkinnonOsaaPienemmänKokonaisuudenOsasuorituksenSuoritus]],
+  todistuksellaNäkyvätLisätiedot: Option[LocalizedString] = None,
+  @KoodistoKoodiarvo("tutkinnonosaapienempikokonaisuus")
+  tyyppi: Koodistokoodiviite = Koodistokoodiviite("tutkinnonosaapienempikokonaisuus", "suorituksentyyppi"),
+  ryhmä: Option[String] = None
+) extends AmmatillinenPäätasonSuoritus with Todistus with Toimipisteellinen with Ryhmällinen with Työssäoppimisjaksoton with Arvioinniton
+
 sealed trait Työssäoppimisjaksoton extends AmmatillinenPäätasonSuoritus {
   override def työssäoppimisjaksot: Option[List[Työssäoppimisjakso]] = None
 }
@@ -1184,6 +1203,30 @@ case class MuunAmmatillisenKoulutuksenOsasuorituksenLisätieto(
   @Description("Lisätiedon kuvaus siinä muodossa, kuin se näytetään todistuksella")
   kuvaus: LocalizedString
 )
+
+case class TutkinnonOsaaPienemmänKokonaisuudenOsasuorituksenSuoritus(
+  koulutusmoduuli: TutkinnonOsaaPienemmänKokonaisuudenOsasuoritus,
+  override val alkamispäivä: Option[LocalDate],
+  arviointi: Option[List[AmmatillinenArviointi]],
+  @Tooltip("Tiedot aiemmin hankitun osaamisen tunnustamisesta.")
+  @ComplexObject
+  tunnustettu: Option[OsaamisenTunnustaminen] = None,
+  @Tooltip("Suoritukseen liittyvät lisätiedot, kuten esimerkiksi mukautettu arviointi tai poikkeus arvioinnissa. Sisältää lisätiedon tyypin sekä vapaamuotoisen kuvauksen.")
+  @ComplexObject
+  lisätiedot: Option[List[MuunAmmatillisenKoulutuksenOsasuorituksenLisätieto]],
+  @KoodistoUri("tutkinnonosat")
+  liittyyTutkinnonOsaan: Koodistokoodiviite,
+  suorituskieli: Option[Koodistokoodiviite],
+  @KoodistoKoodiarvo("tutkinnonosaapienemmänkokonaisuudenosasuoritus")
+  tyyppi: Koodistokoodiviite = Koodistokoodiviite("tutkinnonosaapienemmänkokonaisuudenosasuoritus", koodistoUri = "suorituksentyyppi")
+) extends Suoritus with Vahvistukseton
+
+case class TutkinnonOsaaPienemmänKokonaisuudenOsasuoritus(
+  tunniste: PaikallinenKoodi,
+  pakollinen: Boolean,
+  laajuus: Option[Laajuus],
+  kuvaus: LocalizedString
+) extends PaikallinenKoulutusmoduuli
 
 trait AmmatillinenKoodistostaLöytyväArviointi extends KoodistostaLöytyväArviointi with ArviointiPäivämäärällä {
   @KoodistoUri("arviointiasteikkoammatillinenhyvaksyttyhylatty")

--- a/src/main/scala/fi/oph/koski/schema/Ammatillinen.scala
+++ b/src/main/scala/fi/oph/koski/schema/Ammatillinen.scala
@@ -1114,6 +1114,8 @@ case class MuunAmmatillisenKoulutuksenSuoritus(
   @Tooltip("Osaamisen hankkimistavat (oppisopimus, koulutussopimus, oppilaitosmuotoinen koulutus) eri ajanjaksoina.")
   osaamisenHankkimistavat: Option[List[OsaamisenHankkimistapajakso]] = None,
   koulutussopimukset: Option[List[Koulutussopimusjakso]] = None,
+  @Description("Suoritukseen kuuluvien osasuoritusten suoritukset")
+  override val osasuoritukset: Option[List[MuunAmmatillisenKoulutuksenOsasuorituksenSuoritus]],
   todistuksellaNäkyvätLisätiedot: Option[LocalizedString] = None,
   @KoodistoKoodiarvo("muuammatillinenkoulutus")
   tyyppi: Koodistokoodiviite = Koodistokoodiviite("muuammatillinenkoulutus", "suorituksentyyppi"),
@@ -1144,6 +1146,44 @@ case class PaikallinenMuuAmmatillinenKoulutus(
   @Tooltip("Kuvaus koulutuksen sisällöstä osaamisena.")
   kuvaus: LocalizedString
 ) extends PaikallinenKoulutusmoduuli with MuuAmmatillinenKoulutus
+
+case class MuunAmmatillisenKoulutuksenOsasuorituksenSuoritus(
+  koulutusmoduuli: MuunAmmatillisenKoulutuksenOsasuoritus,
+  override val alkamispäivä: Option[LocalDate],
+  arviointi: Option[List[AmmatillinenArviointi]],
+  @Tooltip("Tiedot aiemmin hankitun osaamisen tunnustamisesta.")
+  @ComplexObject
+  tunnustettu: Option[OsaamisenTunnustaminen] = None,
+  @Tooltip("Suoritukseen liittyvät lisätiedot, kuten esimerkiksi mukautettu arviointi tai poikkeus arvioinnissa. Sisältää lisätiedon tyypin sekä vapaamuotoisen kuvauksen.")
+  @ComplexObject
+  lisätiedot: Option[List[MuunAmmatillisenKoulutuksenOsasuorituksenLisätieto]],
+  suorituskieli: Option[Koodistokoodiviite],
+  @Description("Osasuoritukseen liittyvän näytön tiedot")
+  @Tooltip("Osasuoritukseen kuuluvan ammattiosaamisen näytön tiedot.")
+  @ComplexObject
+  näyttö: Option[Näyttö] = None,
+  @Description("Osasuoritukseen sisältyvien osasuoritusten suoritukset")
+  @Title("Sisältyvät osasuoritukset")
+  override val osasuoritukset: Option[List[MuunAmmatillisenKoulutuksenOsasuorituksenSuoritus]] = None,
+  @KoodistoKoodiarvo("muunammatillisenkoulutuksenosasuoritus")
+  tyyppi: Koodistokoodiviite = Koodistokoodiviite("muunammatillisenkoulutuksenosasuoritus", koodistoUri = "suorituksentyyppi")
+) extends Suoritus with Vahvistukseton
+
+case class MuunAmmatillisenKoulutuksenOsasuoritus(
+  tunniste: PaikallinenKoodi,
+  pakollinen: Boolean,
+  laajuus: Option[Laajuus],
+  kuvaus: LocalizedString
+) extends PaikallinenKoulutusmoduuli
+
+@Description("Suoritukseen liittyvät lisätiedot, kuten esimerkiksi mukautettu arviointi tai poikkeus arvioinnissa.")
+case class MuunAmmatillisenKoulutuksenOsasuorituksenLisätieto(
+  @Description("Lisätiedon tyyppi kooditettuna")
+  @KoodistoUri("ammatillisentutkinnonosanlisatieto")
+  tunniste: Koodistokoodiviite,
+  @Description("Lisätiedon kuvaus siinä muodossa, kuin se näytetään todistuksella")
+  kuvaus: LocalizedString
+)
 
 trait AmmatillinenKoodistostaLöytyväArviointi extends KoodistostaLöytyväArviointi with ArviointiPäivämäärällä {
   @KoodistoUri("arviointiasteikkoammatillinenhyvaksyttyhylatty")

--- a/src/main/scala/fi/oph/koski/schema/Ammatillinen.scala
+++ b/src/main/scala/fi/oph/koski/schema/Ammatillinen.scala
@@ -1115,7 +1115,7 @@ case class MuunAmmatillisenKoulutuksenSuoritus(
   osaamisenHankkimistavat: Option[List[OsaamisenHankkimistapajakso]] = None,
   koulutussopimukset: Option[List[Koulutussopimusjakso]] = None,
   @Description("Suoritukseen kuuluvien osasuoritusten suoritukset")
-  override val osasuoritukset: Option[List[MuunAmmatillisenKoulutuksenOsasuorituksenSuoritus]],
+  override val osasuoritukset: Option[List[MuuAmmatillinenOsasuoritus]],
   todistuksellaNäkyvätLisätiedot: Option[LocalizedString] = None,
   @KoodistoKoodiarvo("muuammatillinenkoulutus")
   tyyppi: Koodistokoodiviite = Koodistokoodiviite("muuammatillinenkoulutus", "suorituksentyyppi"),
@@ -1166,6 +1166,8 @@ case class PaikallinenMuuAmmatillinenKoulutus(
   kuvaus: LocalizedString
 ) extends PaikallinenKoulutusmoduuli with MuuAmmatillinenKoulutus
 
+sealed trait MuuAmmatillinenOsasuoritus extends Suoritus with MahdollisestiSuorituskielellinen
+
 case class MuunAmmatillisenKoulutuksenOsasuorituksenSuoritus(
   koulutusmoduuli: MuunAmmatillisenKoulutuksenOsasuoritus,
   override val alkamispäivä: Option[LocalDate],
@@ -1186,7 +1188,7 @@ case class MuunAmmatillisenKoulutuksenOsasuorituksenSuoritus(
   override val osasuoritukset: Option[List[MuunAmmatillisenKoulutuksenOsasuorituksenSuoritus]] = None,
   @KoodistoKoodiarvo("muunammatillisenkoulutuksenosasuoritus")
   tyyppi: Koodistokoodiviite = Koodistokoodiviite("muunammatillisenkoulutuksenosasuoritus", koodistoUri = "suorituksentyyppi")
-) extends Suoritus with Vahvistukseton
+) extends MuuAmmatillinenOsasuoritus with Vahvistukseton
 
 case class MuunAmmatillisenKoulutuksenOsasuoritus(
   tunniste: PaikallinenKoodi,
@@ -1219,7 +1221,7 @@ case class TutkinnonOsaaPienemmänKokonaisuudenOsasuorituksenSuoritus(
   suorituskieli: Option[Koodistokoodiviite],
   @KoodistoKoodiarvo("tutkinnonosaapienemmänkokonaisuudenosasuoritus")
   tyyppi: Koodistokoodiviite = Koodistokoodiviite("tutkinnonosaapienemmänkokonaisuudenosasuoritus", koodistoUri = "suorituksentyyppi")
-) extends Suoritus with Vahvistukseton
+) extends MuuAmmatillinenOsasuoritus with Vahvistukseton
 
 case class TutkinnonOsaaPienemmänKokonaisuudenOsasuoritus(
   tunniste: PaikallinenKoodi,

--- a/src/main/scala/fi/oph/koski/schema/Ammatillinen.scala
+++ b/src/main/scala/fi/oph/koski/schema/Ammatillinen.scala
@@ -1102,6 +1102,49 @@ case class PaikallinenTelmaKoulutuksenOsa(
   pakollinen: Boolean
 ) extends PaikallinenKoulutusmoduuli with Valinnaisuus with TelmaKoulutuksenOsa
 
+
+case class MuunAmmatillisenKoulutuksenSuoritus(
+  koulutusmoduuli: MuuAmmatillinenKoulutus,
+  täydentääTutkintoa: Option[AmmatillinenTutkintoKoulutus],
+  toimipiste: OrganisaatioWithOid,
+  override val alkamispäivä: Option[LocalDate],
+  vahvistus: Option[HenkilövahvistusValinnaisellaPaikkakunnalla] = None,
+  suorituskieli: Koodistokoodiviite,
+  @Description("Osaamisen hankkimistavat eri ajanjaksoina.")
+  @Tooltip("Osaamisen hankkimistavat (oppisopimus, koulutussopimus, oppilaitosmuotoinen koulutus) eri ajanjaksoina.")
+  osaamisenHankkimistavat: Option[List[OsaamisenHankkimistapajakso]] = None,
+  koulutussopimukset: Option[List[Koulutussopimusjakso]] = None,
+  todistuksellaNäkyvätLisätiedot: Option[LocalizedString] = None,
+  @KoodistoKoodiarvo("muuammatillinenkoulutus")
+  tyyppi: Koodistokoodiviite = Koodistokoodiviite("muuammatillinenkoulutus", "suorituksentyyppi"),
+  ryhmä: Option[String] = None
+) extends AmmatillinenPäätasonSuoritus with Todistus with Toimipisteellinen with Ryhmällinen with Työssäoppimisjaksoton with Arvioinniton
+
+sealed trait Työssäoppimisjaksoton extends AmmatillinenPäätasonSuoritus {
+  override def työssäoppimisjaksot: Option[List[Työssäoppimisjakso]] = None
+}
+
+sealed trait MuuAmmatillinenKoulutus extends Koulutusmoduuli
+
+case class AmmatilliseenTehtäväänValmistavaKoulutus(
+  @KoodistoUri("ammatilliseentehtavaanvalmistavakoulutus")
+  tunniste: Koodistokoodiviite,
+  pakollinen: Boolean,
+  laajuus: Option[Laajuus],
+  @Description("Kuvaus koulutuksen sisällöstä osaamisena.")
+  @Tooltip("Kuvaus koulutuksen sisällöstä osaamisena.")
+  kuvaus: LocalizedString
+) extends KoodistostaLöytyväKoulutusmoduuli with MuuAmmatillinenKoulutus
+
+case class PaikallinenMuuAmmatillinenKoulutus(
+  tunniste: PaikallinenKoodi,
+  pakollinen: Boolean,
+  laajuus: Option[Laajuus],
+  @Description("Kuvaus koulutuksen sisällöstä osaamisena.")
+  @Tooltip("Kuvaus koulutuksen sisällöstä osaamisena.")
+  kuvaus: LocalizedString
+) extends PaikallinenKoulutusmoduuli with MuuAmmatillinenKoulutus
+
 trait AmmatillinenKoodistostaLöytyväArviointi extends KoodistostaLöytyväArviointi with ArviointiPäivämäärällä {
   @KoodistoUri("arviointiasteikkoammatillinenhyvaksyttyhylatty")
   @KoodistoUri("arviointiasteikkoammatillinent1k3")


### PR DESCRIPTION
Lisätään muun ammatillisen koulutuksen tietomallin ensimmäinen luonnos. Sisältää kaksi uutta päätason suoritusta:
- `muuammatillinenkoulutus`
- `tutkinnonosaapienempikokonaisuus`