### PR TITLE
Ignore an already ignored vulnerability in SNYK config

### DIFF
--- a/web/.snyk
+++ b/web/.snyk
@@ -6,4 +6,8 @@ ignore:
     - '*':
         reason: 'not relevant - developer tools only, and we trust developer machines'
         expires: 2019-08-30T08:01:01.564Z
+  'SNYK-JS-CHOWNR-73502':
+    - '*':
+        reason: 'not relevant - developer tools only, and we trust developer machines'
+        expires: 2019-08-30T08:01:01.564Z
 patch: {}


### PR DESCRIPTION
SNYK tests are failing because of vulnerability reported here: https://snyk.io/vuln/SNYK-JS-CHOWNR-73502

We're already ignoring it because the issue affects developer tools only, and developer machines are trusted. So this is just an update to SNYK configuration.