### PR TITLE
Hotfixaa timeoutista johtuva failaava testi

### DIFF
--- a/web/test/spec/perusopetusSpec.js
+++ b/web/test/spec/perusopetusSpec.js
@@ -2163,7 +2163,10 @@ describe('Perusopetus', function() {
     })
 
     describe('Aikuisten perusopetuksen alkuvaihe', function() {
+      this.timeout(15000)
+
       before(
+        timeout.overrideWaitTime(20000),
         prepareForNewOppija('kalle', '230872-7258'),
         addOppija.enterValidDataPerusopetus(),
         addOppija.selectOpiskeluoikeudenTyyppi('Aikuisten perusopetus'),
@@ -2263,6 +2266,8 @@ describe('Perusopetus', function() {
           })
         })
       })
+
+      after(timeout.resetDefaultWaitTime())
     })
 
     describe('Perusopetuksen oppiaineen oppimäärä', function() {

--- a/web/test/util/testHelpers.js
+++ b/web/test/util/testHelpers.js
@@ -1,6 +1,27 @@
 var expect = chai.expect
 chai.config.truncateThreshold = 0; // disable truncating
 
+timeout = (function() {
+  var defaultTimeout = testTimeoutDefault
+
+  return {
+    /**
+     * Overrides timeout for wait.until calls.
+     * This is a helper that allows a global override in case the actual wait.until calls are buried within abstractions.
+     */
+    overrideWaitTime: function(timeoutMs) {
+      return function() { testTimeoutDefault = timeoutMs }
+    },
+    /**
+     * Resets timeout for wait.until calls.
+     * This is a helper that allows resetting the global wait timeout.
+     */
+    resetDefaultWaitTime: function() {
+      return function() { testTimeoutDefault = defaultTimeout }
+    }
+  }
+})()
+
 function S(selector) {
   try {
     if (!testFrame() || !testFrame().jQuery) {


### PR DESCRIPTION
Failaava testi:
```
Perusopetus
    Opiskeluoikeuden lisääminen
        Aikuisten perusopetuksen alkuvaihe
            Päättövaiheen opintojen lisääminen
                "before all" hook:
                    Error: Timeout of 10000ms exceeded.
```

Prefill-pyyntö kestää aikuisten perusopetuksen osalta huomattavan kauan
(responsen koko gzipattuna 611 KB, avattuna 6.6MB). Vastauksen
oppiaineiden prototypes-tietoon sisällytetään valtavasti eri koodeja ja
luokkia, ja hiljattain lisätyt uudet skeemaluokat ja koodit ovat
paisuttaneet vastausta entisestään. Nyt pyyntöjen tekeminen hidastaa
testien suoritusta jo niin paljon, että Jenkinsillä ko. testi failaa
epäsäännöllisesti.

Hotfixataan kasvattamalla ko. testien timeouttia. Varsinainen korjaus
edellyttää prototyyppien koostamisen tutkimista ja optimoimista.