### PR TITLE
Lisätty opiskeluoikeuden tyypin nimi Virta-tietoihin

### DIFF
--- a/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
+++ b/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
@@ -17,7 +17,7 @@ case class KorkeakoulunOpiskeluoikeus(
   lisätiedot: Option[KorkeakoulunOpiskeluoikeudenLisätiedot] = None,
   suoritukset: List[KorkeakouluSuoritus],
   @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.korkeakoulutus.koodiarvo)
-  tyyppi: Koodistokoodiviite = OpiskeluoikeudenTyyppi.korkeakoulutus,
+  tyyppi: Koodistokoodiviite,
   synteettinen: Boolean = false
 ) extends Opiskeluoikeus {
   override def versionumero = None

--- a/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
+++ b/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
@@ -22,6 +22,7 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
     val suoritusNodeList: List[Node] = suoritusNodes(virtaXml)
     val suoritusRoots: List[Node] = suoritusNodeList.filter(isRoot(suoritusNodeList)(_))
     val opiskeluoikeusNodes: List[Node] = (virtaXml \\ "Opiskeluoikeus").toList
+    val ooTyyppi: Koodistokoodiviite = koodistoViitePalvelu.validateRequired(OpiskeluoikeudenTyyppi.korkeakoulutus)
 
     val (orphans, opiskeluoikeudet) = opiskeluoikeusNodes.foldLeft((suoritusRoots, Nil: List[KorkeakoulunOpiskeluoikeus])) { case ((suoritusRootsLeft, opiskeluOikeudet), opiskeluoikeusNode) =>
       val (opiskeluOikeudenSuoritukset: List[Node], muutSuoritukset: List[Node]) = suoritusRootsLeft.partition(sisältyyOpiskeluoikeuteen(_, opiskeluoikeusNode, suoritusNodeList))
@@ -42,6 +43,7 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
         koulutustoimija = None,
         suoritukset = addPäätasonSuoritusIfNecessary(suoritukset, opiskeluoikeusNode, opiskeluoikeudenTila),
         tila = opiskeluoikeudenTila,
+        tyyppi = ooTyyppi,
         lisätiedot = Some(KorkeakoulunOpiskeluoikeudenLisätiedot(
           ensisijaisuus = Some((opiskeluoikeusNode \ "Ensisijaisuus").toList.map { e => Aikajakso(alkuPvm(e), loppuPvm(e)) }).filter(_.nonEmpty),
           virtaOpiskeluoikeudenTyyppi = Some(opiskeluoikeudenTyyppi(opiskeluoikeusNode)),
@@ -62,6 +64,7 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
         koulutustoimija = None,
         suoritukset = suoritukset,
         tila = KorkeakoulunOpiskeluoikeudenTila(Nil),
+        tyyppi = ooTyyppi,
         synteettinen = true
       )
     }

--- a/src/test/scala/fi/oph/koski/api/OpiskeluoikeusTestMethodsKorkeakoulu.scala
+++ b/src/test/scala/fi/oph/koski/api/OpiskeluoikeusTestMethodsKorkeakoulu.scala
@@ -16,6 +16,7 @@ trait OpiskeluoikeusTestMethodsKorkeakoulu extends PutOpiskeluoikeusTestMethods[
       List(
         KorkeakoulunOpiskeluoikeusjakso(date(2012, 9, 1), KorkeakouluTestdata.opiskeluoikeusAktiivinen)
       )
-    )
+    ),
+    tyyppi = koodisto.validateRequired(OpiskeluoikeudenTyyppi.korkeakoulutus)
   )
 }


### PR DESCRIPTION
Virta-vastauksen konvertoinnissa opiskeluoikeuden tyyppi sisälsi aiemmin ainostaan tyypin koodin. Nyt se sisältää myös tyypin nimen.

Poistettu lisäksi Korkeakoulu-skeemasta `tyyppi`-kentän oletusarvo, joka viittasi konstruktoriin jota käyttämällä tyypin nimi jäi tyhjäksi. Täten samanlaista bugia ei jatkossa pääse vahingossa syntymään uudestaan.