### PR TITLE
Muu ammatillinen tietomalliviilaukset

### DIFF
--- a/src/main/resources/localization/default-texts.json
+++ b/src/main/resources/localization/default-texts.json
@@ -1186,6 +1186,7 @@
   "description:Osasuoritukseen liittyvän näytön tiedot" : "Osasuoritukseen liittyvän näytön tiedot",
   "Sisältyvät osasuoritukset" : "Sisältyvät osasuoritukset",
   "description:Tutkinnon osaa pienempään kokonaisuuteen kuuluvien..." : "Tutkinnon osaa pienempään kokonaisuuteen kuuluvien osasuoritusten suoritukset",
-  "description:Osaamisen hankkimistavat eri ajanjaksoina." : "Osaamisen hankkimistavat eri ajanjaksoina."
+  "description:Osaamisen hankkimistavat eri ajanjaksoina." : "Osaamisen hankkimistavat eri ajanjaksoina.",
+  "Pilotti": "Pilotti"
 }
 

--- a/src/main/resources/mockdata/koodisto/koodit/suorituksentyyppi.json
+++ b/src/main/resources/mockdata/koodisto/koodit/suorituksentyyppi.json
@@ -807,15 +807,6 @@
   "versio" : 1,
   "withinCodeElements" : [ ]
 }, {
-  "koodiUri" : "suorituksentyyppi_tutkinnonosaapienempikokonaisuus",
-  "koodiArvo" : "tutkinnonosaapienempikokonaisuus",
-  "metadata" : [ {
-    "nimi" : "Tutkinnon osaa pienempi kokonaisuus",
-    "kieli" : "FI"
-  } ],
-  "versio" : 1,
-  "withinCodeElements" : [ ]
-}, {
   "koodiUri" : "suorituksentyyppi_muunammatillisenkoulutuksenosasuoritus",
   "koodiArvo" : "muunammatillisenkoulutuksenosasuoritus",
   "metadata" : [ {
@@ -825,10 +816,19 @@
   "versio" : 1,
   "withinCodeElements" : [ ]
 }, {
-  "koodiUri" : "suorituksentyyppi_tutkinnonosaapienemmänkokonaisuudenosasuoritus",
-  "koodiArvo" : "tutkinnonosaapienemmänkokonaisuudenosasuoritus",
+  "koodiUri" : "suorituksentyyppi_tutkinnonosaapienemmistäkokonaisuuksistakoostuvasuoritus",
+  "koodiArvo" : "tutkinnonosaapienemmistäkokonaisuuksistakoostuvasuoritus",
   "metadata" : [ {
-    "nimi" : "Muun ammatillisen koulutuksen osasuoritus",
+    "nimi" : "Tutkinnon osaa pienemmistä kokonaisuuksista koostuva suoritus",
+    "kieli" : "FI"
+  } ],
+  "versio" : 1,
+  "withinCodeElements" : [ ]
+}, {
+  "koodiUri" : "suorituksentyyppi_tutkinnonosaapienempikokonaisuus",
+  "koodiArvo" : "tutkinnonosaapienempikokonaisuus",
+  "metadata" : [ {
+    "nimi" : "Tutkinnon osaa pienemmän kokonaisuuden suoritus",
     "kieli" : "FI"
   } ],
   "versio" : 1,

--- a/src/main/scala/fi/oph/koski/schema/Ammatillinen.scala
+++ b/src/main/scala/fi/oph/koski/schema/Ammatillinen.scala
@@ -1151,7 +1151,6 @@ sealed trait MuuAmmatillinenKoulutus extends Koulutusmoduuli
 case class AmmatilliseenTehtäväänValmistavaKoulutus(
   @KoodistoUri("ammatilliseentehtavaanvalmistavakoulutus")
   tunniste: Koodistokoodiviite,
-  pakollinen: Boolean,
   laajuus: Option[Laajuus],
   @Description("Kuvaus koulutuksen sisällöstä osaamisena.")
   @Tooltip("Kuvaus koulutuksen sisällöstä osaamisena.")
@@ -1160,7 +1159,6 @@ case class AmmatilliseenTehtäväänValmistavaKoulutus(
 
 case class PaikallinenMuuAmmatillinenKoulutus(
   tunniste: PaikallinenKoodi,
-  pakollinen: Boolean,
   laajuus: Option[Laajuus],
   @Description("Kuvaus koulutuksen sisällöstä osaamisena.")
   @Tooltip("Kuvaus koulutuksen sisällöstä osaamisena.")
@@ -1193,7 +1191,6 @@ case class MuunAmmatillisenKoulutuksenOsasuorituksenSuoritus(
 
 case class MuunAmmatillisenKoulutuksenOsasuoritus(
   tunniste: PaikallinenKoodi,
-  pakollinen: Boolean,
   laajuus: Option[Laajuus],
   kuvaus: LocalizedString
 ) extends PaikallinenKoulutusmoduuli
@@ -1230,7 +1227,6 @@ case class TutkinnonOsaaPienemmänKokonaisuudenSuoritus(
 
 case class TutkinnonOsaaPienempiKokonaisuus(
   tunniste: PaikallinenKoodi,
-  pakollinen: Boolean,
   laajuus: Option[LaajuusOsaamispisteissä],
   kuvaus: LocalizedString
 ) extends PaikallinenKoulutusmoduuli

--- a/src/main/scala/fi/oph/koski/schema/Ammatillinen.scala
+++ b/src/main/scala/fi/oph/koski/schema/Ammatillinen.scala
@@ -1136,6 +1136,7 @@ case class TutkinnonOsaaPienemmistäKokonaisuuksistaKoostuvaSuoritus(
   @MinItems(1)
   override val osasuoritukset: Option[List[TutkinnonOsaaPienemmänKokonaisuudenSuoritus]],
   todistuksellaNäkyvätLisätiedot: Option[LocalizedString] = None,
+  pilotti: Boolean,
   @KoodistoKoodiarvo("tutkinnonosaapienemmistäkokonaisuuksistakoostuvasuoritus")
   tyyppi: Koodistokoodiviite = Koodistokoodiviite("tutkinnonosaapienemmistäkokonaisuuksistakoostuvasuoritus", "suorituksentyyppi"),
   ryhmä: Option[String] = None

--- a/src/main/scala/fi/oph/koski/schema/Ammatillinen.scala
+++ b/src/main/scala/fi/oph/koski/schema/Ammatillinen.scala
@@ -1122,7 +1122,7 @@ case class MuunAmmatillisenKoulutuksenSuoritus(
   ryhmä: Option[String] = None
 ) extends AmmatillinenPäätasonSuoritus with Todistus with Toimipisteellinen with Ryhmällinen with Työssäoppimisjaksoton with Arvioinniton
 
-case class TutkinnonOsaaPienemmänKokonaisuudenSuoritus(
+case class TutkinnonOsaaPienemmistäKokonaisuuksistaKoostuvaSuoritus(
   koulutusmoduuli: PaikallinenMuuAmmatillinenKoulutus,
   toimipiste: OrganisaatioWithOid,
   override val alkamispäivä: Option[LocalDate],
@@ -1134,10 +1134,10 @@ case class TutkinnonOsaaPienemmänKokonaisuudenSuoritus(
   koulutussopimukset: Option[List[Koulutussopimusjakso]] = None,
   @Description("Tutkinnon osaa pienempään kokonaisuuteen kuuluvien osasuoritusten suoritukset")
   @MinItems(1)
-  override val osasuoritukset: Option[List[TutkinnonOsaaPienemmänKokonaisuudenOsasuorituksenSuoritus]],
+  override val osasuoritukset: Option[List[TutkinnonOsaaPienemmänKokonaisuudenSuoritus]],
   todistuksellaNäkyvätLisätiedot: Option[LocalizedString] = None,
-  @KoodistoKoodiarvo("tutkinnonosaapienempikokonaisuus")
-  tyyppi: Koodistokoodiviite = Koodistokoodiviite("tutkinnonosaapienempikokonaisuus", "suorituksentyyppi"),
+  @KoodistoKoodiarvo("tutkinnonosaapienemmistäkokonaisuuksistakoostuvasuoritus")
+  tyyppi: Koodistokoodiviite = Koodistokoodiviite("tutkinnonosaapienemmistäkokonaisuuksistakoostuvasuoritus", "suorituksentyyppi"),
   ryhmä: Option[String] = None
 ) extends AmmatillinenPäätasonSuoritus with Todistus with Toimipisteellinen with Ryhmällinen with Työssäoppimisjaksoton with Arvioinniton
 
@@ -1206,8 +1206,8 @@ case class MuunAmmatillisenKoulutuksenOsasuorituksenLisätieto(
   kuvaus: LocalizedString
 )
 
-case class TutkinnonOsaaPienemmänKokonaisuudenOsasuorituksenSuoritus(
-  koulutusmoduuli: TutkinnonOsaaPienemmänKokonaisuudenOsasuoritus,
+case class TutkinnonOsaaPienemmänKokonaisuudenSuoritus(
+  koulutusmoduuli: TutkinnonOsaaPienempiKokonaisuus,
   override val alkamispäivä: Option[LocalDate],
   arviointi: Option[List[AmmatillinenArviointi]],
   @Tooltip("Tiedot aiemmin hankitun osaamisen tunnustamisesta.")
@@ -1223,11 +1223,11 @@ case class TutkinnonOsaaPienemmänKokonaisuudenOsasuorituksenSuoritus(
   @KoodistoUri("tutkinnonosat")
   liittyyTutkinnonOsaan: Koodistokoodiviite,
   suorituskieli: Option[Koodistokoodiviite],
-  @KoodistoKoodiarvo("tutkinnonosaapienemmänkokonaisuudenosasuoritus")
-  tyyppi: Koodistokoodiviite = Koodistokoodiviite("tutkinnonosaapienemmänkokonaisuudenosasuoritus", koodistoUri = "suorituksentyyppi")
+  @KoodistoKoodiarvo("tutkinnonosaapienempikokonaisuus")
+  tyyppi: Koodistokoodiviite = Koodistokoodiviite("tutkinnonosaapienempikokonaisuus", koodistoUri = "suorituksentyyppi")
 ) extends MuuAmmatillinenOsasuoritus with Vahvistukseton
 
-case class TutkinnonOsaaPienemmänKokonaisuudenOsasuoritus(
+case class TutkinnonOsaaPienempiKokonaisuus(
   tunniste: PaikallinenKoodi,
   pakollinen: Boolean,
   laajuus: Option[LaajuusOsaamispisteissä],


### PR DESCRIPTION
- lisätään pilotti-tieto
- poistetaan pakollinen-tiedot (turhia muussa ammatillisessa)
- selkeytetään tutkinnon osaa pienemmän kokonaisuuden nimeämistä: _osasuoritukset_ ovat tutkinnon osaa pienempiä kokonaisuuksia, ja päätason suoritus on ainoastaan "kooste" näistä, jotta kokonaisuuksia saadaan liitettyä samaan suoritukseen