### PR TITLE
Ammatillisen tutkinnon keskiarvon esittäminen aina 2 desimaalilla

### DIFF
--- a/src/main/scala/fi/oph/koski/editor/EditorModelSerializer.scala
+++ b/src/main/scala/fi/oph/koski/editor/EditorModelSerializer.scala
@@ -3,7 +3,7 @@ package fi.oph.koski.editor
 import fi.oph.koski.json.{JsonSerializer, LegacyJsonSerialization}
 import fi.oph.koski.log.Logging
 import fi.oph.koski.schema.KoskiSchema
-import fi.oph.koski.schema.annotation.{Example, MultiLineString, UnitOfMeasure}
+import fi.oph.koski.schema.annotation.{Example, MultiLineString, Scale, UnitOfMeasure}
 import fi.oph.scalaschema.annotation._
 import fi.oph.scalaschema.{Metadata, SerializationContext, Serializer}
 import org.json4s.JsonAST.{JObject, JString, JValue}
@@ -100,6 +100,7 @@ object EditorModelSerializer extends Serializer[EditorModel] with Logging {
       case MinValueExclusive(x) => JField("minValueExclusive", JDouble(x))
       case MaxValueExclusive(x) => JField("maxValueExclusive", JDouble(x))
       case MultiLineString(x) => JField("maxLines", JInt(x))
+      case Scale(x) => JField("scale", JInt(x))
       case UnitOfMeasure(x) => JField("unitOfMeasure", JString(x))
       case RegularExpression(x) => JField("regularExpression", JString(x))
       case Example(x) => JField("example", JString(x))

--- a/src/main/scala/fi/oph/koski/schema/Ammatillinen.scala
+++ b/src/main/scala/fi/oph/koski/schema/Ammatillinen.scala
@@ -234,6 +234,7 @@ case class AmmatillisenTutkinnonSuoritus(
   @OnlyWhen("suoritustapa/koodiarvo","ops")
   @MinValue(1)
   @MaxValue(5)
+  @Scale(2)
   keskiarvo: Option[Float] = None
 ) extends AmmatillisenTutkinnonOsittainenTaiKokoSuoritus with Todistus
 

--- a/src/main/scala/fi/oph/koski/schema/Ammatillinen.scala
+++ b/src/main/scala/fi/oph/koski/schema/Ammatillinen.scala
@@ -231,7 +231,7 @@ case class AmmatillisenTutkinnonSuoritus(
   ryhmä: Option[String] = None,
   @Title("Painotettu keskiarvo")
   @Tooltip("Ammatillisen tutkinnon osaamispistein painotettu keskiarvo.")
-  @OnlyWhen("suoritustapa/koodiarvo","ops")
+  @OnlyWhen("suoritustapa/koodiarvo","reformi")
   @MinValue(1)
   @MaxValue(5)
   @Scale(2)

--- a/src/main/scala/fi/oph/koski/schema/annotation/Annotations.scala
+++ b/src/main/scala/fi/oph/koski/schema/annotation/Annotations.scala
@@ -38,3 +38,6 @@ case class Example(text: String) extends RepresentationalMetadata
 case class SensitiveData() extends RepresentationalMetadata
 
 case class Tooltip(text: String) extends RepresentationalMetadata
+
+/* Numeric field should be rendered using this scale */
+case class Scale(numberOfDigits: Int) extends RepresentationalMetadata

--- a/web/app/editor/NumberEditor.jsx
+++ b/web/app/editor/NumberEditor.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {modelData, pushModelValue, wrapOptional, modelSetValue, modelValid} from './EditorModel'
-import {laajuusNumberToString} from '../util/format'
+import {numberToString} from '../util/format'
 
 export class NumberEditor extends React.Component {
   render() {
@@ -9,7 +9,7 @@ export class NumberEditor extends React.Component {
     let onChange = (event) => pushModelValue(wrappedModel, event.target.value ? { data: parseNumber(event.target.value) } : undefined)
 
     let data = modelData(wrappedModel)
-    let value = laajuusNumberToString(data, model.scale)
+    let value = numberToString(data, model.scale)
     let error = !modelValid(model)
 
     return wrapWithUnitOfMeasure(wrappedModel.unitOfMeasure, wrappedModel.context.edit

--- a/web/app/editor/NumberEditor.jsx
+++ b/web/app/editor/NumberEditor.jsx
@@ -9,7 +9,7 @@ export class NumberEditor extends React.Component {
     let onChange = (event) => pushModelValue(wrappedModel, event.target.value ? { data: parseNumber(event.target.value) } : undefined)
 
     let data = modelData(wrappedModel)
-    let value = laajuusNumberToString(data)
+    let value = laajuusNumberToString(data, model.scale)
     let error = !modelValid(model)
 
     return wrapWithUnitOfMeasure(wrappedModel.unitOfMeasure, wrappedModel.context.edit

--- a/web/app/lukio/LukionOppiaineEditor.jsx
+++ b/web/app/lukio/LukionOppiaineEditor.jsx
@@ -11,7 +11,7 @@ import {paikallinenOppiainePrototype} from '../perusopetus/PerusopetuksenOppiain
 import {doActionWhileMounted} from '../util/util'
 import {createOppiaineenSuoritus, suoritetutKurssit, hyväksytystiSuoritetutKurssit, laajuudet} from './lukio'
 import {Arviointi, KoulutusmoduuliPropertiesEditor, Nimi} from './fragments/LukionOppiaine'
-import {laajuusNumberToString} from '../util/format'
+import {numberToString} from '../util/format'
 import {PropertiesEditor} from '../editor/PropertiesEditor'
 
 export class LukionOppiaineEditor extends React.Component {
@@ -72,7 +72,7 @@ export class LukionOppiaineEditor extends React.Component {
           {
             useOppiaineLaajuus
               ? modelData(oppiaine, 'koulutusmoduuli.laajuus.arvo')
-              : laajuusNumberToString(laajuudet(hyväksytystiSuoritetutKurssit(kurssit)))
+              : numberToString(laajuudet(hyväksytystiSuoritetutKurssit(kurssit)))
           }
         </td>
         {

--- a/web/app/lukio/LukionOppiaineetEditor.jsx
+++ b/web/app/lukio/LukionOppiaineetEditor.jsx
@@ -7,7 +7,7 @@ import {LukionOppiaineetTableHead} from './fragments/LukionOppiaineetTableHead'
 import {t} from '../i18n/i18n'
 import {flatMapArray} from '../util/util'
 import {hyväksytystiSuoritetutKurssit, laajuudet} from './lukio'
-import {laajuusNumberToString} from '../util/format.js'
+import {numberToString} from '../util/format.js'
 import {isPaikallinen} from '../suoritus/Koulutusmoduuli'
 import {FootnoteDescriptions} from '../components/footnote'
 
@@ -39,7 +39,7 @@ export const LukionOppiaineetEditor = ({suorituksetModel, classesForUusiOppiaine
         {oppiaineetWithErrorRows}
         </tbody>
       </table>
-      <div className="kurssit-yhteensä">{t('Suoritettujen kurssien laajuus yhteensä') + ': ' + laajuusNumberToString(laajuudet(arvioidutKurssit(oppiaineet)))}</div>
+      <div className="kurssit-yhteensä">{t('Suoritettujen kurssien laajuus yhteensä') + ': ' + numberToString(laajuudet(arvioidutKurssit(oppiaineet)))}</div>
       {paikallisiaLukionOppiaineitaTaiKursseja(oppiaineet) && <FootnoteDescriptions data={[{title: 'Paikallinen kurssi tai oppiaine', hint: '*'}]}/>}
       <UusiLukionOppiaineDropdown
         model={päätasonSuoritusModel}

--- a/web/app/lukio/OmatTiedotLukionOppiaineet.jsx
+++ b/web/app/lukio/OmatTiedotLukionOppiaineet.jsx
@@ -5,7 +5,7 @@ import {t} from '../i18n/i18n'
 import {arvioidutKurssit, paikallisiaLukionOppiaineitaTaiKursseja} from './LukionOppiaineetEditor'
 import {FootnoteDescriptions, FootnoteHint} from '../components/footnote'
 import {kurssienKeskiarvo, Nimi} from './fragments/LukionOppiaine'
-import {laajuusNumberToString} from '../util/format'
+import {numberToString} from '../util/format'
 import {hyväksytystiSuoritetutKurssit, laajuudet, suoritetutKurssit} from './lukio'
 import {KurssitEditor} from '../kurssi/KurssitEditor'
 import {isMobileAtom} from '../util/isMobileAtom'
@@ -34,7 +34,7 @@ export default ({suorituksetModel, suoritusFilter}) => {
           ))}
         </tbody>
       </table>
-      <div className='kurssit-yhteensä'>{t('Suoritettujen kurssien laajuus yhteensä') + ': ' + laajuusNumberToString(laajuudet(arvioidutKurssit(oppiaineet)))}</div>
+      <div className='kurssit-yhteensä'>{t('Suoritettujen kurssien laajuus yhteensä') + ': ' + numberToString(laajuudet(arvioidutKurssit(oppiaineet)))}</div>
       {paikallisiaLukionOppiaineitaTaiKursseja(oppiaineet) && <FootnoteDescriptions data={[{title: 'Paikallinen kurssi tai oppiaine', hint: '*'}]}/>}
     </section>
   )
@@ -63,7 +63,7 @@ export class OmatTiedotLukionOppiaine extends React.Component {
     const oppiaineenKeskiarvo = kurssienKeskiarvo(suoritetutKurssit(kurssit))
     const laajuusYhteensä = useOppiaineLaajuus
       ? modelData(oppiaine, 'koulutusmoduuli.laajuus.arvo')
-      : laajuusNumberToString(laajuudet(hyväksytystiSuoritetutKurssit(kurssit)))
+      : numberToString(laajuudet(hyväksytystiSuoritetutKurssit(kurssit)))
     const laajuusYksikkö = useOppiaineLaajuus
       ? modelTitle(oppiaine, 'koulutusmoduuli.laajuus.yksikkö')
       : t('kurssia')

--- a/web/app/suoritus/YhteensaSuoritettu.jsx
+++ b/web/app/suoritus/YhteensaSuoritettu.jsx
@@ -4,7 +4,7 @@ import * as R from 'ramda'
 import Text from '../i18n/Text'
 import {modelData} from '../editor/EditorModel'
 import Http from '../util/http'
-import {laajuusNumberToString} from '../util/format'
+import {numberToString} from '../util/format'
 
 export const fetchLaajuudet = (suoritus, groupIds) => {
   let diaarinumero = modelData(suoritus, 'koulutusmoduuli.perusteenDiaarinumero')
@@ -53,7 +53,7 @@ export const YhteensäSuoritettu = ({osasuoritukset, laajuusP, laajuusYksikkö=n
     <div>
       <Text name="Yhteensä"/>
       {' '}
-      <span className="laajuudet-yhteensä">{laajuusNumberToString(laajuudetYhteensä)}</span>
+      <span className="laajuudet-yhteensä">{numberToString(laajuudetYhteensä)}</span>
       <span className="separator">{laajuusP.map(v => rangeExists(v) ? ' / ' : null)}</span>
       <span className="laajuus-range">{laajuusP.map(v => laajuusRange(v))}</span>
       {' '}

--- a/web/app/util/format.js
+++ b/web/app/util/format.js
@@ -1,4 +1,4 @@
-const laajuusNumberToString = (s, scale) => {
+const numberToString = (s, scale) => {
   if (s == undefined) return s
   if (scale == undefined || typeof scale !== 'number') {
     return (Math.round(s * 100) / 100).toString().replace('.', ',')
@@ -8,5 +8,5 @@ const laajuusNumberToString = (s, scale) => {
 }
 
 export {
-  laajuusNumberToString
+  numberToString
 }

--- a/web/app/util/format.js
+++ b/web/app/util/format.js
@@ -1,6 +1,10 @@
-const laajuusNumberToString = (s) => {
+const laajuusNumberToString = (s, scale) => {
   if (s == undefined) return s
-  return (Math.round(s * 100) / 100).toString().replace('.', ',')
+  if (scale == undefined || typeof scale !== 'number') {
+    return (Math.round(s * 100) / 100).toString().replace('.', ',')
+  } else {
+    return (Math.round(s * 100) / 100).toFixed(scale).replace('.', ',')
+  }
 }
 
 export {

--- a/web/test/spec/ammatillinenSpec.js
+++ b/web/test/spec/ammatillinenSpec.js
@@ -801,7 +801,10 @@ describe('Ammatillinen koulutus', function() {
           editor.saveChanges
         )
         it('toimii', function() {
-          expect(editor.property('keskiarvo').getValue()).to.equal('3,5')
+          expect(page.isSavedLabelShown()).to.equal(true)
+        })
+        it('keskiarvo näytetään kahden desimaalin tarkkuudella', function() {
+          expect(editor.property('keskiarvo').getValue()).to.equal('3,50')
         })
       })
     })

--- a/web/test/spec/ammatillinenSpec.js
+++ b/web/test/spec/ammatillinenSpec.js
@@ -461,6 +461,39 @@ describe('Ammatillinen koulutus', function() {
           })
         })
       })
+
+      describe('Keskiarvo', function() {
+        describe('Aluksi', function() {
+          before(editor.edit)
+          it('keskiarvo-kenttä on näkyvissä', function() {
+            expect(editor.property('keskiarvo').isVisible()).to.equal(true)
+          })
+          after(editor.cancelChanges)
+        })
+        describe('Ei-validin keskiarvon lisäys', function() {
+          before(
+            editor.edit,
+            editor.property('keskiarvo').setValue(7)
+          )
+          it('ei ole sallittu', function() {
+            expect(editor.canSave()).to.equal(false)
+          })
+          after(editor.cancelChanges)
+        })
+        describe('Validin keskiarvon lisäys', function() {
+          before(
+            editor.edit,
+            editor.property('keskiarvo').setValue(3.5),
+            editor.saveChanges
+          )
+          it('toimii', function() {
+            expect(page.isSavedLabelShown()).to.equal(true)
+          })
+          it('keskiarvo näytetään kahden desimaalin tarkkuudella', function() {
+            expect(editor.property('keskiarvo').getValue()).to.equal('3,50')
+          })
+        })
+      })
     })
 
     describe('Ammatillisen tutkinnon osittainen suoritus', function () {
@@ -777,36 +810,11 @@ describe('Ammatillinen koulutus', function() {
     })
 
     describe('Keskiarvo', function() {
-      describe('Aluksi', function() {
-        before(editor.edit)
-        it('keskiarvo-kenttä on näkyvissä', function() {
-          expect(editor.property('keskiarvo').isVisible()).to.equal(true)
-        })
-        after(editor.cancelChanges)
+      before(editor.edit)
+      it('keskiarvo-kenttä ei ole näkyvissä', function() {
+        expect(editor.property('keskiarvo').isVisible()).to.equal(false)
       })
-      describe('Ei-validin keskiarvon lisäys', function() {
-        before(
-          editor.edit,
-          editor.property('keskiarvo').setValue(7)
-        )
-        it('ei ole sallittu', function() {
-          expect(editor.canSave()).to.equal(false)
-        })
-        after(editor.cancelChanges)
-      })
-      describe('Validin keskiarvon lisäys', function() {
-        before(
-          editor.edit,
-          editor.property('keskiarvo').setValue(3.5),
-          editor.saveChanges
-        )
-        it('toimii', function() {
-          expect(page.isSavedLabelShown()).to.equal(true)
-        })
-        it('keskiarvo näytetään kahden desimaalin tarkkuudella', function() {
-          expect(editor.property('keskiarvo').getValue()).to.equal('3,50')
-        })
-      })
+      after(editor.cancelChanges)
     })
 
     describe('Tutkinnon osat', function() {


### PR DESCRIPTION
* Ammatillisen tutkinnon painotettu keskiarvo näytetään nyt käyttöliittymässä aina kahdella desimaalilla (myös nollat, eli esim. keskiarvo 2 näytetään muodossa 2,00). Tätä varten lisätty skeemaan `Scale` -annotaatio, jolla näytettävien desimaalien lukumäärä voidaan määrittää.
* Lisäksi tehty seuraava korjaus: keskiarvo-kenttä näytetään silloin, kun ammatillisen tutkinnon suoritustapa on "reformi" (ei "ops").