### PR TITLE
Huomioitu ylioppilastutkintorekisterin kenttien nimenmuutos

### DIFF
--- a/src/main/resources/mockdata/ytr/010280-952L.json
+++ b/src/main/resources/mockdata/ytr/010280-952L.json
@@ -1,6 +1,6 @@
 {
-  "graduationSchoolOphOid": "1.2.246.562.24.40675408602",
-  "graduationSchoolYtlNumber": 1648,
+  "certificateSchoolOphOid": "1.2.246.562.24.40675408602",
+  "certificateSchoolYtlNumber": 1648,
   "ssn": "010280-952L",
   "lastname": "Testilä",
   "firstnames": "Tessa",

--- a/src/main/resources/mockdata/ytr/080640-881R.json
+++ b/src/main/resources/mockdata/ytr/080640-881R.json
@@ -1,6 +1,6 @@
 {
   "description": "uudelleen aloittaja, tutkinto valmis",
-  "graduationSchoolOphOid": "1.2.246.562.10.62858797335",
+  "certificateSchoolOphOid": "1.2.246.562.10.62858797335",
   "ssn": "080640-881R",
   "lastname": "Uronen",
   "firstnames": "Raisa Hilkka",

--- a/src/main/resources/mockdata/ytr/080698-967F.json
+++ b/src/main/resources/mockdata/ytr/080698-967F.json
@@ -1,6 +1,6 @@
 {
-  "graduationSchoolOphOid": "1.2.246.562.10.14613773812",
-  "graduationSchoolYtlNumber": 1648,
+  "certificateSchoolOphOid": "1.2.246.562.10.14613773812",
+  "certificateSchoolYtlNumber": 1648,
   "ssn": "080698-967F",
   "lastname": "Ylioppilas",
   "firstnames": "Ynjevi",

--- a/src/main/resources/mockdata/ytr/080845-471D.json
+++ b/src/main/resources/mockdata/ytr/080845-471D.json
@@ -1,6 +1,6 @@
 {
   "description": "Suorittanut ylioppilastutkinnon ennen vuotta 1990",
-  "graduationSchoolOphOid": "1.2.246.562.10.62858797335",
+  "certificateSchoolOphOid": "1.2.246.562.10.62858797335",
   "ssn": "080845-471D",
   "lastname": "Eläkeläinen",
   "firstnames": "Erkki",

--- a/src/main/resources/mockdata/ytr/120872-781Y.json
+++ b/src/main/resources/mockdata/ytr/120872-781Y.json
@@ -1,6 +1,6 @@
 {
   "description": "kreikka ja vanha reaali",
-  "graduationSchoolOphOid": "1.2.246.562.10.62858797335",
+  "certificateSchoolOphOid": "1.2.246.562.10.62858797335",
   "ssn": "120872-781Y",
   "lastname": "Yrjänä",
   "firstnames": "Arvo Tatu",

--- a/src/main/resources/mockdata/ytr/140940-558L.json
+++ b/src/main/resources/mockdata/ytr/140940-558L.json
@@ -1,6 +1,6 @@
 {
   "description": "tosipitkä tutkinto",
-  "graduationSchoolOphOid": "1.2.246.562.10.62858797335",
+  "certificateSchoolOphOid": "1.2.246.562.10.62858797335",
   "ssn": "140940-558L",
   "lastname": "Vuoristo",
   "firstnames": "Hannu Matti",

--- a/src/main/resources/mockdata/ytr/210244-374K.json
+++ b/src/main/resources/mockdata/ytr/210244-374K.json
@@ -1,6 +1,6 @@
 {
-  "graduationSchoolOphOid": "1.2.246.562.10.70411521654",
-  "graduationSchoolYtlNumber": 1648,
+  "certificateSchoolOphOid": "1.2.246.562.10.70411521654",
+  "certificateSchoolYtlNumber": 1648,
   "ssn": "210244-374K",
   "lastname": "Ylioppilas",
   "firstnames": "Ynjevi",

--- a/src/main/resources/mockdata/ytr/250493-602S.json
+++ b/src/main/resources/mockdata/ytr/250493-602S.json
@@ -1,6 +1,6 @@
 {
-  "graduationSchoolOphOid" : "1.2.246.562.10.70411521654",
-  "graduationSchoolYtlNumber" : 1648,
+  "certificateSchoolOphOid" : "1.2.246.562.10.70411521654",
+  "certificateSchoolYtlNumber" : 1648,
   "ssn" : "250493-602S",
   "lastname" : "Aalto",
   "firstnames" : "Christian",

--- a/src/main/resources/mockdata/ytr/280171-2730.json
+++ b/src/main/resources/mockdata/ytr/280171-2730.json
@@ -1,6 +1,6 @@
 {
   "description": "vanha englanti yms",
-  "graduationSchoolOphOid": "1.2.246.562.10.62858797335",
+  "certificateSchoolOphOid": "1.2.246.562.10.62858797335",
   "ssn": "280171-2730",
   "lastname": "Seppänen",
   "firstnames": "Eila Kaiju",

--- a/src/main/scala/fi/oph/koski/ytr/YtrOppija.scala
+++ b/src/main/scala/fi/oph/koski/ytr/YtrOppija.scala
@@ -9,8 +9,8 @@ case class YtrOppija(
   graduationDate: Option[LocalDate], // Toteutunut valmistumispäivä
   graduationPeriod: Option[String], // Toteutunut tutkintokerta
   exams: List[YtrExam],
-  graduationSchoolOphOid: Option[String],
-  graduationSchoolYtlNumber: Option[Int],
+  certificateSchoolOphOid: Option[String],
+  certificateSchoolYtlNumber: Option[Int],
   hasCompletedMandatoryExams: Boolean,
   language: Option[String]
 )

--- a/src/main/scala/fi/oph/koski/ytr/YtrOppijaConverter.scala
+++ b/src/main/scala/fi/oph/koski/ytr/YtrOppijaConverter.scala
@@ -18,7 +18,7 @@ case class YtrOppijaConverter(oppilaitosRepository: OppilaitosRepository, koodis
       Organisaatiovahvistus(graduationDate, helsinki, ytl.toOidOrganisaatio)
     }
 
-    val oppilaitos = ytrOppija.graduationSchoolOphOid.flatMap(oid => oppilaitosRepository.findByOid(oid) match  {
+    val oppilaitos = ytrOppija.certificateSchoolOphOid.flatMap(oid => oppilaitosRepository.findByOid(oid) match  {
       case None =>
         logger.error(s"Oppilaitosta $oid ei löydy")
         None


### PR DESCRIPTION
Ylioppilastutkintorekisterin API:ssa kahden kentän nimi on muuttunut:
- `graduationSchoolOphOid` -> `certificateSchoolOphOid`
- `graduationSchoolYtlNumber` -> `certificateSchoolYtlNumber`

Muutos on toteutettu ylioppilastutkintorekisterin päässä niin, että API:n vastaus sisältää sekä uuden että vanhan nimiset kentät, joten Koski-järjestelmään tämä muutos voidaan tehdä välittömästi.