### PR TITLE
404-virheen käsittely Luvanhallinta-sivulla

### DIFF
--- a/web/app/omadata/luvanhallinta/LuvanHallinta.jsx
+++ b/web/app/omadata/luvanhallinta/LuvanHallinta.jsx
@@ -42,7 +42,13 @@ export class LuvanHallinta extends React.Component {
 
   componentDidMount() {
     const valtuutusS = Http.cachedGet('/koski/api/omadata/valtuutus', {errorHandler: () => this.onHttpGetError()})
-    const birthDayS = Http.cachedGet('/koski/api/omattiedot/editor', {errorHandler: () => this.onHttpGetError()}).map(getBirthDate)
+    const birthDayS = Http.cachedGet('/koski/api/omattiedot/editor', {errorHandler: (e) => {
+      if (e.httpStatus !== 404) {
+        this.onHttpGetError()
+      } else {
+        this.setState({error: undefined, loading: false})
+      }
+    }}).map(getBirthDate)
 
     Bacon.combineAsArray(valtuutusS, birthDayS)
       .onValue(([valtuudet, birthday]) => this.setState({valtuudet, birthday, loading: false}))

--- a/web/app/omadata/luvanhallinta/LuvanHallintaHeadline.jsx
+++ b/web/app/omadata/luvanhallinta/LuvanHallintaHeadline.jsx
@@ -10,6 +10,9 @@ export const LuvanHallintaHeadline = ({birthday}) => (
         <Text name='Tällä sivulla voit tarkastella ja hallinnoida antamiasi käyttölupia tietoihisi. Lisäksi näet...' />{'*'}
       </p>
     </div>
-    <h3 className='oppija-nimi'><span className='nimi'>{userP.map(user => user && user.name)}</span><span className='pvm'>{` s. ${birthday}`}</span></h3>
+    <h3 className='oppija-nimi'>
+      <span className='nimi'>{userP.map(user => user && user.name)}</span>
+      {birthday && <span className='pvm'>{` s. ${birthday}`}</span>}
+    </h3>
   </div>
 )

--- a/web/test/page/tietojenkayttoPage.js
+++ b/web/test/page/tietojenkayttoPage.js
@@ -23,6 +23,12 @@ function TietojenKayttoPage() {
       verifyCancel: function() {
         return click('div.modal-content > div.actions > button.vahvista')()
       }
+    },
+    getUserName: function() {
+      return extractAsText(S('.oppija-nimi > .nimi'))
+    },
+    isErrorShown: function() {
+      return isElementVisible(S("#error.error"))
     }
   }
   return api

--- a/web/test/spec/myDataSpec.js
+++ b/web/test/spec/myDataSpec.js
@@ -100,6 +100,28 @@ describe('MyData', function() {
     })
   })
 
+  describe('Kun käyttäjällä ei ole opintoja Koskessa', function() {
+    before.apply(null, login('fi', '270181-5263', 'Eikoskessa', 'Eino'))
+    before(
+      tietojenkaytto.go,
+      wait.until(tietojenkaytto.isVisible),
+      wait.until(tietojenkaytto.isPermissionsVisible)
+    )
+
+    it('Näytetään käyttäjälle nimi', function() {
+      expect(tietojenkaytto.getUserName()).equal('Eino EiKoskessa')
+    })
+    it('Ei näytetä käyttäjälle syntymäaikaa', function() {
+      expect(isElementVisible(S('.oppija-nimi > .pvm'))).to.equal(false)
+    })
+    it('Näytetään käyttölupien kohdalla oikea teksti', function() {
+      expect(extractAsText(S('.kayttolupa-list > .no-permission'))).equal('Et ole tällä hetkellä antanut millekään palveluntarjoajalle lupaa nähdä opintotietojasi Oma Opintopolusta. Luvan myöntäminen tapahtuu kyseisen palvelutarjoajan sivun kautta.')
+    })
+    it('Ei näytetä virheilmoitusta', function() {
+      expect(tietojenkaytto.isErrorShown()).to.equal(false)
+    })
+  })
+
   describe('Ruotsinkielisenä voidaan kirjautua sisään', function() {
     before.apply(null, login('sv', '100869-192W', 'Dippainssi', 'Dilbert'))
     before(wait.until(mydata.isVisible))

--- a/web/test/spec/myDataSpec.js
+++ b/web/test/spec/myDataSpec.js
@@ -4,7 +4,7 @@ describe('MyData', function() {
   var mydata = MyDataPage()
   var tietojenkaytto = TietojenKayttoPage()
 
-  function login(lang) {
+  function login(lang, hetu, sukunimi, etunimi) {
     return [
       authentication.logout,
       mydata.delAuthCookie,
@@ -13,12 +13,12 @@ describe('MyData', function() {
       },
       mydata.openPage,
       wait.until(korhopankki.isReady),
-      korhopankki.login('100869-192W', 'Dippainssi', 'Dilbert'),
+      korhopankki.login(hetu, sukunimi, etunimi),
       wait.until(mydata.isVisible)
     ]
   }
 
-  before.apply(null, login('fi'))
+  before.apply(null, login('fi', '100869-192W', 'Dippainssi', 'Dilbert'))
 
   describe('Kun käyttäjä on kirjautunut sisään', function() {
     it('Näytetään käyttäjälle nimi', function() {
@@ -60,7 +60,7 @@ describe('MyData', function() {
   })
 
   describe('Kun ollaan hyväksytty tietojen jakaminen', function() {
-    before.apply(null, login('fi'))
+    before.apply(null, login('fi', '100869-192W', 'Dippainssi', 'Dilbert'))
     before(
       tietojenkaytto.go,
       wait.until(tietojenkaytto.isVisible),
@@ -91,7 +91,7 @@ describe('MyData', function() {
   })
 
   describe('Kun klikataan peruuta-nappia', function() {
-    before.apply(null, login('fi'))
+    before.apply(null, login('fi', '100869-192W', 'Dippainssi', 'Dilbert'))
     before(mydata.clickCancel)
     before(wait.until(function() { return isElementVisible(S('.statistics-wrapper')) }))
 
@@ -100,9 +100,8 @@ describe('MyData', function() {
     })
   })
 
-
   describe('Ruotsinkielisenä voidaan kirjautua sisään', function() {
-    before.apply(null, login('sv'))
+    before.apply(null, login('sv', '100869-192W', 'Dippainssi', 'Dilbert'))
     before(wait.until(mydata.isVisible))
 
     /*
@@ -112,7 +111,7 @@ describe('MyData', function() {
   })
 
   describe('Käyttäjä voi vaihtaa kielen', function() {
-    before.apply(null, login('fi'))
+    before.apply(null, login('fi', '100869-192W', 'Dippainssi', 'Dilbert'))
     before(
       mydata.clickChangeLang,
       wait.until(mydata.isInSwedish)


### PR DESCRIPTION
Luvanhallintasivulla käsitellään nyt paremmin `koski/api/omattiedot/editor` -API:sta tuleva 404-virhe (joka tulee silloin kun käyttäjällä ei ole opintoja Koskessa). Virhebanneria ei näytetä ja syntymäaikaa ei enää näytetä (aiemmin sen kohdalla luki "undefined").