### PR TITLE
DIA-vastaavuustodistuksen tiedot

### DIFF
--- a/src/main/resources/localization/default-texts.json
+++ b/src/main/resources/localization/default-texts.json
@@ -1191,6 +1191,10 @@
   "Lukukausisuoritusten kokonaispistemäärä": "Lukukausisuoritusten kokonaispistemäärä",
   "Tutkintoaineiden kokonaispistemäärä": "Tutkintoaineiden kokonaispistemäärä",
   "Kokonaispistemäärästä johdettu keskiarvo": "Kokonaispistemäärästä johdettu keskiarvo",
-  "Koetuloksen nelinkertainen pistemäärä": "Koetuloksen nelinkertainen pistemäärä"
+  "Koetuloksen nelinkertainen pistemäärä": "Koetuloksen nelinkertainen pistemäärä",
+  "Lukio opintojen laajuus" : "Lukio-opintojen laajuus",
+  "tooltip:Valmistavan DIA-vaiheen ja DIA-tutkintovaiheen yhteenlaskettu..." : "Valmistavan DIA-vaiheen ja DIA-tutkintovaiheen yhteenlaskettu laajuus",
+  "Vastaavuustodistuksen tiedot" : "Vastaavuustodistuksen tiedot",
+  "description:Valmistavan DIA-vaiheen ja DIA-tutkintovaiheen yhteenlaskettu..." : "Valmistavan DIA-vaiheen ja DIA-tutkintovaiheen yhteenlaskettu laajuus"
 }
 

--- a/src/main/scala/fi/oph/koski/documentation/DIAExampleData.scala
+++ b/src/main/scala/fi/oph/koski/documentation/DIAExampleData.scala
@@ -25,17 +25,20 @@ object DIAExampleData {
   def diaTutkintoAineSuoritus(oppiaine: DIAOppiaine,
                               lukukaudet: Option[List[(DIAOppiaineenTutkintovaiheenOsasuoritus, String)]] = None,
                               suorituskieli: Option[String] = None,
-                              koetuloksenNelinkertainenPistemäärä: Option[Int] = None) = DIAOppiaineenTutkintovaiheenSuoritus(
-    koulutusmoduuli = oppiaine,
-    suorituskieli = suorituskieli.map(k => Koodistokoodiviite(koodiarvo = k, koodistoUri = "kieli")),
-    koetuloksenNelinkertainenPistemäärä = koetuloksenNelinkertainenPistemäärä,
-    osasuoritukset = lukukaudet.map(_.map { case (lukukausi, arvosana) =>
-      DIAOppiaineenTutkintovaiheenOsasuorituksenSuoritus(
-        koulutusmoduuli = lukukausi,
-        arviointi = diaTutkintovaiheenArviointi(arvosana)
-      )
-    })
-  )
+                              koetuloksenNelinkertainenPistemäärä: Option[Int] = None,
+                              vastaavuustodistuksenTiedot: Option[DIAVastaavuustodistuksenTiedot] = None) =
+    DIAOppiaineenTutkintovaiheenSuoritus(
+      koulutusmoduuli = oppiaine,
+      suorituskieli = suorituskieli.map(k => Koodistokoodiviite(koodiarvo = k, koodistoUri = "kieli")),
+      koetuloksenNelinkertainenPistemäärä = koetuloksenNelinkertainenPistemäärä,
+      vastaavuustodistuksenTiedot = vastaavuustodistuksenTiedot,
+      osasuoritukset = lukukaudet.map(_.map { case (lukukausi, arvosana) =>
+        DIAOppiaineenTutkintovaiheenOsasuorituksenSuoritus(
+          koulutusmoduuli = lukukausi,
+          arviointi = diaTutkintovaiheenArviointi(arvosana)
+        )
+      })
+    )
 
   def diaOppiaineMuu(aine: String, osaAlue: String, laajuus: Option[LaajuusVuosiviikkotunneissa] = None) = DIAOppiaineMuu(
     tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = aine),

--- a/src/main/scala/fi/oph/koski/documentation/ExamplesDIA.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesDIA.scala
@@ -78,7 +78,13 @@ object ExamplesDIA {
       (diaTutkintoLukukausi("5", laajuus(2)), "4"),
       (diaTutkintoLukukausi("6", laajuus(4)), "3"),
       (diaPäättökoe("kirjallinenkoe"), "5")
-    )), koetuloksenNelinkertainenPistemäärä = Some(20)),
+    )),
+      koetuloksenNelinkertainenPistemäärä = Some(20),
+      vastaavuustodistuksenTiedot = Some(DIAVastaavuustodistuksenTiedot(
+        4.0f,
+        LaajuusOpintopisteissä(2.5f)
+      ))
+    ),
     diaTutkintoAineSuoritus(diaOppiaineÄidinkieli("FI", laajuus(8)), Some(List(
       (diaTutkintoLukukausi("3", laajuus(2)), "2"),
       (diaTutkintoLukukausi("4", laajuus(2)), "3"),

--- a/src/main/scala/fi/oph/koski/schema/DIA.scala
+++ b/src/main/scala/fi/oph/koski/schema/DIA.scala
@@ -2,7 +2,7 @@ package fi.oph.koski.schema
 
 import java.time.{LocalDate, LocalDateTime}
 
-import fi.oph.koski.schema.annotation.{KoodistoKoodiarvo, KoodistoUri, OksaUri, Scale, SensitiveData}
+import fi.oph.koski.schema.annotation.{KoodistoKoodiarvo, KoodistoUri, OksaUri, Scale, SensitiveData, Tooltip}
 import fi.oph.scalaschema.annotation._
 
 @Description("Deutsche Internationale Abitur -tutkinnon opiskeluoikeus")
@@ -126,7 +126,7 @@ case class DIAOppiaineenTutkintovaiheenSuoritus(
   @Title("Oppiaine")
   koulutusmoduuli: DIAOppiaine,
   suorituskieli: Option[Koodistokoodiviite] = None,
-  keskiarvo: Option[Float] = None,
+  vastaavuustodistuksenTiedot: Option[DIAVastaavuustodistuksenTiedot] = None,
   @Title("Koetuloksen nelinkertainen pistemäärä")
   @MinValue(0)
   @MaxValue(60)
@@ -198,6 +198,13 @@ case class DIANäyttötutkinto (
   @KoodistoKoodiarvo("nayttotutkinto")
   tunniste: Koodistokoodiviite
 ) extends DIAOppiaineenTutkintovaiheenOsasuoritus with Laajuudeton
+
+case class DIAVastaavuustodistuksenTiedot(
+  keskiarvo: Float,
+  @Description("Valmistavan DIA-vaiheen ja DIA-tutkintovaiheen yhteenlaskettu laajuus")
+  @Tooltip("Valmistavan DIA-vaiheen ja DIA-tutkintovaiheen yhteenlaskettu laajuus")
+  lukioOpintojenLaajuus: LaajuusOpintopisteissäTaiKursseissa
+)
 
 trait DIAArviointi extends KoodistostaLöytyväArviointi {
   def arvosana: Koodistokoodiviite

--- a/src/main/scala/fi/oph/koski/schema/Laajuus.scala
+++ b/src/main/scala/fi/oph/koski/schema/Laajuus.scala
@@ -19,7 +19,7 @@ case class LaajuusOpintopisteissä(
   arvo: Float,
   @KoodistoKoodiarvo("2")
   yksikkö: Koodistokoodiviite = Koodistokoodiviite("2", Some(finnish("opintopistettä")), "opintojenlaajuusyksikko")
-) extends Laajuus
+) extends LaajuusOpintopisteissäTaiKursseissa
 
 case class LaajuusVuosiviikkotunneissa(
   arvo: Float,
@@ -31,7 +31,9 @@ case class LaajuusKursseissa(
   arvo: Float,
   @KoodistoKoodiarvo("4")
   yksikkö: Koodistokoodiviite = Koodistokoodiviite(koodistoUri = "opintojenlaajuusyksikko", koodiarvo = "4", nimi = Some(finnish("kurssia")))
-) extends LaajuusVuosiviikkotunneissaTaiKursseissa
+) extends LaajuusVuosiviikkotunneissaTaiKursseissa with LaajuusOpintopisteissäTaiKursseissa
+
+trait LaajuusOpintopisteissäTaiKursseissa extends Laajuus
 
 // TODO: tarvitaan aikuisten perusopetuksessa jotta voidaan siirtymäaikana käyttää useita laajuusyksiköitä, poistetaan siirtymäajan jälkeen
 trait LaajuusVuosiviikkotunneissaTaiKursseissa extends Laajuus

--- a/web/app/suoritus/RyhmiteltyOppiaineetEditor.jsx
+++ b/web/app/suoritus/RyhmiteltyOppiaineetEditor.jsx
@@ -35,7 +35,11 @@ const typeDependentCustomizations = {
     getFootnote: oppiaine => modelData(oppiaine, 'arviointi.-1.predicted') && arvosanaFootnote
   },
   diavalmistavavaihe: diaCustomizations,
-  diatutkintovaihe: R.mergeDeepWith(R.concat, diaCustomizations, {additionalEditableProperties: ['keskiarvo', 'koetuloksenNelinkertainenPistemäärä']})
+  diatutkintovaihe: R.mergeDeepWith(R.concat, diaCustomizations, {additionalEditableProperties: [
+      'keskiarvo',
+      'koetuloksenNelinkertainenPistemäärä',
+      'vastaavuustodistuksenTiedot'
+    ]})
 }
 
 export const resolvePropertiesByType = päätasonSuorituksenTyyppi => {

--- a/web/test/spec/diaSpec.js
+++ b/web/test/spec/diaSpec.js
@@ -432,7 +432,7 @@ describe('DIA', function( ) {
         expect(extractAsText(S('.osasuoritukset'))).to.equal(
           'Oppiaine Laajuus (vuosiviikkotuntia)\n' +
           'Kielet, kirjallisuus, taide\n' +
-          'Äidinkieli, saksa\nKoetuloksen nelinkertainen pistemäärä 20\n11/I\n3 11/II\n5 12/I\n4 12/II\n3 Kirjallinen koe\n5 10\n' +
+          'Äidinkieli, saksa\nVastaavuustodistuksen tiedot Keskiarvo 4\nLukio-opintojen laajuus 2,5 op\nKoetuloksen nelinkertainen pistemäärä 20\n11/I\n3 11/II\n5 12/I\n4 12/II\n3 Kirjallinen koe\n5 10\n' +
           'Äidinkieli, suomi\n11/I\n2 11/II\n3 12/I\n3 12/II\n3 8\n' +
           'A-kieli, englanti\n11/I\n2 11/II\n3 12/I\n2 6\n' +
           'B1-kieli, ruotsi\n11/I\n2 11/II\n2 12/I\n4 12/II\n3 6\n' +


### PR DESCRIPTION
Luodaan tutkintovaiheen DIA-oppiaineelle uusi rakenne "vastaavuustodistuksen tiedot", jonka alle 
- siirretään nykyinen "keskiarvo"-tieto ja
- lisätään "lukio-opintojen laajuus"
  - 2 mahdollista yksikköä (opintopiste, kurssi)
  - tälle tooltip: "valmistavan DIA-vaiheen ja DIA-tutkintovaiheen yhteenlaskettu laajuus"