### PR TITLE
Korjaa perusopetuksen vuosiluokka raportti

### DIFF
--- a/src/main/scala/fi/oph/koski/db/PostgresDriverWithJsonSupport.scala
+++ b/src/main/scala/fi/oph/koski/db/PostgresDriverWithJsonSupport.scala
@@ -11,7 +11,7 @@ trait PostgresDriverWithJsonSupport extends PostgresProfile with PgJson4sSupport
   type DOCType = JValue
   override val jsonMethods = org.json4s.jackson.JsonMethods
 
-  trait API extends super.API with JsonImplicits with SearchAssistants with SearchImplicits with ArrayImplicits with PgStringImplicits with SimpleArrayPlainImplicits {
+  trait API extends super.API with JsonImplicits with SearchAssistants with SearchImplicits with ArrayImplicits with PgStringImplicits {
     implicit val strListTypeMapper = new SimpleArrayJdbcType[String]("text").to(_.toList)
     implicit val json4sJsonArrayTypeMapper =
       new AdvancedArrayJdbcType[JValue](pgjson,
@@ -21,7 +21,7 @@ trait PostgresDriverWithJsonSupport extends PostgresProfile with PgJson4sSupport
   }
 
   override val api: API = new API {}
-  val plainAPI = new API with Json4sJsonPlainImplicits
+  val plainAPI = new API with Json4sJsonPlainImplicits with SimpleArrayPlainImplicits
 }
 
 object PostgresDriverWithJsonSupport extends PostgresDriverWithJsonSupport

--- a/src/main/scala/fi/oph/koski/documentation/PerusopetusExampleData.scala
+++ b/src/main/scala/fi/oph/koski/documentation/PerusopetusExampleData.scala
@@ -136,6 +136,15 @@ object PerusopetusExampleData {
     vahvistus = vahvistusPaikkakunnalla(date(2015, 5, 30))
   )
 
+  val kahdeksannenLuokanLuokalleJääntiSuoritus = PerusopetuksenVuosiluokanSuoritus(
+    koulutusmoduuli = PerusopetuksenLuokkaAste(8, perusopetuksenDiaarinumero), luokka = "8", alkamispäivä = Some(date(2013, 8, 15)),
+    jääLuokalle = true,
+    toimipiste = jyväskylänNormaalikoulu,
+    suorituskieli = suomenKieli,
+    osasuoritukset = kaikkiAineet.map(_.map(_.copy(arviointi = arviointi(4), yksilöllistettyOppimäärä = false)).filter(_.koulutusmoduuli.pakollinen)),
+    vahvistus = vahvistusPaikkakunnalla(date(2015, 5, 30))
+  )
+
   val seitsemännenLuokanSuoritus = PerusopetuksenVuosiluokanSuoritus(
     koulutusmoduuli = PerusopetuksenLuokkaAste(7, perusopetuksenDiaarinumero), luokka = "7C", alkamispäivä = Some(date(2013, 8, 15)),
     toimipiste = jyväskylänNormaalikoulu,
@@ -165,6 +174,15 @@ object PerusopetusExampleData {
     koulutusmoduuli = PerusopetuksenLuokkaAste(9, perusopetuksenDiaarinumero), luokka = "9C", alkamispäivä = Some(date(2015, 8, 15)),
     toimipiste = jyväskylänNormaalikoulu,
     suorituskieli = suomenKieli,
+    vahvistus = vahvistusPaikkakunnalla(date(2016, 5, 30))
+  )
+
+  val yhdeksännenLuokanLuokallejääntiSuoritus = PerusopetuksenVuosiluokanSuoritus(
+    koulutusmoduuli = PerusopetuksenLuokkaAste(9, perusopetuksenDiaarinumero), luokka = "9A", alkamispäivä = Some(date(2014, 8, 15)),
+    jääLuokalle = true,
+    toimipiste = jyväskylänNormaalikoulu,
+    suorituskieli = suomenKieli,
+    osasuoritukset = kaikkiAineet.map(_.map(_.copy(arviointi = arviointi(4), yksilöllistettyOppimäärä = false)).filter(_.koulutusmoduuli.pakollinen)),
     vahvistus = vahvistusPaikkakunnalla(date(2016, 5, 30))
   )
 

--- a/src/main/scala/fi/oph/koski/raportit/PerusopetuksenRaportitRepository.scala
+++ b/src/main/scala/fi/oph/koski/raportit/PerusopetuksenRaportitRepository.scala
@@ -109,6 +109,7 @@ case class PerusopetuksenRaportitRepository(db: DB) extends KoskiDatabaseMethods
       oo.koulutusmuoto = 'perusopetus' and
       pts.suorituksen_tyyppi = 'perusopetuksenvuosiluokka' and
       pts.koulutusmoduuli_koodiarvo = $vuosiluokka and
+      (pts.vahvistus_paiva >= $paiva or pts.vahvistus_paiva is null) and
       aikaj.alku <= $paiva and (aikaj.loppu >= $paiva or aikaj.loppu is null)
     group by oo.opiskeluoikeus_oid"""
   }

--- a/src/main/scala/fi/oph/koski/raportit/PerusopetuksenRaportitRepository.scala
+++ b/src/main/scala/fi/oph/koski/raportit/PerusopetuksenRaportitRepository.scala
@@ -89,6 +89,7 @@ case class PerusopetuksenRaportitRepository(db: DB) extends KoskiDatabaseMethods
   }
 
   private def opiskeluoikeusAikajaksotPaatasonSuorituksetResult(oppilaitos: Organisaatio.Oid, paiva: LocalDate, vuosiluokka: String) = {
+    import fi.oph.koski.db.PostgresDriverWithJsonSupport.plainAPI._
     implicit val getResult = GetResult[(OpiskeluoikeusOid, Seq[PäätasonSuoritusId], Seq[AikajaksoId])](pr => (pr.nextString(), pr.nextArray(), pr.nextArray()))
     runDbSync(opiskeluoikeusAikajaksotPaatasonSuorituksetQuery(oppilaitos, Date.valueOf(paiva), vuosiluokka).as[(OpiskeluoikeusOid, Seq[PäätasonSuoritusId], Seq[AikajaksoId])])
   }
@@ -123,6 +124,7 @@ case class PerusopetuksenRaportitRepository(db: DB) extends KoskiDatabaseMethods
   }
 
   private def luokalleJäävätOpiskeluoikeusAikajaksotPäätasonSuorituksetResult(oppilaitos: String, paiva: LocalDate, vuosiluokka: String) = {
+    import fi.oph.koski.db.PostgresDriverWithJsonSupport.plainAPI._
     implicit val getResult = GetResult[(OpiskeluoikeusOid, Seq[PäätasonSuoritusId], Seq[AikajaksoId])](pr => (pr.nextString(), pr.nextArray(), pr.nextArray()))
     runDbSync(luokalleJäävätOpiskeluoikeusAikajaksotPaatasonSuorituksetQuery(oppilaitos, Date.valueOf(paiva), vuosiluokka).as[(OpiskeluoikeusOid, Seq[PäätasonSuoritusId], Seq[AikajaksoId])])
   }
@@ -133,43 +135,73 @@ case class PerusopetuksenRaportitRepository(db: DB) extends KoskiDatabaseMethods
       oo.opiskeluoikeus_oid,
       array_agg(pts.paatason_suoritus_id),
       array_agg(aikaj.id)
-    from r_opiskeluoikeus oo
-    join r_paatason_suoritus pts
-      on pts.opiskeluoikeus_oid = oo.opiskeluoikeus_oid
-    join r_opiskeluoikeus_aikajakso aikaj
-      on aikaj.opiskeluoikeus_oid = oo.opiskeluoikeus_oid
+    from
+      r_opiskeluoikeus oo
+    join
+      r_paatason_suoritus pts
+    on
+      pts.opiskeluoikeus_oid = oo.opiskeluoikeus_oid
+    join
+      r_opiskeluoikeus_aikajakso aikaj
+    on
+      aikaj.opiskeluoikeus_oid = oo.opiskeluoikeus_oid
     where
       oo.oppilaitos_oid = $oppilaitos and
       oo.koulutusmuoto = 'perusopetus' and
       pts.suorituksen_tyyppi = 'perusopetuksenvuosiluokka' and
-      pts.koulutusmoduuli_koodiarvo = $vuosiluokka and
-      ((pts.data->>'jääLuokalle')::boolean) and
+      pts.koulutusmoduuli_koodiarvo = '9' and
+      (pts.data->>'jääLuokalle')::boolean and
+      (pts.vahvistus_paiva is null or pts.vahvistus_paiva >= $paiva) and
       aikaj.alku <= $paiva and (aikaj.loppu >= $paiva or aikaj.loppu is null)
-    group by oo.opiskeluoikeus_oid"""
+    group by
+      oo.opiskeluoikeus_oid"""
   }
 
   private def peruskoulunPäättävätOpiskeluoikeusAikajaksotPäätasonSuorituksetResult(oppilaitos: String, paiva: LocalDate, vuosiluokka: String, luokalleJaavat: Seq[String]) = {
+    import fi.oph.koski.db.PostgresDriverWithJsonSupport.plainAPI._
     implicit val getResult = GetResult[(OpiskeluoikeusOid, Seq[PäätasonSuoritusId], Seq[AikajaksoId])](pr => (pr.nextString(), pr.nextArray(), pr.nextArray()))
     runDbSync(peruskoulunPäättävätOpiskeluoikeusAikajaksotPäätasonSuorituksetQuery(oppilaitos, Date.valueOf(paiva), vuosiluokka, luokalleJaavat).as[(OpiskeluoikeusOid, Seq[PäätasonSuoritusId], Seq[AikajaksoId])])
   }
 
   private def peruskoulunPäättävätOpiskeluoikeusAikajaksotPäätasonSuorituksetQuery(oppilaitos: String, paiva: Date, vuosiluokka: String, luokalleJaavatOidit: Seq[String]) = {
+    import fi.oph.koski.db.PostgresDriverWithJsonSupport.plainAPI._
     sql"""
-     select
-      oo.opiskeluoikeus_oid,
-      array_agg(pts.paatason_suoritus_id),
-      array_agg(aikaj.id)
-    from r_opiskeluoikeus oo
-    join r_paatason_suoritus pts
-      on pts.opiskeluoikeus_oid = oo.opiskeluoikeus_oid
-    join r_opiskeluoikeus_aikajakso aikaj
-      on aikaj.opiskeluoikeus_oid = oo.opiskeluoikeus_oid
-    where
-      oo.oppilaitos_oid = $oppilaitos and
-      oo.koulutusmuoto = 'perusopetus' and
-      not (oo.opiskeluoikeus_oid = any ($luokalleJaavatOidit)) and
-      pts.suorituksen_tyyppi = 'perusopetuksenoppimaara' and
-      aikaj.alku <= $paiva and (aikaj.loppu >= $paiva or aikaj.loppu is null)
-    group by oo.opiskeluoikeus_oid"""
+      with koulun_paattavat_ysiluokkalaiset as (
+        select
+          oo.opiskeluoikeus_oid
+        from
+          r_opiskeluoikeus oo
+        inner join
+          r_paatason_suoritus pts
+        on
+          pts.opiskeluoikeus_oid = oo.opiskeluoikeus_oid
+        where
+          oo.oppilaitos_oid = $oppilaitos and
+          oo.koulutusmuoto = 'perusopetus' and
+          not (oo.opiskeluoikeus_oid = any ($luokalleJaavatOidit)) and
+          pts.suorituksen_tyyppi = 'perusopetuksenvuosiluokka' and
+          pts.koulutusmoduuli_koodiarvo = '9' and
+          (pts.vahvistus_paiva is null or pts.vahvistus_paiva >= $paiva)
+      )
+      select
+        oo.opiskeluoikeus_oid,
+        array_agg(pts.paatason_suoritus_id),
+        array_agg(aikaj.id)
+      from
+        koulun_paattavat_ysiluokkalaiset oo
+      join
+        r_opiskeluoikeus_aikajakso aikaj
+      on
+        aikaj.opiskeluoikeus_oid = oo.opiskeluoikeus_oid
+      join
+        r_paatason_suoritus pts
+      on
+        pts.opiskeluoikeus_oid = oo.opiskeluoikeus_oid
+      where
+        pts.suorituksen_tyyppi = 'perusopetuksenoppimaara' and
+        (pts.vahvistus_paiva is null or pts.vahvistus_paiva >= $paiva) and
+        aikaj.alku <= $paiva and (aikaj.loppu >= $paiva or aikaj.loppu is null)
+      group by
+        oo.opiskeluoikeus_oid"""
   }
 }

--- a/src/test/scala/fi/oph/koski/raportit/PerusopetuksenVuosiluokkaSpec.scala
+++ b/src/test/scala/fi/oph/koski/raportit/PerusopetuksenVuosiluokkaSpec.scala
@@ -5,7 +5,8 @@ import java.time.LocalDate.{of => date}
 
 import fi.oph.koski.KoskiApplicationForTests
 import fi.oph.koski.api.OpiskeluoikeusTestMethodsPerusopetus
-import fi.oph.koski.documentation.PerusopetusExampleData
+import fi.oph.koski.documentation.ExampleData._
+import fi.oph.koski.documentation.PerusopetusExampleData._
 import fi.oph.koski.henkilo.{MockOppijat, OppijaHenkilö}
 import fi.oph.koski.organisaatio.MockOrganisaatiot
 import fi.oph.koski.raportointikanta.RaportointikantaTestMethods
@@ -40,7 +41,7 @@ class PerusopetuksenVuosiluokkaSpec extends FreeSpec with Matchers with Raportoi
 
     "Monta saman vuosiluokan suoritusta eritellään omiksi riveiksi" in {
       resetFixtures
-      withAdditionalVuosiluokkaSuoritus(MockOppijat.ysiluokkalainen, kahdeksannenLuokanLuokallejääntiSuoritus) {
+      withAdditionalSuoritukset(MockOppijat.ysiluokkalainen, List(kahdeksannenLuokanLuokalleJääntiSuoritus.copy(luokka = "8C"))) {
         val result = PerusopetuksenVuosiluokka.buildRaportti(repository, MockOrganisaatiot.jyväskylänNormaalikoulu, LocalDate.of(2014, 1, 1), vuosiluokka = "8")
         val ynjevinOpiskeluoikeusOid = lastOpiskeluoikeus(MockOppijat.ysiluokkalainen.oid).oid.get
         val rivit = result.filter(_.opiskeluoikeusOid == ynjevinOpiskeluoikeusOid)
@@ -67,20 +68,47 @@ class PerusopetuksenVuosiluokkaSpec extends FreeSpec with Matchers with Raportoi
       "Hakee tiedot peruskoulun oppimäärän suorituksesta" in {
         val result = PerusopetuksenVuosiluokka.buildRaportti(repository, MockOrganisaatiot.jyväskylänNormaalikoulu, LocalDate.of(2016, 1, 1), "10")
         val kaisanOpiskeluoikeusOid = getOpiskeluoikeudet(MockOppijat.koululainen.oid).find(_.tyyppi.koodiarvo == "perusopetus").get.oid.get
-        val kaisanRivi = result.find(_.opiskeluoikeusOid == kaisanOpiskeluoikeusOid)
-        kaisanRivi shouldBe defined
+        val rivit = result.filter(_.opiskeluoikeusOid == kaisanOpiskeluoikeusOid)
+        rivit.length should equal(1)
+        val kaisanRivi = rivit.head
 
-        kaisanRivi.get should equal(kaisanPäättötodistusRow.copy(opiskeluoikeusOid = kaisanOpiskeluoikeusOid))
+        kaisanRivi should equal(kaisanPäättötodistusRow.copy(opiskeluoikeusOid = kaisanOpiskeluoikeusOid))
       }
 
       "Jos oppilas on jäämässä luokalle käytetään yhdeksännen luokan vuosiluokka suoritusta" in {
-        withAdditionalVuosiluokkaSuoritus(MockOppijat.koululainen, yhdeksännenLuokanLuokallejääntiSuoritus) {
-          val result = PerusopetuksenVuosiluokka.buildRaportti(repository, MockOrganisaatiot.jyväskylänNormaalikoulu, LocalDate.of(2016, 1, 1), "10")
-          val kaisanOpiskeluoikeusOid = getOpiskeluoikeudet(MockOppijat.koululainen.oid).find(_.tyyppi.koodiarvo == "perusopetus").get.oid.get
-          val kaisanRivi = result.find(_.opiskeluoikeusOid == kaisanOpiskeluoikeusOid)
-          kaisanRivi shouldBe defined
+        withAdditionalSuoritukset(MockOppijat.vuosiluokkalainen, List(perusopetuksenOppimääränSuoritus, yhdeksännenLuokanLuokallejääntiSuoritus, kahdeksannenLuokanSuoritus)) {
+          val result = PerusopetuksenVuosiluokka.buildRaportti(repository, MockOrganisaatiot.jyväskylänNormaalikoulu, date(2016, 1, 1), "10")
+          val opiskeluoikeusOid = getOpiskeluoikeudet(MockOppijat.vuosiluokkalainen.oid).find(_.tyyppi.koodiarvo == "perusopetus").get.oid.get
+          val rows = result.filter(_.opiskeluoikeusOid == opiskeluoikeusOid)
+          rows.length should equal(1)
+          rows.head should equal(yhdeksännenLuokanLuokalleJääntiRow.copy(opiskeluoikeusOid = opiskeluoikeusOid))
+        }
+      }
 
-          kaisanRivi.get should equal(kaisanYhdeksännenLuokanLuokalleJääntiRow.copy(opiskeluoikeusOid = kaisanOpiskeluoikeusOid))
+      "Jos oppilas on jäämässä luokalle käytetään yhdeksännen luokan vuosiluokka suoritusta (ei vahvistusta luokalle jäänti suorituksella)" in {
+        withAdditionalSuoritukset(MockOppijat.vuosiluokkalainen, List(perusopetuksenOppimääränSuoritus.copy(vahvistus = None), yhdeksännenLuokanLuokallejääntiSuoritus.copy(vahvistus = None), kahdeksannenLuokanSuoritus)) {
+          val result = PerusopetuksenVuosiluokka.buildRaportti(repository, MockOrganisaatiot.jyväskylänNormaalikoulu, date(2016, 1, 1), "10")
+          val opiskeluoikeusOid = getOpiskeluoikeudet(MockOppijat.vuosiluokkalainen.oid).find(_.tyyppi.koodiarvo == "perusopetus").get.oid.get
+          val rows = result.filter(_.opiskeluoikeusOid == opiskeluoikeusOid)
+          rows.length should equal(1)
+          rows.head should equal(yhdeksännenLuokanLuokalleJääntiRow.copy(opiskeluoikeusOid = opiskeluoikeusOid, suorituksenTila = "kesken", suorituksenVahvistuspaiva = "", voimassaolevatVuosiluokat = "9"))
+        }
+      }
+
+      "Jos oppilas on jäänyt aikaisemmin luokalle mutta nyt suorittanut perusopetuksen oppimäärän" in {
+        withAdditionalSuoritukset(MockOppijat.vuosiluokkalainen, List(perusopetuksenOppimääränSuoritus.copy(vahvistus = None), yhdeksännenLuokanSuoritus, yhdeksännenLuokanLuokallejääntiSuoritus.copy(vahvistus = vahvistusPaikkakunnalla(date(2015, 1, 1))), kahdeksannenLuokanSuoritus)) {
+          val result = PerusopetuksenVuosiluokka.buildRaportti(repository, MockOrganisaatiot.jyväskylänNormaalikoulu, date(2016, 1, 1), "10")
+          val opiskeluoikeusOid = getOpiskeluoikeudet(MockOppijat.vuosiluokkalainen.oid).find(_.tyyppi.koodiarvo == "perusopetus").get.oid.get
+          val rows = result.filter(_.opiskeluoikeusOid == opiskeluoikeusOid)
+          rows.length should equal(1)
+          rows.head should equal(kaisanPäättötodistusRow.copy(opiskeluoikeusOid = opiskeluoikeusOid, oppijaOid = MockOppijat.vuosiluokkalainen.oid, hetu = MockOppijat.vuosiluokkalainen.hetu, sukunimi = Some(MockOppijat.vuosiluokkalainen.sukunimi), etunimet = Some(MockOppijat.vuosiluokkalainen.etunimet), suorituksenTila = "kesken", suorituksenVahvistuspaiva = ""))
+        }
+      }
+
+      "Ei tulosta tulosta päättötodistusta oppijoilla joilla ei ole yhdeksännen luokan opintoja" in {
+        withAdditionalSuoritukset(MockOppijat.vuosiluokkalainen, List(perusopetuksenOppimääränSuoritus)) {
+          val result = PerusopetuksenVuosiluokka.buildRaportti(repository, MockOrganisaatiot.jyväskylänNormaalikoulu, date(2016, 6, 1), "10")
+          result.map(_.oppijaOid) shouldNot contain(MockOppijat.vuosiluokkalainen.oid)
         }
       }
     }
@@ -172,10 +200,8 @@ class PerusopetuksenVuosiluokkaSpec extends FreeSpec with Matchers with Raportoi
 
   val kahdeksannenLuokanLuokalleJääntiRow = defaultYnjeviExpectedKasiLuokkaRow.copy(
     jaaLuokalle = true,
-    luokka = "8B",
     viimeisinTila = "lasna",
     suorituksenTila = "valmis",
-    suorituksenVahvistuspaiva = "2014-05-30",
     voimassaolevatVuosiluokat = "9",
     aidinkieli = "4",
     pakollisenAidinkielenOppimaara = "Suomen kieli ja kirjallisuus",
@@ -209,15 +235,16 @@ class PerusopetuksenVuosiluokkaSpec extends FreeSpec with Matchers with Raportoi
     valinnaisetEiLaajuutta = ""
   )
 
-  val kaisanYhdeksännenLuokanLuokalleJääntiRow = kahdeksannenLuokanLuokalleJääntiRow.copy(
-    oppijaOid = MockOppijat.koululainen.oid,
-    hetu = MockOppijat.koululainen.hetu,
-    sukunimi = Some(MockOppijat.koululainen.sukunimi),
-    etunimet = Some(MockOppijat.koululainen.etunimet),
+  val yhdeksännenLuokanLuokalleJääntiRow = kahdeksannenLuokanLuokalleJääntiRow.copy(
+    oppijaOid = MockOppijat.vuosiluokkalainen.oid,
+    hetu = MockOppijat.vuosiluokkalainen.hetu,
+    sukunimi = Some(MockOppijat.vuosiluokkalainen.sukunimi),
+    etunimet = Some(MockOppijat.vuosiluokkalainen.etunimet),
     luokka = "9A",
     viimeisinTila = "lasna",
     suorituksenTila = "valmis",
-    voimassaolevatVuosiluokat = ""
+    voimassaolevatVuosiluokat = "",
+    suorituksenVahvistuspaiva = "2016-05-30"
   )
 
   val kaisanPäättötodistusRow = defaultYnjeviExpectedKasiLuokkaRow.copy(
@@ -234,9 +261,10 @@ class PerusopetuksenVuosiluokkaSpec extends FreeSpec with Matchers with Raportoi
     kayttaymisenArvio = ""
   )
 
-  private def withAdditionalVuosiluokkaSuoritus(oppija: OppijaHenkilö, vuosiluokanSuoritus: PerusopetuksenVuosiluokanSuoritus)(f: => Any) = {
+  private def withAdditionalSuoritukset(oppija: OppijaHenkilö, vuosiluokanSuoritus: List[PerusopetuksenPäätasonSuoritus])(f: => Any) = {
+    resetFixtures
     val oo = getOpiskeluoikeudet(oppija.oid).collect { case oo: PerusopetuksenOpiskeluoikeus => oo }.head
-    val lisatyllaVuosiluokanSuorituksella = oo.copy(suoritukset = (vuosiluokanSuoritus :: oo.suoritukset))
+    val lisatyllaVuosiluokanSuorituksella = oo.copy(suoritukset = (vuosiluokanSuoritus ::: oo.suoritukset), tila = NuortenPerusopetuksenOpiskeluoikeudenTila(List(NuortenPerusopetuksenOpiskeluoikeusjakso(date(2001, 1, 1), opiskeluoikeusLäsnä))))
     putOppija(Oppija(oppija, List(lisatyllaVuosiluokanSuorituksella))) {
       loadRaportointikantaFixtures
       f
@@ -256,16 +284,6 @@ class PerusopetuksenVuosiluokkaSpec extends FreeSpec with Matchers with Raportoi
   private def makeQueryString(oppilaitosOid: String, paiva: LocalDate, vuosiluokka: String) = {
     s"oppilaitosOid=$oppilaitosOid&paiva=${paiva.toString}&vuosiluokka=$vuosiluokka"
   }
-
-  private val kahdeksannenLuokanLuokallejääntiSuoritus = PerusopetusExampleData.seitsemännenLuokanLuokallejääntiSuoritus.copy(
-    koulutusmoduuli = PerusopetuksenLuokkaAste(8, PerusopetusExampleData.perusopetuksenDiaarinumero),
-    luokka = "8B"
-  )
-
-  private val yhdeksännenLuokanLuokallejääntiSuoritus = PerusopetusExampleData.seitsemännenLuokanLuokallejääntiSuoritus.copy(
-    koulutusmoduuli = PerusopetuksenLuokkaAste(9, PerusopetusExampleData.perusopetuksenDiaarinumero),
-    luokka = "9A"
-  )
 
   private val mennytAikajakso = Aikajakso(date(2000, 1, 1), Some(date(2001, 1, 1)))
   private val voimassaolevaAikajakso = Aikajakso(date(2008, 1, 1), None)

--- a/src/test/scala/fi/oph/koski/raportit/PerusopetuksenVuosiluokkaSpec.scala
+++ b/src/test/scala/fi/oph/koski/raportit/PerusopetuksenVuosiluokkaSpec.scala
@@ -51,6 +51,17 @@ class PerusopetuksenVuosiluokkaSpec extends FreeSpec with Matchers with Raportoi
       }
     }
 
+    "Raportille ei päädy vuosiluokkien suorituksia joiden vahvistuspäivä on menneisyydessä" in {
+      val hakuDate = date(2015, 5, 30)
+      val rows = PerusopetuksenVuosiluokka.buildRaportti(repository, MockOrganisaatiot.jyväskylänNormaalikoulu, hakuDate, "7")
+      rows.map(_.suorituksenVahvistuspaiva).foreach(paivaStr => {
+        if (!paivaStr.isEmpty) {
+          val paiva = LocalDate.parse(paivaStr)
+          paiva.isBefore(hakuDate) shouldBe (false)
+        }
+      })
+    }
+
     "Peruskoulun päättävät" - {
 
       "Hakee tiedot peruskoulun oppimäärän suorituksesta" in {


### PR DESCRIPTION
Raportille tulostui kaikki oppilaitoksessa aktiivisena olevien oppijoiden vuosiluokka suoritus haetulta vuodelta => Nyt tulostetaan vain ne vuosiluokka suoritukset joiden vahvistuspäivä on sama tai tulevaisuudessa suhteessa parametrina annettuun päivään

Raportille tulostui tyhjiä oppimäärän suorituksia => Nyt tulostetaan vain niiden oppijoiden oppimäärän suoritukset joilla on viimeisin ysiluokan suoritus sellainen jota ei ole merkitty luokalle jääväksi