### PR TITLE
 Ammatillisen suoritustietoraportin korjaus

### DIFF
--- a/src/main/scala/fi/oph/koski/raportit/AmmatillinenOsittainenRaportti.scala
+++ b/src/main/scala/fi/oph/koski/raportit/AmmatillinenOsittainenRaportti.scala
@@ -64,7 +64,9 @@ object AmmatillinenOsittainenRaportti extends AikajaksoRaportti with Ammatilline
       suoritettujenYhteistenTutkinnonOsienYhteislaajuus = yhteislaajuus(yhteistenTutkinnonOsienSuoritukset),
       suoritettujenYhteistenTutkinnonOsienOsaalueidenYhteislaajuus = yhteislaajuus(yhteistenTutkinnonOsienOsaSuoritukset),
       pakollistenYhteistenTutkinnonOsienOsaalueidenYhteislaajuus = yhteislaajuus(pakolliset(yhteistenTutkinnonOsienOsaSuoritukset)),
-      valinnaistenYhteistenTutkinnonOsienOsaalueidenYhteisLaajuus = yhteislaajuus(valinnaiset(yhteistenTutkinnonOsienOsaSuoritukset))
+      valinnaistenYhteistenTutkinnonOsienOsaalueidenYhteisLaajuus = yhteislaajuus(valinnaiset(yhteistenTutkinnonOsienOsaSuoritukset)),
+      valmiitVapaaValintaisetTutkinnonOsatLkm = 1,
+      valmiitTutkintoaYksilöllisestiLaajentavatTutkinnonOsatLkm = 1
     )
   }
 
@@ -147,7 +149,9 @@ object AmmatillinenOsittainenRaportti extends AikajaksoRaportti with Ammatilline
     "suoritettujenYhteistenTutkinnonOsienYhteislaajuus" -> CompactColumn("KOSKI-palveluun siirrettyjen yhteisten tutkinnon osien (valmis- tai kesken-tilaiset) yhteislaajuus"),
     "suoritettujenYhteistenTutkinnonOsienOsaalueidenYhteislaajuus" -> CompactColumn("Suoritettujen yhteisten tutkinnon osien osa-alueiden yhteislaajuus"),
     "pakollistenYhteistenTutkinnonOsienOsaalueidenYhteislaajuus" -> CompactColumn("Pakollisten yhteisten tutkinnon osien osa-alueiden yhteislaajuus"),
-    "valinnaistenYhteistenTutkinnonOsienOsaalueidenYhteisLaajuus" -> CompactColumn("Valinnaisten yhteisten tutkinnon osien osa-aluiden yhteislaajuus")
+    "valinnaistenYhteistenTutkinnonOsienOsaalueidenYhteisLaajuus" -> CompactColumn("Valinnaisten yhteisten tutkinnon osien osa-aluiden yhteislaajuus"),
+    "valmiitVapaaValintaisetTutkinnonOsatLkm" -> CompactColumn("Valmiiden vapaavalintaisten tutkinnon osien lukumäärä"),
+    "valmiitTutkintoaYksilöllisestiLaajentavatTutkinnonOsatLkm" -> CompactColumn("Valmiiden tutkintoa yksilöllisesti laajentavien tutkinnon osien lukumäärä")
   )
 }
 
@@ -188,5 +192,7 @@ case class AmmatillinenOsittainRaporttiRow(
   suoritettujenYhteistenTutkinnonOsienYhteislaajuus: Double,
   suoritettujenYhteistenTutkinnonOsienOsaalueidenYhteislaajuus: Double,
   pakollistenYhteistenTutkinnonOsienOsaalueidenYhteislaajuus: Double,
-  valinnaistenYhteistenTutkinnonOsienOsaalueidenYhteisLaajuus: Double
+  valinnaistenYhteistenTutkinnonOsienOsaalueidenYhteisLaajuus: Double,
+  valmiitVapaaValintaisetTutkinnonOsatLkm: Int,
+  valmiitTutkintoaYksilöllisestiLaajentavatTutkinnonOsatLkm: Int
 )

--- a/src/main/scala/fi/oph/koski/raportit/AmmatillinenRaporttiUtils.scala
+++ b/src/main/scala/fi/oph/koski/raportit/AmmatillinenRaporttiUtils.scala
@@ -96,9 +96,9 @@ trait AmmatillinenRaporttiUtils {
   val tutkinnonosatvalinnanmahdollisuusKoodiarvot = Seq("1,", "2")
 
   val isAmmatillisenTutkinnonOsa: ROsasuoritusRow => Boolean = osasuoritus => {
-    !tutkinnonosatvalinnanmahdollisuusKoodiarvot.contains(osasuoritus.koulutusmoduuliKoodiarvo) &&
-      osasuoritus.koulutusmoduuliKoodisto.exists(_ == "tutkinnonosat") &&
-      osasuoritus.suorituksenTyyppi == "ammatillisentutkinnonosa" &&
-      !isYhteinenTutkinnonOsa(osasuoritus)
+    osasuoritus.suorituksenTyyppi == "ammatillisentutkinnonosa" &&
+      !tutkinnonosatvalinnanmahdollisuusKoodiarvot.contains(osasuoritus.koulutusmoduuliKoodiarvo) &&
+      !isYhteinenTutkinnonOsa(osasuoritus) &&
+      !tutkinnonOsanRyhmä(osasuoritus, "3", "4")
   }
 }

--- a/src/main/scala/fi/oph/koski/raportit/AmmatillinenTutkintoRaportti.scala
+++ b/src/main/scala/fi/oph/koski/raportit/AmmatillinenTutkintoRaportti.scala
@@ -82,7 +82,6 @@ object AmmatillinenTutkintoRaportti extends AikajaksoRaportti with AmmatillinenR
     isAmmatillisenLukioOpintoja,
     isAmmatillisenKorkeakouluOpintoja,
     isAmmatillinenMuitaOpintoValmiuksiaTukeviaOpintoja,
-    isAmmatillinenTutkinnonOsaaPienempiKokonaisuus,
     isAmmatillisenTutkinnonOsanOsaalue
   )
 
@@ -92,7 +91,6 @@ object AmmatillinenTutkintoRaportti extends AikajaksoRaportti with AmmatillinenR
         isAmmatillisenLukioOpintoja,
         isAmmatillisenKorkeakouluOpintoja,
         isAmmatillinenMuitaOpintoValmiuksiaTukeviaOpintoja,
-        isAmmatillinenTutkinnonOsaaPienempiKokonaisuus,
         isAmmatillisenTutkinnonOsa,
         isAmmatillisenYhteisenTutkinnonOsienOsaalue(_, osasuoritukset)
       ))

--- a/src/test/scala/fi/oph/koski/raportit/AmmatillinenOsittainenRaporttiSpec.scala
+++ b/src/test/scala/fi/oph/koski/raportit/AmmatillinenOsittainenRaporttiSpec.scala
@@ -70,7 +70,9 @@ class AmmatillinenOsittainenRaporttiSpec extends FreeSpec with Matchers with Rap
     suoritettujenYhteistenTutkinnonOsienYhteislaajuus = 9.0,
     suoritettujenYhteistenTutkinnonOsienOsaalueidenYhteislaajuus = 22.0,
     pakollistenYhteistenTutkinnonOsienOsaalueidenYhteislaajuus = 19.0,
-    valinnaistenYhteistenTutkinnonOsienOsaalueidenYhteisLaajuus = 3.0
+    valinnaistenYhteistenTutkinnonOsienOsaalueidenYhteisLaajuus = 3.0,
+    valmiitVapaaValintaisetTutkinnonOsatLkm = 1,
+    valmiitTutkintoaYksilöllisestiLaajentavatTutkinnonOsatLkm = 1
   )
 
   def makeRaporttiFilterRowsByHetu(hetu: Option[String], oppilaitosOid: String = MockOrganisaatiot.stadinAmmattiopisto, alku: LocalDate = date(2016, 1, 1), loppu: LocalDate = date(2016, 12, 12)) = {

--- a/src/test/scala/fi/oph/koski/raportit/AmmatillinenTutkintoRaporttiSpec.scala
+++ b/src/test/scala/fi/oph/koski/raportit/AmmatillinenTutkintoRaporttiSpec.scala
@@ -29,17 +29,17 @@ class AmmatillinenTutkintoRaporttiSpec extends FreeSpec with Matchers with Rapor
 
     "Laskenta" - {
       "Suorituksia yhteesä" in {
-        rivi.suoritettujenOpintojenYhteislaajuus should equal(157.0)
+        rivi.suoritettujenOpintojenYhteislaajuus should equal(180.0)
       }
       "Ammatilliset tutkinnon osat" - {
         "Valmiiden ammatillisten tutkinnon osien lukumäärä" in {
-          rivi.valmiitAmmatillisetTutkinnonOsatLkm should equal(7)
+          rivi.valmiitAmmatillisetTutkinnonOsatLkm should equal(6)
         }
         "Pakolliset ammatilliset tutkinnon osat" in {
           rivi.pakollisetAmmatillisetTutkinnonOsatLkm should equal(6)
         }
         "Valinnaiset ammatilliset tutkinnon osat" in {
-          rivi.valinnaisetAmmatillisetTutkinnonOsatLkm should equal(1)
+          rivi.valinnaisetAmmatillisetTutkinnonOsatLkm should equal(0)
         }
         "Näyttöjä ammatillisissa valmiissa tutkinnon osissa" in {
           rivi.näyttöjäAmmatillisessaValmiistaTutkinnonOsistaLkm should equal(3)
@@ -95,6 +95,12 @@ class AmmatillinenTutkintoRaporttiSpec extends FreeSpec with Matchers with Rapor
           rivi.valinnaistenYhteistenTutkinnonOsienOsaalueidenYhteisLaajuus should equal(3)
         }
       }
+      "Valmiit vapaavalintaiset tutkinnon osat lukumäärä" in {
+        rivi.valmiitVapaaValintaisetTutkinnonOsatLkm should equal(1)
+      }
+      "Valmiit tutkintoa yksilöllisesti laajentavat tutkinnon osat lukumäärä" in {
+        rivi.valmiitTutkintoaYksilöllisestiLaajentavatTutkinnonOsatLkm should equal(1)
+      }
     }
     "Sisällytetyt opiskeluoikeudet"  - {
       "Opiskeluoikeuteen sisältyvät opiskeluioikeudet toistesta oppilaitoksesta" in {
@@ -103,7 +109,7 @@ class AmmatillinenTutkintoRaporttiSpec extends FreeSpec with Matchers with Rapor
           aarnenRivit.length should equal(2)
           val stadinLinkitettyOpiskeluoikeus = aarnenRivit.find(_.linkitetynOpiskeluoikeudenOppilaitos == stadinAmmattiOpistonNimi)
           stadinLinkitettyOpiskeluoikeus shouldBe defined
-          stadinLinkitettyOpiskeluoikeus.get.suoritettujenOpintojenYhteislaajuus should equal(157.0)
+          stadinLinkitettyOpiskeluoikeus.get.suoritettujenOpintojenYhteislaajuus should equal(180.0)
         }
       }
       "Sisältävä opiskeluoikeus ei tule sisällytetyn opiskeluoikeuden oppilaitoksen raportille" in {


### PR DESCRIPTION
Vapaasti valittavat tutkinnon osat ja tutkintoa yksilöllisesti laajentavat tutkinnon osat lasketaan mukaan tutkinnon yhteislaajuuteen.

Valmiiden vapaasti tutkinnon osien ja tutkintoa yksilöllisesti laajentavien tutkinnon osien lukumäärä omiin kolumneihin excelissä.

"ammatillisentutkinnonosaapienempikokonaisuus" tyyppisiä osasuorituksia ei lasketa mihinkään