### PR TITLE
Mahdollista excel-kommenttinen lisäys Columniin

### DIFF
--- a/src/main/scala/fi/oph/koski/raportit/Excel.scala
+++ b/src/main/scala/fi/oph/koski/raportit/Excel.scala
@@ -1,10 +1,10 @@
 package fi.oph.koski.raportit
 
 
-case class Column(title: String, width: Option[Int] = None)
+case class Column(title: String, width: Option[Int] = None, comment: Option[String] = None)
 
 object CompactColumn {
-  def apply(title: String): Column = Column(title, width = Some(2000))
+  def apply(title: String, comment: Option[String] = None): Column = Column(title, width = Some(2000), comment = comment)
 }
 
 sealed trait Sheet {

--- a/src/main/scala/fi/oph/koski/raportit/ExcelWriter.scala
+++ b/src/main/scala/fi/oph/koski/raportit/ExcelWriter.scala
@@ -18,7 +18,6 @@ import scala.collection.JavaConverters._
 object ExcelWriter {
 
   private lazy val HEADING_ROW = 0
-  private lazy val ONE_COMMENT_CHARACTER_WIDTH = 270 //ad hoc approximation
 
   def writeExcel(workbookSettings: WorkbookSettings, sheets: Seq[Sheet], out: OutputStream): Unit = {
 
@@ -197,35 +196,13 @@ object ExcelWriter {
 
   private def createAnchor(creationHelper: CreationHelper, sh: SXSSFSheet, cell: Cell, commentText: String) = {
     //Size of an Comment is reserved by allocating cells and rows
-    val leftColumnIndex = cell.getColumnIndex
-    val (rightColumnIndex, rowIndex) = calculateCommentSize(sh, leftColumnIndex, commentText)
-
+    val columnIndex = cell.getColumnIndex
     val anchor = creationHelper.createClientAnchor
     anchor.setRow1(HEADING_ROW)
-    anchor.setRow2(rowIndex)
-    anchor.setCol1(leftColumnIndex)
-    anchor.setCol2(rightColumnIndex)
+    anchor.setRow2(HEADING_ROW + 5)
+    anchor.setCol1(columnIndex)
+    anchor.setCol2(columnIndex + 10)
     anchor
-  }
-
-  private def calculateCommentSize(sh: SXSSFSheet, startIndex: Int, commentText: String) = {
-    val commentMaxWidth = 20000
-
-    val textWidth = commentText.length * ONE_COMMENT_CHARACTER_WIDTH
-
-    val requiredWidth = Math.min(commentMaxWidth, textWidth)
-
-    val requiredHeight = textWidth.toDouble / commentMaxWidth
-    val rowIndex = if (requiredHeight < 2) 2 else requiredHeight.floor.toInt
-
-    var currentWidth = 0
-    var columnIndex = startIndex
-    while (columnIndex < startIndex + 10 && currentWidth < requiredWidth) {
-      currentWidth += sh.getColumnWidth(columnIndex)
-      columnIndex += 1
-    }
-
-    (columnIndex, rowIndex)
   }
 
   private def writeDocumentationSheet(wb: SXSSFWorkbook, sh: SXSSFSheet, documentationSheet: DocumentationSheet): Unit = {

--- a/src/main/scala/fi/oph/koski/raportit/ExcelWriter.scala
+++ b/src/main/scala/fi/oph/koski/raportit/ExcelWriter.scala
@@ -10,10 +10,15 @@ import org.apache.poi.poifs.crypt.temp.{EncryptedTempData, SXSSFWorkbookWithCust
 import org.apache.poi.poifs.filesystem.POIFSFileSystem
 import org.apache.poi.ss.usermodel._
 import org.apache.poi.ss.util.CellRangeAddress
-import org.apache.poi.xssf.streaming.{SXSSFCell, SXSSFSheet, SXSSFWorkbook}
+import org.apache.poi.xssf.streaming.{SXSSFCell, SXSSFDrawing, SXSSFSheet, SXSSFWorkbook}
 import org.apache.poi.xssf.usermodel.XSSFSheet
 
+import scala.collection.JavaConverters._
+
 object ExcelWriter {
+
+  private lazy val HEADING_ROW = 0
+  private lazy val ONE_COMMENT_CHARACTER_WIDTH = 270 //ad hoc approximation
 
   def writeExcel(workbookSettings: WorkbookSettings, sheets: Seq[Sheet], out: OutputStream): Unit = {
 
@@ -84,6 +89,17 @@ object ExcelWriter {
         sh.autoSizeColumn(col)
       }
     }
+
+    val creationHelper = wb.getCreationHelper
+    val drawing = sh.createDrawingPatriarch
+    val cellsAndColumnsWithIndex = sh.getRow(HEADING_ROW).cellIterator.asScala.toSeq.zip(dataSheet.columnSettingsWithIndex)
+    for ((cell, (column, _)) <- cellsAndColumnsWithIndex) {
+      if (column.comment.isDefined) {
+        val anchor = createAnchor(creationHelper, sh, cell, column.comment.get)
+        val comment = createComment(drawing, anchor, creationHelper, column.comment.get)
+        cell.setCellComment(comment)
+      }
+    }
   }
 
   private def addIgnoredErrors(sh: SXSSFSheet) = {
@@ -95,7 +111,7 @@ object ExcelWriter {
   }
 
   private def createHeadingRow(sh: SXSSFSheet) = {
-    val headingRow = sh.createRow(0)
+    val headingRow = sh.createRow(HEADING_ROW)
     headingRow.setHeightInPoints(25)
     headingRow
   }
@@ -171,6 +187,45 @@ object ExcelWriter {
       // use the default style
     }
     cell.setCellValue(f)
+  }
+
+  private def createComment(drawing: SXSSFDrawing, anchor: ClientAnchor, creationHelper: CreationHelper, commentText: String) = {
+    val comment = drawing.createCellComment(anchor)
+    comment.setString(creationHelper.createRichTextString(commentText))
+    comment
+  }
+
+  private def createAnchor(creationHelper: CreationHelper, sh: SXSSFSheet, cell: Cell, commentText: String) = {
+    //Size of an Comment is reserved by allocating cells and rows
+    val leftColumnIndex = cell.getColumnIndex
+    val (rightColumnIndex, rowIndex) = calculateCommentSize(sh, leftColumnIndex, commentText)
+
+    val anchor = creationHelper.createClientAnchor
+    anchor.setRow1(HEADING_ROW)
+    anchor.setRow2(rowIndex)
+    anchor.setCol1(leftColumnIndex)
+    anchor.setCol2(rightColumnIndex)
+    anchor
+  }
+
+  private def calculateCommentSize(sh: SXSSFSheet, startIndex: Int, commentText: String) = {
+    val commentMaxWidth = 20000
+
+    val textWidth = commentText.length * ONE_COMMENT_CHARACTER_WIDTH
+
+    val requiredWidth = Math.min(commentMaxWidth, textWidth)
+
+    val requiredHeight = textWidth.toDouble / commentMaxWidth
+    val rowIndex = if (requiredHeight < 2) 2 else requiredHeight.floor.toInt
+
+    var currentWidth = 0
+    var columnIndex = startIndex
+    while (columnIndex < startIndex + 10 && currentWidth < requiredWidth) {
+      currentWidth += sh.getColumnWidth(columnIndex)
+      columnIndex += 1
+    }
+
+    (columnIndex, rowIndex)
   }
 
   private def writeDocumentationSheet(wb: SXSSFWorkbook, sh: SXSSFSheet, documentationSheet: DocumentationSheet): Unit = {

--- a/src/test/scala/fi/oph/koski/raportit/ExcelWriterSpec.scala
+++ b/src/test/scala/fi/oph/koski/raportit/ExcelWriterSpec.scala
@@ -11,6 +11,8 @@ import java.time.LocalDate.{of => date}
 
 import org.apache.poi.EncryptedDocumentException
 
+import scala.collection.JavaConverters._
+
 
 class ExcelWriterSpec extends FreeSpec with Matchers {
 
@@ -62,6 +64,14 @@ class ExcelWriterSpec extends FreeSpec with Matchers {
 
             headingRow.getCell(9).getCellTypeEnum should equal(CellType.STRING)
             headingRow.getCell(9).getStringCellValue should equal("OptionBoolean")
+          }
+          "Luo otsikko riville kommentit" in {
+            val headingRow = wb.getSheet("data_sheet_title").iterator.next
+            headingRow.getCell(0).getCellComment.getString.getString should equal("kommentti")
+          }
+          "Ei luo kommenttia jos sitä ei ole määritelty" in {
+            val headingRow = wb.getSheet("data_sheet_title").iterator.next
+            headingRow.iterator.asScala.drop(1).foreach(_.getCellComment should equal(null))
           }
           "Data solujen formatointi" - {
             val dataSheetIterator = wb.getSheet("data_sheet_title").iterator
@@ -284,7 +294,7 @@ class ExcelWriterSpec extends FreeSpec with Matchers {
   lazy val expectedExcelTitle = "expected_excel_title"
   lazy val excelPassword = "kalasana"
   lazy val mockDataColumnSettings: Seq[(String, Column)] = Seq(
-    "str" -> Column("Str"),
+    "str" -> Column("Str", comment = Some("kommentti")),
     "optionStr" -> Column("OptionStr"),
     "localdate" -> Column("LocalDate"),
     "optionLocaldate" -> Column("OptionLocalDate"),


### PR DESCRIPTION
Korvataan huonosti luettava "Ohjeet" välilehti raportointi-exceleistä asettamalla kommentteja otsikkorivin sarakkeisiin, joihin halutaan tarkempi ohjeistus.