### PR TITLE
[WIP] TOR-636 

### DIFF
--- a/src/main/scala/fi/oph/koski/documentation/ExamplesAikuistenPerusopetus.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesAikuistenPerusopetus.scala
@@ -40,6 +40,51 @@ object ExamplesAikuistenPerusopetus {
     )
   }
 
+  lazy val oppiaineenOppimäärienOpiskeluoikeusLäsnä: AikuistenPerusopetuksenOpiskeluoikeus = {
+    AikuistenPerusopetuksenOpiskeluoikeus(
+      oppilaitos = Some(jyväskylänNormaalikoulu),
+      koulutustoimija = None,
+      suoritukset = List(
+        AikuistenPerusopetuksenOppiaineenOppimääränSuoritus(
+          äidinkieli("AI1", diaarinumero = Some("19/011/2015")),
+          toimipiste = jyväskylänNormaalikoulu,
+          suorituskieli = suomenKieli,
+          suoritustapa = suoritustapaErityinenTutkinto,
+          arviointi = arviointi(10)
+        ),
+        AikuistenPerusopetuksenOppiaineenOppimääränSuoritus(
+          koulutusmoduuli = AikuistenPerusopetuksenUskonto(tunniste = Koodistokoodiviite(koodistoUri = "koskioppiaineetyleissivistava",
+            koodiarvo = "KT"),
+            perusteenDiaarinumero = Some("19/011/2015")
+          ),
+          toimipiste = jyväskylänNormaalikoulu,
+          suorituskieli = suomenKieli,
+          suoritustapa = suoritustapaErityinenTutkinto,
+          arviointi = arviointi(9)
+        )
+      ),
+      tila = AikuistenPerusopetuksenOpiskeluoikeudenTila(
+        List(
+          AikuistenPerusopetuksenOpiskeluoikeusjakso(date(2008, 8, 15), opiskeluoikeusLäsnä)
+        )
+      )
+    )
+  }
+
+  lazy val oppiaineenOppimäärienOpiskeluoikeusLäsnäJaEiTiedossaSuorituksia: AikuistenPerusopetuksenOpiskeluoikeus =
+    oppiaineenOppimäärienOpiskeluoikeusLäsnä.copy(suoritukset =
+      List(
+        oppiaineenOppimääränSuoritus(äidinkieli("AI1", diaarinumero = Some("19/011/2015"))),
+        AikuistenPerusopetuksenOppiaineenOppimääränSuoritus(
+          koulutusmoduuli = EiTiedossaOppiaine(),
+          toimipiste = jyväskylänNormaalikoulu,
+          suorituskieli = suomenKieli,
+          suoritustapa = suoritustapaErityinenTutkinto,
+          arviointi = arviointi(9)
+        )
+      )
+    )
+
   lazy val montaOppiaineenOppimääränSuoritustaOpiskeluoikeus: AikuistenPerusopetuksenOpiskeluoikeus = oppiaineenOppimääräOpiskeluoikeus.copy(
     suoritukset =
       oppiaineenOppimääränSuoritus(aikuistenOppiaine("YH").copy(perusteenDiaarinumero = Some("19/011/2015"))).copy(arviointi = arviointi(10)) ::

--- a/src/main/scala/fi/oph/koski/documentation/ExamplesLukio.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesLukio.scala
@@ -281,83 +281,23 @@ object ExamplesLukio {
       )
     )
 
-  val aineOpiskelijaAktiivinenEiVahvistettujaSuorituksia =
-    LukionOpiskeluoikeus(
-      versionumero = None,
-      lähdejärjestelmänId = None,
-      oppilaitos = Some(jyväskylänNormaalikoulu),
-      suoritukset = List(
-        LukionOppiaineenOppimääränSuoritus(
-          koulutusmoduuli = lukionOppiaine("HI", diaarinumero = Some("60/011/2015")),
-          suorituskieli = suomenKieli,
-          toimipiste = jyväskylänNormaalikoulu,
-          arviointi = arviointi("9"),
-          osasuoritukset = Some(List(
-            kurssisuoritus(valtakunnallinenVanhanOpsinKurssi("HI1")).copy(arviointi = numeerinenArviointi(7, päivä = date(2016, 1, 10))),
-            kurssisuoritus(valtakunnallinenKurssi("HI2")).copy(arviointi = numeerinenArviointi(8, päivä = date(2016, 1, 10))),
-            kurssisuoritus(valtakunnallinenKurssi("HI3")).copy(arviointi = numeerinenArviointi(7, päivä = date(2016, 1, 10))),
-            kurssisuoritus(valtakunnallinenKurssi("HI4")).copy(arviointi = numeerinenArviointi(6, päivä = date(2016, 1, 10)))
-          ))
-        ),
-        LukionOppiaineenOppimääränSuoritus(
-          koulutusmoduuli = lukionOppiaine("KE", diaarinumero = Some("60/011/2015")),
-          suorituskieli = suomenKieli,
-          toimipiste = jyväskylänNormaalikoulu,
-          arviointi = arviointi("8"),
-          osasuoritukset = Some(List(
-            kurssisuoritus(valtakunnallinenVanhanOpsinKurssi("KE1")).copy(arviointi = numeerinenArviointi(7, päivä = date(2016, 1, 10)))
-          ))
-        ),
-        LukionOppiaineenOppimääränSuoritus(
-          koulutusmoduuli = lukionOppiaine("FI", diaarinumero = Some("60/011/2015")),
-          suorituskieli = suomenKieli,
-          toimipiste = jyväskylänNormaalikoulu,
-          arviointi = arviointi("9"),
-          osasuoritukset = Some(List(
-            kurssisuoritus(valtakunnallinenVanhanOpsinKurssi("FI1")).copy(arviointi = numeerinenArviointi(7, päivä = date(2016, 1, 10)))
-          ))
-        )
-      ),
-      tila = LukionOpiskeluoikeudenTila(
-        List(
-          LukionOpiskeluoikeusjakso(alku = date(2015, 9, 1), tila = opiskeluoikeusAktiivinen)
-        )
-      )
-    )
+  val aineOpiskelijaAktiivinenEiVahvistettujaSuorituksia = aineOpiskelijaAktiivinen.copy(
+    suoritukset = aineOpiskelijaAktiivinen.suoritukset.map(suoritus => suoritus.asInstanceOf[LukionOppiaineenOppimääränSuoritus].copy(vahvistus = None)),
+    tila = LukionOpiskeluoikeudenTila(List(LukionOpiskeluoikeusjakso(alku = date(2015, 9, 1), tila = opiskeluoikeusAktiivinen)))
+  )
 
-  val aineOpiskelijaAktiivinenVahvistettujaSuorituksiaJaOppiaineEiTiedossaSuoritus =
-    LukionOpiskeluoikeus(
-      versionumero = None,
-      lähdejärjestelmänId = None,
-      oppilaitos = Some(jyväskylänNormaalikoulu),
-      suoritukset = List(
-        LukionOppiaineenOppimääränSuoritus(
-          koulutusmoduuli = lukionOppiaine("HI", diaarinumero = Some("60/011/2015")),
-          vahvistus = vahvistusPaikkakunnalla(päivä = date(2016, 1, 10)),
-          suorituskieli = suomenKieli,
-          toimipiste = jyväskylänNormaalikoulu,
-          arviointi = arviointi("9"),
-          osasuoritukset = Some(List(
-            kurssisuoritus(valtakunnallinenVanhanOpsinKurssi("HI1")).copy(arviointi = numeerinenArviointi(7, päivä = date(2016, 1, 10)))
-          ))
-        ),
-        LukionOppiaineenOppimääränSuoritus(
-          koulutusmoduuli = EiTiedossaOppiaine(),
-          suorituskieli = suomenKieli,
-          toimipiste = jyväskylänNormaalikoulu,
-          arviointi = arviointi("9"),
-          osasuoritukset = Some(List(
-            kurssisuoritus(valtakunnallinenVanhanOpsinKurssi("FI1")).copy(arviointi = numeerinenArviointi(7, päivä = date(2016, 1, 10)))
-          ))
-        )
-      ),
-      tila = LukionOpiskeluoikeudenTila(
-        List(
-          LukionOpiskeluoikeusjakso(alku = date(2015, 9, 1), tila = opiskeluoikeusAktiivinen)
-        )
-      )
-    )
-
+  val aineOpiskelijaAktiivinenVahvistettujaSuorituksiaJaOppiaineEiTiedossaSuoritus = aineOpiskelijaAktiivinen.copy(
+    suoritukset = aineOpiskelijaAktiivinen.suoritukset ::: List(
+      LukionOppiaineenOppimääränSuoritus(
+        koulutusmoduuli = EiTiedossaOppiaine(),
+        suorituskieli = suomenKieli,
+        toimipiste = jyväskylänNormaalikoulu,
+        arviointi = arviointi("9"),
+        osasuoritukset = Some(List(
+          kurssisuoritus(valtakunnallinenVanhanOpsinKurssi("FI1")).copy(arviointi = numeerinenArviointi(7, päivä = date(2016, 1, 10)))
+        ))
+      ))
+  )
 
   val lukioKesken =
     LukionOpiskeluoikeus(

--- a/src/main/scala/fi/oph/koski/documentation/ExamplesLukio.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesLukio.scala
@@ -281,6 +281,84 @@ object ExamplesLukio {
       )
     )
 
+  val aineOpiskelijaAktiivinenEiVahvistettujaSuorituksia =
+    LukionOpiskeluoikeus(
+      versionumero = None,
+      lähdejärjestelmänId = None,
+      oppilaitos = Some(jyväskylänNormaalikoulu),
+      suoritukset = List(
+        LukionOppiaineenOppimääränSuoritus(
+          koulutusmoduuli = lukionOppiaine("HI", diaarinumero = Some("60/011/2015")),
+          suorituskieli = suomenKieli,
+          toimipiste = jyväskylänNormaalikoulu,
+          arviointi = arviointi("9"),
+          osasuoritukset = Some(List(
+            kurssisuoritus(valtakunnallinenVanhanOpsinKurssi("HI1")).copy(arviointi = numeerinenArviointi(7, päivä = date(2016, 1, 10))),
+            kurssisuoritus(valtakunnallinenKurssi("HI2")).copy(arviointi = numeerinenArviointi(8, päivä = date(2016, 1, 10))),
+            kurssisuoritus(valtakunnallinenKurssi("HI3")).copy(arviointi = numeerinenArviointi(7, päivä = date(2016, 1, 10))),
+            kurssisuoritus(valtakunnallinenKurssi("HI4")).copy(arviointi = numeerinenArviointi(6, päivä = date(2016, 1, 10)))
+          ))
+        ),
+        LukionOppiaineenOppimääränSuoritus(
+          koulutusmoduuli = lukionOppiaine("KE", diaarinumero = Some("60/011/2015")),
+          suorituskieli = suomenKieli,
+          toimipiste = jyväskylänNormaalikoulu,
+          arviointi = arviointi("8"),
+          osasuoritukset = Some(List(
+            kurssisuoritus(valtakunnallinenVanhanOpsinKurssi("KE1")).copy(arviointi = numeerinenArviointi(7, päivä = date(2016, 1, 10)))
+          ))
+        ),
+        LukionOppiaineenOppimääränSuoritus(
+          koulutusmoduuli = lukionOppiaine("FI", diaarinumero = Some("60/011/2015")),
+          suorituskieli = suomenKieli,
+          toimipiste = jyväskylänNormaalikoulu,
+          arviointi = arviointi("9"),
+          osasuoritukset = Some(List(
+            kurssisuoritus(valtakunnallinenVanhanOpsinKurssi("FI1")).copy(arviointi = numeerinenArviointi(7, päivä = date(2016, 1, 10)))
+          ))
+        )
+      ),
+      tila = LukionOpiskeluoikeudenTila(
+        List(
+          LukionOpiskeluoikeusjakso(alku = date(2015, 9, 1), tila = opiskeluoikeusAktiivinen)
+        )
+      )
+    )
+
+  val aineOpiskelijaAktiivinenVahvistettujaSuorituksiaJaOppiaineEiTiedossaSuoritus =
+    LukionOpiskeluoikeus(
+      versionumero = None,
+      lähdejärjestelmänId = None,
+      oppilaitos = Some(jyväskylänNormaalikoulu),
+      suoritukset = List(
+        LukionOppiaineenOppimääränSuoritus(
+          koulutusmoduuli = lukionOppiaine("HI", diaarinumero = Some("60/011/2015")),
+          vahvistus = vahvistusPaikkakunnalla(päivä = date(2016, 1, 10)),
+          suorituskieli = suomenKieli,
+          toimipiste = jyväskylänNormaalikoulu,
+          arviointi = arviointi("9"),
+          osasuoritukset = Some(List(
+            kurssisuoritus(valtakunnallinenVanhanOpsinKurssi("HI1")).copy(arviointi = numeerinenArviointi(7, päivä = date(2016, 1, 10)))
+          ))
+        ),
+        LukionOppiaineenOppimääränSuoritus(
+          koulutusmoduuli = EiTiedossaOppiaine(),
+          suorituskieli = suomenKieli,
+          toimipiste = jyväskylänNormaalikoulu,
+          arviointi = arviointi("9"),
+          osasuoritukset = Some(List(
+            kurssisuoritus(valtakunnallinenVanhanOpsinKurssi("FI1")).copy(arviointi = numeerinenArviointi(7, päivä = date(2016, 1, 10)))
+          ))
+        )
+      ),
+      tila = LukionOpiskeluoikeudenTila(
+        List(
+          LukionOpiskeluoikeusjakso(alku = date(2015, 9, 1), tila = opiskeluoikeusAktiivinen)
+        )
+      )
+    )
+
+
   val lukioKesken =
     LukionOpiskeluoikeus(
       versionumero = None,

--- a/src/main/scala/fi/oph/koski/fixture/KoskiDatabaseFixtures.scala
+++ b/src/main/scala/fi/oph/koski/fixture/KoskiDatabaseFixtures.scala
@@ -105,6 +105,8 @@ class KoskiDatabaseFixtureCreator(application: KoskiApplication) extends KoskiDa
       (MockOppijat.lukioKesken, ExamplesLukio.lukioKesken),
       (MockOppijat.lukionAineopiskelija, ExamplesLukio.aineopiskelija),
       (MockOppijat.lukionAineopiskelijaAktiivinen, ExamplesLukio.aineOpiskelijaAktiivinen),
+      (MockOppijat.lukionAineopiskelijaAktiivinenEiVahvistettuja, ExamplesLukio.aineOpiskelijaAktiivinenEiVahvistettujaSuorituksia),
+      (MockOppijat.lukionAineopiskelijaAktiivinenVahvistettujaJaEiTiedossa, ExamplesLukio.aineOpiskelijaAktiivinenVahvistettujaSuorituksiaJaOppiaineEiTiedossaSuoritus),
       (MockOppijat.luva, ExamplesLukioonValmistavaKoulutus.luvaTodistus.tallennettavatOpiskeluoikeudet.head),
       (MockOppijat.ammattilainen, AmmatillinenExampleData.perustutkintoOpiskeluoikeusValmis()),
       (MockOppijat.tutkinnonOsaaPienempiKokonaisuus, TutkinnonOsaaPienempiKokonaisuusExample.opiskeluoikeus),

--- a/src/main/scala/fi/oph/koski/fixture/KoskiDatabaseFixtures.scala
+++ b/src/main/scala/fi/oph/koski/fixture/KoskiDatabaseFixtures.scala
@@ -97,6 +97,8 @@ class KoskiDatabaseFixtureCreator(application: KoskiApplication) extends KoskiDa
       (MockOppijat.vuosiluokkalainen, PerusopetusExampleData.vuosiluokanOpiskeluoikeus()),
       (MockOppijat.toimintaAlueittainOpiskelija, ExamplesPerusopetus.toimintaAlueittainOpiskelija.tallennettavatOpiskeluoikeudet.head),
       (MockOppijat.oppiaineenKorottaja, ExamplesAikuistenPerusopetus.oppiaineenOppimääräOpiskeluoikeus),
+      (MockOppijat.oppiaineenKorottajaAktiivinen, ExamplesAikuistenPerusopetus.oppiaineenOppimäärienOpiskeluoikeusLäsnä),
+      (MockOppijat.oppiaineenKorottajaAktiivinenEiTiedossaOppiainetta, ExamplesAikuistenPerusopetus.oppiaineenOppimäärienOpiskeluoikeusLäsnäJaEiTiedossaSuorituksia),
       (MockOppijat.montaOppiaineenOppimäärääOpiskeluoikeudessa, ExamplesAikuistenPerusopetus.montaOppiaineenOppimääränSuoritustaOpiskeluoikeus),
       (MockOppijat.aikuisOpiskelija, ExamplesAikuistenPerusopetus.aikuistenPerusopetuksenOpiskeluoikeusAlkuvaiheineen),
       (MockOppijat.kymppiluokkalainen, ExamplesPerusopetuksenLisaopetus.lisäopetuksenPäättötodistus.tallennettavatOpiskeluoikeudet.head),

--- a/src/main/scala/fi/oph/koski/henkilo/MockOppijat.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/MockOppijat.scala
@@ -30,6 +30,8 @@ object MockOppijat {
   val lukioKesken = oppijat.oppija("Lukiokesken", "Leila", "190363-279X")
   val lukionAineopiskelija = oppijat.oppija("Lukioaineopiskelija", "Aino", "210163-2367")
   val lukionAineopiskelijaAktiivinen = oppijat.oppija("Lukioaineopiskelija", "Aktiivinen", "200300-624E")
+  val lukionAineopiskelijaAktiivinenEiVahvistettuja = oppijat.oppija("Lukioaineopiskelija", "Aktiivinen-Ei-Vahvistettuja", "110122-5090")
+  val lukionAineopiskelijaAktiivinenVahvistettujaJaEiTiedossa = oppijat.oppija("Lukioaineopiskelija", "Aktiivinen-Ei-Vahvistettuja-Ei-Tiedossa", "151132-746V")
   val ammattilainen = oppijat.oppija("Ammattilainen", "Aarne", "280618-402H")
   val tutkinnonOsaaPienempiKokonaisuus = oppijat.oppija("Pieni-Kokonaisuus", "Pentti", "040754-054W")
   val muuAmmatillinen = oppijat.oppija("Muu-Ammatillinen", "Marjo", "130320-899Y")

--- a/src/main/scala/fi/oph/koski/henkilo/MockOppijat.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/MockOppijat.scala
@@ -49,6 +49,8 @@ object MockOppijat {
   val monimutkainenKorkeakoululainen = oppijat.oppija("Korkeakoululainen", "Kompleksi", "060458-331R")
   val virtaEiVastaa = oppijat.oppija("Virtanen", "Eivastaa", "250390-680P")
   val oppiaineenKorottaja = oppijat.oppija("Oppiaineenkorottaja", "Olli", "110738-839L")
+  val oppiaineenKorottajaAktiivinen = oppijat.oppija("Oppiaineenkorottaja", "Olli-Aktiivinen", "271080-364V")
+  val oppiaineenKorottajaAktiivinenEiTiedossaOppiainetta = oppijat.oppija("Oppiaineenkorottaja", "Olli-Aktiivinen Oppiaineeton", "240175-3276") // TÄMÄ
   val montaOppiaineenOppimäärääOpiskeluoikeudessa = oppijat.oppija("Mervi", "Monioppiaineinen", "131298-5248")
   val aikuisOpiskelija = oppijat.oppija("Aikuisopiskelija", "Aini", "280598-2415", vanhaHetu = Some("280598-326W"))
   val kymppiluokkalainen = oppijat.oppija("Kymppiluokkalainen", "Kaisa", "131025-6573")

--- a/web/app/opiskeluoikeus/OpiskeluoikeudenTilaEditor.jsx
+++ b/web/app/opiskeluoikeus/OpiskeluoikeudenTilaEditor.jsx
@@ -32,7 +32,8 @@ export class OpiskeluoikeudenTilaEditor extends React.Component {
     let items = modelItems(jaksotModel).slice(0).reverse()
     let suorituksiaKesken = wrappedModel.context.edit && R.any(s => !arvioituTaiVahvistettu(s))(modelItems(wrappedModel, 'suoritukset'))
     let suoritettuAineopinto = wrappedModel.context.edit && hasAtLeastOneCompletedAineopinto(modelLookup(model, 'suoritukset'))
-    let eiSaaAsettaaValmiiksi = suorituksiaKesken && !suoritettuAineopinto
+    let eiTiedossaOppiaineita = hasSomeEiTiedossaAineopinto(modelLookup(model, 'suoritukset'))
+    let eiSaaAsettaaValmiiksi = eiTiedossaOppiaineita || (suorituksiaKesken && !suoritettuAineopinto)
 
     let showAddDialog = () => this.showOpiskeluoikeudenTilaDialog.modify(x => !x)
 
@@ -139,9 +140,22 @@ const hasAtLeastOneCompletedAineopinto = (suoritukset) => {
   if (!suoritukset || !suoritukset.value) return false
 
   const aineopinnot = suoritukset.value.filter(isAineopinto)
-  return aineopinnot.some(opinto => arvioituTaiVahvistettu(opinto))
+  return aineopinnot.some(opinto => arvioituTaiVahvistettu(opinto)) // FIXME: Test for "Vahvistus"
 }
 
+const hasSomeEiTiedossaAineopinto = (suoritukset) => {
+  if (!suoritukset) return false
+
+  return suoritukset.value.some(suoritus =>
+    suoritus.value.properties &&
+    suoritus.value.properties.some(property =>
+      property.model.value && property.model.value.properties &&
+      property.model.value.properties.some(p =>
+        p.model.value && p.model.value.data && p.model.value.data.koodiarvo === 'XX'
+      )
+    )
+  )
+}
 
 const opiskeluoikeusjaksot = (opiskeluoikeus) => {
   return modelLookup(opiskeluoikeus, 'tila.opiskeluoikeusjaksot')

--- a/web/app/opiskeluoikeus/OpiskeluoikeudenUusiTilaPopup.jsx
+++ b/web/app/opiskeluoikeus/OpiskeluoikeudenUusiTilaPopup.jsx
@@ -14,7 +14,7 @@ import Text from '../i18n/Text'
 import {ift} from '../util/util'
 import {filterTilatByOpiskeluoikeudenTyyppi} from './opiskeluoikeus'
 
-export const OpiskeluoikeudenUusiTilaPopup = ({edellisenTilanAlkupäivä, suorituksiaKesken, tilaListModel, resultCallback}) => {
+export const OpiskeluoikeudenUusiTilaPopup = ({edellisenTilanAlkupäivä, disabloiValmistunut: disabloiValmistunut, tilaListModel, resultCallback}) => {
   let submitBus = Bacon.Bus()
   let initialModel = contextualizeSubModel(tilaListModel.arrayPrototype, tilaListModel, modelItems(tilaListModel).length)
 
@@ -39,7 +39,7 @@ export const OpiskeluoikeudenUusiTilaPopup = ({edellisenTilanAlkupäivä, suorit
     </div>
     <div className="property tila">
       <label><Text name="Tila"/>{':'}</label>
-      <Editor baret-lift asRadiogroup={true} model={tilaModel} disabledValue={suorituksiaKesken && 'koskiopiskeluoikeudentila_valmistunut'} fetchAlternatives={fetchTilat} />
+      <Editor baret-lift asRadiogroup={true} model={tilaModel} disabledValue={disabloiValmistunut && 'koskiopiskeluoikeudentila_valmistunut'} fetchAlternatives={fetchTilat} />
     </div>
     {
       ift(rahoitusModel, (<div className="property rahoitus" key="rahoitus">

--- a/web/app/suoritus/Suoritus.js
+++ b/web/app/suoritus/Suoritus.js
@@ -11,6 +11,10 @@ import {tutkinnonNimi} from './Koulutusmoduuli'
 
 const isInPast = dateStr => parseISODate(dateStr) < new Date()
 
+export const suoritusVahvistettu = suoritus => (
+  suoritus.value.classes.includes('paatasonsuoritus') && !!modelData(suoritus, 'vahvistus')
+)
+
 export const arvioituTaiVahvistettu = suoritus => {
   if (suoritus.value.classes.includes('paatasonsuoritus')) {
     return !!modelData(suoritus, 'vahvistus')

--- a/web/app/suoritus/Suoritus.js
+++ b/web/app/suoritus/Suoritus.js
@@ -11,10 +11,6 @@ import {tutkinnonNimi} from './Koulutusmoduuli'
 
 const isInPast = dateStr => parseISODate(dateStr) < new Date()
 
-export const suoritusVahvistettu = suoritus => (
-  suoritus.value.classes.includes('paatasonsuoritus') && !!modelData(suoritus, 'vahvistus')
-)
-
 export const arvioituTaiVahvistettu = suoritus => {
   if (suoritus.value.classes.includes('paatasonsuoritus')) {
     return !!modelData(suoritus, 'vahvistus')

--- a/web/app/suoritus/TilaJaVahvistusEditor.jsx
+++ b/web/app/suoritus/TilaJaVahvistusEditor.jsx
@@ -78,4 +78,4 @@ const MerkitseValmiiksiButton = ({model}) => {
   </span>)
 }
 
-const eiTiedossaOppiaine = suoritus => modelData(suoritus, 'koulutusmoduuli.tunniste.koodiarvo') === 'XX'
+export const eiTiedossaOppiaine = suoritus => modelData(suoritus, 'koulutusmoduuli.tunniste.koodiarvo') === 'XX'

--- a/web/test/spec/lukioSpec.js
+++ b/web/test/spec/lukioSpec.js
@@ -530,6 +530,56 @@ describe('Lukiokoulutus', function( ){
     })
   })
 
+  describe('Lukion useamman oppiaineen aineopiskelija', function() {
+    before(
+      page.openPage,
+      page.oppijaHaku.searchAndSelect('110122-5090')
+    )
+
+    describe('Opiskeluoikeuden tilaa', function () {
+      before(
+        editor.edit,
+        opinnot.valitseSuoritus(undefined, 'Kemia'),
+        opinnot.opiskeluoikeusEditor().edit,
+        opinnot.avaaLisaysDialogi
+      )
+      it('ei voida merkitä valmiiksi', function () {
+        expect(OpiskeluoikeusDialog().radioEnabled('valmistunut')).to.equal(false)
+        after(editor.cancelChanges)
+      })
+    })
+
+    describe('Kun yksikin suoritus merkitään valmiiksi', function () {
+      before(
+        editor.edit,
+        opinnot.tilaJaVahvistus.merkitseValmiiksi,
+        opinnot.tilaJaVahvistus.lisääVahvistus('01.01.2000'),
+        opinnot.opiskeluoikeusEditor().edit,
+        opinnot.avaaLisaysDialogi
+      )
+
+      it('myös opiskeluoikeuden tila voidaan merkitä valmiiksi', function () {
+        expect(OpiskeluoikeusDialog().radioEnabled('valmistunut')).to.equal(true)
+        after(editor.cancelChanges)
+      })
+    })
+
+    describe('Jos opiskelijalla on "ei tiedossa"-oppiaineita', function () {
+      before(
+        page.openPage,
+        page.oppijaHaku.searchAndSelect('151132-746V'),
+        editor.edit,
+        opinnot.opiskeluoikeusEditor().edit,
+        opinnot.avaaLisaysDialogi
+      )
+
+      it('Opiskeluoikeuden tilaa ei voi merkitä valmiiksi', function () {
+        expect(OpiskeluoikeusDialog().radioEnabled('valmistunut')).to.equal(false)
+        after(editor.cancelChanges)
+      })
+    })
+  })
+
   describe('Opiskeluoikeuden lisääminen', function() {
     describe('Lukion oppimäärä', function() {
       describe('Nuorten 2015 oppimäärä', function() {

--- a/web/test/spec/lukioSpec.js
+++ b/web/test/spec/lukioSpec.js
@@ -531,37 +531,31 @@ describe('Lukiokoulutus', function( ){
   })
 
   describe('Lukion useamman oppiaineen aineopiskelija', function() {
-    before(
-      page.openPage,
-      page.oppijaHaku.searchAndSelect('110122-5090')
-    )
-
     describe('Opiskeluoikeuden tilaa', function () {
       before(
+        page.openPage,
+        page.oppijaHaku.searchAndSelect('110122-5090'),
         editor.edit,
         opinnot.valitseSuoritus(undefined, 'Kemia'),
-        opinnot.opiskeluoikeusEditor().edit,
         opinnot.avaaLisaysDialogi
       )
+
       it('ei voida merkitä valmiiksi', function () {
         expect(OpiskeluoikeusDialog().radioEnabled('valmistunut')).to.equal(false)
-        after(editor.cancelChanges)
       })
-    })
 
-    describe('Kun yksikin suoritus merkitään valmiiksi', function () {
-      before(
-        editor.edit,
-        opinnot.tilaJaVahvistus.merkitseValmiiksi,
-        opinnot.tilaJaVahvistus.lisääVahvistus('01.01.2000'),
-        opinnot.opiskeluoikeusEditor().edit,
-        opinnot.avaaLisaysDialogi
-      )
+      describe('Kun yksikin suoritus merkitään valmiiksi', function () {
+        before(
+          opinnot.tilaJaVahvistus.merkitseValmiiksi,
+          opinnot.tilaJaVahvistus.lisääVahvistus('01.01.2000'),
+          opinnot.avaaLisaysDialogi
+        )
 
-      it('myös opiskeluoikeuden tila voidaan merkitä valmiiksi', function () {
-        expect(OpiskeluoikeusDialog().radioEnabled('valmistunut')).to.equal(true)
-        after(editor.cancelChanges)
+        it('myös opiskeluoikeuden tila voidaan merkitä valmiiksi', function () {
+          expect(OpiskeluoikeusDialog().radioEnabled('valmistunut')).to.equal(true)
+        })
       })
+      after(editor.cancelChanges)
     })
 
     describe('Jos opiskelijalla on "ei tiedossa"-oppiaineita', function () {
@@ -575,8 +569,8 @@ describe('Lukiokoulutus', function( ){
 
       it('Opiskeluoikeuden tilaa ei voi merkitä valmiiksi', function () {
         expect(OpiskeluoikeusDialog().radioEnabled('valmistunut')).to.equal(false)
-        after(editor.cancelChanges)
       })
+      after(editor.cancelChanges)
     })
   })
 

--- a/web/test/spec/oppijataulukkoSpec.js
+++ b/web/test/spec/oppijataulukkoSpec.js
@@ -43,8 +43,13 @@ describe('Oppijataulukko', function() {
     describe('koulutuksen tyypillä', function() {
       before(page.oppijataulukko.filterBy('nimi'), page.oppijataulukko.filterBy('tyyppi', 'Aikuisten perusopetus'), page.oppijataulukko.filterBy('koulutus', 'Perusopetuksen oppiaineen oppimäärä'))
       it('toimii', function() {
-        expect(page.oppijataulukko.names()).to.deep.equal([ 'Mervi, Monioppiaineinen', 'Oppiaineenkorottaja, Olli' ])
-        expect(page.opiskeluoikeudeTotal()).to.equal('2')
+        expect(page.oppijataulukko.names()).to.deep.equal([
+          'Mervi, Monioppiaineinen',
+          'Oppiaineenkorottaja, Olli',
+          'Oppiaineenkorottaja, Olli-Aktiivinen',
+          'Oppiaineenkorottaja, Olli-Aktiivinen Oppiaineeton'
+        ])
+        expect(page.opiskeluoikeudeTotal()).to.equal('4')
       })
     })
 

--- a/web/test/spec/perusopetusSpec.js
+++ b/web/test/spec/perusopetusSpec.js
@@ -3062,6 +3062,58 @@ describe('Perusopetus', function() {
     })
   })
 
+
+  describe('Perusopetuksen useamman oppiaineen aineopiskelija', function() {
+    before(
+      page.openPage,
+      page.oppijaHaku.searchAndSelect('271080-364V')
+    )
+
+    describe('Opiskeluoikeuden tilaa', function () {
+      before(
+        editor.edit,
+        opinnot.valitseSuoritus(undefined, 'Äidinkieli ja kirjallisuus'),
+        opinnot.opiskeluoikeusEditor().edit,
+        opinnot.avaaLisaysDialogi
+      )
+      it('ei voida merkitä valmiiksi', function () {
+        expect(OpiskeluoikeusDialog().radioEnabled('valmistunut')).to.equal(false)
+        after(editor.cancelChanges)
+      })
+    })
+
+    describe('Kun yksikin suoritus merkitään valmiiksi', function () {
+      before(
+        editor.edit,
+        opinnot.tilaJaVahvistus.merkitseValmiiksi,
+        opinnot.tilaJaVahvistus.lisääVahvistus('01.01.2000'),
+        opinnot.opiskeluoikeusEditor().edit,
+        opinnot.avaaLisaysDialogi
+      )
+
+      it('myös opiskeluoikeuden tila voidaan merkitä valmiiksi', function () {
+        expect(OpiskeluoikeusDialog().radioEnabled('valmistunut')).to.equal(true)
+        after(editor.cancelChanges)
+      })
+    })
+
+    describe('Jos opiskelijalla on "ei tiedossa"-oppiaineita', function () {
+      before(
+        page.openPage,
+        page.oppijaHaku.searchAndSelect('240175-3276'),
+        editor.edit,
+        opinnot.opiskeluoikeusEditor().edit,
+        opinnot.avaaLisaysDialogi
+      )
+
+      it('Opiskeluoikeuden tilaa ei voi merkitä valmiiksi', function () {
+        expect(OpiskeluoikeusDialog().radioEnabled('valmistunut')).to.equal(false)
+        after(editor.cancelChanges)
+      })
+    })
+  })
+
+
   describe('Perusopetuksen lisäopetus', function() {
     before(page.openPage, page.oppijaHaku.searchAndSelect('131025-6573'))
     describe('Kaikki tiedot näkyvissä', function() {

--- a/web/test/spec/perusopetusSpec.js
+++ b/web/test/spec/perusopetusSpec.js
@@ -3064,37 +3064,32 @@ describe('Perusopetus', function() {
 
 
   describe('Perusopetuksen useamman oppiaineen aineopiskelija', function() {
-    before(
-      page.openPage,
-      page.oppijaHaku.searchAndSelect('271080-364V')
-    )
-
     describe('Opiskeluoikeuden tilaa', function () {
       before(
+        page.openPage,
+        page.oppijaHaku.searchAndSelect('271080-364V'),
         editor.edit,
         opinnot.valitseSuoritus(undefined, 'Äidinkieli ja kirjallisuus'),
-        opinnot.opiskeluoikeusEditor().edit,
         opinnot.avaaLisaysDialogi
       )
+
       it('ei voida merkitä valmiiksi', function () {
         expect(OpiskeluoikeusDialog().radioEnabled('valmistunut')).to.equal(false)
-        after(editor.cancelChanges)
       })
-    })
 
-    describe('Kun yksikin suoritus merkitään valmiiksi', function () {
-      before(
-        editor.edit,
-        opinnot.tilaJaVahvistus.merkitseValmiiksi,
-        opinnot.tilaJaVahvistus.lisääVahvistus('01.01.2000'),
-        opinnot.opiskeluoikeusEditor().edit,
-        opinnot.avaaLisaysDialogi
-      )
+      describe('Kun yksikin suoritus merkitään valmiiksi', function () {
+        before(
+          opinnot.tilaJaVahvistus.merkitseValmiiksi,
+          opinnot.tilaJaVahvistus.lisääVahvistus('01.01.2000'),
+          opinnot.avaaLisaysDialogi
+        )
 
-      it('myös opiskeluoikeuden tila voidaan merkitä valmiiksi', function () {
-        expect(OpiskeluoikeusDialog().radioEnabled('valmistunut')).to.equal(true)
-        after(editor.cancelChanges)
+        it('myös opiskeluoikeuden tila voidaan merkitä valmiiksi', function () {
+          expect(OpiskeluoikeusDialog().radioEnabled('valmistunut')).to.equal(true)
+        })
       })
+
+      after(editor.cancelChanges)
     })
 
     describe('Jos opiskelijalla on "ei tiedossa"-oppiaineita', function () {
@@ -3108,8 +3103,9 @@ describe('Perusopetus', function() {
 
       it('Opiskeluoikeuden tilaa ei voi merkitä valmiiksi', function () {
         expect(OpiskeluoikeusDialog().radioEnabled('valmistunut')).to.equal(false)
-        after(editor.cancelChanges)
       })
+
+      after(editor.cancelChanges)
     })
   })
 


### PR DESCRIPTION
Lukion ja perusopetuksen aineopiskelijoiden validointiin muutos, että valmistuminen hyväksytään, jos yhdessäkin oppiaineessa vahvistus.

Eli oppiaineita voi jäädä kesken- tilaan. Ei kuitenkaan tuleva "Ei tiedossa- oppiaine" voi olla se yksi valmistunut oppiaine. "Ei tiedossa"-oppiaine ei myöskään voi olla kesken-tilaisena valmistunut-tilaisessa opiskeluoikeudessa.