### PR TITLE
Korjaa erikoismerkeistä aihetuva virhe excelien luonnissa

### DIFF
--- a/src/main/scala/fi/oph/koski/raportit/ExcelWriter.scala
+++ b/src/main/scala/fi/oph/koski/raportit/ExcelWriter.scala
@@ -10,6 +10,7 @@ import org.apache.poi.poifs.crypt.temp.{EncryptedTempData, SXSSFWorkbookWithCust
 import org.apache.poi.poifs.filesystem.POIFSFileSystem
 import org.apache.poi.ss.usermodel._
 import org.apache.poi.ss.util.CellRangeAddress
+import org.apache.poi.ss.util.WorkbookUtil.createSafeSheetName
 import org.apache.poi.xssf.streaming.{SXSSFCell, SXSSFDrawing, SXSSFSheet, SXSSFWorkbook}
 import org.apache.poi.xssf.usermodel.XSSFSheet
 
@@ -27,7 +28,7 @@ object ExcelWriter {
       coreProps.setTitle(workbookSettings.title)
       coreProps.setCreator("Koski")
       sheets.foreach { sheet =>
-        val sh = wb.createSheet(sheet.title)
+        val sh = wb.createSheet(createSafeSheetName(sheet.title, ' '))
         sheet match {
           case ds: SheetWithColumnSettings => writeDataSheet(wb, sh, ds)
           case ds: DocumentationSheet => writeDocumentationSheet(wb, sh, ds)

--- a/src/main/scala/fi/oph/koski/raportit/LukioRaportti.scala
+++ b/src/main/scala/fi/oph/koski/raportit/LukioRaportti.scala
@@ -223,7 +223,7 @@ object LukioRaportti {
   }
 
   private def kurssitColumnSettings(kurssit: Seq[LukioRaporttiKurssi]) = {
-    kurssit.map(_.toColumnTitle).map(removeForbiddenCharactersInExcel).map(CompactColumn(_))
+    kurssit.map(_.toColumnTitle).map(CompactColumn(_))
   }
 
   private def kurssiSheets(data: Seq[LukioRaporttiRows], suoritusData: Seq[LukioRaporttiOppiaineJaKurssit])(implicit executionContext: ExecutionContextExecutor) = {
@@ -238,7 +238,7 @@ object LukioRaportti {
     val filtered = data.filter(notOppimääränOpiskelijaFromAnotherOppiaine(oppiaine))
 
     DynamicDataSheet(
-      title = removeForbiddenCharactersInExcel(oppiaine.toSheetTitle),
+      title = oppiaine.toSheetTitle,
       rows = filtered.map(kurssiSheetRow(_, kurssit)),
       columnSettings = henkiloTietoColumns ++ kurssitColumnSettings(kurssit)
     )
@@ -268,10 +268,6 @@ object LukioRaportti {
     val tunnustettu = if (isTunnustettu) ",tunnustettu" else ""
 
     s"${arvosana},${laajuus},${kurssityyppi}${tunnustettu}"
-  }
-
-  private def removeForbiddenCharactersInExcel(str: String) = {
-    str.filter(c => c.isLetterOrDigit || c.isWhitespace)
   }
 }
 

--- a/src/test/scala/fi/oph/koski/raportit/ExcelWriterSpec.scala
+++ b/src/test/scala/fi/oph/koski/raportit/ExcelWriterSpec.scala
@@ -22,6 +22,15 @@ class ExcelWriterSpec extends FreeSpec with Matchers {
       an[EncryptedDocumentException] should be thrownBy (withExcel(dataSheetAndDocumentationSheetTestCase(password = "wrong_password")) { _ => 1 should equal(1) })
     }
 
+    "Erikoismerkit muutetaan välilyönneiksi välilehtien nimessä ja eivät aiheuta muualla virhettä" in {
+      noException shouldBe thrownBy(
+        withExcel(erikoismerkkienKäsittelyTestCase()) { wb =>
+          wb.getNumberOfSheets should equal(1)
+          wb.getSheetAt(0).getSheetName should equal("       datasheet_title")
+        }
+      )
+    }
+
     "Excelin luonti, DataSheet ja DocumentationSheet" - {
       withExcel(dataSheetAndDocumentationSheetTestCase()) { wb =>
         "Luo data ja dokumentaatio välilehdet" in {
@@ -261,6 +270,16 @@ class ExcelWriterSpec extends FreeSpec with Matchers {
     val documentationSheet = DocumentationSheet("documentation_sheet_title", "dokumentaatio")
 
     (workbookSettings, Seq(dataSheet, documentationSheet))
+  }
+
+  private lazy val erikoismerkit = "[]?*\\/:"
+
+  private def erikoismerkkienKäsittelyTestCase() = {
+    val workbookSettings = WorkbookSettings(expectedExcelTitle, Some(excelPassword))
+    val dynamicRows= Seq(Seq("foo"))
+    val dynamicColumnSettings = Seq(Column(s"${erikoismerkit}bar", comment = Some(erikoismerkit)))
+    val dataSheet = DynamicDataSheet(s"${erikoismerkit}datasheet_title", dynamicRows, dynamicColumnSettings)
+    (workbookSettings, Seq(dataSheet))
   }
 
   private def withExcel(params: (WorkbookSettings, Seq[Sheet]))(tests: (Workbook => Unit)): Unit = {

--- a/src/test/scala/fi/oph/koski/raportit/LukioRaporttiSpec.scala
+++ b/src/test/scala/fi/oph/koski/raportit/LukioRaporttiSpec.scala
@@ -52,7 +52,7 @@ class LukioRaporttiSpec extends FreeSpec with Matchers with RaportointikantaTest
             "A1 v englanti", "AI v Suomen kieli ja kirjallisuus", "B1 v ruotsi", "B3 v latina",
             "BI v Biologia", "FI v Filosofia", "FY v Fysiikka", "GE v Maantieto", "HI v Historia",
             "ITT p Tanssi ja liike", "KE v Kemia", "KT v Islam", "KU v Kuvataide", "LI v Liikunta",
-            "MA v Matematiikka pitkä oppimäärä", "MU v Musiikki", "OA v Oman äidinkielen opinnot",
+            "MA v Matematiikka, pitkä oppimäärä", "MU v Musiikki", "OA v Oman äidinkielen opinnot",
             "PS v Psykologia", "TE v Terveystieto", "TO v Teemaopinnot", "YH v Yhteiskuntaoppi"
           ))
         }


### PR DESCRIPTION
- Erikoismerkkejä ei filtteröidä kokonaan pois sillä tämä voi aiheuttaa kaksi saman nimistä välilehteä
- kielletyt merkit korvataan välilyönneillä