### PR TITLE
tor-677: korkeakoulun opiskeluoikeuden otsikko

### DIFF
--- a/src/main/resources/mockdata/virta/opintotiedot/270680-459P.xml
+++ b/src/main/resources/mockdata/virta/opintotiedot/270680-459P.xml
@@ -1,0 +1,74 @@
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Header/>
+    <SOAP-ENV:Body>
+        <virtaluku:OpiskelijanKaikkiTiedotResponse xmlns:virtaluku="http://tietovaranto.csc.fi/luku">
+            <virta:Virta xmlns:virta="urn:mace:funet.fi:virta/2015/09/01">
+                <virta:Opiskelija avain="TY¤59374">
+                    <virta:Henkilotunnus>270680-459P</virta:Henkilotunnus>
+                    <virta:Opiskeluoikeudet>
+                        <virta:Opiskeluoikeus opiskelijaAvain="TY¤59374" avain="TY¤59374¤83368¤Y">
+                            <virta:Tila>
+                                <virta:AlkuPvm>2008-06-20</virta:AlkuPvm>
+                                <virta:Koodi>3</virta:Koodi>
+                            </virta:Tila>
+                            <virta:Tila>
+                                <virta:AlkuPvm>2000-08-15</virta:AlkuPvm>
+                                <virta:LoppuPvm>2008-06-19</virta:LoppuPvm>
+                                <virta:Koodi>1</virta:Koodi>
+                            </virta:Tila>
+                            <virta:Tyyppi>4</virta:Tyyppi>
+                            <virta:Myontaja>10089</virta:Myontaja>
+                            <virta:Jakso koulutusmoduulitunniste="">
+                                <virta:AlkuPvm>2000-08-15</virta:AlkuPvm>
+                                <virta:LoppuPvm>2004-09-01</virta:LoppuPvm>
+                                <virta:Koulutuskoodi>726103</virta:Koulutuskoodi>
+                                <virta:Koulutuskunta>853</virta:Koulutuskunta>
+                                <virta:Koulutuskieli>fi</virta:Koulutuskieli>
+                            </virta:Jakso>
+                            <virta:Jakso koulutusmoduulitunniste="">
+                                <virta:AlkuPvm>2004-09-02</virta:AlkuPvm>
+                                <virta:LoppuPvm>2008-06-19</virta:LoppuPvm>
+                                <virta:Koulutuskoodi>726103</virta:Koulutuskoodi>
+                                <virta:Koulutuskunta>853</virta:Koulutuskunta>
+                                <virta:Koulutuskieli>fi</virta:Koulutuskieli>
+                            </virta:Jakso>
+                            <virta:Koulutusala versio="ohjausala">3</virta:Koulutusala>
+                        </virta:Opiskeluoikeus>
+                    </virta:Opiskeluoikeudet>
+                    <virta:Opintosuoritukset>
+                        <virta:Opintosuoritus opiskeluoikeusAvain="TY¤59374¤83368¤Y" opiskelijaAvain="TY¤59374" koulutusmoduulitunniste="TUTK1131" avain="TY¤59374¤1972">
+                            <virta:SuoritusPvm>2007-12-31</virta:SuoritusPvm>
+                            <virta:Laajuus>
+                                <virta:Opintopiste>0.0</virta:Opintopiste>
+                            </virta:Laajuus>
+                            <virta:Arvosana>
+                                <virta:Hyvaksytty>HYV</virta:Hyvaksytty>
+                            </virta:Arvosana>
+                            <virta:Myontaja>10089</virta:Myontaja>
+                            <virta:Laji>1</virta:Laji>
+                            <virta:Nimi kieli="fi">HUMANISTISTEN TIETEIDEN KANDIDAATTI </virta:Nimi>
+                            <virta:Nimi kieli="en">Bachelor of Arts </virta:Nimi>
+                            <virta:Kieli>fi</virta:Kieli>
+                            <virta:Koulutuskoodi>623103</virta:Koulutuskoodi>
+                        </virta:Opintosuoritus>
+                        <virta:Opintosuoritus opiskeluoikeusAvain="TY¤59374¤83368¤Y" opiskelijaAvain="TY¤59374" koulutusmoduulitunniste="TUTK1231" avain="TY¤59374¤1968">
+                            <virta:SuoritusPvm>2008-06-19</virta:SuoritusPvm>
+                            <virta:Laajuus>
+                                <virta:Opintopiste>0.0</virta:Opintopiste>
+                            </virta:Laajuus>
+                            <virta:Arvosana>
+                                <virta:Hyvaksytty>HYV</virta:Hyvaksytty>
+                            </virta:Arvosana>
+                            <virta:Myontaja>10089</virta:Myontaja>
+                            <virta:Laji>1</virta:Laji>
+                            <virta:Nimi kieli="fi">FILOSOFIAN MAISTERI, HUMANISTINEN TDK </virta:Nimi>
+                            <virta:Nimi kieli="en">Master of Arts </virta:Nimi>
+                            <virta:Kieli>fi</virta:Kieli>
+                            <virta:Koulutuskoodi>726103</virta:Koulutuskoodi>
+                        </virta:Opintosuoritus>
+                    </virta:Opintosuoritukset>
+                </virta:Opiskelija>
+            </virta:Virta>
+        </virtaluku:OpiskelijanKaikkiTiedotResponse>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/src/main/scala/fi/oph/koski/editor/OppijaEditorModel.scala
+++ b/src/main/scala/fi/oph/koski/editor/OppijaEditorModel.scala
@@ -65,6 +65,7 @@ object OppijaEditorModel extends Timing {
       case oo: IBOpiskeluoikeus => oo.copy(suoritukset = oo.suoritukset.sortBy(ibSuoritustenJärjestysKriteeri))
       case oo: DIAOpiskeluoikeus => oo.copy(suoritukset = oo.suoritukset.sortBy(diaSuoritustenJärjestysKritteri))
       case oo: InternationalSchoolOpiskeluoikeus => oo.copy(suoritukset = oo.suoritukset.sortBy(internationalSchoolJärjestysKriteeri))
+      case oo: KorkeakoulunOpiskeluoikeus => oo.copy(suoritukset = oo.suoritukset.sortBy(_.vahvistus.map(_.päivä))(localDateOptionOrdering).reverse)
       case oo: Any => oo
     })
   }

--- a/src/main/scala/fi/oph/koski/henkilo/MockOppijat.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/MockOppijat.scala
@@ -49,6 +49,7 @@ object MockOppijat {
   val virtaEiVastaa = oppijat.oppija("Virtanen", "Eivastaa", "250390-680P")
   val oppiaineenKorottaja = oppijat.oppija("Oppiaineenkorottaja", "Olli", "110738-839L")
   val montaOppiaineenOppimäärääOpiskeluoikeudessa = oppijat.oppija("Mervi", "Monioppiaineinen", "131298-5248")
+  val virtaKaksiPäätösonSuoritusta = oppijat.oppija("Kaksi-Päinen", "Ville", "270680-459P")
   val aikuisOpiskelija = oppijat.oppija("Aikuisopiskelija", "Aini", "280598-2415", vanhaHetu = Some("280598-326W"))
   val kymppiluokkalainen = oppijat.oppija("Kymppiluokkalainen", "Kaisa", "131025-6573")
   val luva = oppijat.oppija("Lukioonvalmistautuja", "Luke", "211007-442N")

--- a/web/test/spec/korkeakouluSpec.js
+++ b/web/test/spec/korkeakouluSpec.js
@@ -136,4 +136,16 @@ describe('Korkeakoulutus', function() {
       expect(opinnot.opiskeluoikeudet.opiskeluoikeuksienOtsikot()).to.deep.equal( [ 'Tampereen yliopisto, Farmasian kandidaatti', 'Tampereen yliopisto, Proviisori (2016—2019, päättynyt)' ])
     })
   })
+
+  describe('Kaksi päätason suoritusta', function () {
+    before(
+      Authentication().login('pää'),
+      page.openPage,
+      page.oppijaHaku.searchAndSelect('270680-459P')
+    )
+
+    it('Otsikkona näytetään se jolla viimeisin vahvistus', function () {
+      expect(opinnot.opiskeluoikeudet.opiskeluoikeuksienOtsikot()).to.deep.equal( [ 'Aalto-yliopisto, Fil. maist., englannin kieli (2000—, päättynyt)' ])
+    })
+  })
 })

--- a/web/test/spec/omatTiedotSpec.js
+++ b/web/test/spec/omatTiedotSpec.js
@@ -604,18 +604,18 @@ describe('Omat tiedot', function() {
                     '24.8.2011 aktiivinen\n' +
                     'Lisätiedot\n' +
                     'Opintojakso Laajuus Arvosana\n' +
+                    '+\nLaajaverkot 3 op 5\n' +
                     '+\nIP-verkkojen hallinta 4 op 1\n' +
                     '+\nTietoverkkojen tietoturva 5 op 5\n' +
-                    '+\nVirtuaalilähiverkot (CCNA3) 3 op 5\n' +
-                    '+\nWeb-ohjelmointi 5 op 3\n' +
-                    '+\nMikrotietokoneen hallinta 3 op hyväksytty\n' +
-                    '+\nPhotoshopin perusteet 3 op hyväksytty\n' +
-                    '+\nTietoturvallisuuden perusteet 3 op 2\n' +
-                    '+\nLähiverkot (CCNA1) 3 op 4\n' +
-                    '+\nReititinverkot (CCNA2) 3 op 4\n' +
                     '+\nTekninen tietoturva 3 op 4\n' +
-                    '+\nLaajaverkot 3 op 5\n' +
+                    '+\nWeb-ohjelmointi 5 op 3\n' +
                     '+\nLinuxin asennus ja ylläpito 5 op hyväksytty\n' +
+                    '+\nTietoturvallisuuden perusteet 3 op 2\n' +
+                    '+\nPhotoshopin perusteet 3 op hyväksytty\n' +
+                    '+\nVirtuaalilähiverkot (CCNA3) 3 op 5\n' +
+                    '+\nReititinverkot (CCNA2) 3 op 4\n' +
+                    '+\nLähiverkot (CCNA1) 3 op 4\n' +
+                    '+\nMikrotietokoneen hallinta 3 op hyväksytty\n' +
                     'Yhteensä 43 op'
                   )
                   })


### PR DESCRIPTION
Jos opiskeluoikeuden alla on kaksi päätason suoritusta, valitaan otsikkoon se päätason suoritus jolla on uusin vahvistus