### PR TITLE
Create koskitest db in docker-compose init

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,8 @@ services:
     - "POSTGRES_PASSWORD=oph"
     ports:
     - "5432:5432"
+    volumes:
+    - "./postgresql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d"
 
   elasticsearch:
     build: "./elasticsearch"

--- a/postgresql/docker-entrypoint-initdb.d/create-test-db.sql
+++ b/postgresql/docker-entrypoint-initdb.d/create-test-db.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE koskitest;


### PR DESCRIPTION
Luodaan docker-composen käynnistyksen yhteydessä myös `koskitest` kanta