### PR TITLE
Korjaa EsiopetusRaporttiSpec kun se ajetaan ennen muita testejä

### DIFF
--- a/src/test/scala/fi/oph/koski/raportit/EsiopetusRaporttiSpec.scala
+++ b/src/test/scala/fi/oph/koski/raportit/EsiopetusRaporttiSpec.scala
@@ -8,16 +8,17 @@ import fi.oph.koski.henkilo.{LaajatOppijaHenkilöTiedot, MockOppijat}
 import fi.oph.koski.log.AuditLogTester
 import fi.oph.koski.organisaatio.MockOrganisaatiot
 import fi.oph.koski.raportointikanta.RaportointikantaTestMethods
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.{FreeSpec, Matchers, BeforeAndAfterAll}
 
-class EsiopetusRaporttiSpec extends FreeSpec with Matchers with RaportointikantaTestMethods {
+class EsiopetusRaporttiSpec extends FreeSpec with Matchers with RaportointikantaTestMethods with BeforeAndAfterAll {
 
   lazy val raportti = {
-    loadRaportointikantaFixtures
     val raporttiBuilder = EsiopetusRaportti(KoskiApplicationForTests.raportointiDatabase.db)
     val päivä = Date.valueOf("2007-01-01")
     raporttiBuilder.build(MockOrganisaatiot.jyväskylänNormaalikoulu, päivä).rows.map(_.asInstanceOf[EsiopetusRaporttiRow])
   }
+
+  override def beforeAll(): Unit = loadRaportointikantaFixtures
 
   "Esiopetuksen raportti" - {
     "Raportti voidaan ladata ja lataaminen tuottaa auditlogin" in {


### PR DESCRIPTION
Testin _"Raportti voidaan ladata ja lataaminen tuottaa auditlogin"_ osuus feilaa jos fixtureita ei olla ajettu sisään ennen testin ajoa. Joten siirretään `loadRaportointikantaFixtures`-kutsu `beforeAll`-koukkuun, jotta se on varmasti ajettuna ennen testejä.