### PR TITLE
Vanhentuneiden sessioiden poisto

### DIFF
--- a/src/main/scala/fi/oph/koski/schedule/KoskiScheduledTasks.scala
+++ b/src/main/scala/fi/oph/koski/schedule/KoskiScheduledTasks.scala
@@ -7,6 +7,7 @@ class KoskiScheduledTasks(application: KoskiApplication) {
   val updateHenkilötScheduler: Option[Scheduler] = new UpdateHenkilotTask(application).scheduler
   val syncPerustiedot: Option[Scheduler] = application.perustiedotSyncScheduler.scheduler
   val syncTiedonsiirrot = new TiedonsiirtoScheduler(application.masterDatabase.db, application.config, application.koskiElasticSearchIndex, application.tiedonsiirtoService)
+  val purgeOldSessions: Option[Scheduler] = new PurgeOldSessionsTask(application).scheduler
   def init {}
 }
 

--- a/src/main/scala/fi/oph/koski/schedule/PurgeOldSessionsTask.scala
+++ b/src/main/scala/fi/oph/koski/schedule/PurgeOldSessionsTask.scala
@@ -1,0 +1,32 @@
+package fi.oph.koski.schedule
+
+import java.time.{Duration, ZonedDateTime}
+
+import fi.oph.koski.config.KoskiApplication
+import fi.oph.koski.util.Timing
+import org.json4s.JValue
+
+class PurgeOldSessionsTask(app: KoskiApplication) extends Timing {
+  def scheduler: Option[Scheduler] = Some(new Scheduler(
+    app.masterDatabase.db,
+    "purge-old-sessions",
+    new IntervalSchedule(Duration.ofHours(3)),
+    None,
+    tryRun,
+  ))
+
+  private def tryRun(unused: Option[JValue]) = timed("purgeOldSessions") {
+    try {
+      run()
+    } catch {
+      case e: Exception =>
+        logger.error(e)("Purging old sessions failed")
+    }
+    None
+  }
+
+  private def run(): Unit = {
+    val purgeBefore = ZonedDateTime.now().minusYears(1).toInstant
+    app.koskiSessionRepository.purgeOldSessions(purgeBefore)
+  }
+}

--- a/src/test/scala/fi/oph/koski/sso/KoskiSessionRepositorySpec.scala
+++ b/src/test/scala/fi/oph/koski/sso/KoskiSessionRepositorySpec.scala
@@ -1,0 +1,50 @@
+package fi.oph.koski.sso
+
+import java.sql.Timestamp
+import java.time.ZonedDateTime
+import java.util.UUID
+
+import fi.oph.koski.KoskiApplicationForTests
+import fi.oph.koski.api.DatabaseTestMethods
+import fi.oph.koski.db.PostgresDriverWithJsonSupport.api._
+import fi.oph.koski.db.{SSOSessionRow, Tables}
+import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+
+class KoskiSessionRepositorySpec extends FreeSpec with Matchers with DatabaseTestMethods with BeforeAndAfterAll {
+  private def createDummySession(dateTime: ZonedDateTime) = {
+    val fakeServiceTicket: String = "koski-" + UUID.randomUUID()
+    val sqlTimestamp = new Timestamp(dateTime.toInstant.toEpochMilli)
+    runDbSync(Tables.CasServiceTicketSessions += SSOSessionRow(
+      fakeServiceTicket, "test", "test", "test", sqlTimestamp, sqlTimestamp)
+    )
+  }
+
+  private def sessionsStarteds = {
+    val query = Tables.CasServiceTicketSessions.map(_.started)
+    runDbSync(query.result)
+  }
+
+  override protected def beforeAll(): Unit = {
+    runDbSync(Tables.CasServiceTicketSessions.delete)
+  }
+
+  "Vanhentuneiden sessioiden poisto" in {
+    val staleSessions = Vector(
+      ZonedDateTime.now().minusMonths(22),
+      ZonedDateTime.now().minusMonths(13),
+    )
+    val currentSessions = Vector(
+      ZonedDateTime.now().minusMonths(11),
+      ZonedDateTime.now().minusMonths(1),
+    )
+    (staleSessions ++ currentSessions).foreach(createDummySession)
+    sessionsStarteds.length should be(4)
+
+    val purgeBefore = ZonedDateTime.now().minusYears(1).toInstant
+    KoskiApplicationForTests.koskiSessionRepository.purgeOldSessions(purgeBefore)
+
+    sessionsStarteds.map(_.toInstant) should contain theSameElementsAs(
+      currentSessions.map(_.toInstant)
+    )
+  }
+}


### PR DESCRIPTION
https://jira.csc.fi/browse/TOR-817

Lisätään ajastettu tehtävä poistamaan yli vuoden vanhat sessiot `casserviceticket`-taulusta kerran päivässä.

Kommentoikaa mielellään matalalla kynnyksellä kaikesta mikä näyttää vähänkin oudolta projektin tyyli tai yleinen Scala-tyyli huomioiden tai ylipäänsä. 🙂 

Toteutuksessa on mahdollinen ongelma liittyen siihen, että tehtävä ajetaan ensimmäistä kertaa vasta 24h käynnistyksen jälkeen. Tällä hetkellä ei aiheuttane ongelmia, mutta jos siirrytään AWS:ään ja kontteihin, voi olla teoriassa mahdollista, ettei kontit ole tarpeeksi pitkään hengissä?