### PR TITLE
käytä vanhinta olemassa olevaa organisaation nimeä, jos hakupäivä on …

### DIFF
--- a/src/main/scala/fi/oph/koski/organisaatio/RemoteOrganisaatioRepository.scala
+++ b/src/main/scala/fi/oph/koski/organisaatio/RemoteOrganisaatioRepository.scala
@@ -77,10 +77,13 @@ class RemoteOrganisaatioRepository(http: Http, koodisto: KoodistoViitePalvelu)(i
   }
 
   override def getOrganisaationNimiHetkellä(oid: String, date: LocalDate) = {
-    val nimet: List[OrganisaationNimihakuTulos] = nimetCache(oid)
-    nimet.sortBy(_.alkuPvm)(DateOrdering.localDateOrdering)
+    val nimetSorted: List[OrganisaationNimihakuTulos] = nimetCache(oid).sortBy(_.alkuPvm)(DateOrdering.localDateOrdering)
+    val oldest = nimetSorted.headOption
+    nimetSorted
       .takeWhile(nimi => nimi.alkuPvm.isBefore(date) || nimi.alkuPvm.isEqual(date))
-      .lastOption.flatMap(n => LocalizedString.sanitize(n.nimi))
+      .lastOption
+      .orElse(oldest)
+      .flatMap(n => LocalizedString.sanitize(n.nimi))
   }
 
   override def findSähköpostiVirheidenRaportointiin(oid: String): Option[SähköpostiVirheidenRaportointiin] = {


### PR DESCRIPTION
…vanhempi kuin organisaation vanhin päivä.

korjaa bugin korkeakoulusuorituksissa, joissa näytettiin väärä oppilaitoksen nimi, sillä suoritus päivä on vanhempi kuin organisaatiopalvelusta löytyvä historiatieto.