### PR TITLE
TOR-1012 Korjaa valmiiden yhteisten tutkinnon osien laskeminen

### DIFF
--- a/src/main/scala/fi/oph/koski/raportit/AmmatillinenTutkintoRaportti.scala
+++ b/src/main/scala/fi/oph/koski/raportit/AmmatillinenTutkintoRaportti.scala
@@ -70,7 +70,7 @@ object AmmatillinenTutkintoRaportti {
       suoritetutAmmatillisetTutkinnonOsatYhteislaajuus = yhteislaajuus(ammatillisetTutkinnonOsatJaOsasuoritukset),
       pakollisetAmmatillisetTutkinnonOsatYhteislaajuus = yhteislaajuus(pakolliset(ammatillisetTutkinnonOsatJaOsasuoritukset)),
       valinnaisetAmmatillisetTutkinnonOsatYhteislaajuus = yhteislaajuus(valinnaiset(ammatillisetTutkinnonOsatJaOsasuoritukset)),
-      valmiitYhteistenTutkinnonOsatLkm = yhteisetTutkinnonOsat.size,
+      valmiitYhteistenTutkinnonOsatLkm = yhteisetTutkinnonOsat.count(isVahvistusPäivällinen),
       pakollisetYhteistenTutkinnonOsienOsaalueidenLkm = pakolliset(yhteistenTutkinnonOsienOsaAlueet).size,
       valinnaistenYhteistenTutkinnonOsienOsaalueidenLKm = valinnaiset(yhteistenTutkinnonOsienOsaAlueet).size,
       tunnustettujaTukinnonOsanOsaalueitaValmiissaTutkinnonOsanOsalueissaLkm = tunnustetut(yhteistenTutkinnonOsienOsaAlueet).size,


### PR DESCRIPTION
"Ammatillisen koulutuksen suoritustietoraportti laskee nyt suoritetuksi sellaisenkin yhteisen tutkinnon osan, jolla ei ole arviointia. Pitää korjata niin, että laskee suoritetuksi vain sellaiset yhteiset tutkinnon osat, joilla on arviointi. "