### PR TITLE
Korjaa esiopetuksen tallentaminen validaatioita

### DIFF
--- a/src/main/resources/mockdata/organisaatio/hierarkia/1.2.246.562.10.15679231819.json
+++ b/src/main/resources/mockdata/organisaatio/hierarkia/1.2.246.562.10.15679231819.json
@@ -1,0 +1,51 @@
+{
+  "numHits": 9,
+  "organisaatiot": [
+    {
+      "oid": "1.2.246.562.10.15679231819",
+      "alkuPvm": 1168812000000,
+      "parentOid": "1.2.246.562.10.00000000001",
+      "parentOidPath": "1.2.246.562.10.15679231819/1.2.246.562.10.00000000001",
+      "ytunnus": "2087642-1",
+      "toimipistekoodi": "",
+      "match": true,
+      "nimi": {
+        "fi": "Norlandia Päiväkodit Jyvässeutu Oy"
+      },
+      "kieletUris": [
+        "oppilaitoksenopetuskieli_1#1"
+      ],
+      "kotipaikkaUri": "kunta_049",
+      "children": [
+        {
+          "oid": "1.2.246.562.10.21747360762",
+          "alkuPvm": 1325368800000,
+          "parentOid": "1.2.246.562.10.15679231819",
+          "parentOidPath": "1.2.246.562.10.21747360762/1.2.246.562.10.15679231819/1.2.246.562.10.00000000001",
+          "toimipistekoodi": "",
+          "match": false,
+          "nimi": {
+            "sv": "Tarina",
+            "fi": "Tarina",
+            "en": "Tarina"
+          },
+          "kieletUris": [
+            "oppilaitoksenopetuskieli_1#1"
+          ],
+          "kotipaikkaUri": "kunta_179",
+          "children": [],
+          "aliOrganisaatioMaara": 0,
+          "organisaatiotyypit": [
+            "VARHAISKASVATUKSEN_TOIMIPAIKKA"
+          ],
+          "status": "AKTIIVINEN"
+        }
+      ],
+      "aliOrganisaatioMaara": 8,
+      "organisaatiotyypit": [
+        "VARHAISKASVATUKSEN_JARJESTAJA"
+      ],
+      "status": "AKTIIVINEN"
+    }
+  ]
+}

--- a/src/main/resources/mockdata/organisaatio/varhaiskasvatustoimipisteet.json
+++ b/src/main/resources/mockdata/organisaatio/varhaiskasvatustoimipisteet.json
@@ -67670,6 +67670,29 @@
         "organisaatiotyyppi_08"
       ],
       "status": "AKTIIVINEN"
+    },
+    {
+      "oid": "1.2.246.562.10.21747360762",
+      "alkuPvm": 1325368800000,
+      "parentOid": "1.2.246.562.10.15679231819",
+      "parentOidPath": "1.2.246.562.10.21747360762/1.2.246.562.10.15679231819/1.2.246.562.10.00000000001",
+      "toimipistekoodi": "",
+      "match": false,
+      "nimi": {
+        "sv": "Tarina",
+        "fi": "Tarina",
+        "en": "Tarina"
+      },
+      "kieletUris": [
+        "oppilaitoksenopetuskieli_1#1"
+      ],
+      "kotipaikkaUri": "kunta_179",
+      "children": [],
+      "aliOrganisaatioMaara": 0,
+      "organisaatiotyypit": [
+        "organisaatiotyyppi_08"
+      ],
+      "status": "AKTIIVINEN"
     }
   ]
 }

--- a/src/main/resources/mockdata/organisaatio/varhaiskasvatustoimipisteet.json
+++ b/src/main/resources/mockdata/organisaatio/varhaiskasvatustoimipisteet.json
@@ -1,5 +1,5 @@
 {
-  "numHits": 2952,
+  "numHits": 2953,
   "organisaatiot": [
     {
       "oid": "1.2.246.562.10.25398219250",

--- a/src/main/scala/fi/oph/koski/documentation/YleissivistavakoulutusExampleData.scala
+++ b/src/main/scala/fi/oph/koski/documentation/YleissivistavakoulutusExampleData.scala
@@ -1,6 +1,5 @@
 package fi.oph.koski.documentation
 
-import fi.oph.koski.localization.LocalizedStringImplicits._
 import fi.oph.koski.organisaatio.{MockOrganisaatioRepository, MockOrganisaatiot}
 import fi.oph.koski.schema._
 

--- a/src/main/scala/fi/oph/koski/organisaatio/MockOrganisaatioRepository.scala
+++ b/src/main/scala/fi/oph/koski/organisaatio/MockOrganisaatioRepository.scala
@@ -42,6 +42,8 @@ object MockOrganisaatiot {
   val internationalSchool = "1.2.246.562.10.67636414343"
   val päiväkotiTouhula = "1.2.246.562.10.63518646078"
   val päiväkotiMajakka = "1.2.246.562.10.90219092054"
+  val norlandiaPäiväkodit = "1.2.246.562.10.15679231819"
+  val päiväkotiTarina = "1.2.246.562.10.21747360762"
 
   val oppilaitokset: List[String] = List(
     stadinAmmattiopisto,
@@ -72,7 +74,8 @@ object MockOrganisaatiot {
     ylioppilastutkintolautakunta, aapajoenKoulu,
     kouluyhdistysPestalozziSchulvereinSkolföreningen,
     helsinginKansainvälisenKoulunVanhempainyhdistys,
-    pyhtäänKunta
+    pyhtäänKunta,
+    norlandiaPäiväkodit
   )
 }
 

--- a/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
+++ b/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
@@ -187,7 +187,7 @@ class KoskiValidator(tutkintoRepository: TutkintoRepository, val koodistoPalvelu
   }
 
   private def järjestettyOmanOrganisaationUlkopuolella(oo: EsiopetuksenOpiskeluoikeus) = oo.oppilaitos.exists { oppilaitos =>
-    oo.koulutustoimija.forall(kt => organisaatioRepository.findKoulutustoimijaForOppilaitos(oppilaitos).exists(_.oid != kt.oid))
+    oo.koulutustoimija.forall(kt => organisaatioRepository.findKoulutustoimijaForOppilaitos(oppilaitos).forall(_.oid != kt.oid))
   }
 
   private def päiväkodinEsiopetus(oo: EsiopetuksenOpiskeluoikeus) = {

--- a/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
+++ b/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
@@ -173,33 +173,35 @@ class KoskiValidator(tutkintoRepository: TutkintoRepository, val koodistoPalvelu
     }
   }
 
-  private def validateAndAddVarhaiskasvatusKoulutustoimija(oo: EsiopetuksenOpiskeluoikeus)(implicit user: KoskiSession) = (päiväkodinEsiopetus(oo), järjestettyOmanOrganisaationUlkopuolella(oo)) match {
-    case (true, true) =>
-      if (oo.koulutustoimija.isDefined && user.hasVarhaiskasvatusAccess(oo.koulutustoimija.get.oid, oo.getOppilaitos.oid, AccessType.write)) {
-        Right(oo)
-      } else {
-        addVarhaiskasvatusKoulutustoimija(oo, user)
-      }
-    case (false, true) =>
-      Left(KoskiErrorCategory.badRequest.validation.koodisto.vääräKoulutuksenTunniste(s"Järjestämismuoto sallittu vain päiväkodissa järjestettävälle esiopetukselle ($päiväkodinEsiopetuksenTunniste)"))
-    case _ =>
-      Left(KoskiErrorCategory.badRequest.validation.organisaatio.järjestämismuoto())
+  private def validateAndAddVarhaiskasvatusKoulutustoimija(oo: EsiopetuksenOpiskeluoikeus)(implicit user: KoskiSession) = {
+    val koulutustoimija = inferKoulutustoimija(user)
+    (päiväkodinEsiopetus(oo), järjestettyOmanOrganisaationUlkopuolella(oo.oppilaitos, oo.koulutustoimija.orElse(koulutustoimija.toOption))) match {
+      case (true, true) =>
+        if (oo.koulutustoimija.isDefined && user.hasVarhaiskasvatusAccess(oo.koulutustoimija.get.oid, oo.getOppilaitos.oid, AccessType.write)) {
+          Right(oo)
+        } else {
+          koulutustoimija.map(oo.withKoulutustoimija)
+        }
+      case (false, true) =>
+        Left(KoskiErrorCategory.badRequest.validation.koodisto.vääräKoulutuksenTunniste(s"Järjestämismuoto sallittu vain päiväkodissa järjestettävälle esiopetukselle ($päiväkodinEsiopetuksenTunniste)"))
+      case _ =>
+        Left(KoskiErrorCategory.badRequest.validation.organisaatio.järjestämismuoto())
+    }
   }
 
-  private def järjestettyOmanOrganisaationUlkopuolella(oo: EsiopetuksenOpiskeluoikeus) = oo.oppilaitos.exists { oppilaitos =>
-    oo.koulutustoimija.forall(kt => organisaatioRepository.findKoulutustoimijaForOppilaitos(oppilaitos).forall(_.oid != kt.oid))
+  private def järjestettyOmanOrganisaationUlkopuolella(oppilaitos: Option[Oppilaitos], koulutustoimija: Option[Koulutustoimija]) = oppilaitos.exists { oppilaitos =>
+    koulutustoimija.forall(kt => organisaatioRepository.findKoulutustoimijaForOppilaitos(oppilaitos).forall(_.oid != kt.oid))
   }
 
   private def päiväkodinEsiopetus(oo: EsiopetuksenOpiskeluoikeus) = {
     oo.suoritukset.forall(päiväkodissaJärjestettyEsiopetuksenSuoritus)
   }
 
-  private def addVarhaiskasvatusKoulutustoimija(oo: EsiopetuksenOpiskeluoikeus, user: KoskiSession) = {
+  private def inferKoulutustoimija(user: KoskiSession) = {
     user.varhaiskasvatusKäyttöoikeudet.map(_.koulutustoimija.oid).toList match {
       case koulutustoimijaOid :: Nil =>
         organisaatioRepository.getOrganisaatio(koulutustoimijaOid)
           .flatMap(_.toKoulutustoimija)
-          .map(oo.withKoulutustoimija)
           .toRight(KoskiErrorCategory.badRequest.validation.organisaatio.tuntematon(s"Koulutustoimijaa $koulutustoimijaOid ei löydy"))
       case Nil =>
         Left(KoskiErrorCategory.forbidden.vainVarhaiskasvatuksenJärjestäjä("Operaatio on sallittu vain käyttäjälle joka on luotu varhaiskasvatusta järjestävälle koulutustoimijalle"))

--- a/src/test/scala/fi/oph/koski/api/VarhaiskasvatusSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/VarhaiskasvatusSpec.scala
@@ -1,12 +1,12 @@
 package fi.oph.koski.api
 
 import fi.oph.koski.documentation.ExamplesEsiopetus.{ostopalvelu, päiväkodinEsiopetuksenTunniste}
-import fi.oph.koski.documentation.YleissivistavakoulutusExampleData.{päiväkotiTouhula, päiväkotiVironniemi}
-import fi.oph.koski.henkilo.MockOppijat
+import fi.oph.koski.documentation.YleissivistavakoulutusExampleData.{oidOrganisaatio, päiväkotiTouhula, päiväkotiVironniemi}
 import fi.oph.koski.henkilo.MockOppijat.{asUusiOppija, ysiluokkalainen}
 import fi.oph.koski.http.KoskiErrorCategory
 import fi.oph.koski.koskiuser.MockUsers
 import fi.oph.koski.organisaatio.MockOrganisaatiot
+import fi.oph.koski.organisaatio.MockOrganisaatiot.päiväkotiTarina
 import fi.oph.koski.schema.EsiopetuksenOpiskeluoikeus
 import org.scalatest.FreeSpec
 
@@ -37,6 +37,14 @@ class VarhaiskasvatusSpec extends FreeSpec with EsiopetusSpecification {
         }
 
         delete(s"api/opiskeluoikeus/${resp.opiskeluoikeudet.head.oid}", headers = authHeaders(MockUsers.helsinkiTallentaja)) {
+          verifyResponseStatusOk()
+        }
+      }
+
+
+      "voi tallentaa opiskeluoikeuden jonka oppilaitoksena on yksityinen päiväkoti joka ei ole koulutustoimijan alla organisaatiohierarkiassa" in {
+        val opiskeluoikeus = päiväkotiEsiopetus(oidOrganisaatio(päiväkotiTarina), ostopalvelu).copy(koulutustoimija = hki)
+        putOpiskeluoikeus(opiskeluoikeus, headers = authHeaders(MockUsers.helsinkiTallentaja) ++ jsonContent) {
           verifyResponseStatusOk()
         }
       }
@@ -113,6 +121,13 @@ class VarhaiskasvatusSpec extends FreeSpec with EsiopetusSpecification {
 
       "voi tallentaa opiskeluoikeuden jonka oppilaitoksena on päiväkoti joka ei ole koulutustoimijan alla organisaatiohierarkiassa" in {
         val opiskeluoikeus = päiväkotiEsiopetus(päiväkotiTouhula, ostopalvelu).copy(koulutustoimija = hki)
+        putOpiskeluoikeus(opiskeluoikeus, headers = authHeaders(MockUsers.paakayttaja) ++ jsonContent) {
+          verifyResponseStatusOk()
+        }
+      }
+
+      "voi tallentaa opiskeluoikeuden jonka oppilaitoksena on yksityinen päiväkoti joka ei ole koulutustoimijan alla organisaatiohierarkiassa" in {
+        val opiskeluoikeus = päiväkotiEsiopetus(oidOrganisaatio(päiväkotiTarina), ostopalvelu).copy(koulutustoimija = hki)
         putOpiskeluoikeus(opiskeluoikeus, headers = authHeaders(MockUsers.paakayttaja) ++ jsonContent) {
           verifyResponseStatusOk()
         }

--- a/src/test/scala/fi/oph/koski/api/VarhaiskasvatusSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/VarhaiskasvatusSpec.scala
@@ -41,6 +41,12 @@ class VarhaiskasvatusSpec extends FreeSpec with EsiopetusSpecification {
         }
       }
 
+      "ei voi tallentaa opiskeluoikeutta jonka oppilaitos on päiväkoti joka on omassa organisaatiohierarkiassa" in {
+        val opiskeluoikeus = päiväkotiEsiopetus(päiväkotiVironniemi, ostopalvelu)
+        putOpiskeluoikeus(opiskeluoikeus, headers = authHeaders(MockUsers.helsinkiTallentaja) ++ jsonContent) {
+          verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.organisaatio.järjestämismuoto())
+        }
+      }
 
       "voi tallentaa opiskeluoikeuden jonka oppilaitoksena on yksityinen päiväkoti joka ei ole koulutustoimijan alla organisaatiohierarkiassa" in {
         val opiskeluoikeus = päiväkotiEsiopetus(oidOrganisaatio(päiväkotiTarina), ostopalvelu).copy(koulutustoimija = hki)

--- a/web/test/page/addOppijaPage.js
+++ b/web/test/page/addOppijaPage.js
@@ -180,6 +180,7 @@ function AddOppijaPage() {
       return OrganisaatioHaku(form).select(name)
     },
     oppilaitokset: OrganisaatioHaku(form).oppilaitokset,
+    toimipisteet: OrganisaatioHaku(form).toimipisteet,
     oppilaitos: OrganisaatioHaku(form).oppilaitos,
     selectTutkinto: function(name) {
       if (!name) { return wait.forAjax }

--- a/web/test/page/organisaatioHaku.js
+++ b/web/test/page/organisaatioHaku.js
@@ -34,6 +34,9 @@ function OrganisaatioHaku(elem) {
     oppilaitokset: function() {
       return textsOf(elem().find('.organisaatiot li'))
     },
+    toimipisteet: function() {
+      return textsOf(elem().find('.organisaatiot .aliorganisaatiot li'))
+    },
     oppilaitos: function() {
       return elem().find('.organisaatio-selection').text()
     }

--- a/web/test/spec/esiopetusSpec.js
+++ b/web/test/spec/esiopetusSpec.js
@@ -126,8 +126,8 @@ describe('Esiopetus', function() {
         )
 
         it('vain oman organisaation ulkopuoliset varhaiskasvatustoimipisteet näytetään', function () {
-          expect(addOppija.oppilaitokset()).to.deep.equal([
-            'Pyhtään kunta Päiväkoti Majakka Päiväkoti Touhula',
+          expect(addOppija.toimipisteet()).to.deep.equal([
+            'Tarina',
             'Päiväkoti Majakka',
             'Päiväkoti Touhula'
           ])


### PR DESCRIPTION
- Korjaa virheen validaatiossa kun yksityisen päiväkodin organisaatiohierarkian juuresta ei löydykään koulutustoimijaa (TOR-1027)
- Korjaa toisen virheen validaatiossa missä pääsee tallentamaan järjestämismuodollisen esiopetuksen opiskeluoikeuden omaan organisaation silloin kun koulutustoimijaa ei määritellä eksplisiittisesti 