### PR TITLE
Käytä uusinta scalastyle-pluginia ja scalastyleä

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -601,7 +601,14 @@
           <plugin>
             <groupId>org.scalastyle</groupId>
             <artifactId>scalastyle-maven-plugin</artifactId>
-            <version>0.8.0</version>
+            <version>1.0.0</version>
+            <dependencies>
+              <dependency>
+                <groupId>com.beautiful-scala</groupId>
+                <artifactId>scalastyle_2.12</artifactId>
+                <version>1.4.0</version>
+              </dependency>
+            </dependencies>
             <configuration>
               <verbose>false</verbose>
               <failOnViolation>true</failOnViolation>


### PR DESCRIPTION
Alkuperäisen scalastylen ylläpitäjät ovat kadonneet, joten piti vaihtaa uuteen fork:iin, jonka kehitys jatkuu, ja joka osaa parsia esim. scala-koodia, jossa käytetty trailing comma:a.

Historiaa: https://github.com/scalastyle/scalastyle/issues/327#issuecomment-570951273
Uuden forkin websivu: https://scalastyle.beautiful-scala.com/

Uutta scalastyle-maven-pluginia forkin tekijä ei ole tehnyt, siksi piti muuttaa riippuvuus käsin pom.xml:ssä.