### PR TITLE
Tor-1038 Uuden oppijan luonti epäonnistuu Firefoxilla

### DIFF
--- a/web/app/uusioppija/UusiOppija.jsx
+++ b/web/app/uusioppija/UusiOppija.jsx
@@ -37,7 +37,12 @@ export const UusiOppija = ({hetu, oid}) => {
         <UusiHenkilö {...{ hetu, oid, henkilöAtom, henkilöValidAtom }}/>
         <hr/>
         <UusiOpiskeluoikeus opiskeluoikeusAtom={opiskeluoikeusAtom}/>
-        <button type='button' className='koski-button' disabled={submitEnabledP.not()} onClick={() => submitBus.push()}>{buttonTextP}</button>
+        <button
+          type='button'
+          className='koski-button'
+          disabled={submitEnabledP.not()}
+          onClick={() => submitBus.push()}
+        >{buttonTextP}</button>
       </form>
     </div>
   )

--- a/web/app/uusioppija/UusiOppija.jsx
+++ b/web/app/uusioppija/UusiOppija.jsx
@@ -37,7 +37,7 @@ export const UusiOppija = ({hetu, oid}) => {
         <UusiHenkilö {...{ hetu, oid, henkilöAtom, henkilöValidAtom }}/>
         <hr/>
         <UusiOpiskeluoikeus opiskeluoikeusAtom={opiskeluoikeusAtom}/>
-        <button className='koski-button' disabled={submitEnabledP.not()} onClick={() => submitBus.push()}>{buttonTextP}</button>
+        <button type='button' className='koski-button' disabled={submitEnabledP.not()} onClick={() => submitBus.push()}>{buttonTextP}</button>
       </form>
     </div>
   )


### PR DESCRIPTION
Button-elementti on oletuksena submit-tyyppinen, eli lähettää formin sivuvaikutuksena. Formin lähetys katkaisee Firefoxissa fetch-pyynnöt (Firefox toimii tiukemmin speksin mukaan kuin muut selaimet). Tällöin vaihtelevasti pyyntö joko jää palvelimella kesken, ja uutta oppijaa ei luoda, tai selain ei vastaanota palvelimen vastausta, jolloin oppija on luotu, mutta käyttöliittymä joutuu virhetilaan eikä näytä luotua oppijaa.

Korjataan muuttamalla nappi button-tyyppiseksi, jolloin formia ei lähetetä ja Bacon saa rauhassa tehdä työnsä. Muutos poistaa käytöstä formin lähettämisen enter-nappia painamalla. Tämä ei tosin tähän mennessäkään ilmeisesti toiminut fokuksen ollessa dropdown-kentissä. 🤷 