### PR TITLE
"Linkitys tehty"-validaatio tarkistaa vain opiskeluoikeus oidin

### DIFF
--- a/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
+++ b/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
@@ -525,9 +525,8 @@ class KoskiValidator(tutkintoRepository: TutkintoRepository, val koodistoPalvelu
   }
 
   private def linkitysTehty(opiskeluoikeusOid: String, oppilaitosOid: Oid, oppijaOids: List[Oid]) =
-    koskiOpiskeluoikeudet.findByOppijaOids(oppijaOids)(KoskiSession.systemUser).exists(_.sisältyyOpiskeluoikeuteen.exists(s =>
-      s.oid == opiskeluoikeusOid && s.oppilaitos.oid == oppilaitosOid
-    ))
+    koskiOpiskeluoikeudet.findByOppijaOids(oppijaOids)(KoskiSession.systemUser)
+      .exists(_.sisältyyOpiskeluoikeuteen.exists(_.oid == opiskeluoikeusOid))
 
   private def validateValmiinSuorituksenStatus(suoritus: Suoritus) = {
     suoritus.rekursiivisetOsasuoritukset.find(_.kesken).fold(HttpStatus.ok) { keskeneräinenOsasuoritus =>


### PR DESCRIPTION
Mahdollistaa muutokset sisältävään opiskeluoikeuteen (kuoreen) vaikka sisältyvän
opiskeluoikeuden (pihvin) oppilaitos olisi muuttunut