### PR TITLE
tor-902 piilota uudet kentät toistaiseksi

### DIFF
--- a/src/main/resources/localization/default-texts.json
+++ b/src/main/resources/localization/default-texts.json
@@ -1340,5 +1340,6 @@
   "tooltip:Osallistuuko oppilas osa-aikaiseen erityisopetukseen lukuvuoden..." : "Osallistuuko oppilas osa-aikaiseen erityisopetukseen lukuvuoden aikana",
   "tooltip:Oppilaan osallistuminen osa-aikaiseen erityisopetukseen lukuvuoden..." : "Oppilaan osallistuminen osa-aikaiseen erityisopetukseen lukuvuoden aikana",
   "deprecated:Käytä korvaavia kenttiä Erityisen tuen..." : "Käytä korvaavia kenttiä Erityisen tuen päätökset, Osa-aikainen erityisopetus lukuvuoden aikana ja Osa-aikainen erityisopetus perusopetuksen lisäopetuksen aikana",
-  "Osa-aikainen erityisopetus perusopetuksen lisäopetuksen aikana" : "Osa-aikainen erityisopetus perusopetuksen lisäopetuksen aikana"
+  "Osa-aikainen erityisopetus perusopetuksen lisäopetuksen aikana" : "Osa-aikainen erityisopetus perusopetuksen lisäopetuksen aikana",
+  "deprecated:Tätä kenttää ei toistaiseksi käytetä." : "Tätä kenttää ei toistaiseksi käytetä."
 }

--- a/src/main/scala/fi/oph/koski/schema/Esiopetus.scala
+++ b/src/main/scala/fi/oph/koski/schema/Esiopetus.scala
@@ -109,6 +109,7 @@ case class EsiopetuksenSuoritus(
   @Tooltip("Oppilaan osallistuminen osa-aikaiseen erityisopetukseen lukuvuoden aikana")
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KAIKKI_TIEDOT))
   @KoodistoUri("osaaikainenerityisopetuslukuvuodenaikana")
+  @Deprecated("Tätä kenttää ei toistaiseksi käytetä.")
   osaAikainenErityisopetus: Option[List[Koodistokoodiviite]] = None,
   @KoodistoKoodiarvo("esiopetuksensuoritus")
   tyyppi: Koodistokoodiviite = Koodistokoodiviite("esiopetuksensuoritus", koodistoUri = "suorituksentyyppi"),

--- a/src/main/scala/fi/oph/koski/schema/NuortenPerusopetus.scala
+++ b/src/main/scala/fi/oph/koski/schema/NuortenPerusopetus.scala
@@ -169,6 +169,7 @@ trait Tukimuodollinen {
   @Description("Oppilaan saamat laissa säädetyt tukimuodot.")
   @Tooltip("Oppilaan saamat laissa säädetyt tukimuodot. Voi olla useita.")
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KAIKKI_TIEDOT))
+  @Deprecated("Tätä kenttää ei toistaiseksi käytetä.")
   def tukimuodot: Option[List[Koodistokoodiviite]]
 
   def tukimuotoLista: List[Koodistokoodiviite] = tukimuodot.getOrElse(List())
@@ -198,6 +199,7 @@ Huom: toiminta-alue arviointeineen on kuvattu oppiaineen suorituksessa.""")
   @KoodistoUri("erityisopetuksentoteutuspaikka")
   @Title("Erityisopetuksen toteutuspaikka")
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KAIKKI_TIEDOT))
+  @Deprecated("Tätä kenttää ei toistaiseksi käytetä.")
   toteutuspaikka: Option[Koodistokoodiviite] = None,
   tukimuodot: Option[List[Koodistokoodiviite]] = None
 ) extends MahdollisestiAlkupäivällinenJakso with Tukimuodollinen {
@@ -246,6 +248,7 @@ case class PerusopetuksenVuosiluokanSuoritus(
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KAIKKI_TIEDOT))
   @DefaultValue(false)
   @Title("Osa-aikainen erityisopetus lukuvuoden aikana")
+  @Deprecated("Tätä kenttää ei toistaiseksi käytetä.")
   osaAikainenErityisopetus: Boolean = false,
   @Description("Tieto siitä, että oppilas jää luokalle")
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KAIKKI_TIEDOT))

--- a/src/main/scala/fi/oph/koski/schema/PerusopetuksenLisaopetus.scala
+++ b/src/main/scala/fi/oph/koski/schema/PerusopetuksenLisaopetus.scala
@@ -3,7 +3,7 @@ package fi.oph.koski.schema
 import java.time.{LocalDate, LocalDateTime}
 
 import fi.oph.koski.koskiuser.Rooli
-import fi.oph.koski.schema.annotation.{Hidden, KoodistoKoodiarvo, SensitiveData, Tooltip}
+import fi.oph.koski.schema.annotation.{Deprecated, Hidden, KoodistoKoodiarvo, SensitiveData, Tooltip}
 import fi.oph.scalaschema.annotation._
 
 @Description("Perusopetuksen lisäopetuksen opiskeluoikeus")
@@ -50,6 +50,7 @@ case class PerusopetuksenLisäopetuksenSuoritus(
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KAIKKI_TIEDOT))
   @DefaultValue(false)
   @Title("Osa-aikainen erityisopetus perusopetuksen lisäopetuksen aikana")
+  @Deprecated("Tätä kenttää ei toistaiseksi käytetä.")
   osaAikainenErityisopetus: Boolean = false,
   @Description("Oppiaineiden suoritukset")
   @Title("Oppiaineet")

--- a/web/test/spec/perusopetusSpec.js
+++ b/web/test/spec/perusopetusSpec.js
@@ -1192,7 +1192,8 @@ describe('Perusopetus', function() {
           after(pidennettyOppivelvollisuus.setLoppu(currentDateStr), editor.saveChanges, wait.until(page.isSavedLabelShown))
         })
 
-        describe('Tukimuodot', function() {
+        // Ks. https://github.com/Opetushallitus/koski/pull/876 : väliaikaisesti disabloitu
+        describe.skip('Tukimuodot', function() {
           describe('Lisättäessä ensimmäinen', function() {
             before(
               editor.edit,


### PR DESCRIPTION
Luultavasti laki muuttuu syksyllä, minkä jälkeen kentät voidaan ottaa käyttöön. Ennen sitä niihin datan tallentaminen on kuitenkin kiellettyä, mistä on viestitty myös koulujärjestelmien
kehittäjille.

Pitäisikö lisätä validointi, joka estää uusiin kenttiin tietojen tallentamisen kokonaan? Vastaus: ei lisätä