### PR TITLE
TOR-1073: Ota käyttöön uudempi patch-versio http4s:stä

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,12 +195,12 @@
     <dependency>
       <groupId>org.http4s</groupId>
       <artifactId>http4s-blaze-client_2.12</artifactId>
-      <version>0.16.6</version>
+      <version>0.16.6a</version>
     </dependency>
     <dependency>
       <groupId>org.http4s</groupId>
       <artifactId>http4s-dsl_2.12</artifactId>
-      <version>0.16.6</version>
+      <version>0.16.6a</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/src/main/scala/fi/oph/koski/healthcheck/HealthChecker.scala
+++ b/src/main/scala/fi/oph/koski/healthcheck/HealthChecker.scala
@@ -137,7 +137,7 @@ trait HealthCheck extends Logging {
   }
 
   private def get[T](key: String, f: => T, timeout: Duration = 5 seconds): Either[HttpStatus, T] = try {
-    Right(Task(f).runFor(timeout))
+    Right(Task(f).unsafePerformSyncFor(timeout))
   } catch {
     case e: HttpStatusException =>
       Left(HttpStatus(e.status, List(ErrorDetail(key, e.text))))

--- a/src/main/scala/fi/oph/koski/http/Http.scala
+++ b/src/main/scala/fi/oph/koski/http/Http.scala
@@ -109,7 +109,7 @@ object Http extends Logging {
   }
 
   // Http task runner: runs at most 2 minutes. We must avoid using the timeout-less run method, that may block forever.
-  def runTask[A](task: Task[A]): A = task.runFor(2.minutes)
+  def runTask[A](task: Task[A]): A = task.unsafePerformSyncFor(2.minutes)
 
   type Decode[ResultType] = (Int, String, Request) => ResultType
 

--- a/src/main/scala/fi/oph/koski/huoltaja/HuollettavatRepository.scala
+++ b/src/main/scala/fi/oph/koski/huoltaja/HuollettavatRepository.scala
@@ -31,7 +31,7 @@ class RemoteHuollettavatRepository(val http: Http) extends HuollettavatRepositor
           logger.error(e.toString)
           Left(KoskiErrorCategory.unavailable.huollettavat())
       }
-      .run
+      .unsafePerformSync
   }
 }
 

--- a/src/main/scala/fi/oph/koski/sso/CasServlet.scala
+++ b/src/main/scala/fi/oph/koski/sso/CasServlet.scala
@@ -60,6 +60,6 @@ class CasServlet(implicit val application: KoskiApplication) extends HtmlServlet
   }
 
   def validateServiceTicket(service: String, ticket: String): Username =
-    casClient.validateServiceTicket(service)(ticket).run
+    casClient.validateServiceTicket(service)(ticket).unsafePerformSync
 }
 

--- a/src/main/scala/fi/oph/koski/ytr/YtrClient.scala
+++ b/src/main/scala/fi/oph/koski/ytr/YtrClient.scala
@@ -42,6 +42,6 @@ case class RemoteYtrClient(rootUrl: String, user: String, password: String, inse
   private val clientConfig: BlazeClientConfig = if (insecure) BlazeClientConfig.insecure else BlazeClientConfig.defaultConfig
   private val http = Http(rootUrl, ClientWithBasicAuthentication(Http.newClient("ytr", clientConfig), user, password))
   def oppijaJsonByHetu(hetu: String): Option[JValue] = {
-    http.get(uri"/api/oph-koski/student/$hetu")(Http.parseJsonOptional[JValue]).run
+    http.get(uri"/api/oph-koski/student/$hetu")(Http.parseJsonOptional[JValue]).unsafePerformSync
   }
 }

--- a/src/test/scala/fi/oph/koski/henkilo/OppijanumeroRekisteriClientSpec.scala
+++ b/src/test/scala/fi/oph/koski/henkilo/OppijanumeroRekisteriClientSpec.scala
@@ -138,101 +138,101 @@ class OppijanumeroRekisteriClientSpec extends FreeSpec with Matchers with Either
   "OppijanumeroRekisteriClient" - {
 
     "perustaa uuden oppijahenkilön" in {
-      val result = mockClient.findOrCreate(UusiOppijaHenkilö(Some(hetu), "Mallikas", "Mikko Alfons", "Mikko")).run
+      val result = mockClient.findOrCreate(UusiOppijaHenkilö(Some(hetu), "Mallikas", "Mikko Alfons", "Mikko")).unsafePerformSync
       result.right.value should equal(expectedSuppeatOppijaHenkilötiedot)
     }
 
     "tunnistaa 400-vastauksen uutta oppijahenkilöä perustaessa" in {
-      val result = mockClient.findOrCreate(UusiOppijaHenkilö(Some(hetu), "", "Mikko Alfons", "Mikko")).run
+      val result = mockClient.findOrCreate(UusiOppijaHenkilö(Some(hetu), "", "Mikko Alfons", "Mikko")).unsafePerformSync
       result.left.value.statusCode should equal(400)
     }
 
     "palauttaa käyttäjähenkilön tiedot oid:n perusteella" in {
-      val result = mockClient.findKäyttäjäByOid(oid).run
+      val result = mockClient.findKäyttäjäByOid(oid).unsafePerformSync
       result.value should equal(expectedKäyttäjäHenkilö)
     }
 
     "palauttaa oppijahenkilön tiedot oid:n perusteella" in {
-      val result = mockClient.findOppijaByOid(oid).run
+      val result = mockClient.findOppijaByOid(oid).unsafePerformSync
       result.value should equal(expectedLaajatOppijaHenkilötiedot)
     }
 
     "palauttaa oppijahenkilön master-tiedot oid:n perusteella" in {
-      val result = mockClient.findMasterOppija(oid).run
+      val result = mockClient.findMasterOppija(oid).unsafePerformSync
       result.value should equal(expectedLaajatOppijaHenkilötiedot)
     }
 
     "palauttaa oppijahenkilön tiedot oid-listan perusteella" in {
-      val result = mockClient.findOppijatNoSlaveOids(List(oid)).run
+      val result = mockClient.findOppijatNoSlaveOids(List(oid)).unsafePerformSync
       result should contain only expectedSuppeatOppijaHenkilötiedot
     }
 
     "palauttaa muuttuneiden oppijahenkilön oid:t" in {
-      val result = mockClient.findChangedOppijaOids(1541163791, 0, 1).run
+      val result = mockClient.findChangedOppijaOids(1541163791, 0, 1).unsafePerformSync
       result should contain only (oid)
     }
 
     "palauttaa oppijahenkilön tiedot hetun perusteella" in {
-      val result = mockClient.findOppijaByHetu(hetu).run
+      val result = mockClient.findOppijaByHetu(hetu).unsafePerformSync
       result.value should equal(expectedLaajatOppijaHenkilötiedot)
     }
 
     "palauttaa oppijahenkilön tiedot hetu-listan perusteella" in {
-      val result = mockClient.findOppijatByHetusNoSlaveOids(List(hetu)).run
+      val result = mockClient.findOppijatByHetusNoSlaveOids(List(hetu)).unsafePerformSync
       result should contain only expectedSuppeatOppijaHenkilötiedot
     }
 
     "kutsumanimen puuttuessa käyttää ensimmäistä etunimeä kutsumanimenä" in {
       mockEndpoints(defaultHenkilöResponse + ("kutsumanimi" -> None))
-      val result = mockClient.findOppijaByHetu(hetu).run
+      val result = mockClient.findOppijaByHetu(hetu).unsafePerformSync
       result.value should equal(expectedLaajatOppijaHenkilötiedot)
     }
 
     "palauttaa listan slave oideista" in {
       mockEndpoints(slaveOidsResponseData = List(Map("oidHenkilo" -> slaveOid, "etunimet" -> "Paavo", "sukunimi" -> "Pesusieni", "modified" -> 1541163791)))
-      val result = mockClient.findSlaveOids(oid).run
+      val result = mockClient.findSlaveOids(oid).unsafePerformSync
       result should contain only slaveOid
     }
 
     "palauttaa listan slave oideista vaikka datasta puuttuu etunimet ja sukunimi" in {
       mockEndpoints(slaveOidsResponseData = List(Map("oidHenkilo" -> slaveOid, "etunimet" -> None, "sukunimi" -> None, "modified" -> 1541163791)))
-      val result = mockClient.findSlaveOids(oid).run
+      val result = mockClient.findSlaveOids(oid).unsafePerformSync
       result should contain only slaveOid
     }
 
     "palauttaa annetun kotikunnan jos kotikunta on asetettu" in {
       mockEndpoints(defaultHenkilöResponse + ("kotikunta" -> "091"))
-      val result = mockClient.findMasterOppija(oid).run
+      val result = mockClient.findMasterOppija(oid).unsafePerformSync
       result.value.kotikunta should equal(Some("091"))
     }
 
     "palauttaa kotikuntana None jos kotikunta on null" in {
       mockEndpoints(defaultHenkilöResponse + ("kotikunta" -> None))
-      val result = mockClient.findMasterOppija(oid).run
+      val result = mockClient.findMasterOppija(oid).unsafePerformSync
       result.value.kotikunta should equal(None)
     }
 
     "palauttaa kotikuntana None jos kotikunta ei ole määritelty" in {
       mockEndpoints(defaultHenkilöResponse - "kotikunta")
-      val result = mockClient.findMasterOppija(oid).run
+      val result = mockClient.findMasterOppija(oid).unsafePerformSync
       result.value.kotikunta should equal(None)
     }
 
     "palauttaa yksilöintitiedon mikäli asetettu" in {
       mockEndpoints(defaultHenkilöResponse + ("yksiloity" -> true, "yksiloityVTJ" -> true))
-      val result = mockClient.findMasterOppija(oid).run
+      val result = mockClient.findMasterOppija(oid).unsafePerformSync
       result.value.yksilöity should equal(true)
     }
 
     "palauttaa yksilöity false jos yksilöintitieto on null" in {
       mockEndpoints(defaultHenkilöResponse + ("yksiloity" -> None, "yksiloityVTJ" -> None))
-      val result = mockClient.findMasterOppija(oid).run
+      val result = mockClient.findMasterOppija(oid).unsafePerformSync
       result.value.yksilöity should equal(false)
     }
 
     "palauttaa yksilöity false jos yksilöintitietoa ei ole määritelty" in {
       mockEndpoints(defaultHenkilöResponse - ("yksiloity", "yksiloityVTJ"))
-      val result = mockClient.findMasterOppija(oid).run
+      val result = mockClient.findMasterOppija(oid).unsafePerformSync
       result.value.yksilöity should equal(false)
     }
   }

--- a/src/test/scala/fi/oph/koski/localization/EPerusteetLocalizationTest.scala
+++ b/src/test/scala/fi/oph/koski/localization/EPerusteetLocalizationTest.scala
@@ -20,11 +20,11 @@ class EPerusteetLocalizationTest extends FreeSpec with Matchers {
   private lazy val eperusteetHttp = Http(root + "/eperusteet-service", "eperusteet-localization-test")
 
   private def haePerusteidenInfot(startingFromPage: Int = 0): List[EPerusteInfo] = {
-    val thisPage = eperusteetHttp.get(uri"/api/perusteet/info?sivukoko=100&sivu=$startingFromPage")(Http.parseJson[EPerusteInfot]).run.data
+    val thisPage = eperusteetHttp.get(uri"/api/perusteet/info?sivukoko=100&sivu=$startingFromPage")(Http.parseJson[EPerusteInfot]).unsafePerformSync.data
     if (thisPage.isEmpty) thisPage else thisPage ++ haePerusteidenInfot(startingFromPage + 1)
   }
   private def haeRakenne(id: Int): EPerusteRakenneLocalization =
-    eperusteetHttp.get(uri"/api/perusteet/$id/kaikki")(Http.parseJson[EPerusteRakenneLocalization]).run
+    eperusteetHttp.get(uri"/api/perusteet/$id/kaikki")(Http.parseJson[EPerusteRakenneLocalization]).unsafePerformSync
 
   private def kanoninenNimi(s: String) =
     s.stripSuffix("*").stripSuffix("(*)").replace('\u00a0', ' ').replaceAll("\\s+", " ").trim


### PR DESCRIPTION
scala-cas_2.12:n riippuvuus on päivitetty 0.16.6 => 0.16.6a (https://github.com/Opetushallitus/scala-utils/blob/master/scala-cas_2.12/pom.xml#L42) , tee sama päivitys myös Koskessa. 

Tämä näyttäisi alustavien testien perusteella korjaavan raportointikanta-app:n timeoutteja, mutta selviää oikeasti vasta pidempään testattuna.