### PR TITLE
WIP: TOR-1088: Näytä virkailija-raamit aina paitsi lokaalissa kehityksessä

### DIFF
--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -14,7 +14,7 @@ import fi.oph.koski.localization.LocalizationServlet
 import fi.oph.koski.log.Logging
 import fi.oph.koski.luovutuspalvelu.{LuovutuspalveluServlet, PalveluvaylaServlet, TilastokeskusServlet}
 import fi.oph.koski.mydata.{ApiProxyServlet, MyDataReactServlet, MyDataServlet}
-import fi.oph.koski.omattiedot.OmatTiedotServlet
+import fi.oph.koski.omattiedot.{OmatTiedotHtmlServlet, OmatTiedotServlet}
 import fi.oph.koski.opiskeluoikeus.{OpiskeluoikeusServlet, OpiskeluoikeusValidationServlet}
 import fi.oph.koski.oppija.{OppijaServlet, OppijaServletV2}
 import fi.oph.koski.oppilaitos.OppilaitosServlet
@@ -48,7 +48,9 @@ class ScalatraBootstrap extends LifeCycle with Logging with GlobalExecutionConte
     application.init // start parallel initialization tasks
 
     mount("/", new IndexServlet)
-    mount("/login", new LoginPageServlet)
+    mount("/omattiedot", new OmatTiedotHtmlServlet)
+    mount("/login", new VirkailijaLoginPageServlet)
+    mount("/login/shibboleth", new OppijaLoginPageServlet)
     mount("/pulssi", new PulssiHtmlServlet)
     mount("/todistus", new TodistusServlet)
     mount("/opintosuoritusote", new SuoritusServlet)

--- a/src/main/scala/fi/oph/koski/documentation/DocumentationServlet.scala
+++ b/src/main/scala/fi/oph/koski/documentation/DocumentationServlet.scala
@@ -6,18 +6,18 @@ import fi.oph.koski.http.KoskiErrorCategory
 import fi.oph.koski.koodisto.{Koodisto, KoodistoKoodiMetadata}
 import fi.oph.koski.koskiuser.AuthenticationSupport
 import fi.oph.koski.schema.{Henkilö, LocalizedString, OsaamisenTunnustaminen}
-import fi.oph.koski.servlet.HtmlServlet
+import fi.oph.koski.servlet.VirkailijaHtmlServlet
 import fi.oph.scalaschema.ClassSchema
 import org.scalatra.ScalatraServlet
 
 import scala.Function.const
 import scala.xml.NodeSeq
 
-class DocumentationServlet(implicit val application: KoskiApplication) extends ScalatraServlet with HtmlServlet with AuthenticationSupport with KoodistoFinder {
+class DocumentationServlet(implicit val application: KoskiApplication) extends ScalatraServlet with VirkailijaHtmlServlet with AuthenticationSupport with KoodistoFinder {
   val koodistoPalvelu = application.koodistoPalvelu
 
   get("^/(|tietomalli|koodistot|rajapinnat/oppilashallintojarjestelmat|rajapinnat/luovutuspalvelu|rajapinnat/palveluvayla-omadata)$".r){
-    htmlIndex("koski-main.js", raamit = if (raamitHeaderSet && isAuthenticated) Virkailija else EiRaameja, allowIndexing = true)
+    htmlIndex("koski-main.js", raamit = if (virkailijaRaamitSet && isAuthenticated) Virkailija else EiRaameja, allowIndexing = true)
   }
 
   get("/koski-oppija-schema.html") {

--- a/src/main/scala/fi/oph/koski/healthcheck/HealthCheckHtmlServlet.scala
+++ b/src/main/scala/fi/oph/koski/healthcheck/HealthCheckHtmlServlet.scala
@@ -1,9 +1,9 @@
 package fi.oph.koski.healthcheck
 
 import fi.oph.koski.config.KoskiApplication
-import fi.oph.koski.servlet.HtmlServlet
+import fi.oph.koski.servlet.VirkailijaHtmlServlet
 
-class HealthCheckHtmlServlet(implicit val application: KoskiApplication) extends HtmlServlet{
+class HealthCheckHtmlServlet(implicit val application: KoskiApplication) extends VirkailijaHtmlServlet{
   get("/") {
     val healthcheck = application.healthCheck.healthcheck
     val version = buildVersionProperties.map(_.getProperty("version", null)).filter(_ != null).getOrElse("local")

--- a/src/main/scala/fi/oph/koski/koskiuser/LogoutServlet.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/LogoutServlet.scala
@@ -3,10 +3,10 @@ package fi.oph.koski.koskiuser
 import java.net.URLEncoder
 
 import fi.oph.koski.config.KoskiApplication
-import fi.oph.koski.servlet.HtmlServlet
+import fi.oph.koski.servlet.{VirkailijaHtmlServlet}
 import fi.oph.koski.sso.SSOSupport
 
-class LogoutServlet(implicit val application: KoskiApplication) extends HtmlServlet with SSOSupport {
+class LogoutServlet(implicit val application: KoskiApplication) extends VirkailijaHtmlServlet with SSOSupport {
   get("/") {
     logger.info("Logged out")
 

--- a/src/main/scala/fi/oph/koski/mydata/MyDataReactServlet.scala
+++ b/src/main/scala/fi/oph/koski/mydata/MyDataReactServlet.scala
@@ -2,14 +2,14 @@ package fi.oph.koski.mydata
 
 import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.koskiuser.AuthenticationSupport
-import fi.oph.koski.servlet.{HtmlServlet, OmaOpintopolkuSupport}
+import fi.oph.koski.servlet.{OmaOpintopolkuSupport, OppijaHtmlServlet}
 import org.scalatra.ScalatraServlet
 
 import scala.util.matching.Regex
 
 
 class MyDataReactServlet(implicit val application: KoskiApplication) extends ScalatraServlet
-  with HtmlServlet with AuthenticationSupport with OmaOpintopolkuSupport with MyDataSupport {
+  with OppijaHtmlServlet with AuthenticationSupport with OmaOpintopolkuSupport with MyDataSupport {
 
   val nonErrorPage: Regex = "^(?!/error)\\S+$".r
 

--- a/src/main/scala/fi/oph/koski/omattiedot/OmatTiedotHtmlServlet.scala
+++ b/src/main/scala/fi/oph/koski/omattiedot/OmatTiedotHtmlServlet.scala
@@ -1,0 +1,24 @@
+package fi.oph.koski.omattiedot
+
+import fi.oph.koski.config.KoskiApplication
+import fi.oph.koski.servlet.{OmaOpintopolkuSupport, OppijaHtmlServlet}
+import org.scalatra.ScalatraServlet
+
+class OmatTiedotHtmlServlet(implicit val application: KoskiApplication) extends ScalatraServlet with OppijaHtmlServlet with OmaOpintopolkuSupport {
+  before("/") {
+    setLangCookieFromDomainIfNecessary
+    sessionOrStatus match {
+      case Right(_) if shibbolethCookieFound =>
+      case Left(_) if shibbolethCookieFound => redirect("/user/shibbolethlogin")
+      case _ => redirect(shibbolethUrl)
+    }
+  }
+
+  get("/") {
+    htmlIndex(
+      scriptBundleName = "koski-omattiedot.js",
+      raamit = oppijaRaamit,
+      responsive = true
+    )
+  }
+}

--- a/src/main/scala/fi/oph/koski/pulssi/PulssiHtmlServlet.scala
+++ b/src/main/scala/fi/oph/koski/pulssi/PulssiHtmlServlet.scala
@@ -5,11 +5,11 @@ import java.time.LocalDateTime.now
 import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.html.EiRaameja
 import fi.oph.koski.http.KoskiErrorCategory
-import fi.oph.koski.servlet.HtmlServlet
+import fi.oph.koski.servlet.VirkailijaHtmlServlet
 import fi.oph.koski.util.FinnishDateFormat.finnishDateTimeFormat
 import org.scalatra.ScalatraServlet
 
-class PulssiHtmlServlet(implicit val application: KoskiApplication) extends ScalatraServlet with HtmlServlet {
+class PulssiHtmlServlet(implicit val application: KoskiApplication) extends ScalatraServlet with VirkailijaHtmlServlet {
   get("/") {
     htmlIndex("koski-pulssi.js", raamit = EiRaameja, responsive = true)
   }

--- a/src/main/scala/fi/oph/koski/servlet/EiSuorituksiaServlet.scala
+++ b/src/main/scala/fi/oph/koski/servlet/EiSuorituksiaServlet.scala
@@ -3,7 +3,7 @@ package fi.oph.koski.servlet
 import fi.oph.koski.config.KoskiApplication
 import org.scalatra.ScalatraServlet
 
-class EiSuorituksiaServlet(implicit val application: KoskiApplication) extends ScalatraServlet with HtmlServlet with OmaOpintopolkuSupport {
+class EiSuorituksiaServlet(implicit val application: KoskiApplication) extends ScalatraServlet with OppijaHtmlServlet with OmaOpintopolkuSupport {
   get("/") {
     htmlIndex("koski-eisuorituksia.js", raamit = oppijaRaamit, responsive = true)
   }

--- a/src/main/scala/fi/oph/koski/servlet/HtmlServlet.scala
+++ b/src/main/scala/fi/oph/koski/servlet/HtmlServlet.scala
@@ -2,6 +2,7 @@ package fi.oph.koski.servlet
 
 import java.util.Properties
 
+import fi.oph.koski.config.Environment
 import fi.oph.koski.html.{EiRaameja, HtmlNodes, Raamit, Virkailija}
 import fi.oph.koski.http.{HttpStatus, KoskiErrorCategory}
 import fi.oph.koski.koskiuser.AuthenticationSupport
@@ -46,7 +47,6 @@ trait HtmlServlet extends KoskiBaseServlet with AuthenticationSupport with HtmlN
       renderStatus(KoskiErrorCategory.internalError())
   }
 
-  def raamitHeaderSet: Boolean = Option(request.getHeader("X-Raamit")).exists(r => Try(r.toBoolean).getOrElse(false))
-  def virkailijaRaamit: Raamit = if (raamitHeaderSet || useVirkailijaRaamitProxy) Virkailija else EiRaameja
-  private val useVirkailijaRaamitProxy = application.config.hasPath("virkailijaRaamitProxy")
+  def virkailijaRaamitSet: Boolean
+  def virkailijaRaamit: Raamit
 }

--- a/src/main/scala/fi/oph/koski/servlet/IndexServlet.scala
+++ b/src/main/scala/fi/oph/koski/servlet/IndexServlet.scala
@@ -5,16 +5,9 @@ import org.scalatra.ScalatraServlet
 
 import scala.xml.Unparsed
 
-class IndexServlet(implicit val application: KoskiApplication) extends ScalatraServlet with HtmlServlet with OmaOpintopolkuSupport {
-  before("/omattiedot") {
-    setLangCookieFromDomainIfNecessary
-    sessionOrStatus match {
-      case Right(_) if shibbolethCookieFound =>
-      case Left(_) if shibbolethCookieFound => redirect("/user/shibbolethlogin")
-      case _ => redirect(shibbolethUrl)
-    }
-  }
 
+
+class IndexServlet(implicit val application: KoskiApplication) extends ScalatraServlet with VirkailijaHtmlServlet with OmaOpintopolkuSupport {
   before("/.+".r) {
     if (!isAuthenticated) {
       redirectToLogin
@@ -53,14 +46,6 @@ class IndexServlet(implicit val application: KoskiApplication) extends ScalatraS
 
   get("/oppija/:oid") {
     indexHtml
-  }
-
-  get("/omattiedot") {
-    htmlIndex(
-      scriptBundleName = "koski-omattiedot.js",
-      raamit = oppijaRaamit,
-      responsive = true
-    )
   }
 
   get("/tiedonsiirrot*") {

--- a/src/main/scala/fi/oph/koski/servlet/OmaOpintopolkuSupport.scala
+++ b/src/main/scala/fi/oph/koski/servlet/OmaOpintopolkuSupport.scala
@@ -1,15 +1,17 @@
 package fi.oph.koski.servlet
 
+import fi.oph.koski.config.Environment
 import fi.oph.koski.html.{EiRaameja, Oppija, Raamit}
 import fi.oph.koski.koskiuser.AuthenticationSupport
 import org.scalatra.servlet.RichRequest
 
 trait OmaOpintopolkuSupport extends AuthenticationSupport with LanguageSupport {
-  def oppijaRaamit: Raamit = if (raamitHeaderSet || useOppijaRaamitProxy) Oppija(koskiSessionOption, request, shibbolethUrl) else EiRaameja
+  def oppijaRaamit: Raamit = if (oppijaRaamitSet || useOppijaRaamitProxy) Oppija(koskiSessionOption, request, shibbolethUrl) else EiRaameja
   def shibbolethCookieFound: Boolean = OmaOpintopolkuSupport.shibbolethCookieFound(request)
   def shibbolethUrl: String = application.config.getString("identification.url." + langFromCookie.getOrElse(langFromDomain))
-  def raamitHeaderSet: Boolean
+  def oppijaRaamitSet: Boolean = isCloudEnvironment
   private val useOppijaRaamitProxy = application.config.hasPath("oppijaRaamitProxy")
+  private lazy val isCloudEnvironment = !Environment.isLocalDevelopmentEnvironment
 }
 
 object OmaOpintopolkuSupport {

--- a/src/main/scala/fi/oph/koski/servlet/OppijaHtmlServlet.scala
+++ b/src/main/scala/fi/oph/koski/servlet/OppijaHtmlServlet.scala
@@ -1,0 +1,8 @@
+package fi.oph.koski.servlet
+
+import fi.oph.koski.html.{EiRaameja, Raamit}
+
+trait OppijaHtmlServlet extends HtmlServlet {
+  def virkailijaRaamitSet: Boolean = false
+  def virkailijaRaamit: Raamit = EiRaameja
+}

--- a/src/main/scala/fi/oph/koski/servlet/OppijaLoginPageServlet.scala
+++ b/src/main/scala/fi/oph/koski/servlet/OppijaLoginPageServlet.scala
@@ -8,16 +8,8 @@ import org.scalatra.ScalatraServlet
 
 import scala.xml.Unparsed
 
-class LoginPageServlet(implicit val application: KoskiApplication) extends ScalatraServlet with HtmlServlet with SSOSupport {
+class OppijaLoginPageServlet(implicit val application: KoskiApplication) extends ScalatraServlet with OppijaHtmlServlet with SSOSupport {
   get("/") {
-    if (ssoConfig.isCasSsoUsed) {
-      redirect("/")
-    } else {
-      htmlIndex("koski-login.js")
-    }
-  }
-
-  get("/shibboleth") {
     if (application.features.shibboleth && application.config.getString("shibboleth.security") == "mock") {
       htmlIndex(
         scriptBundleName = "koski-korhopankki.js",

--- a/src/main/scala/fi/oph/koski/servlet/SuoritusjakoHtmlServlet.scala
+++ b/src/main/scala/fi/oph/koski/servlet/SuoritusjakoHtmlServlet.scala
@@ -3,7 +3,7 @@ package fi.oph.koski.servlet
 import fi.oph.koski.config.KoskiApplication
 import org.scalatra.ScalatraServlet
 
-class SuoritusjakoHtmlServlet(implicit val application: KoskiApplication) extends ScalatraServlet with HtmlServlet with OmaOpintopolkuSupport {
+class SuoritusjakoHtmlServlet(implicit val application: KoskiApplication) extends ScalatraServlet with OppijaHtmlServlet with OmaOpintopolkuSupport {
   get("/:secret") {
     setLangCookieFromDomainIfNecessary
     htmlIndex("koski-suoritusjako.js", responsive = true)

--- a/src/main/scala/fi/oph/koski/servlet/VirhesivuServlet.scala
+++ b/src/main/scala/fi/oph/koski/servlet/VirhesivuServlet.scala
@@ -3,7 +3,7 @@ package fi.oph.koski.servlet
 import fi.oph.koski.config.KoskiApplication
 import org.scalatra.ScalatraServlet
 
-class VirhesivuServlet(implicit val application: KoskiApplication) extends ScalatraServlet with HtmlServlet with OmaOpintopolkuSupport {
+class VirhesivuServlet(implicit val application: KoskiApplication) extends ScalatraServlet with OppijaHtmlServlet with OmaOpintopolkuSupport {
   get("/") {
     response.setHeader("X-Virhesivu", "1") // for korhopankki/HetuLogin.jsx
     <html lang={lang}>

--- a/src/main/scala/fi/oph/koski/servlet/VirkailijaHtmlServlet.scala
+++ b/src/main/scala/fi/oph/koski/servlet/VirkailijaHtmlServlet.scala
@@ -1,0 +1,13 @@
+package fi.oph.koski.servlet
+
+import fi.oph.koski.config.Environment
+import fi.oph.koski.html.{EiRaameja, Raamit, Virkailija}
+
+trait VirkailijaHtmlServlet extends HtmlServlet {
+  def virkailijaRaamitSet: Boolean = isCloudEnvironment
+  def virkailijaRaamit: Raamit = if (virkailijaRaamitSet || useVirkailijaRaamitProxy) Virkailija else EiRaameja
+
+  private val useVirkailijaRaamitProxy = application.config.hasPath("virkailijaRaamitProxy")
+
+  private lazy val isCloudEnvironment = !Environment.isLocalDevelopmentEnvironment
+}

--- a/src/main/scala/fi/oph/koski/servlet/VirkailijaLoginPageServlet.scala
+++ b/src/main/scala/fi/oph/koski/servlet/VirkailijaLoginPageServlet.scala
@@ -1,0 +1,15 @@
+package fi.oph.koski.servlet
+
+import fi.oph.koski.config.KoskiApplication
+import fi.oph.koski.sso.SSOSupport
+import org.scalatra.ScalatraServlet
+
+class VirkailijaLoginPageServlet(implicit val application: KoskiApplication) extends ScalatraServlet with VirkailijaHtmlServlet with SSOSupport {
+  get("/") {
+    if (ssoConfig.isCasSsoUsed) {
+      redirect("/")
+    } else {
+      htmlIndex("koski-login.js")
+    }
+  }
+}

--- a/src/main/scala/fi/oph/koski/sso/CasServlet.scala
+++ b/src/main/scala/fi/oph/koski/sso/CasServlet.scala
@@ -4,14 +4,14 @@ import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.http.{Http, KoskiErrorCategory, OpintopolkuCallerId}
 import fi.oph.koski.koskiuser.{AuthenticationSupport, DirectoryClientLogin, KoskiUserLanguage}
 import fi.oph.koski.log.LogUserContext
-import fi.oph.koski.servlet.{HtmlServlet, NoCache}
+import fi.oph.koski.servlet.{NoCache, VirkailijaHtmlServlet}
 import fi.vm.sade.utils.cas.CasClient.Username
 import fi.vm.sade.utils.cas.{CasClient, CasLogout}
 
 /**
   *  This is where the user lands after a CAS login / logout
   */
-class CasServlet(implicit val application: KoskiApplication) extends HtmlServlet with AuthenticationSupport with NoCache {
+class CasServlet(implicit val application: KoskiApplication) extends VirkailijaHtmlServlet with AuthenticationSupport with NoCache {
   private val casClient = new CasClient(application.config.getString("opintopolku.virkailija.url"), Http.newClient("cas.serviceticketvalidation"), OpintopolkuCallerId.koski)
   private val koskiSessions = application.koskiSessionRepository
 

--- a/src/main/scala/fi/oph/koski/suoritusote/SuoritusServlet.scala
+++ b/src/main/scala/fi/oph/koski/suoritusote/SuoritusServlet.scala
@@ -4,11 +4,11 @@ import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.http.KoskiErrorCategory
 import fi.oph.koski.koskiuser.RequiresVirkailijaOrPalvelukäyttäjä
 import fi.oph.koski.schema._
-import fi.oph.koski.servlet.HtmlServlet
+import fi.oph.koski.servlet.VirkailijaHtmlServlet
 
 import scala.xml.Elem
 
-class SuoritusServlet(implicit val application: KoskiApplication) extends HtmlServlet with RequiresVirkailijaOrPalvelukäyttäjä {
+class SuoritusServlet(implicit val application: KoskiApplication) extends VirkailijaHtmlServlet with RequiresVirkailijaOrPalvelukäyttäjä {
 
   get("/:oppijaOid") {
     val oppijaOid = params("oppijaOid")

--- a/src/main/scala/fi/oph/koski/todistus/TodistusServlet.scala
+++ b/src/main/scala/fi/oph/koski/todistus/TodistusServlet.scala
@@ -4,12 +4,12 @@ import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.http.KoskiErrorCategory
 import fi.oph.koski.koskiuser.RequiresVirkailijaOrPalvelukäyttäjä
 import fi.oph.koski.schema._
-import fi.oph.koski.servlet.HtmlServlet
+import fi.oph.koski.servlet.VirkailijaHtmlServlet
 import fi.oph.koski.suoritusote.OpiskeluoikeusFinder
 
 import scala.xml.Elem
 
-class TodistusServlet(implicit val application: KoskiApplication) extends HtmlServlet with RequiresVirkailijaOrPalvelukäyttäjä {
+class TodistusServlet(implicit val application: KoskiApplication) extends VirkailijaHtmlServlet with RequiresVirkailijaOrPalvelukäyttäjä {
   get("/:oppijaOid") {
     val oppijaOid = params("oppijaOid")
     implicit val localizations = application.localizationRepository

--- a/src/main/scala/fi/oph/koski/ytr/YtrKoesuoritusServlet.scala
+++ b/src/main/scala/fi/oph/koski/ytr/YtrKoesuoritusServlet.scala
@@ -7,9 +7,9 @@ import fi.oph.koski.koskiuser.{KoskiSession, RequiresKansalainen}
 import fi.oph.koski.log.KoskiOperation.KoskiOperation
 import fi.oph.koski.log.{AuditLog, AuditLogMessage, KoskiMessageField}
 import fi.oph.koski.log.KoskiOperation.{KANSALAINEN_YLIOPPILASKOE_HAKU, KANSALAINEN_HUOLTAJA_YLIOPPILASKOE_HAKU}
-import fi.oph.koski.servlet.HtmlServlet
+import fi.oph.koski.servlet.OppijaHtmlServlet
 
-class YtrKoesuoritusServlet(implicit val application: KoskiApplication) extends HtmlServlet with RequiresKansalainen {
+class YtrKoesuoritusServlet(implicit val application: KoskiApplication) extends OppijaHtmlServlet with RequiresKansalainen {
   private val koesuoritukset: KoesuoritusService = KoesuoritusService(application.config)
 
   get("/:copyOfExamPaper") {


### PR DESCRIPTION
Aiemmin virkailija-raamit päälle asettava X-Raamit header on asetettu HAProxy:ssä, mitä ei enää AWS-ympäristössä ole käytössä.