### PR TITLE
TOR-xxxx: Lisää mekanismi osasuoritustyyppien tallennuksen disablointiin

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -78,6 +78,8 @@ features = {
   ]
   disabledPäätasonSuoritusLuokat = [
   ]
+  disabledOsasuoritusTyypit = [
+  ]
   valpas = true
 }
 

--- a/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
+++ b/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
@@ -80,7 +80,7 @@ class KoskiValidator(
 
   private def validateOpiskeluoikeus(opiskeluoikeus: Opiskeluoikeus, henkilö: Option[Henkilö])(implicit user: KoskiSpecificSession, accessType: AccessType.Value): Either[HttpStatus, Opiskeluoikeus] = opiskeluoikeus match {
     case opiskeluoikeus: KoskeenTallennettavaOpiskeluoikeus =>
-        updateFields(opiskeluoikeus).right.flatMap { opiskeluoikeus =>
+      updateFields(opiskeluoikeus).right.flatMap { opiskeluoikeus =>
         (validateAccess(opiskeluoikeus)
           .onSuccess {
             validateLähdejärjestelmä(opiskeluoikeus)
@@ -96,6 +96,7 @@ class KoskiValidator(
             HttpStatus.fold(
               päätasonSuoritusTyypitEnabled(opiskeluoikeus),
               päätasonSuoritusLuokatEnabled(opiskeluoikeus),
+              osasuoritusTyypitEnabled(opiskeluoikeus),
               validateOpintojenrahoitus(opiskeluoikeus),
               validateSisältyvyys(henkilö, opiskeluoikeus),
               validatePäivämäärät(opiskeluoikeus),
@@ -657,7 +658,7 @@ class KoskiValidator(
       case _:OppivelvollisilleSuunnatunVapaanSivistystyönOsaamiskokonaisuudenSuoritus => true
       case _ => false
     })
-    .exists(s => hyväksytystiArvioidutOsasuoritukset(s.osasuoritusLista).map(_.koulutusmoduuli.laajuusArvo(0)).sum < 4.0)) {
+      .exists(s => hyväksytystiArvioidutOsasuoritukset(s.osasuoritusLista).map(_.koulutusmoduuli.laajuusArvo(0)).sum < 4.0)) {
       KoskiErrorCategory.badRequest.validation.tila.vapaanSivistystyönVahvistetunPäätasonSuorituksenLaajuus("Päätason suoritus " + suorituksenTunniste(suoritus) + " on vahvistettu, mutta sillä on hyväksytyksi arvioituja osaamiskokonaisuuksia, joiden laajuus on alle 4 opintopistettä")
     }
     else {
@@ -997,6 +998,15 @@ class KoskiValidator(
     val päätasonSuoritusLuokat = opiskeluoikeus.suoritukset.map(_.getClass.getSimpleName)
     päätasonSuoritusLuokat.find(disabled.contains(_)) match {
       case Some(luokka) => KoskiErrorCategory.notImplemented(s"Päätason suorituksen luokka $luokka ei ole käytössä tässä ympäristössä")
+      case _ => HttpStatus.ok
+    }
+  }
+
+  private def osasuoritusTyypitEnabled(opiskeluoikeus: KoskeenTallennettavaOpiskeluoikeus): HttpStatus = {
+    val disabled = config.getStringList("features.disabledOsasuoritusTyypit")
+    val osasuoritusTyypit = opiskeluoikeus.suoritukset.flatMap(_.rekursiivisetOsasuoritukset).map(_.tyyppi.koodiarvo)
+    osasuoritusTyypit.find(disabled.contains(_)) match {
+      case Some(tyyppi) => KoskiErrorCategory.notImplemented(s"Osasuorituksen tyyppi $tyyppi ei ole käytössä tässä ympäristössä")
       case _ => HttpStatus.ok
     }
   }

--- a/src/test/scala/fi/oph/koski/api/OpiskeluoikeusValidationSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OpiskeluoikeusValidationSpec.scala
@@ -35,6 +35,8 @@ class OpiskeluoikeusValidationSpec extends FreeSpec with Matchers with Opiskeluo
             ]
             disabledPäätasonSuoritusLuokat = [
             ]
+            disabledOsasuoritusTyypit = [
+            ]
           }
         """.stripMargin)
       val opiskelija = oppija(KoskiSpecificMockOppijat.valma.oid)
@@ -51,10 +53,30 @@ class OpiskeluoikeusValidationSpec extends FreeSpec with Matchers with Opiskeluo
             disabledPäätasonSuoritusLuokat = [
               ValmaKoulutuksenSuoritus
             ]
+            disabledOsasuoritusTyypit = [
+            ]
           }
         """.stripMargin)
       val opiskelija = oppija(KoskiSpecificMockOppijat.valma.oid)
       mockKoskiValidator(mockConfig).validateAsJson(opiskelija).left.get should equal (KoskiErrorCategory.notImplemented("Päätason suorituksen luokka ValmaKoulutuksenSuoritus ei ole käytössä tässä ympäristössä"))
+    }
+
+    "Osasuorituksen tyyppi jonka käyttö on estetty" in {
+      implicit val accessType = AccessType.read
+      val mockConfig = ConfigFactory.parseString(
+        """
+          features = {
+            disabledPäätasonSuoritusTyypit = [
+            ]
+            disabledPäätasonSuoritusLuokat = [
+            ]
+            disabledOsasuoritusTyypit = [
+              valmakoulutuksenosa
+            ]
+          }
+        """.stripMargin)
+      val opiskelija = oppija(KoskiSpecificMockOppijat.valma.oid)
+      mockKoskiValidator(mockConfig).validateAsJson(opiskelija).left.get should equal (KoskiErrorCategory.notImplemented("Osasuorituksen tyyppi valmakoulutuksenosa ei ole käytössä tässä ympäristössä"))
     }
   }
 


### PR DESCRIPTION
Tämä voi olla hyödyllinen, kun tietomallia toteutaan vähitellen osasuoritusten osalta. Päätason suorituksille tällainen esto on jo toteutettu aiemmin.

Tälle vaikutti tulevan käyttöä Pre IB + Lops2021 -yhdistelmän kanssa, mutta ei sitten vielä tarvittukaan.

Haluttaisiinko tämä ominaisuus lisätä kuitenkin jo nyt tulevaisuutta ajatellen, vai jätetäänkö hautumaan?