### PR TITLE
TOR-xxxx: Korjaa dev-ympäristön logitus

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -149,4 +149,9 @@
     <packageUrl regex="true">^pkg:maven/log4j/log4j@.*$</packageUrl>
     <cve>CVE-2020-9488</cve>
   </suppress>
+  <suppress>
+    <notes>SMTP appender not used in project</notes>
+    <gav regex="true">^log4j:apache-log4j-extras:.*$</gav>
+    <cve>CVE-2020-9488</cve>
+  </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,11 @@
       <version>1.6.1</version>
     </dependency>
     <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>apache-log4j-extras</artifactId>
+      <version>1.2.17</version>
+    </dependency>
+    <dependency>
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-core</artifactId>
       <version>3.2.1</version>

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -17,7 +17,9 @@ log4j.appender.access.File=log/koski-access.log
 log4j.appender.access.layout=org.apache.log4j.PatternLayout
 log4j.appender.access.layout.ConversionPattern=%m%n
 
-log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file=org.apache.log4j.rolling.RollingFileAppender
+log4j.appender.file.RollingPolicy=org.apache.log4j.rolling.TimeBasedRollingPolicy
+log4j.appender.file.RollingPolicy.FileNamePattern=log/koski.log.%d{yyyy-MM}.zip
 log4j.appender.file.append=false
 log4j.appender.file.File=log/koski.log
 log4j.appender.file.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
Toisin kuin koodissa oletetaan, org.apache.log4j.rolling.RollingFileAppender on meillä käytössä vielä testiympäristössä. 

Palauta riippuvuus ja suppressoi riippuvuuden tietoturvailmoitus myös apache-log4j-extras osalta samalla perusteella kuin se on suppressoitu jo log4j:n osalta.