### PR TITLE
tor-780: korjaa rikkinäinen kelan json-schema-viewer

### DIFF
--- a/src/main/scala/fi/oph/koski/kela/KelaOppijaConverter.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaOppijaConverter.scala
@@ -371,7 +371,11 @@ object KelaOppijaConverter extends Logging {
       },
       alkamispäivä = suoritus.alkamispäivä,
       tunnustettu = suoritus match {
-        case x: schema.MahdollisestiTunnustettu => x.tunnustettu
+        case x: schema.MahdollisestiTunnustettu => x.tunnustettu.map(osaamisenTunnustaminen => OsaamisenTunnustaminen(
+          osaaminen = osaamisenTunnustaminen.osaaminen.map(convertOsasuoritus),
+          selite = osaamisenTunnustaminen.selite,
+          rahoituksenPiirissä = osaamisenTunnustaminen.rahoituksenPiirissä
+        ))
         case _ => None
       },
       toinenOsaamisala = suoritus match {

--- a/src/main/scala/fi/oph/koski/kela/KelaSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaSchema.scala
@@ -135,7 +135,7 @@ case class Osasuoritus(
   tutkinnonOsanRyhmä: Option[Koodistokoodiviite],
   osaamisala: Option[List[schema.Osaamisalajakso]],
   alkamispäivä: Option[LocalDate],
-  tunnustettu: Option[schema.OsaamisenTunnustaminen],
+  tunnustettu: Option[OsaamisenTunnustaminen],
   toinenOsaamisala: Option[Boolean],
   toinenTutkintonimike: Option[Boolean],
   näyttö: Option[Näyttö],
@@ -223,6 +223,12 @@ case class OsaamisenHankkimistapajakso(
   alku: LocalDate,
   loppu: Option[LocalDate],
   osaamisenHankkimistapa: OsaamisenHankkimistapa
+)
+
+case class OsaamisenTunnustaminen(
+  osaaminen: Option[Osasuoritus],
+  selite: schema.LocalizedString,
+  rahoituksenPiirissä: Boolean
 )
 
 case class Vahvistus(


### PR DESCRIPTION
OsaamisenTunnistaminen-rakennetta oli käytetty Kosken alkuperäisestä skeemasta (virhe) ja tämä sisälsi kentän jonka tyyppi oli Suoritus. Kelan skeemassa oli myös määritelty Suoritus niminen tyyppi, tosin eri packageen. Tämä nimien yhteentörmäys aiheutti bugin jossa json-schema-vieweria ei voinut avata kelan skeemalla.