### PR TITLE
tor-780: piilota dia:n osasuorituksilta arviointi-kolumnit kelan käyt…

### DIFF
--- a/web/app/kela/KelaOsasuorituksetTable.jsx
+++ b/web/app/kela/KelaOsasuorituksetTable.jsx
@@ -4,7 +4,7 @@ import Atom from 'bacon.atom'
 import {BooleanView, DateView, KeyValueTable, NumberView} from './KeyValueTable'
 import {t} from '../i18n/i18n'
 
-export const KelaOsasuorituksetTable = ({osasuoritukset, path, nested}) => {
+export const KelaOsasuorituksetTable = ({osasuoritukset, path, nested, piilotaArviointiSarakkeet}) => {
   const currentPath = path + '.osasuoritukset'
   const laajuudenYksikko = R.head(R.uniq(osasuoritukset.map(findLaajuudenYksikko).filter(R.identity)))
   return (
@@ -14,21 +14,24 @@ export const KelaOsasuorituksetTable = ({osasuoritukset, path, nested}) => {
       <tr>
         <th className='osasuoritukset-title'>{'Osasuoritukset'}</th>
         <th className='arviointi'>{t('Laajuus' + ((laajuudenYksikko && ` (${laajuudenYksikko})`) || ''))}</th>
+      {!piilotaArviointiSarakkeet && <>
         <th className='arviointi'>{t('Arviointipäivä')}</th>
         <th className='arviointi'>{t('Hyväksytty')}</th>
+      </>}
       </tr>
       </tbody>
     {osasuoritukset.map((osasuoritus, index) => (
       <ExpandableOsasuoritus key={index}
                              osasuoritus={osasuoritus}
                              path={currentPath}
+                             piilotaArviointiSarakkeet={piilotaArviointiSarakkeet}
       />
     ))}
     </table>
   )
 }
 
-const ExpandableOsasuoritus = ({osasuoritus, path}) => {
+const ExpandableOsasuoritus = ({osasuoritus, path, piilotaArviointiSarakkeet}) => {
   const expandedAtom = Atom(false)
   const mahdollinenSuorituksenLaajuus = osasuoritus.koulutusmoduuli.laajuus || {}
   const laajuus = mahdollinenSuorituksenLaajuus.arvo || osasuoritustenYhteislaajuus(osasuoritus)
@@ -49,12 +52,14 @@ const ExpandableOsasuoritus = ({osasuoritus, path}) => {
       <td className='laajuus'>
         <NumberView value={laajuus} />
       </td>
+    {!piilotaArviointiSarakkeet && <>
       <td className='arviointi'>
         <DateView value={mahdollinenArviointi.päivä} />
       </td>
       <td className='arviointi'>
         <BooleanView value={mahdollinenArviointi.hyväksytty} />
       </td>
+    </>}
     </tr>
       { (expanded && isExpandable) && (
         <tr>

--- a/web/app/kela/KelaSuoritus.jsx
+++ b/web/app/kela/KelaSuoritus.jsx
@@ -44,11 +44,15 @@ const SuoritusTabs = ({suoritukset, selectedIndex, setCurrentIndex}) => {
 const SuoritusView = ({suoritus, path}) => {
   const properties = R.omit(['osasuoritukset', 'vahvistus', 'koulutusmoduuli'], suoritus)
   const osasuoritukset = suoritus.osasuoritukset
+  const piilotaArviointiSarakkeet = ['diatutkintovaihe', 'diavalmistavavaihe'].includes(suoritus.tyyppi.koodiarvo)
   return (
     <>
       <KeyValueTable object={properties} path={path}/>
       <SuorituksenVahvistus vahvistus={suoritus.vahvistus}/>
-      {osasuoritukset && <KelaOsasuorituksetTable osasuoritukset={osasuoritukset} path={path}/>}
+      {osasuoritukset && <KelaOsasuorituksetTable osasuoritukset={osasuoritukset}
+                                                  piilotaArviointiSarakkeet={piilotaArviointiSarakkeet}
+                                                  path={path}
+      />}
     </>
   )
 }

--- a/web/test/spec/kelaSpec.js
+++ b/web/test/spec/kelaSpec.js
@@ -96,4 +96,26 @@ describe('Kela', function () {
       expect(kela.getCurrentUrl().endsWith('/koski/kela')).to.equal(true)
     })
   })
+
+  describe('DIA:n ensimmäisen tason osasuorituksilta piilotetaan arviointi-sarakkeet, koska näillä ei ole arviointia', function () {
+    before(
+      Authentication().login('Laaja'),
+      kela.openPage,
+      kela.searchAndSelect('151013-2195', 'Dia')
+    )
+
+    var sarakkeetSisältääArvioinnin = 'Osasuoritukset Laajuus (vuosiviikkotuntia) Arviointipäivä Hyväksytty\n'
+
+    it('Taulukosta on piilotettu arviointi-sarakkeet', function () {
+      expect(extractAsText(S('table.osasuoritukset'))).to.not.include(sarakkeetSisältääArvioinnin)
+    })
+
+    describe('Osasuorituksen osasuorituksille näytetään arviointi-sarakkeet', function () {
+      before(kela.selectOsasuoritus('Matematiikka'))
+
+      it('Toimii', function () {
+        expect(extractAsText(S('table.osasuoritukset'))).to.include(sarakkeetSisältääArvioinnin)
+      })
+    })
+  })
 })


### PR DESCRIPTION
…töliittymästä, koska dia:n ensimmäisen tason osasuorituksilla ei ole arviointia