### PR TITLE
tor-780: Kela UI korjauksia

### DIFF
--- a/web/app/i18n/i18n.js
+++ b/web/app/i18n/i18n.js
@@ -15,7 +15,7 @@ export const t = (s, ignoreMissing, languageOverride) => {
   if (!s) return ''
   if (typeof s == 'object') {
     // assume it's a localized string
-    return s[usedLanguage] || s['fi'] || s['sv']
+    return s[usedLanguage] || s['fi'] || s['sv'] || s['en']
   }
   if (typeof s == 'string') {
     // try to find a localization from the bundle

--- a/web/app/kela/KelaOsasuorituksetTable.jsx
+++ b/web/app/kela/KelaOsasuorituksetTable.jsx
@@ -80,8 +80,8 @@ const ExpandableOsasuoritus = ({osasuoritus, path, piilotaArviointiSarakkeet}) =
 
 const suorituksenNimi = koulutusmoduuli => {
   const koodiarvo = t(koulutusmoduuli.tunniste.nimi)
-  const kieli = t(koulutusmoduuli.nimi || {})
-  const oppimaara = t(koulutusmoduuli.oppimäärä || {})
+  const kieli = t((koulutusmoduuli.kieli && koulutusmoduuli.kieli.nimi) || {})
+  const oppimaara = t((koulutusmoduuli.oppimäärä && koulutusmoduuli.oppimäärä.nimi) || {})
 
   return [koodiarvo, kieli, oppimaara].filter(R.identity).join(', ')
 }

--- a/web/test/spec/kelaSpec.js
+++ b/web/test/spec/kelaSpec.js
@@ -22,6 +22,8 @@ describe('Kela', function () {
     it('Näytetään valitun henkilon opinnot', function () {
       expect(kela.getOppijanNimi()).to.equal('Koululainen, Kaisa (220109-784L)')
       expect(kela.getValittuOpiskeluoikeusOtsikko()).to.include('Jyväskylän normaalikoulu (2008 - 2016, Valmistunut)')
+      expect(extractAsText(S('table.osasuoritukset'))).to.include('Äidinkieli ja kirjallisuus, Suomen kieli ja kirjallisuus')
+      expect(extractAsText(S('table.osasuoritukset'))).to.include('B1-kieli, ruotsi')
     })
 
     describe('Valitaan toinen päätason suoritus', function () {

--- a/web/test/spec/kelaSpec.js
+++ b/web/test/spec/kelaSpec.js
@@ -118,4 +118,18 @@ describe('Kela', function () {
       })
     })
   })
+
+  describe('Jos käännös on vain englanniksi, suomenkielinen virkailija näkee käännöksen englanniksi', function () {
+    before(
+      Authentication().login('Laaja'),
+      kela.openPage,
+      kela.searchAndSelect('040701-432D', 'Iina'),
+      kela.selectSuoritus('IB-tutkinto (International Baccalaureate)'),
+      kela.selectOsasuoritus('Language A: literature')
+    )
+
+    it('Näytetään englanninkielinen käännös', function () {
+      expect(extractAsText(S('table.osasuoritukset.nested'))).to.include('FIN_S1')
+    })
+  })
 })


### PR DESCRIPTION
- jos LocalizedString sisältää vain englanninkielisen käännöksen, näytetään englanninkielinen käännös vaikka valittu kieli olisi joku muu
- bugfix: näytä suorituksen nimessä suoritettu kieli jos kyseessä on kieliaine ja oppimäärän nimi jos suoritus sisältää oppimäärän