### PR TITLE
tor-780: Kela UI lisäyksiä

### DIFF
--- a/web/app/kela/KelaOsasuorituksetTable.jsx
+++ b/web/app/kela/KelaOsasuorituksetTable.jsx
@@ -6,7 +6,7 @@ import {t} from '../i18n/i18n'
 
 export const KelaOsasuorituksetTable = ({osasuoritukset, path, nested, piilotaArviointiSarakkeet}) => {
   const currentPath = path + '.osasuoritukset'
-  const laajuudenYksikko = R.head(R.uniq(osasuoritukset.map(findLaajuudenYksikko).filter(R.identity)))
+  const laajuudenYksikko = findLaajuudenYksikkoTakeFirst(osasuoritukset)
   return (
     <table className={pathToClassnames(currentPath) + (nested ? ' nested' : '')}>
       <thead></thead>
@@ -34,7 +34,7 @@ export const KelaOsasuorituksetTable = ({osasuoritukset, path, nested, piilotaAr
 const ExpandableOsasuoritus = ({osasuoritus, path, piilotaArviointiSarakkeet}) => {
   const expandedAtom = Atom(R.length(osasuoritus.osasuoritukset || []) > 0)
   const mahdollinenSuorituksenLaajuus = osasuoritus.koulutusmoduuli.laajuus || {}
-  const laajuus = mahdollinenSuorituksenLaajuus.arvo || osasuoritustenYhteislaajuus(osasuoritus)
+  const laajuus = mahdollinenSuorituksenLaajuus.arvo || laskeLaajuusOsasuorituksista(osasuoritus)
   const mahdollinenArviointi = R.last(osasuoritus.arviointi || []) || {}
   const properties = R.omit(['osasuoritukset', 'arviointi', 'koulutusmoduuli'], osasuoritus)
   const isExpandable = !R.isEmpty(properties) || osasuoritus.osasuoritukset
@@ -86,6 +86,10 @@ const suorituksenNimi = koulutusmoduuli => {
   return [koodiarvo, kieli, oppimaara].filter(R.identity).join(', ')
 }
 
+export const findLaajuudenYksikkoTakeFirst = osasuoritukset => {
+  return R.head(R.uniq(osasuoritukset.map(findLaajuudenYksikko).filter(R.identity)))
+}
+
 const findLaajuudenYksikko = osasuoritus => {
   const laajuus = osasuoritus.koulutusmoduuli.laajuus || {}
   const laajuudenYksikkoOsasuorituksista = R.head((osasuoritus.osasuoritukset || [])
@@ -99,7 +103,7 @@ const findLaajuudenYksikko = osasuoritus => {
   }
 }
 
-const osasuoritustenYhteislaajuus = osasuoritus => {
+export const laskeLaajuusOsasuorituksista = osasuoritus => {
   const osasuoritukset = osasuoritus.osasuoritukset || []
   const hyvaksytytOsasuoritukset = osasuoritukset.filter(isHyvaksytty)
   return R.sum(hyvaksytytOsasuoritukset.map(osasuorituksenLaajuus))
@@ -111,8 +115,8 @@ const isHyvaksytty = osasuoritus => {
 }
 
 const osasuorituksenLaajuus = osasuoritus => {
-  const mahdollinenLaajuus = osasuoritus.laajuus || {}
-  return mahdollinenLaajuus.arvo || 1
+  const mahdollinenLaajuus = osasuoritus.koulutusmoduuli.laajuus || {}
+  return mahdollinenLaajuus.arvo || 0
 }
 
 export const pathToClassnames = path => path.split('.').join(' ')

--- a/web/app/kela/KelaOsasuorituksetTable.jsx
+++ b/web/app/kela/KelaOsasuorituksetTable.jsx
@@ -32,7 +32,7 @@ export const KelaOsasuorituksetTable = ({osasuoritukset, path, nested, piilotaAr
 }
 
 const ExpandableOsasuoritus = ({osasuoritus, path, piilotaArviointiSarakkeet}) => {
-  const expandedAtom = Atom(false)
+  const expandedAtom = Atom(R.length(osasuoritus.osasuoritukset || []) > 0)
   const mahdollinenSuorituksenLaajuus = osasuoritus.koulutusmoduuli.laajuus || {}
   const laajuus = mahdollinenSuorituksenLaajuus.arvo || osasuoritustenYhteislaajuus(osasuoritus)
   const mahdollinenArviointi = R.last(osasuoritus.arviointi || []) || {}

--- a/web/app/kela/KelaSuoritus.jsx
+++ b/web/app/kela/KelaSuoritus.jsx
@@ -2,7 +2,7 @@ import React from 'baret'
 import * as R from 'ramda'
 import Atom from 'bacon.atom'
 import {DateView, KeyValueTable} from './KeyValueTable'
-import {KelaOsasuorituksetTable} from './KelaOsasuorituksetTable'
+import {findLaajuudenYksikkoTakeFirst, KelaOsasuorituksetTable, laskeLaajuusOsasuorituksista} from './KelaOsasuorituksetTable'
 import {t} from '../i18n/i18n'
 import Text from '../i18n/Text'
 
@@ -49,10 +49,12 @@ const SuoritusView = ({suoritus, path}) => {
     <>
       <KeyValueTable object={properties} path={path}/>
       <SuorituksenVahvistus vahvistus={suoritus.vahvistus}/>
-      {osasuoritukset && <KelaOsasuorituksetTable osasuoritukset={osasuoritukset}
+      {osasuoritukset && <>
+        <OsasuoritustenYhteislaajuus osasuoritukset={osasuoritukset} />
+        <KelaOsasuorituksetTable osasuoritukset={osasuoritukset}
                                                   piilotaArviointiSarakkeet={piilotaArviointiSarakkeet}
-                                                  path={path}
-      />}
+                                                  path={path}/>
+      </>}
     </>
   )
 }
@@ -70,6 +72,21 @@ const SuorituksenVahvistus = ({vahvistus}) => (
     )}
   </div>
 )
+
+const OsasuoritustenYhteislaajuus = ({osasuoritukset}) => {
+  const laajuudenYksikko = findLaajuudenYksikkoTakeFirst(osasuoritukset)
+  const yhteislaajuus = R.sum(osasuoritukset.map(osasuoritus => {
+    const mahdollinenSuorituksenLaajuus = osasuoritus.koulutusmoduuli.laajuus || {}
+    return mahdollinenSuorituksenLaajuus.arvo || laskeLaajuusOsasuorituksista(osasuoritus)
+  }))
+
+  return (
+    <div className='suoritus yhteislaajuus'>
+      <span className='yhteislaajuus'>{t('Yhteislaajuus')}</span>
+      <span>{`${yhteislaajuus} ${laajuudenYksikko ? laajuudenYksikko : ''}`}</span>
+    </div>
+  )
+}
 
 const suorituksenNimi = koulutusmoduuli => {
   return koulutusmoduuli && koulutusmoduuli.tunniste && t(koulutusmoduuli.tunniste.nimi) || null

--- a/web/app/style/kela-virkailija.less
+++ b/web/app/style/kela-virkailija.less
@@ -187,6 +187,15 @@
       }
     }
 
+    .suoritus.yhteislaajuus {
+      > span {
+        margin: 0.2rem;
+      }
+      .yhteislaajuus {
+        font-weight: 600;
+      }
+    }
+
     &.suoritukset {
       .tabs {
 

--- a/web/test/spec/kelaSpec.js
+++ b/web/test/spec/kelaSpec.js
@@ -26,6 +26,10 @@ describe('Kela', function () {
       expect(extractAsText(S('table.osasuoritukset'))).to.include('B1-kieli, ruotsi')
     })
 
+    it('Kaikkien osasuoritusten yhteislaajuus', function () {
+      expect(extractAsText(S('.yhteislaajuus'))).to.include('Yhteislaajuus 6.5 vuosiviikkotuntia')
+    })
+
     describe('Valitaan toinen päätason suoritus', function () {
       before(
         kela.selectSuoritus('9. vuosiluokka')

--- a/web/test/spec/kelaSpec.js
+++ b/web/test/spec/kelaSpec.js
@@ -58,19 +58,19 @@ describe('Kela', function () {
 
     var osasuorituksenSisältö = 'Osasuoritukset Laajuus (osaamispistettä) Arviointipäivä Hyväksytty\n' +
       'Matematiikka 3 20.10.2014 kyllä\n' +
-      'Fysiikka ja kemia 3 20.10.2014 kyllä'
+      'Fysiikka ja kemia 3 20.10.2014 kyllä\n'
 
-    describe('Ennen avaamista', function () {
-      it('Ei näy osasuorituksen sisältämiä tietoja', function () {
-        expect(extractAsText(S('table.osasuoritukset'))).to.not.include(osasuorituksenSisältö)
+    describe('Osasuorituksen osasuoritukset on valmiiksi auki', function () {
+      it('Toimii', function () {
+        expect(extractAsText(S('table.osasuoritukset'))).to.include(osasuorituksenSisältö)
       })
     })
 
-    describe('Avataan osasuoritus', function () {
+    describe('Osasuoritus voidaan sulkea', function () {
       before(kela.selectOsasuoritus('Matemaattis-luonnontieteellinen osaaminen'))
 
-      it('Osasuoritus avautuu', function () {
-        expect(extractAsText(S('table.osasuoritukset'))).to.include(osasuorituksenSisältö)
+      it('Ei näy sulkemisen jälkeen', function () {
+        expect(extractAsText(S('table.osasuoritukset'))).to.not.include(osasuorituksenSisältö)
       })
     })
   })
@@ -106,19 +106,20 @@ describe('Kela', function () {
       kela.searchAndSelect('151013-2195', 'Dia')
     )
 
-    var sarakkeetSisältääArvioinnin = 'Osasuoritukset Laajuus (vuosiviikkotuntia) Arviointipäivä Hyväksytty\n'
+    var ensimmäisenTasonOsasuoritus = 'Osasuoritukset Laajuus (vuosiviikkotuntia)\n' +
+      'Äidinkieli, saksa 3'
 
-    it('Taulukosta on piilotettu arviointi-sarakkeet', function () {
-      expect(extractAsText(S('table.osasuoritukset'))).to.not.include(sarakkeetSisältääArvioinnin)
+    var toisenTasonOsasuoritus = 'Osasuoritukset Laajuus (vuosiviikkotuntia) Arviointipäivä Hyväksytty\n' +
+      '10/I 1 4.6.2016 kyllä'
+
+    it('Ensimmäisen tason osasuorituksella ei ole arviointi-sarakkeita', function () {
+      expect(extractAsText(S('table.osasuoritukset'))).to.include(ensimmäisenTasonOsasuoritus)
     })
 
-    describe('Osasuorituksen osasuorituksille näytetään arviointi-sarakkeet', function () {
-      before(kela.selectOsasuoritus('Matematiikka'))
-
-      it('Toimii', function () {
-        expect(extractAsText(S('table.osasuoritukset'))).to.include(sarakkeetSisältääArvioinnin)
-      })
+    it('Toisen tason osasuorituksella on arviointi-sarakkeet', function () {
+      expect(extractAsText(S('table.osasuoritukset'))).to.include(toisenTasonOsasuoritus)
     })
+
   })
 
   describe('Jos käännös on vain englanniksi, suomenkielinen virkailija näkee käännöksen englanniksi', function () {
@@ -126,8 +127,7 @@ describe('Kela', function () {
       Authentication().login('Laaja'),
       kela.openPage,
       kela.searchAndSelect('040701-432D', 'Iina'),
-      kela.selectSuoritus('IB-tutkinto (International Baccalaureate)'),
-      kela.selectOsasuoritus('Language A: literature')
+      kela.selectSuoritus('IB-tutkinto (International Baccalaureate)')
     )
 
     it('Näytetään englanninkielinen käännös', function () {


### PR DESCRIPTION
- Osasuoritukset jotka sisältävät lisää osasuorituksia on nyt defaultisti auki
- Näytetään kaikkien osasuoritusten yhteislaajuus valmiiksi laskettuna