### PR TITLE
Päättele suorituskopion content-type nimestä

### DIFF
--- a/src/main/scala/fi/oph/koski/ytr/YtrKoesuoritusServlet.scala
+++ b/src/main/scala/fi/oph/koski/ytr/YtrKoesuoritusServlet.scala
@@ -16,7 +16,7 @@ class YtrKoesuoritusServlet(implicit val application: KoskiApplication) extends 
     val examPaper = getStringParam("copyOfExamPaper")
     val hasAccess = hasAccessTo(examPaper)
     if (koesuoritukset.koesuoritusExists(examPaper) && hasAccess) {
-      contentType = "application/pdf"
+      contentType = if (examPaper.contains("pdf")) "application/pdf" else "text/html"
       koesuoritukset.writeKoesuoritus(examPaper, response.getOutputStream)
     } else {
       logger.warn(s"Exam paper $examPaper not found, hasAccess: $hasAccess")


### PR DESCRIPTION
Content typeksi vanhoille pdf-päätteisille suorituskopioille asetetaan application/pdf ja uudemmille html-päätteisille text/html.