### PR TITLE
Lyhennetään taulun nimi alle 32 merkkiseksi

### DIFF
--- a/src/main/scala/fi/oph/koski/raportit/EsiopetuksenOppijamäärätRaportti.scala
+++ b/src/main/scala/fi/oph/koski/raportit/EsiopetuksenOppijamäärätRaportti.scala
@@ -72,7 +72,7 @@ case class EsiopetuksenOppijamäärätRaportti(db: DB, organisaatioService: Orga
       count(case when sisaoppilaitosmainen_majoitus = true then 1 end) as sisäoppilaitosmainenMajoitus
     from r_opiskeluoikeus
     join r_henkilo on r_henkilo.oppija_oid = r_opiskeluoikeus.oppija_oid
-    join esiopetus_opiskeluoikeus_aikajakso aikajakso on aikajakso.opiskeluoikeus_oid = r_opiskeluoikeus.opiskeluoikeus_oid
+    join esiopetus_opiskeluoik_aikajakso aikajakso on aikajakso.opiskeluoikeus_oid = r_opiskeluoikeus.opiskeluoikeus_oid
     join r_organisaatio_kieli on r_organisaatio_kieli.organisaatio_oid = oppilaitos_oid
     join r_koodisto_koodi on r_koodisto_koodi.koodisto_uri = split_part(split_part(kielikoodi, '#', 1), '_', 1) and r_koodisto_koodi.koodiarvo = split_part(kielikoodi, '#', 2)
     join r_organisaatio on r_organisaatio.organisaatio_oid = oppilaitos_oid

--- a/src/main/scala/fi/oph/koski/raportit/EsiopetusRaportti.scala
+++ b/src/main/scala/fi/oph/koski/raportit/EsiopetusRaportti.scala
@@ -92,7 +92,7 @@ case class EsiopetusRaportti(db: DB, organisaatioService: OrganisaatioService) e
       r_opiskeluoikeus.data -> 'järjestämismuoto' ->> 'koodiarvo'
     from r_opiskeluoikeus
     join r_henkilo on r_henkilo.oppija_oid = r_opiskeluoikeus.oppija_oid
-    join esiopetus_opiskeluoikeus_aikajakso aikajakso on aikajakso.opiskeluoikeus_oid = r_opiskeluoikeus.opiskeluoikeus_oid
+    join esiopetus_opiskeluoik_aikajakso aikajakso on aikajakso.opiskeluoikeus_oid = r_opiskeluoikeus.opiskeluoikeus_oid
     left join r_paatason_suoritus on r_paatason_suoritus.opiskeluoikeus_oid = r_opiskeluoikeus.opiskeluoikeus_oid
     where (r_opiskeluoikeus.oppilaitos_oid in (#${SQL.toSqlListUnsafe(oppilaitosOidit)}) or r_opiskeluoikeus.koulutustoimija_oid in (#${SQL.toSqlListUnsafe(oppilaitosOidit)}))
       and r_opiskeluoikeus.koulutusmuoto = 'esiopetus'

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabaseSchema.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabaseSchema.scala
@@ -45,8 +45,8 @@ object RaportointiDatabaseSchema {
     sqlu"CREATE INDEX ON #${s.name}.r_osasuoritus(vahvistus_paiva)",
     sqlu"CREATE INDEX ON #${s.name}.r_osasuoritus(suorituksen_tyyppi)",
     sqlu"CREATE INDEX ON #${s.name}.r_osasuoritus(ylempi_osasuoritus_id)",
-    sqlu"CREATE INDEX ON #${s.name}.esiopetus_opiskeluoikeus_aikajakso(opiskeluoikeus_oid)",
-    sqlu"CREATE INDEX ON #${s.name}.esiopetus_opiskeluoikeus_aikajakso(alku)" // TODO: turha indeksi?
+    sqlu"CREATE INDEX ON #${s.name}.esiopetus_opiskeluoik_aikajakso(opiskeluoikeus_oid)",
+    sqlu"CREATE INDEX ON #${s.name}.esiopetus_opiskeluoik_aikajakso(alku)" // TODO: turha indeksi?
   )
 
   def createOtherIndexes(s: Schema) = DBIO.seq(
@@ -58,7 +58,8 @@ object RaportointiDatabaseSchema {
   def dropAllIfExists(s: Schema) = DBIO.seq(
     sqlu"DROP TABLE IF EXISTS #${s.name}.r_opiskeluoikeus CASCADE",
     sqlu"DROP TABLE IF EXISTS #${s.name}.r_opiskeluoikeus_aikajakso CASCADE",
-    sqlu"DROP TABLE IF EXISTS #${s.name}.esiopetus_opiskeluoikeus_aikajakso CASCADE",
+    sqlu"DROP TABLE IF EXISTS #${s.name}.esiopetus_opiskeluoikeus_aikajakso CASCADE", // TODO: Voidaan poistaa kun on ajettu kerran vanha taulu pois kannasta
+    sqlu"DROP TABLE IF EXISTS #${s.name}.esiopetus_opiskeluoik_aikajakso CASCADE",
     sqlu"DROP TABLE IF EXISTS #${s.name}.r_paatason_suoritus CASCADE",
     sqlu"DROP TABLE IF EXISTS #${s.name}.r_osasuoritus CASCADE",
     sqlu"DROP TABLE IF EXISTS #${s.name}.r_henkilo CASCADE",
@@ -89,7 +90,7 @@ object RaportointiDatabaseSchema {
       TO raportointikanta_katselija, raportointikanta_henkilo_katselija""",
     sqlu"""GRANT SELECT ON
       #${s.name}.r_henkilo,
-      #${s.name}.esiopetus_opiskeluoikeus_aikajakso,
+      #${s.name}.esiopetus_opiskeluoik_aikajakso,
       #${s.name}.muu_ammatillinen_raportointi,
       #${s.name}.topks_ammatillinen_raportointi
       TO raportointikanta_henkilo_katselija"""
@@ -191,7 +192,7 @@ object RaportointiDatabaseSchema {
   }
   class ROpiskeluoikeusAikajaksoTableTemp(tag: Tag) extends ROpiskeluoikeusAikajaksoTable(tag, Temp)
 
-  class EsiopetusOpiskeluoikeusAikajaksoTable(tag: Tag, schema: Schema = Public) extends Table[EsiopetusOpiskeluoikeusAikajaksoRow](tag, schema.nameOpt, "esiopetus_opiskeluoikeus_aikajakso") {
+  class EsiopetusOpiskeluoikeusAikajaksoTable(tag: Tag, schema: Schema = Public) extends Table[EsiopetusOpiskeluoikeusAikajaksoRow](tag, schema.nameOpt, "esiopetus_opiskeluoik_aikajakso") {
     val opiskeluoikeusOid = column[String]("opiskeluoikeus_oid", StringIdentifierType)
     val alku = column[Date]("alku")
     val loppu = column[Date]("loppu")


### PR DESCRIPTION
Jotta kaikki dataa hyödyntävät järjestelmät osaavat ladata taulun.

Raportointikannan hajottava muutos. Vietäessä tuotantoon voidaan tilanne korjata ajamalla manuaalisesti 
ALTER TABLE esiopetus_opiskeluoikeus_aikajakso RENAME TO esiopetus_opiskeluoik_aikajakso;