### PR TITLE
Raportointikannan huoltoa

### DIFF
--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
@@ -43,6 +43,14 @@ case class RaportointiDatabase(config: KoskiDatabaseConfig) extends Logging with
     TOPKSAmmatillinenOsasuoritusRaportointi
   )
 
+  def vacuumAnalyze(): Unit = {
+    logger.info("Vacuuming and analysing RaportointiDatabase...")
+    val started = System.currentTimeMillis
+    runDbSync(sqlu"""VACUUM ANALYZE""")
+    val duration = (System.currentTimeMillis - started) / 1000
+    logger.info(s"Vacuuming and analysing RaportointiDatabase done in ${duration} s")
+  }
+
   def moveTo(newSchema: Schema): Unit = {
     logger.info(s"Moving ${schema.name} -> ${newSchema.name}")
     runDbSync(DBIO.seq(
@@ -59,6 +67,7 @@ case class RaportointiDatabase(config: KoskiDatabaseConfig) extends Logging with
       RaportointiDatabaseSchema.createRolesIfNotExists,
       RaportointiDatabaseSchema.grantPermissions(Public)
     ).transactionally)
+    logger.info("RaportointiDatabase schema swapped")
   }
 
   def dropAndCreateObjects: Unit = {

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabaseSchema.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabaseSchema.scala
@@ -41,8 +41,6 @@ object RaportointiDatabaseSchema {
     sqlu"CREATE UNIQUE INDEX ON #${s.name}.r_osasuoritus(osasuoritus_id)",
     sqlu"CREATE INDEX ON #${s.name}.r_osasuoritus(paatason_suoritus_id)",
     sqlu"CREATE INDEX ON #${s.name}.r_osasuoritus(opiskeluoikeus_oid)",
-    sqlu"CREATE INDEX ON #${s.name}.r_osasuoritus(vahvistus_paiva)",
-    sqlu"CREATE INDEX ON #${s.name}.r_osasuoritus(suorituksen_tyyppi)",
     sqlu"CREATE INDEX ON #${s.name}.r_osasuoritus(ylempi_osasuoritus_id)",
     sqlu"CREATE INDEX ON #${s.name}.esiopetus_opiskeluoik_aikajakso(opiskeluoikeus_oid)",
   )

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabaseSchema.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabaseSchema.scala
@@ -58,7 +58,6 @@ object RaportointiDatabaseSchema {
   def dropAllIfExists(s: Schema) = DBIO.seq(
     sqlu"DROP TABLE IF EXISTS #${s.name}.r_opiskeluoikeus CASCADE",
     sqlu"DROP TABLE IF EXISTS #${s.name}.r_opiskeluoikeus_aikajakso CASCADE",
-    sqlu"DROP TABLE IF EXISTS #${s.name}.esiopetus_opiskeluoikeus_aikajakso CASCADE", // TODO: Voidaan poistaa kun on ajettu kerran vanha taulu pois kannasta
     sqlu"DROP TABLE IF EXISTS #${s.name}.esiopetus_opiskeluoik_aikajakso CASCADE",
     sqlu"DROP TABLE IF EXISTS #${s.name}.r_paatason_suoritus CASCADE",
     sqlu"DROP TABLE IF EXISTS #${s.name}.r_osasuoritus CASCADE",

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabaseSchema.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabaseSchema.scala
@@ -34,7 +34,6 @@ object RaportointiDatabaseSchema {
     sqlu"CREATE INDEX ON #${s.name}.r_opiskeluoikeus(koulutusmuoto)",
     sqlu"CREATE INDEX ON #${s.name}.r_opiskeluoikeus(sisaltyy_opiskeluoikeuteen_oid)",
     sqlu"CREATE INDEX ON #${s.name}.r_opiskeluoikeus_aikajakso(opiskeluoikeus_oid)",
-    sqlu"CREATE INDEX ON #${s.name}.r_opiskeluoikeus_aikajakso(alku)",
     sqlu"CREATE UNIQUE INDEX ON #${s.name}.r_paatason_suoritus(paatason_suoritus_id)",
     sqlu"CREATE INDEX ON #${s.name}.r_paatason_suoritus(opiskeluoikeus_oid)",
     sqlu"CREATE INDEX ON #${s.name}.r_paatason_suoritus(vahvistus_paiva)",
@@ -46,7 +45,6 @@ object RaportointiDatabaseSchema {
     sqlu"CREATE INDEX ON #${s.name}.r_osasuoritus(suorituksen_tyyppi)",
     sqlu"CREATE INDEX ON #${s.name}.r_osasuoritus(ylempi_osasuoritus_id)",
     sqlu"CREATE INDEX ON #${s.name}.esiopetus_opiskeluoik_aikajakso(opiskeluoikeus_oid)",
-    sqlu"CREATE INDEX ON #${s.name}.esiopetus_opiskeluoik_aikajakso(alku)" // TODO: turha indeksi?
   )
 
   def createOtherIndexes(s: Schema) = DBIO.seq(

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointikantaService.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointikantaService.scala
@@ -65,6 +65,7 @@ class RaportointikantaService(application: KoskiApplication) extends Logging {
     loadOrganisaatiot(loadDatabase)
     loadKoodistot(loadDatabase)
     swapRaportointikanta()
+    raportointiDatabase.vacuumAnalyze()
   }
 
   protected lazy val defaultScheduler: Scheduler = NewThreadScheduler()


### PR DESCRIPTION
Indeksejä voisi katsoa uudestaan tarkemmin kun ollaan toteutettu jatkuvasti lataava raportointikanta, jolloin indeksien statistiikka oikeasti kertookin jotain.

`VACUUM ANALYSE` voi potentiaalisesti parantaa kyselyjen suorituskykyä reilustikin. Sen ajamisessa kestää noin 20 minuuttia, mutta kantaa voi periaatteessa käyttää samalla, joskin se voi olla hidas.