### PR TITLE
Raportointikannan lataus ei lopu ekaan virheeseen

### DIFF
--- a/src/main/scala/fi/oph/koski/util/Retry.scala
+++ b/src/main/scala/fi/oph/koski/util/Retry.scala
@@ -1,0 +1,16 @@
+package fi.oph.koski.util
+
+import fi.oph.koski.log.Logging
+
+object Retry extends Logging {
+  def retryWithInterval[T](n: Int, intervalMs: Long)(fn: => T): T = {
+    try {
+      fn
+    } catch {
+      case e if n > 1 =>
+        logger.error(e)(s"${e.getMessage}. Retrying. Retries left: ${n - 1}")
+        Thread.sleep(intervalMs)
+        retryWithInterval(n - 1, intervalMs)(fn)
+    }
+  }
+}


### PR DESCRIPTION
Opiskeluoikeuksien lataus sivuittain saattaa välillä epäonnistua ja
epäonnistuminen johtaa koko raportointikannan latauksen keskeytymiseen