### PR TITLE
TOR-1144: Maskaa kela-URLeista hetu access-lokeissa

### DIFF
--- a/src/main/scala/fi/oph/koski/log/MaskedSlf4jRequestLogWriter.scala
+++ b/src/main/scala/fi/oph/koski/log/MaskedSlf4jRequestLogWriter.scala
@@ -17,5 +17,6 @@ class MaskedSlf4jRequestLogWriter extends Slf4jRequestLogWriter {
       .replaceAll("(/koski/api/henkilo/search\\?query=)(\\S+)", "$1*")
       .replaceAll("(/koski/api/henkilo/search\\?query=)(\\S+)", "$1*")
       .replaceAll("(/koski/api/luovutuspalvelu/valvira/)(\\S+)", "$1******-****")
+      .replaceAll("(/koski/kela/)(\\d\\S+)", "$1******-****")
   }
 }


### PR DESCRIPTION
Näin on ollut tapana tehdä Koskessa. Ylimääräinen \d regexpissä, koska on myös route kela/versiohistoria/... , jota ei tarvitse maskata.