### PR TITLE
Korjaa virta opintojakson nimen päättely;

### DIFF
--- a/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
+++ b/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
@@ -412,7 +412,7 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
   }
 
   private def nimi(suoritus: Node): LocalizedString = {
-    sanitize((suoritus \\ "Nimi" map (nimi => ((nimi \ "@kieli").text, nimi.text))).toMap).getOrElse(finnish("Suoritus: " + avain(suoritus)))
+    sanitize((suoritus \ "Nimi" map { nimi => (nimi \ "@kieli").text -> nimi.text }).toMap).getOrElse(finnish("Suoritus: " + avain(suoritus)))
   }
 
   private def oppilaitos(node: Node, vahvistusPäivä: Option[LocalDate]): Oppilaitos =


### PR DESCRIPTION
`\\`-selector palauttaa kaikki matchaavat xml-rakenteet, childit + grandchildit.., tästä syystä opintojakson arviointien nimet valittiin myös mukaan opintojakson nimen päättelyyn. Suuressa osassa tapauksia tämä virhe piiloutui, koska arviointien `Nimi`-rakenteilla ei ole `kieli`-propertyä, suorituksen `Nimi`-rakenteella se on. Mutta tapauksessa jossa, suorituksen `Nimi`-rakenteella ei ole suomenkielistä käännöstä, valittiin virheellisesti suomenkieliseksi käännökseksi arvioinnin `Nimi`-rakenteesta löytyvä arvo.

Korjaus: käytetään selectoria joka palauttaa vain `Opintosuoritus`-rakenteen alta suoraan löytyvät `Nimi`-rakenteet
`\`-selector palauttaa vain annetun noden childit, ei grandchildeja