### PR TITLE
Korjaa nimihaku linkiteyille oppijoille

### DIFF
--- a/src/main/scala/fi/oph/koski/henkilo/HenkiloRepository.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/HenkiloRepository.scala
@@ -46,8 +46,6 @@ case class HenkilöRepository(opintopolku: OpintopolkuHenkilöRepository, virta:
   def findByOid(oid: String, findMasterIfSlaveOid: Boolean = false): Option[LaajatOppijaHenkilöTiedot] = oidCache(HenkilöCacheKey(oid, findMasterIfSlaveOid))
   // Other methods just call the non-cached implementation
 
-  def findByOidsNoSlaveOids(oids: List[String]): List[OppijaHenkilö] = opintopolku.findByOidsNoSlaveOids(oids)
-
   def findOrCreate(henkilö: UusiHenkilö): Either[HttpStatus, OppijaHenkilö] = opintopolku.findOrCreate(henkilö)
 
   // Etsii oppija-henkilön hetun perusteella oppijanumerorekisteristä. Jos henkilöä ei löydy oppijanumerorekisteristä,
@@ -94,8 +92,8 @@ case class HenkilöRepository(opintopolku: OpintopolkuHenkilöRepository, virta:
     }
   }
 
-  def findHenkilötiedotNoSlaveOids(query: String)(implicit user: KoskiSession): List[OppijaHenkilö] =
-    findByOidsNoSlaveOids(perustiedotRepository.findOids(query))
+  def findByOids(query: String)(implicit session: KoskiSession): List[LaajatOppijaHenkilöTiedot] =
+    opintopolku.findMastersByOids(perustiedotRepository.findOids(query))
 
   def oppijaHenkilöToTäydellisetHenkilötiedot(henkilö: OppijaHenkilö): TäydellisetHenkilötiedot =
     opintopolku.oppijaHenkilöToTäydellisetHenkilötiedot(henkilö)

--- a/src/main/scala/fi/oph/koski/henkilo/HenkilotiedotSearchFacade.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/HenkilotiedotSearchFacade.scala
@@ -36,7 +36,7 @@ private[henkilo] case class HenkilötiedotSearchFacade(henkilöRepository: Henki
 
   // Sisällyttää vain henkilöt, joilta löytyy vähintään yksi (tälle käyttäjälle näkyvä) opiskeluoikeus Koskesta, ei tarkista Virta- eikä YTR-palvelusta
   private def searchHenkilötiedot(queryString: String)(implicit user: KoskiSession): HenkilötiedotSearchResponse = {
-    val filtered = koskiOpiskeluoikeudet.filterOppijat(henkilöRepository.findHenkilötiedotNoSlaveOids(queryString)).map(_.toHenkilötiedotJaOid)
+    val filtered = koskiOpiskeluoikeudet.filterOppijat(henkilöRepository.findByOids(queryString)).map(_.toHenkilötiedotJaOid)
     HenkilötiedotSearchResponse(filtered.sortBy(oppija => (oppija.sukunimi, oppija.etunimet)))
   }
 

--- a/src/main/scala/fi/oph/koski/henkilo/OpintopolkuHenkiloRepository.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/OpintopolkuHenkiloRepository.scala
@@ -105,13 +105,12 @@ case class OpintopolkuHenkilöRepository(henkilöt: OpintopolkuHenkilöFacade, k
     henkilöt.findMasterOppija(oid)
   }
 
-  def findByOid(oid: String): Option[LaajatOppijaHenkilöTiedot] = {
-    henkilöt.findOppijaByOid(oid)
+  def findMastersByOids(oids: List[String]): List[LaajatOppijaHenkilöTiedot] = {
+    henkilöt.findMasterOppijat(oids).values.toList
   }
 
-  def findByOidsNoSlaveOids(oids: List[String]): List[OppijaHenkilö] = oids match {
-    case Nil => Nil // <- authentication-service fails miserably with empty input list
-    case _ => henkilöt.findOppijatNoSlaveOids(oids)
+  def findByOid(oid: String): Option[LaajatOppijaHenkilöTiedot] = {
+    henkilöt.findOppijaByOid(oid)
   }
 
   // Hakee master-henkilön, jos eri kuin tämä henkilö


### PR DESCRIPTION
Jos linkitetyllä oppijalla on vain yksi opiskeluoikeus joka, on siirretty passivoidulla oppijanumerolla, nimihaku ei löytänyt tälläistä henkilöä,
koska elasticsearchin haku palautti aina oppijan uusimman oidin, ja tällä haettaessa kosken kannasta ei löydy yhtään opiskeluoikeutta.
Ongelma ratkaistiin käyttämällä oppijanumerorekisteristä rajapintaa, mikä palauttaa aina kaikki oppijan oidit