### PR TITLE
TOR-1000: Lukion kurssikertymäraportin korjaukset

### DIFF
--- a/src/main/scala/fi/oph/koski/raportit/LukioOppiaineRahoitusmuodonMukaan.scala
+++ b/src/main/scala/fi/oph/koski/raportit/LukioOppiaineRahoitusmuodonMukaan.scala
@@ -54,7 +54,6 @@ object LukioOppiaineRahoitusmuodonMukaan extends DatabaseConverters {
           where
             oppilaitos_oid = any($oppilaitosOids)
             and r_paatason_suoritus.suorituksen_tyyppi = 'lukionoppiaineenoppimaara'
-            and r_opiskeluoikeus_aikajakso.tila = 'lasna'
             and r_opiskeluoikeus_aikajakso.alku <= $viimeistaan
             and r_opiskeluoikeus_aikajakso.loppu >= $aikaisintaan
             and r_opiskeluoikeus_aikajakso.opintojen_rahoitus #${rahoitusmuoto match {

--- a/src/main/scala/fi/oph/koski/raportit/LukioOppiaineenOppimaaranKurssikertymat.scala
+++ b/src/main/scala/fi/oph/koski/raportit/LukioOppiaineenOppimaaranKurssikertymat.scala
@@ -81,7 +81,6 @@ object LukioOppiaineenOppimaaranKurssikertymat extends DatabaseConverters {
             -- lukion aineoppimäärä
             and r_paatason_suoritus.suorituksen_tyyppi = 'lukionoppiaineenoppimaara'
             and r_osasuoritus.suorituksen_tyyppi = 'lukionkurssi'
-            and r_opiskeluoikeus_aikajakso.tila = 'lasna'
             -- kurssi menee parametrien sisään
             and r_osasuoritus.arviointi_paiva >= $aikaisintaan
             and r_osasuoritus.arviointi_paiva <= $viimeistaan

--- a/src/main/scala/fi/oph/koski/raportit/LukioOppimaaranKussikertymat.scala
+++ b/src/main/scala/fi/oph/koski/raportit/LukioOppimaaranKussikertymat.scala
@@ -69,9 +69,9 @@ object LukioOppimaaranKussikertymat extends DatabaseConverters {
   val columnSettings: Seq[(String, Column)] = Seq(
     "oppilaitosOid" -> Column("Oppilaitoksen oid-tunniste"),
     "oppilaitos" -> Column("Oppilaitos"),
+    "kurssejaYhteensa" -> Column("Kursseja yhteensä", comment = Some("Kaikki sellaiset kurssit, joiden arviointipäivämäärä osuu tulostusparametreissa määritellyn aikajakson sisään.")),
     "suoritettujaKursseja" -> Column("Suoritetut kurssit", comment = Some("Kaikki sellaiset kurssit, joiden arviointipäivämäärä osuu tulostusparametreissa määritellyn aikajakson sisään ja joita ei ole merkitty tunnustetuiksi.")),
     "tunnustettujaKursseja" -> Column("Tunnustetut kurssit", comment = Some("Kaikki sellaiset kurssit, joiden arviointipäivämäärä osuu tulostusparametreissa määritellyn aikajakson sisään ja jotka on merkitty tunnustetuiksi.")),
-    "kurssejaYhteensa" -> Column("Kursseja yhteensä", comment = Some("Kaikki sellaiset kurssit, joiden arviointipäivämäärä osuu tulostusparametreissa määritellyn aikajakson sisään.")),
     "tunnustettujaKursseja_rahoituksenPiirissa" -> Column("Tunnustetut kurssit - rahoituksen piirissä", comment = Some("Kaikki sellaiset kurssit, joiden arviointipäivämäärä osuu tulostusparametreissa määritellyn aikajakson sisään, jotka on merkitty tunnustetuiksi ja jotka on merkitty rahoituksen piirissä oleviksi."))
   )
 }
@@ -79,8 +79,8 @@ object LukioOppimaaranKussikertymat extends DatabaseConverters {
 case class LukioKurssikertymaOppimaaraRow(
   oppilaitosOid: String,
   oppilaitos: String,
+  kurssejaYhteensa: Int,
   suoritettujaKursseja: Int,
   tunnustettujaKursseja: Int,
-  kurssejaYhteensa: Int,
   tunnustettujaKursseja_rahoituksenPiirissa: Int
 )

--- a/src/main/scala/fi/oph/koski/raportit/LukioOppimaaranKussikertymat.scala
+++ b/src/main/scala/fi/oph/koski/raportit/LukioOppimaaranKussikertymat.scala
@@ -21,36 +21,24 @@ object LukioOppimaaranKussikertymat extends DatabaseConverters {
 
   def queryOppimaara(oppilaitosOids: List[String], aikaisintaan: LocalDate, viimeistaan: LocalDate) = {
     sql"""
-          with paatason_suoritus as (
-            select
-              r_opiskeluoikeus.oppilaitos_nimi,
-              r_opiskeluoikeus.oppilaitos_oid,
-              r_paatason_suoritus.paatason_suoritus_id
-            from r_opiskeluoikeus
-            join r_paatason_suoritus on r_opiskeluoikeus.opiskeluoikeus_oid = r_paatason_suoritus.opiskeluoikeus_oid
-            where
-              oppilaitos_oid = any($oppilaitosOids)
-              and r_paatason_suoritus.suorituksen_tyyppi = 'lukionoppimaara'
-              and exists (
-                select 1 from r_opiskeluoikeus_aikajakso
-                where r_opiskeluoikeus.opiskeluoikeus_oid = r_opiskeluoikeus_aikajakso.opiskeluoikeus_oid
-                  and r_opiskeluoikeus_aikajakso.tila = 'lasna'
-                  and r_opiskeluoikeus_aikajakso.alku <= $viimeistaan
-                  and r_opiskeluoikeus_aikajakso.loppu >= $aikaisintaan
-              )
-      ) select
-          oppilaitos_nimi oppilaitos,
-          oppilaitos_oid,
-          count(*) filter (where tunnustettu = false) suoritettuja,
-          count(*) filter (where tunnustettu) tunnustettuja,
-          count(*) yhteensa,
-          count(*) filter (where tunnustettu_rahoituksen_piirissa) tunnustettuja_rahoituksen_piirissa
-        from paatason_suoritus
-        join r_osasuoritus on paatason_suoritus.paatason_suoritus_id = r_osasuoritus.paatason_suoritus_id
-        where r_osasuoritus.suorituksen_tyyppi = 'lukionkurssi'
-          and r_osasuoritus.arviointi_paiva >= $aikaisintaan
-          and r_osasuoritus.arviointi_paiva <= $viimeistaan
-        group by paatason_suoritus.oppilaitos_nimi, oppilaitos_oid;
+      select
+        oppilaitos_nimi oppilaitos,
+        oppilaitos_oid,
+        count(*) filter (where tunnustettu = false) suoritettuja,
+        count(*) filter (where tunnustettu) tunnustettuja,
+        count(*) yhteensa,
+        count(*) filter (where tunnustettu_rahoituksen_piirissa) tunnustettuja_rahoituksen_piirissa
+      from r_osasuoritus
+      join r_paatason_suoritus
+        on r_paatason_suoritus.paatason_suoritus_id = r_osasuoritus.paatason_suoritus_id
+      join r_opiskeluoikeus
+        on r_opiskeluoikeus.opiskeluoikeus_oid = r_paatason_suoritus.opiskeluoikeus_oid
+      where r_opiskeluoikeus.oppilaitos_oid = any($oppilaitosOids)
+        and r_paatason_suoritus.suorituksen_tyyppi = 'lukionoppimaara'
+        and r_osasuoritus.suorituksen_tyyppi = 'lukionkurssi'
+        and r_osasuoritus.arviointi_paiva >= $aikaisintaan
+        and r_osasuoritus.arviointi_paiva <= $viimeistaan
+      group by r_opiskeluoikeus.oppilaitos_nimi, r_opiskeluoikeus.oppilaitos_oid;
     """.as[LukioKurssikertymaOppimaaraRow]
   }
 

--- a/src/test/scala/fi/oph/koski/raportit/LukioKurssikertymaRaporttiSpec.scala
+++ b/src/test/scala/fi/oph/koski/raportit/LukioKurssikertymaRaporttiSpec.scala
@@ -49,10 +49,10 @@ class LukioKurssikertymaRaporttiSpec extends FreeSpec with RaportointikantaTestM
         ressunAineopiskelijat.oppilaitosOid shouldBe(MockOrganisaatiot.ressunLukio)
       }
       "Yhteensä" in {
-        ressunAineopiskelijat.kurssejaYhteensa shouldBe(11)
+        ressunAineopiskelijat.kurssejaYhteensa shouldBe(12)
       }
       "Suoritettuja" in {
-        ressunAineopiskelijat.suoritettujaKursseja shouldBe(5)
+        ressunAineopiskelijat.suoritettujaKursseja shouldBe(6)
       }
       "Tunnustettuja" in {
         ressunAineopiskelijat.tunnustettujaKursseja shouldBe(6)
@@ -61,19 +61,19 @@ class LukioKurssikertymaRaporttiSpec extends FreeSpec with RaportointikantaTestM
         ressunAineopiskelijat.tunnustettujaKursseja_rahoituksenPiirissa shouldBe(3)
       }
       "Pakollisia tai valtakunnallinen ja syventava" in {
-        ressunAineopiskelijat.pakollisia_tai_valtakunnallisiaSyventavia shouldBe(8)
+        ressunAineopiskelijat.pakollisia_tai_valtakunnallisiaSyventavia shouldBe(9)
       }
       "Pakollisia" in {
-        ressunAineopiskelijat.pakollisiaKursseja shouldBe(5)
+        ressunAineopiskelijat.pakollisiaKursseja shouldBe(6)
       }
       "Valtakunnallisia syventavia" in {
         ressunAineopiskelijat.valtakunnallisestiSyventaviaKursseja shouldBe(3)
       }
       "Suoritettuja pakollisia ja suoritettuja valtakunnallisia syventavia" in {
-        ressunAineopiskelijat.suoritettujaPakollisia_ja_suoritettujaValtakunnallisiaSyventavia shouldBe(4)
+        ressunAineopiskelijat.suoritettujaPakollisia_ja_suoritettujaValtakunnallisiaSyventavia shouldBe(5)
       }
       "Suoritettuja pakollisia" in {
-        ressunAineopiskelijat.suoritettujaPakollisiaKursseja shouldBe(3)
+        ressunAineopiskelijat.suoritettujaPakollisiaKursseja shouldBe(4)
       }
       "Suoritettuja valtakunnallisia syventavia" in {
         ressunAineopiskelijat.suoritettujaValtakunnallisiaSyventaviaKursseja shouldBe(1)


### PR DESCRIPTION
* Oppimäärä välilehti: Sarakkeen "Kursseja yhteensä" pitäisi olla ennen sarakkeita "Suoritetut kurssit" ja "Tunnustetut kurssit"
* Nykyinen kysely tarkistaa, että opiskeluoikeus, joista kursseja lasketaan on ollut "Läsnä"-tilainen päivänkin sinä tulostusparametreissa määriteltynä päivänä. Se on ihan turha tsekkaus, eli pitäisi etsiä vain osasuorituksia, joiden arviointipäivä osuu sen aikajakson väliin, mikä on tulostusparametreissa määritelty.
* Sama korjaus muidenkin välilehtien kyselyille.