### PR TITLE
TOR-1000: Kyselyiden korjailua ja performanssiparannus

### DIFF
--- a/src/main/scala/fi/oph/koski/raportit/LukioOppiaineOpiskeluoikeudenUlkopuoliset.scala
+++ b/src/main/scala/fi/oph/koski/raportit/LukioOppiaineOpiskeluoikeudenUlkopuoliset.scala
@@ -35,8 +35,7 @@ object LukioOppiaineOpiskeluoikeudenUlkopuoliset extends DatabaseConverters {
         and r_paatason_suoritus.suorituksen_tyyppi = 'lukionoppiaineenoppimaara'
         and r_osasuoritus.suorituksen_tyyppi = 'lukionkurssi'
         -- kurssi menee parametrien sisään
-        and r_osasuoritus.arviointi_paiva >= $aikaisintaan
-        and r_osasuoritus.arviointi_paiva <= $viimeistaan
+        and r_osasuoritus.arviointi_paiva between $aikaisintaan and $viimeistaan
         -- mutta kurssi jää opiskeluoikeuden ulkopuolelle
         and (
           r_osasuoritus.arviointi_paiva < r_opiskeluoikeus.alkamispaiva
@@ -45,11 +44,16 @@ object LukioOppiaineOpiskeluoikeudenUlkopuoliset extends DatabaseConverters {
             and r_opiskeluoikeus.viimeisin_tila = 'valmistunut'
           )
         )
-        -- pakolliset tai valtakunnalliset syventävät kurssit, jotka ovat joko suoritettuja tai tunnustettuja ja rahoituksen piirissä olevia
+        -- pakolliset tai valtakunnalliset syventävät kurssit
         and (
           koulutusmoduuli_kurssin_tyyppi = 'pakollinen'
           or (koulutusmoduuli_kurssin_tyyppi = 'syventava' and koulutusmoduuli_paikallinen = false)
-        );
+        )
+        -- jotka ovat joko suoritettuja tai tunnustettuja ja rahoituksen piirissä olevia
+        and (
+            tunnustettu = false
+            or tunnustettu_rahoituksen_piirissa
+        )
       """.as[LukioOppiaineOpiskeluoikeudenUlkopuolisetRow]
   }
 

--- a/src/main/scala/fi/oph/koski/raportit/LukioOppiaineOpiskeluoikeudenUlkopuoliset.scala
+++ b/src/main/scala/fi/oph/koski/raportit/LukioOppiaineOpiskeluoikeudenUlkopuoliset.scala
@@ -23,6 +23,7 @@ object LukioOppiaineOpiskeluoikeudenUlkopuoliset extends DatabaseConverters {
     sql"""
       select
         r_opiskeluoikeus.opiskeluoikeus_oid,
+        r_opiskeluoikeus.oppija_oid,
         r_osasuoritus.koulutusmoduuli_koodiarvo as kurssikoodi,
         r_osasuoritus.koulutusmoduuli_nimi as kurssin_nimi
       from r_osasuoritus
@@ -61,6 +62,7 @@ object LukioOppiaineOpiskeluoikeudenUlkopuoliset extends DatabaseConverters {
     val rs: ResultSet = r.rs
     LukioOppiaineOpiskeluoikeudenUlkopuolisetRow(
       opiskeluoikeusOid = rs.getString("opiskeluoikeus_oid"),
+      oppijaOid = rs.getString("oppija_oid"),
       kurssikoodi = rs.getString("kurssikoodi"),
       kurssinNimi = rs.getString("kurssin_nimi")
     )
@@ -68,6 +70,7 @@ object LukioOppiaineOpiskeluoikeudenUlkopuoliset extends DatabaseConverters {
 
   val columnSettings: Seq[(String, Column)] = Seq(
     "opiskeluoikeusOid" -> Column("Opiskeluoikeuden oid"),
+    "oppijaOid" -> Column("Oppijan oid"),
     "kurssikoodi" -> Column("Kurssikoodi"),
     "kurssinNimi" -> Column("Kurssin nimi")
   )
@@ -75,6 +78,7 @@ object LukioOppiaineOpiskeluoikeudenUlkopuoliset extends DatabaseConverters {
 
 case class LukioOppiaineOpiskeluoikeudenUlkopuolisetRow(
   opiskeluoikeusOid: String,
+  oppijaOid: String,
   kurssikoodi: String,
   kurssinNimi: String
 )

--- a/src/main/scala/fi/oph/koski/raportit/LukioOppiaineRahoitusmuodonMukaan.scala
+++ b/src/main/scala/fi/oph/koski/raportit/LukioOppiaineRahoitusmuodonMukaan.scala
@@ -44,6 +44,7 @@ object LukioOppiaineRahoitusmuodonMukaan extends DatabaseConverters {
     sql"""
         select
           r_osasuoritus.opiskeluoikeus_oid,
+          r_opiskeluoikeus.oppija_oid,
           r_osasuoritus.koulutusmoduuli_koodiarvo,
           r_osasuoritus.koulutusmoduuli_nimi
         from r_osasuoritus
@@ -81,6 +82,7 @@ object LukioOppiaineRahoitusmuodonMukaan extends DatabaseConverters {
     val rs = r.rs
     LukioKurssinRahoitusmuotoRow(
       opiskeluoikeusOid = rs.getString("opiskeluoikeus_oid"),
+      oppijaOid = rs.getString("oppija_oid"),
       koulutusmoduuliKoodiarvo = rs.getString("koulutusmoduuli_koodiarvo"),
       koulutusmoduuliNimi = rs.getString("koulutusmoduuli_nimi")
     )
@@ -88,6 +90,7 @@ object LukioOppiaineRahoitusmuodonMukaan extends DatabaseConverters {
 
   val columnSettings: Seq[(String, Column)] = Seq(
     "opiskeluoikeusOid" -> Column("Opiskeluoikeuden oid"),
+    "oppijaOid" -> Column("Oppijan oid"),
     "koulutusmoduuliKoodiarvo" -> Column("Kurssikoodi"),
     "koulutusmoduuliNimi" -> Column("Kurssin nimi"),
   )
@@ -95,6 +98,7 @@ object LukioOppiaineRahoitusmuodonMukaan extends DatabaseConverters {
 
 case class LukioKurssinRahoitusmuotoRow(
   opiskeluoikeusOid: String,
+  oppijaOid: String,
   koulutusmoduuliKoodiarvo: String,
   koulutusmoduuliNimi: String,
 )

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabaseSchema.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabaseSchema.scala
@@ -44,13 +44,14 @@ object RaportointiDatabaseSchema {
 
     sqlu"CREATE UNIQUE INDEX ON #${s.name}.r_paatason_suoritus(paatason_suoritus_id)",
     sqlu"CREATE INDEX ON #${s.name}.r_paatason_suoritus(opiskeluoikeus_oid, suorituksen_tyyppi)",
+    sqlu"CREATE INDEX ON #${s.name}.r_paatason_suoritus(suorituksen_tyyppi)",
     sqlu"CREATE INDEX ON #${s.name}.r_paatason_suoritus(vahvistus_paiva)",
 
     sqlu"CREATE UNIQUE INDEX ON #${s.name}.r_osasuoritus(osasuoritus_id)",
     sqlu"CREATE INDEX ON #${s.name}.r_osasuoritus(paatason_suoritus_id)",
     sqlu"CREATE INDEX ON #${s.name}.r_osasuoritus(opiskeluoikeus_oid)",
     sqlu"CREATE INDEX ON #${s.name}.r_osasuoritus(ylempi_osasuoritus_id)",
-    sqlu"CREATE INDEX ON #${s.name}.r_osasuoritus(arviointi_paiva, paatason_suoritus_id)",
+    sqlu"CREATE INDEX ON #${s.name}.r_osasuoritus(arviointi_paiva, paatason_suoritus_id, suorituksen_tyyppi)",
 
     sqlu"CREATE INDEX ON #${s.name}.esiopetus_opiskeluoik_aikajakso(opiskeluoikeus_oid)",
   )

--- a/src/test/scala/fi/oph/koski/raportit/LukioKurssikertymaRaporttiSpec.scala
+++ b/src/test/scala/fi/oph/koski/raportit/LukioKurssikertymaRaporttiSpec.scala
@@ -49,10 +49,10 @@ class LukioKurssikertymaRaporttiSpec extends FreeSpec with RaportointikantaTestM
         ressunAineopiskelijat.oppilaitosOid shouldBe(MockOrganisaatiot.ressunLukio)
       }
       "Yhteensä" in {
-        ressunAineopiskelijat.kurssejaYhteensa shouldBe(12)
+        ressunAineopiskelijat.kurssejaYhteensa shouldBe(14)
       }
       "Suoritettuja" in {
-        ressunAineopiskelijat.suoritettujaKursseja shouldBe(6)
+        ressunAineopiskelijat.suoritettujaKursseja shouldBe(8)
       }
       "Tunnustettuja" in {
         ressunAineopiskelijat.tunnustettujaKursseja shouldBe(6)
@@ -61,19 +61,19 @@ class LukioKurssikertymaRaporttiSpec extends FreeSpec with RaportointikantaTestM
         ressunAineopiskelijat.tunnustettujaKursseja_rahoituksenPiirissa shouldBe(3)
       }
       "Pakollisia tai valtakunnallinen ja syventava" in {
-        ressunAineopiskelijat.pakollisia_tai_valtakunnallisiaSyventavia shouldBe(9)
+        ressunAineopiskelijat.pakollisia_tai_valtakunnallisiaSyventavia shouldBe(11)
       }
       "Pakollisia" in {
-        ressunAineopiskelijat.pakollisiaKursseja shouldBe(6)
+        ressunAineopiskelijat.pakollisiaKursseja shouldBe(8)
       }
       "Valtakunnallisia syventavia" in {
         ressunAineopiskelijat.valtakunnallisestiSyventaviaKursseja shouldBe(3)
       }
       "Suoritettuja pakollisia ja suoritettuja valtakunnallisia syventavia" in {
-        ressunAineopiskelijat.suoritettujaPakollisia_ja_suoritettujaValtakunnallisiaSyventavia shouldBe(5)
+        ressunAineopiskelijat.suoritettujaPakollisia_ja_suoritettujaValtakunnallisiaSyventavia shouldBe(7)
       }
       "Suoritettuja pakollisia" in {
-        ressunAineopiskelijat.suoritettujaPakollisiaKursseja shouldBe(4)
+        ressunAineopiskelijat.suoritettujaPakollisiaKursseja shouldBe(6)
       }
       "Suoritettuja valtakunnallisia syventavia" in {
         ressunAineopiskelijat.suoritettujaValtakunnallisiaSyventaviaKursseja shouldBe(1)
@@ -100,7 +100,7 @@ class LukioKurssikertymaRaporttiSpec extends FreeSpec with RaportointikantaTestM
         ressunAineopiskelijat.suoritetutTaiRahoitetut_muutaKauttaRahoitetut shouldBe 1
       }
       "Suoritetut tai rahoituksen piirissä oleviksi merkityt tunnustetut kurssit - rahoitusmuoto ei tiedossa" in {
-        ressunAineopiskelijat.suoritetutTaiRahoitetut_rahoitusmuotoEiTiedossa shouldBe 0
+        ressunAineopiskelijat.suoritetutTaiRahoitetut_rahoitusmuotoEiTiedossa shouldBe 2
       }
       "Suoritetut tai rahoituksen piirissä oleviksi merkityt tunnustetut kurssit – arviointipäivä ei opiskeluoikeuden sisällä" in {
         ressunAineopiskelijat.suoritetutTaiRahoitetut_eiOpiskeluoikeudenSisalla shouldBe 1
@@ -108,12 +108,12 @@ class LukioKurssikertymaRaporttiSpec extends FreeSpec with RaportointikantaTestM
     }
     "Muuta kautta rahoitetuttujen välilehti" - {
       "Listan pituus sama kuin aineopiskelijoiden välilehdellä oleva laskuri" in {
-        ressunMuutaKauttaRahoitetut.length shouldBe 1
+        ressunMuutaKauttaRahoitetut.length shouldBe ressunAineopiskelijat.suoritetutTaiRahoitetut_muutaKauttaRahoitetut
       }
     }
     "Rahoitusmuoto ei tiedossa -välilehti" - {
       "Listan pituus sama kuin aineopiskelijoiden välilehdellä oleva laskuri" in {
-        ressunRahoitusmuotoEiTiedossa.length shouldBe 0
+        ressunRahoitusmuotoEiTiedossa.length shouldBe ressunAineopiskelijat.suoritetutTaiRahoitetut_rahoitusmuotoEiTiedossa
       }
     }
     "Arviointipäivä opiskeluoikeuden ulkopuolella -välilehti" - {

--- a/web/app/raportit/Raportit.jsx
+++ b/web/app/raportit/Raportit.jsx
@@ -36,7 +36,7 @@ export const raportitContentP = () => {
             {raportit && raportit.includes('perusopetuksenoppijamääräraportti') && <PerusopetuksenOppijamäärätRaportti organisaatioAtom={organisaatioAtom}/>}
             {raportit && raportit.includes('perusopetuksenlisäopetuksenoppijamääräraportti') && <PerusopetuksenLisäopetuksenOppijamäärätRaportti organisaatioAtom={organisaatioAtom}/>}
             {raportit && raportit.includes('lukionsuoritustietojentarkistus') && <Lukioraportti organisaatioAtom={organisaatioAtom} />}
-            {document.location.search.includes('tilastoraportit=true') && raportit && raportit.includes('lukiokurssikertyma') && <LukioKurssikertyma organisaatioAtom={organisaatioAtom}/>}
+            {raportit && raportit.includes('lukiokurssikertyma') && <LukioKurssikertyma organisaatioAtom={organisaatioAtom}/>}
             {raportit && raportit.includes('lukiodiaibinternationalopiskelijamaarat') && <LukioDiaIBInternationalOpiskelijamaarat organisaatioAtom={organisaatioAtom} />}
             {raportit && raportit.includes('luvaopiskelijamaarat') && <LuvaOpiskelijamaaratRaportti organisaatioAtom={organisaatioAtom} />}
             {raportit && raportit.includes('aikuistenperusopetussuoritustietojentarkistus') && <AikuistenPerusopetusRaportti organisaatioAtom={organisaatioAtom} />}


### PR DESCRIPTION
* Korjaus: Lasketaan kurssimääriin mukaan myös sellaiset suoritukset, jotka eivät joinaannu opiskeluoikeuden aikajaksoon.
* Korjaus: Opiskeluoikeuden ulkopuolisten suoritusten rajaamisesta puuttui ehto *"suoritettu tai tunnustettuja ja rahoituksen piirissä oleva"*
* Korjaus: Muuta kautta rahoitetut ja Ei rahoitusmuotoa -välilehdet näyttivät merkillisiä tuloksia. Korjattu logiikka vastaamaan Aineopiskelijat-välilehden logiikkaa.
* Lisätty indeksejä performanssia parantamaan. Korjaa timeoutien aiheuttamia error 500 -herjoja.
* Lisätty oppijan oid kolmelle viimeiselle välilehdelle.