### PR TITLE
Esilaske kurssikertymat lukion aineopiskelijoille

### DIFF
--- a/src/main/scala/fi/oph/koski/raportit/LukioOppiaineenOppimaaranKurssikertymat.scala
+++ b/src/main/scala/fi/oph/koski/raportit/LukioOppiaineenOppimaaranKurssikertymat.scala
@@ -19,76 +19,91 @@ object LukioOppiaineenOppimaaranKurssikertymat extends DatabaseConverters {
     )
   }
 
-  private def queryAineopiskelija(oppilaitosOids: List[String], aikaisintaan: LocalDate, viimeistaan: LocalDate) = {
-    sql"""
-      select
-        oppimaaran_kurssikertymat.*,
-        coalesce(opiskeluoikeuden_ulkopuoliset.yhteensa, 0) as opiskeluoikeuden_ulkopuoliset
-
-      -- oppimaaran_kurssikertymat
+  def createMaterializedView =
+    sqlu"""
+      create materialized view lukion_oppiaineen_oppimaaran_kurssikertyma as select
+        oppilaitos_oid,
+        arviointi_paiva,
+        count(*) yhteensa,
+        count(*) filter (where suoritettu) suoritettuja,
+        count(*) filter (where tunnustettu) tunnustettuja,
+        count(*) filter (where tunnustettu_rahoituksen_piirissa) tunnustettuja_rahoituksen_piirissa,
+        count(*) filter (where pakollinen or (valtakunnallinen and syventava)) pakollisia_tai_valtakunnallisia_syventavia,
+        count(*) filter (where pakollinen) pakollisia,
+        count(*) filter (where valtakunnallinen and syventava) valtakunnallisia_syventavia,
+        count(*) filter (where suoritettu and (pakollinen or (valtakunnallinen and syventava))) suoritettuja_pakollisia_ja_valtakunnallisia_syventavia,
+        count(*) filter (where pakollinen and suoritettu) suoritettuja_pakollisia,
+        count(*) filter (where suoritettu and valtakunnallinen and syventava) suoritettuja_valtakunnallisia_syventavia,
+        count(*) filter (where tunnustettu and (pakollinen or (syventava and valtakunnallinen))) tunnustettuja_pakollisia_ja_valtakunnallisia_syventavia,
+        count(*) filter (where tunnustettu and pakollinen) tunnustettuja_pakollisia,
+        count(*) filter (where tunnustettu and valtakunnallinen and syventava) tunnustettuja_valtakunnallisia_syventavia,
+        count(*) filter (where tunnustettu_rahoituksen_piirissa and (pakollinen or (valtakunnallinen and syventava))) tunnustut_pakolliset_ja_valtakunnalliset_syventavat_rahoitus,
+        count(*) filter (where tunnustettu_rahoituksen_piirissa and pakollinen) pakollisia_tunnustettuja_rahoituksen_piirissa,
+        count(*) filter (where valtakunnallinen and syventava and tunnustettu_rahoituksen_piirissa) "valtakunnallisia_syventavia_tunnustettuja_rahoituksen_piirissa",
+        count(*) filter (where valtakunnallinen and (suoritettu or tunnustettu_rahoituksen_piirissa) and opintojen_rahoitus = '6') suoritetut_tai_rahoitetut_muuta_kautta_rahoitetut,
+        count(*) filter (where valtakunnallinen and (suoritettu or tunnustettu_rahoituksen_piirissa) and opintojen_rahoitus is null) suoritetut_tai_rahoitetut_rahoitusmuoto_ei_tiedossa
       from (
         select
           oppilaitos_oid,
-          oppilaitos_nimi oppilaitos,
-          count(*) yhteensa,
-          count(*) filter (where suoritettu) suoritettuja,
-          count(*) filter (where tunnustettu) tunnustettuja,
-          count(*) filter (where tunnustettu_rahoituksen_piirissa) tunnustettuja_rahoituksen_piirissa,
-          count(*) filter (where pakollinen or (valtakunnallinen and syventava)) pakollisia_tai_valtakunnallisia_syventavia,
-          count(*) filter (where pakollinen) pakollisia,
-          count(*) filter (where valtakunnallinen and syventava) valtakunnallisia_syventavia,
-          count(*) filter (where suoritettu and (pakollinen or (valtakunnallinen and syventava))) suoritettuja_pakollisia_ja_valtakunnallisia_syventavia,
-          count(*) filter (where pakollinen and suoritettu) suoritettuja_pakollisia,
-          count(*) filter (where suoritettu and valtakunnallinen and syventava) suoritettuja_valtakunnallisia_syventavia,
-          count(*) filter (where tunnustettu and (pakollinen or (syventava and valtakunnallinen))) tunnustettuja_pakollisia_ja_valtakunnallisia_syventavia,
-          count(*) filter (where tunnustettu and pakollinen) tunnustettuja_pakollisia,
-          count(*) filter (where tunnustettu and valtakunnallinen and syventava) tunnustettuja_valtakunnallisia_syventavia,
-          count(*) filter (where tunnustettu_rahoituksen_piirissa and (pakollinen or (valtakunnallinen and syventava))) tunnustut_pakolliset_ja_valtakunnalliset_syventavat_rahoitus,
-          count(*) filter (where tunnustettu_rahoituksen_piirissa and pakollinen) pakollisia_tunnustettuja_rahoituksen_piirissa,
-          count(*) filter (where valtakunnallinen and syventava and tunnustettu_rahoituksen_piirissa) "valtakunnallisia_syventavia_tunnustettuja_rahoituksen_piirissa",
-          count(*) filter (where
-            valtakunnallinen
-            and (suoritettu or tunnustettu_rahoituksen_piirissa)
-            and opintojen_rahoitus = '6'
-          ) suoritetut_tai_rahoitetut_muuta_kautta_rahoitetut,
-          count(*) filter (where
-            valtakunnallinen
-            and (suoritettu or tunnustettu_rahoituksen_piirissa)
-            and opintojen_rahoitus is null
-          ) suoritetut_tai_rahoitetut_rahoitusmuoto_ei_tiedossa
-        from (
-          select
-            r_opiskeluoikeus.oppilaitos_oid,
-            r_opiskeluoikeus.oppilaitos_nimi,
-            tunnustettu,
-            tunnustettu = false as suoritettu,
-            tunnustettu_rahoituksen_piirissa,
-            koulutusmoduuli_kurssin_tyyppi,
-            koulutusmoduuli_kurssin_tyyppi = 'pakollinen' as pakollinen,
-            koulutusmoduuli_kurssin_tyyppi = 'syventava' as syventava,
-            koulutusmoduuli_paikallinen = false as valtakunnallinen,
-            r_opiskeluoikeus_aikajakso.opintojen_rahoitus
-          from r_osasuoritus
-          join r_paatason_suoritus
-            on r_paatason_suoritus.paatason_suoritus_id = r_osasuoritus.paatason_suoritus_id
-          join r_opiskeluoikeus
-            on r_opiskeluoikeus.opiskeluoikeus_oid = r_osasuoritus.opiskeluoikeus_oid
+          r_osasuoritus.arviointi_paiva,
+          tunnustettu,
+          tunnustettu = false as suoritettu,
+          tunnustettu_rahoituksen_piirissa,
+          koulutusmoduuli_kurssin_tyyppi,
+          koulutusmoduuli_kurssin_tyyppi = 'pakollinen' as pakollinen,
+          koulutusmoduuli_kurssin_tyyppi = 'syventava' as syventava,
+          koulutusmoduuli_paikallinen = false as valtakunnallinen,
+          opintojen_rahoitus
+        from r_paatason_suoritus
+          join r_opiskeluoikeus on r_paatason_suoritus.opiskeluoikeus_oid = r_opiskeluoikeus.opiskeluoikeus_oid
+          join r_osasuoritus on r_osasuoritus.paatason_suoritus_id = r_paatason_suoritus.paatason_suoritus_id
           left join r_opiskeluoikeus_aikajakso
             on r_opiskeluoikeus_aikajakso.opiskeluoikeus_oid = r_osasuoritus.opiskeluoikeus_oid
-            and (r_osasuoritus.arviointi_paiva between r_opiskeluoikeus_aikajakso.alku and r_opiskeluoikeus_aikajakso.loppu)
-          where r_opiskeluoikeus.oppilaitos_oid = any($oppilaitosOids)
-            -- lukion aineoppimäärä
-            and r_paatason_suoritus.suorituksen_tyyppi = 'lukionoppiaineenoppimaara'
-            and r_osasuoritus.suorituksen_tyyppi = 'lukionkurssi'
-            -- kurssi menee parametrien sisään
-            and (r_osasuoritus.arviointi_paiva between $aikaisintaan and $viimeistaan)
-          ) kurssit
-        group by
-          oppilaitos_oid,
-          oppilaitos_nimi
-      ) oppimaaran_kurssikertymat
+              and (r_osasuoritus.arviointi_paiva between r_opiskeluoikeus_aikajakso.alku and r_opiskeluoikeus_aikajakso.loppu)
+        where r_paatason_suoritus.suorituksen_tyyppi = 'lukionoppiaineenoppimaara'
+          and r_osasuoritus.suorituksen_tyyppi = 'lukionkurssi'
+      ) kurssit
+    group by
+      oppilaitos_oid,
+      arviointi_paiva
+    """
 
-      -- opiskeluoikeuden_ulkopuoliset
+  def createIndex =
+    sqlu"create index on lukion_oppiaineen_oppimaaran_kurssikertyma(oppilaitos_oid, arviointi_paiva)"
+
+
+  private def queryAineopiskelija(oppilaitosOids: List[String], aikaisintaan: LocalDate, viimeistaan: LocalDate) = {
+    sql"""
+      select
+        r_organisaatio.nimi oppilaitos,
+        oppimaaran_kurssikertymat.*,
+        coalesce(opiskeluoikeuden_ulkopuoliset.yhteensa, 0) as opiskeluoikeuden_ulkopuoliset
+      from (
+        select
+          oppilaitos_oid,
+          sum(yhteensa) yhteensa,
+          sum(suoritettuja) suoritettuja,
+          sum(tunnustettuja) tunnustettuja,
+          sum(tunnustettuja_rahoituksen_piirissa) tunnustettuja_rahoituksen_piirissa,
+          sum(pakollisia_tai_valtakunnallisia_syventavia) pakollisia_tai_valtakunnallisia_syventavia,
+          sum(pakollisia) pakollisia,
+          sum(valtakunnallisia_syventavia) valtakunnallisia_syventavia,
+          sum(suoritettuja_pakollisia_ja_valtakunnallisia_syventavia) suoritettuja_pakollisia_ja_valtakunnallisia_syventavia,
+          sum(suoritettuja_pakollisia) suoritettuja_pakollisia,
+          sum(suoritettuja_valtakunnallisia_syventavia) suoritettuja_valtakunnallisia_syventavia,
+          sum(tunnustettuja_pakollisia_ja_valtakunnallisia_syventavia) tunnustettuja_pakollisia_ja_valtakunnallisia_syventavia,
+          sum(tunnustettuja_pakollisia) tunnustettuja_pakollisia,
+          sum(tunnustettuja_valtakunnallisia_syventavia) tunnustettuja_valtakunnallisia_syventavia,
+          sum(tunnustut_pakolliset_ja_valtakunnalliset_syventavat_rahoitus) tunnustut_pakolliset_ja_valtakunnalliset_syventavat_rahoitus,
+          sum(pakollisia_tunnustettuja_rahoituksen_piirissa) pakollisia_tunnustettuja_rahoituksen_piirissa,
+          sum(valtakunnallisia_syventavia_tunnustettuja_rahoituksen_piirissa) valtakunnallisia_syventavia_tunnustettuja_rahoituksen_piirissa,
+          sum(suoritetut_tai_rahoitetut_muuta_kautta_rahoitetut) suoritetut_tai_rahoitetut_muuta_kautta_rahoitetut,
+          sum(suoritetut_tai_rahoitetut_rahoitusmuoto_ei_tiedossa) suoritetut_tai_rahoitetut_rahoitusmuoto_ei_tiedossa
+        from lukion_oppiaineen_oppimaaran_kurssikertyma
+          where oppilaitos_oid = any($oppilaitosOids)
+            and arviointi_paiva between $aikaisintaan and $viimeistaan
+          group by oppilaitos_oid
+      ) oppimaaran_kurssikertymat
       left join (
         select
           r_opiskeluoikeus.oppilaitos_oid,
@@ -124,7 +139,8 @@ object LukioOppiaineenOppimaaranKurssikertymat extends DatabaseConverters {
           )
         group by oppilaitos_oid
       ) opiskeluoikeuden_ulkopuoliset
-        on opiskeluoikeuden_ulkopuoliset.oppilaitos_oid = oppimaaran_kurssikertymat.oppilaitos_oid;
+          on opiskeluoikeuden_ulkopuoliset.oppilaitos_oid = oppimaaran_kurssikertymat.oppilaitos_oid
+      join r_organisaatio on oppimaaran_kurssikertymat.oppilaitos_oid = r_organisaatio.organisaatio_oid
     """.as[LukioKurssikertymaAineopiskelijaRow]
   }
 

--- a/src/main/scala/fi/oph/koski/raportit/LukioOppiaineenOppimaaranKurssikertymat.scala
+++ b/src/main/scala/fi/oph/koski/raportit/LukioOppiaineenOppimaaranKurssikertymat.scala
@@ -106,37 +106,22 @@ object LukioOppiaineenOppimaaranKurssikertymat extends DatabaseConverters {
       ) oppimaaran_kurssikertymat
       left join (
         select
-          r_opiskeluoikeus.oppilaitos_oid,
+          oppilaitos_oid,
           count(*) yhteensa
-        from r_osasuoritus
-        join r_paatason_suoritus
-          on r_paatason_suoritus.paatason_suoritus_id = r_osasuoritus.paatason_suoritus_id
-        join r_opiskeluoikeus
-          on r_opiskeluoikeus.opiskeluoikeus_oid = r_osasuoritus.opiskeluoikeus_oid
-        where r_opiskeluoikeus.oppilaitos_oid = any($oppilaitosOids)
-          -- lukion aineoppimäärä
-          and r_paatason_suoritus.suorituksen_tyyppi = 'lukionoppiaineenoppimaara'
-          and r_osasuoritus.suorituksen_tyyppi = 'lukionkurssi'
-          -- kurssi menee parametrien sisään
-          and (r_osasuoritus.arviointi_paiva between $aikaisintaan and $viimeistaan)
-          -- mutta kurssi jää opiskeluoikeuden ulkopuolelle
-          and (
-            r_osasuoritus.arviointi_paiva < r_opiskeluoikeus.alkamispaiva
-            or (
-              r_osasuoritus.arviointi_paiva > r_opiskeluoikeus.paattymispaiva
-              and r_opiskeluoikeus.viimeisin_tila = 'valmistunut'
+        from osasuoritus_arvioitu_opiskeluoikeuden_ulkopuolella
+          join r_osasuoritus on r_osasuoritus.osasuoritus_id = osasuoritus_arvioitu_opiskeluoikeuden_ulkopuolella.osasuoritus_id
+          where oppilaitos_oid = any($oppilaitosOids)
+            and osasuorituksen_tyyppi = 'lukionkurssi'
+            and paatason_suorituksen_tyyppi = 'lukionoppiaineenoppimaara'
+            and (osasuorituksen_arviointi_paiva between $aikaisintaan and $viimeistaan)
+            and (
+              koulutusmoduuli_kurssin_tyyppi = 'pakollinen'
+              or (koulutusmoduuli_kurssin_tyyppi = 'syventava' and koulutusmoduuli_paikallinen = false)
             )
-          )
-          -- pakolliset tai valtakunnalliset syventävät kurssit
-          and (
-            koulutusmoduuli_kurssin_tyyppi = 'pakollinen'
-            or (koulutusmoduuli_kurssin_tyyppi = 'syventava' and koulutusmoduuli_paikallinen = false)
-          )
-          -- jotka ovat joko suoritettuja tai tunnustettuja ja rahoituksen piirissä olevia
-          and (
+            and (
               tunnustettu = false
               or tunnustettu_rahoituksen_piirissa
-          )
+            )
         group by oppilaitos_oid
       ) opiskeluoikeuden_ulkopuoliset
           on opiskeluoikeuden_ulkopuoliset.oppilaitos_oid = oppimaaran_kurssikertymat.oppilaitos_oid

--- a/src/main/scala/fi/oph/koski/raportit/LukioOppimaaranKussikertymat.scala
+++ b/src/main/scala/fi/oph/koski/raportit/LukioOppimaaranKussikertymat.scala
@@ -5,7 +5,7 @@ import java.time.LocalDate
 
 import fi.oph.koski.db.DatabaseConverters
 import fi.oph.koski.db.PostgresDriverWithJsonSupport.plainAPI._
-import fi.oph.koski.raportointikanta.RaportointiDatabase
+import fi.oph.koski.raportointikanta.{RaportointiDatabase, Schema}
 import slick.jdbc.GetResult
 
 object LukioOppimaaranKussikertymat extends DatabaseConverters {
@@ -19,25 +19,25 @@ object LukioOppimaaranKussikertymat extends DatabaseConverters {
     )
   }
 
-  def createMaterializedView =
+  def createMaterializedView(s: Schema) =
     sqlu"""
-      create materialized view lukion_oppimaaran_kurssikertyma as select
+      create materialized view #${s.name}.lukion_oppimaaran_kurssikertyma as select
         oppilaitos_oid,
-        r_osasuoritus.arviointi_paiva,
+        osasuoritus.arviointi_paiva,
         count(*) filter (where tunnustettu = false) suoritettuja,
         count(*) filter (where tunnustettu) tunnustettuja,
         count(*) yhteensa,
         count(*) filter (where tunnustettu_rahoituksen_piirissa) tunnustettuja_rahoituksen_piirissa
-      from r_osasuoritus
-        join r_paatason_suoritus on r_paatason_suoritus.paatason_suoritus_id = r_osasuoritus.paatason_suoritus_id
-        join r_opiskeluoikeus on r_opiskeluoikeus.opiskeluoikeus_oid = r_paatason_suoritus.opiskeluoikeus_oid
-      where r_paatason_suoritus.suorituksen_tyyppi = 'lukionoppimaara'
-        and r_osasuoritus.suorituksen_tyyppi = 'lukionkurssi'
-      group by r_opiskeluoikeus.oppilaitos_oid, r_osasuoritus.arviointi_paiva
+      from #${s.name}.r_osasuoritus osasuoritus
+        join #${s.name}.r_paatason_suoritus paatason_suoritus on paatason_suoritus.paatason_suoritus_id = osasuoritus.paatason_suoritus_id
+        join #${s.name}.r_opiskeluoikeus opiskeluoikeus on opiskeluoikeus.opiskeluoikeus_oid = paatason_suoritus.opiskeluoikeus_oid
+      where paatason_suoritus.suorituksen_tyyppi = 'lukionoppimaara'
+        and osasuoritus.suorituksen_tyyppi = 'lukionkurssi'
+      group by opiskeluoikeus.oppilaitos_oid, osasuoritus.arviointi_paiva
     """
 
-  def createIndex =
-    sqlu"create index on lukion_oppimaaran_kurssikertyma(oppilaitos_oid, arviointi_paiva)"
+  def createIndex(s: Schema) =
+    sqlu"create index on #${s.name}.lukion_oppimaaran_kurssikertyma(oppilaitos_oid, arviointi_paiva)"
 
   def queryOppimaara(oppilaitosOids: List[String], aikaisintaan: LocalDate, viimeistaan: LocalDate) = {
     sql"""

--- a/src/main/scala/fi/oph/koski/raportit/LukioOppimaaranKussikertymat.scala
+++ b/src/main/scala/fi/oph/koski/raportit/LukioOppimaaranKussikertymat.scala
@@ -19,26 +19,44 @@ object LukioOppimaaranKussikertymat extends DatabaseConverters {
     )
   }
 
-  def queryOppimaara(oppilaitosOids: List[String], aikaisintaan: LocalDate, viimeistaan: LocalDate) = {
-    sql"""
-      select
-        oppilaitos_nimi oppilaitos,
+  def createMaterializedView =
+    sqlu"""
+      create materialized view lukion_oppimaaran_kurssikertyma as select
         oppilaitos_oid,
+        r_osasuoritus.arviointi_paiva,
         count(*) filter (where tunnustettu = false) suoritettuja,
         count(*) filter (where tunnustettu) tunnustettuja,
         count(*) yhteensa,
         count(*) filter (where tunnustettu_rahoituksen_piirissa) tunnustettuja_rahoituksen_piirissa
       from r_osasuoritus
-      join r_paatason_suoritus
-        on r_paatason_suoritus.paatason_suoritus_id = r_osasuoritus.paatason_suoritus_id
-      join r_opiskeluoikeus
-        on r_opiskeluoikeus.opiskeluoikeus_oid = r_paatason_suoritus.opiskeluoikeus_oid
-      where r_opiskeluoikeus.oppilaitos_oid = any($oppilaitosOids)
-        and r_paatason_suoritus.suorituksen_tyyppi = 'lukionoppimaara'
+        join r_paatason_suoritus on r_paatason_suoritus.paatason_suoritus_id = r_osasuoritus.paatason_suoritus_id
+        join r_opiskeluoikeus on r_opiskeluoikeus.opiskeluoikeus_oid = r_paatason_suoritus.opiskeluoikeus_oid
+      where r_paatason_suoritus.suorituksen_tyyppi = 'lukionoppimaara'
         and r_osasuoritus.suorituksen_tyyppi = 'lukionkurssi'
-        and r_osasuoritus.arviointi_paiva >= $aikaisintaan
-        and r_osasuoritus.arviointi_paiva <= $viimeistaan
-      group by r_opiskeluoikeus.oppilaitos_nimi, r_opiskeluoikeus.oppilaitos_oid;
+      group by r_opiskeluoikeus.oppilaitos_oid, r_osasuoritus.arviointi_paiva
+    """
+
+  def createIndex =
+    sqlu"create index on lukion_oppimaaran_kurssikertyma(oppilaitos_oid, arviointi_paiva)"
+
+  def queryOppimaara(oppilaitosOids: List[String], aikaisintaan: LocalDate, viimeistaan: LocalDate) = {
+    sql"""
+      select
+        nimi oppilaitos,
+        kurssikertyma.*
+      from (
+        select
+          oppilaitos_oid,
+          sum(suoritettuja) suoritettuja,
+          sum(tunnustettuja) tunnustettuja,
+          sum(yhteensa) yhteensa,
+          sum(tunnustettuja_rahoituksen_piirissa) tunnustettuja_rahoituksen_piirissa
+        from lukion_oppimaaran_kurssikertyma
+          where oppilaitos_oid = any($oppilaitosOids)
+            and (arviointi_paiva between $aikaisintaan and $viimeistaan)
+          group by oppilaitos_oid
+      ) kurssikertyma
+      join r_organisaatio on organisaatio_oid = oppilaitos_oid
     """.as[LukioKurssikertymaOppimaaraRow]
   }
 

--- a/src/main/scala/fi/oph/koski/raportointikanta/OpiskeluoikeudenUlkopuolellaArvioidutOsasuoritukset.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/OpiskeluoikeudenUlkopuolellaArvioidutOsasuoritukset.scala
@@ -1,0 +1,28 @@
+package fi.oph.koski.raportointikanta
+
+import fi.oph.koski.db.PostgresDriverWithJsonSupport.api._
+
+object OpiskeluoikeudenUlkopuolellaArvioidutOsasuoritukset {
+
+  def createMaterializedView =
+    sqlu"""
+      create materialized view osasuoritus_arvioitu_opiskeluoikeuden_ulkopuolella as select
+        r_opiskeluoikeus.opiskeluoikeus_oid,
+        r_opiskeluoikeus.oppilaitos_oid,
+        r_osasuoritus.osasuoritus_id,
+        r_osasuoritus.arviointi_paiva osasuorituksen_arviointi_paiva,
+        r_osasuoritus.suorituksen_tyyppi osasuorituksen_tyyppi,
+        r_paatason_suoritus.suorituksen_tyyppi paatason_suorituksen_tyyppi
+      from r_opiskeluoikeus
+        join r_osasuoritus on r_osasuoritus.opiskeluoikeus_oid = r_opiskeluoikeus.opiskeluoikeus_oid
+          and (
+            r_osasuoritus.arviointi_paiva < r_opiskeluoikeus.alkamispaiva
+            or
+           (r_osasuoritus.arviointi_paiva > coalesce(r_opiskeluoikeus.paattymispaiva, '9999-12-31') and viimeisin_tila = 'valmistunut')
+          )
+        join r_paatason_suoritus on r_paatason_suoritus.paatason_suoritus_id = r_osasuoritus.paatason_suoritus_id
+    """
+
+  def createIndex =
+    sqlu"create index on osasuoritus_arvioitu_opiskeluoikeuden_ulkopuolella(oppilaitos_oid)"
+}

--- a/src/main/scala/fi/oph/koski/raportointikanta/OpiskeluoikeudenUlkopuolellaArvioidutOsasuoritukset.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/OpiskeluoikeudenUlkopuolellaArvioidutOsasuoritukset.scala
@@ -4,25 +4,25 @@ import fi.oph.koski.db.PostgresDriverWithJsonSupport.api._
 
 object OpiskeluoikeudenUlkopuolellaArvioidutOsasuoritukset {
 
-  def createMaterializedView =
+  def createMaterializedView(s: Schema) =
     sqlu"""
-      create materialized view osasuoritus_arvioitu_opiskeluoikeuden_ulkopuolella as select
-        r_opiskeluoikeus.opiskeluoikeus_oid,
-        r_opiskeluoikeus.oppilaitos_oid,
-        r_osasuoritus.osasuoritus_id,
-        r_osasuoritus.arviointi_paiva osasuorituksen_arviointi_paiva,
-        r_osasuoritus.suorituksen_tyyppi osasuorituksen_tyyppi,
-        r_paatason_suoritus.suorituksen_tyyppi paatason_suorituksen_tyyppi
-      from r_opiskeluoikeus
-        join r_osasuoritus on r_osasuoritus.opiskeluoikeus_oid = r_opiskeluoikeus.opiskeluoikeus_oid
+      create materialized view #${s.name}.osasuoritus_arvioitu_opiskeluoikeuden_ulkopuolella as select
+        opiskeluoikeus.opiskeluoikeus_oid,
+        opiskeluoikeus.oppilaitos_oid,
+        osasuoritus.osasuoritus_id,
+        osasuoritus.arviointi_paiva osasuorituksen_arviointi_paiva,
+        osasuoritus.suorituksen_tyyppi osasuorituksen_tyyppi,
+        paatason_suoritus.suorituksen_tyyppi paatason_suorituksen_tyyppi
+      from #${s.name}.r_opiskeluoikeus opiskeluoikeus
+        join #${s.name}.r_osasuoritus osasuoritus on osasuoritus.opiskeluoikeus_oid = opiskeluoikeus.opiskeluoikeus_oid
           and (
-            r_osasuoritus.arviointi_paiva < r_opiskeluoikeus.alkamispaiva
+            osasuoritus.arviointi_paiva < opiskeluoikeus.alkamispaiva
             or
-           (r_osasuoritus.arviointi_paiva > coalesce(r_opiskeluoikeus.paattymispaiva, '9999-12-31') and viimeisin_tila = 'valmistunut')
+           (osasuoritus.arviointi_paiva > coalesce(opiskeluoikeus.paattymispaiva, '9999-12-31') and viimeisin_tila = 'valmistunut')
           )
-        join r_paatason_suoritus on r_paatason_suoritus.paatason_suoritus_id = r_osasuoritus.paatason_suoritus_id
+        join #${s.name}.r_paatason_suoritus paatason_suoritus on paatason_suoritus.paatason_suoritus_id = osasuoritus.paatason_suoritus_id
     """
 
-  def createIndex =
-    sqlu"create index on osasuoritus_arvioitu_opiskeluoikeuden_ulkopuolella(oppilaitos_oid)"
+  def createIndex(s: Schema) =
+    sqlu"create index on #${s.name}.osasuoritus_arvioitu_opiskeluoikeuden_ulkopuolella(oppilaitos_oid)"
 }

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
@@ -96,8 +96,10 @@ case class RaportointiDatabase(config: KoskiDatabaseConfig) extends Logging with
       PaallekkaisetOpiskeluoikeudet.createMaterializedView,
       PaallekkaisetOpiskeluoikeudet.createIndex,
       LukioOppiaineenOppimaaranKurssikertymat.createMaterializedView,
-      LukioOppiaineenOppimaaranKurssikertymat.createIndex
-    ), timeout = 30.minutes)
+      LukioOppiaineenOppimaaranKurssikertymat.createIndex,
+      OpiskeluoikeudenUlkopuolellaArvioidutOsasuoritukset.createMaterializedView,
+      OpiskeluoikeudenUlkopuolellaArvioidutOsasuoritukset.createIndex
+    ), timeout = 60.minutes)
     val duration = (System.currentTimeMillis - started) / 1000
     logger.info(s"Materialized views created in $duration s")
   }

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
@@ -102,7 +102,7 @@ case class RaportointiDatabase(config: KoskiDatabaseConfig) extends Logging with
       OpiskeluoikeudenUlkopuolellaArvioidutOsasuoritukset.createIndex(schema),
       LukioOppiaineenOppimaaranKurssikertymat.createMaterializedView(schema),
       LukioOppiaineenOppimaaranKurssikertymat.createIndex(schema)
-    ), timeout = 60.minutes)
+    ), timeout = 120.minutes)
     val duration = (System.currentTimeMillis - started) / 1000
     setStatusLoadCompleted("materialized_views")
     logger.info(s"Materialized views created in $duration s")

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
@@ -92,6 +92,7 @@ case class RaportointiDatabase(config: KoskiDatabaseConfig) extends Logging with
   def createMaterializedViews: Unit = {
     logger.info("Creating materialized views")
     val started = System.currentTimeMillis
+    setStatusLoadStarted("materialized_views")
     runDbSync(DBIO.seq(
       PaallekkaisetOpiskeluoikeudet.createMaterializedView,
       PaallekkaisetOpiskeluoikeudet.createIndex,
@@ -101,6 +102,7 @@ case class RaportointiDatabase(config: KoskiDatabaseConfig) extends Logging with
       OpiskeluoikeudenUlkopuolellaArvioidutOsasuoritukset.createIndex
     ), timeout = 60.minutes)
     val duration = (System.currentTimeMillis - started) / 1000
+    setStatusLoadCompleted("materialized_views")
     logger.info(s"Materialized views created in $duration s")
   }
 
@@ -332,7 +334,7 @@ case class RaportointiDatabase(config: KoskiDatabaseConfig) extends Logging with
 }
 
 case class RaportointikantaStatusResponse(schema: String, statuses: Seq[RaportointikantaStatusRow]) {
-  private val allNames = Seq("opiskeluoikeudet", "henkilot", "organisaatiot", "koodistot")
+  private val allNames = Seq("opiskeluoikeudet", "henkilot", "organisaatiot", "koodistot", "materialized_views")
 
   @SyntheticProperty
   def isComplete: Boolean = completionTime.isDefined && !isEmpty && allNames.forall(statuses.map(_.name).contains)

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
@@ -9,7 +9,7 @@ import fi.oph.koski.db.KoskiDatabase._
 import fi.oph.koski.db.PostgresDriverWithJsonSupport.api._
 import fi.oph.koski.db.{KoskiDatabaseConfig, KoskiDatabaseMethods}
 import fi.oph.koski.log.Logging
-import fi.oph.koski.raportit.PaallekkaisetOpiskeluoikeudet
+import fi.oph.koski.raportit.{LukioOppiaineenOppimaaranKurssikertymat, PaallekkaisetOpiskeluoikeudet}
 import fi.oph.koski.raportointikanta.RaportointiDatabaseSchema._
 import fi.oph.koski.schema.Organisaatio
 import fi.oph.koski.util.DateOrdering.{sqlDateOrdering, sqlTimestampOrdering}
@@ -91,11 +91,15 @@ case class RaportointiDatabase(config: KoskiDatabaseConfig) extends Logging with
 
   def createMaterializedViews: Unit = {
     logger.info("Creating materialized views")
+    val started = System.currentTimeMillis
     runDbSync(DBIO.seq(
       PaallekkaisetOpiskeluoikeudet.createMaterializedView,
-      PaallekkaisetOpiskeluoikeudet.createIndex
-    ), timeout = 10.minutes)
-    logger.info("Materialized views created")
+      PaallekkaisetOpiskeluoikeudet.createIndex,
+      LukioOppiaineenOppimaaranKurssikertymat.createMaterializedView,
+      LukioOppiaineenOppimaaranKurssikertymat.createIndex
+    ), timeout = 30.minutes)
+    val duration = (System.currentTimeMillis - started) / 1000
+    logger.info(s"Materialized views created in $duration s")
   }
 
   def deleteOpiskeluoikeudet =

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
@@ -94,14 +94,14 @@ case class RaportointiDatabase(config: KoskiDatabaseConfig) extends Logging with
     val started = System.currentTimeMillis
     setStatusLoadStarted("materialized_views")
     runDbSync(DBIO.seq(
-      PaallekkaisetOpiskeluoikeudet.createMaterializedView,
-      PaallekkaisetOpiskeluoikeudet.createIndex,
-      LukioOppimaaranKussikertymat.createMaterializedView,
-      LukioOppimaaranKussikertymat.createIndex,
-      LukioOppiaineenOppimaaranKurssikertymat.createMaterializedView,
-      LukioOppiaineenOppimaaranKurssikertymat.createIndex,
-      OpiskeluoikeudenUlkopuolellaArvioidutOsasuoritukset.createMaterializedView,
-      OpiskeluoikeudenUlkopuolellaArvioidutOsasuoritukset.createIndex
+      PaallekkaisetOpiskeluoikeudet.createMaterializedView(schema),
+      PaallekkaisetOpiskeluoikeudet.createIndex(schema),
+      LukioOppimaaranKussikertymat.createMaterializedView(schema),
+      LukioOppimaaranKussikertymat.createIndex(schema),
+      OpiskeluoikeudenUlkopuolellaArvioidutOsasuoritukset.createMaterializedView(schema),
+      OpiskeluoikeudenUlkopuolellaArvioidutOsasuoritukset.createIndex(schema),
+      LukioOppiaineenOppimaaranKurssikertymat.createMaterializedView(schema),
+      LukioOppiaineenOppimaaranKurssikertymat.createIndex(schema)
     ), timeout = 60.minutes)
     val duration = (System.currentTimeMillis - started) / 1000
     setStatusLoadCompleted("materialized_views")

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
@@ -9,7 +9,7 @@ import fi.oph.koski.db.KoskiDatabase._
 import fi.oph.koski.db.PostgresDriverWithJsonSupport.api._
 import fi.oph.koski.db.{KoskiDatabaseConfig, KoskiDatabaseMethods}
 import fi.oph.koski.log.Logging
-import fi.oph.koski.raportit.{LukioOppiaineenOppimaaranKurssikertymat, PaallekkaisetOpiskeluoikeudet}
+import fi.oph.koski.raportit.{LukioOppiaineenOppimaaranKurssikertymat, LukioOppimaaranKussikertymat, PaallekkaisetOpiskeluoikeudet}
 import fi.oph.koski.raportointikanta.RaportointiDatabaseSchema._
 import fi.oph.koski.schema.Organisaatio
 import fi.oph.koski.util.DateOrdering.{sqlDateOrdering, sqlTimestampOrdering}
@@ -96,6 +96,8 @@ case class RaportointiDatabase(config: KoskiDatabaseConfig) extends Logging with
     runDbSync(DBIO.seq(
       PaallekkaisetOpiskeluoikeudet.createMaterializedView,
       PaallekkaisetOpiskeluoikeudet.createIndex,
+      LukioOppimaaranKussikertymat.createMaterializedView,
+      LukioOppimaaranKussikertymat.createIndex,
       LukioOppiaineenOppimaaranKurssikertymat.createMaterializedView,
       LukioOppiaineenOppimaaranKurssikertymat.createIndex,
       OpiskeluoikeudenUlkopuolellaArvioidutOsasuoritukset.createMaterializedView,

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabaseSchema.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabaseSchema.scala
@@ -51,7 +51,7 @@ object RaportointiDatabaseSchema {
     sqlu"CREATE INDEX ON #${s.name}.r_osasuoritus(paatason_suoritus_id)",
     sqlu"CREATE INDEX ON #${s.name}.r_osasuoritus(opiskeluoikeus_oid)",
     sqlu"CREATE INDEX ON #${s.name}.r_osasuoritus(ylempi_osasuoritus_id)",
-    sqlu"CREATE INDEX ON #${s.name}.r_osasuoritus(arviointi_paiva, paatason_suoritus_id, suorituksen_tyyppi)",
+    sqlu"CREATE INDEX ON #${s.name}.r_osasuoritus(paatason_suoritus_id, suorituksen_tyyppi, arviointi_paiva)",
 
     sqlu"CREATE INDEX ON #${s.name}.esiopetus_opiskeluoik_aikajakso(opiskeluoikeus_oid)",
   )

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointikantaService.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointikantaService.scala
@@ -64,8 +64,8 @@ class RaportointikantaService(application: KoskiApplication) extends Logging {
     loadHenkilöt(loadDatabase)
     loadOrganisaatiot(loadDatabase)
     loadKoodistot(loadDatabase)
+    loadDatabase.createMaterializedViews
     swapRaportointikanta()
-    raportointiDatabase.createMaterializedViews
     raportointiDatabase.vacuumAnalyze()
   }
 


### PR DESCRIPTION
Kurssikertymien laskenta lennosta todettiin liian hitaaksi.

`lukion_oppiaineen_oppimaaran_kurssikertyma` view:n luonti tämän hetkisellä datamäärällä ~6min

Oppilaitoksella kaikista arviointipäivistä 10% pitää sisällään 70% kaikista kurssiesta. Joten data voidaan pakata suhteellisen tehokkaasti. (Todennettu oppilaitoksella jolla on eniten aineopiskelijoita Helsingissä)

`osasuoritus_arvioitu_opiskeluoikeuden_ulkopuolella ` view:n luonti tämän hetkisellä datamäärällä ~9min

`lukion_oppimaaran_kurssikertyma ` view:n luonti tämän hetkisellä datamäärällä ~30min