### PR TITLE
Esilaske lukion oppiaineen oppimaaran kursseille rahoitusmuodot.

### DIFF
--- a/src/main/scala/fi/oph/koski/raportit/LukioOppiaineRahoitusmuodonMukaan.scala
+++ b/src/main/scala/fi/oph/koski/raportit/LukioOppiaineRahoitusmuodonMukaan.scala
@@ -53,11 +53,10 @@ object LukioOppiaineRahoitusmuodonMukaan extends DatabaseConverters {
       from #${s.name}.r_paatason_suoritus paatason_suoritus
         join #${s.name}.r_osasuoritus osasuoritus on paatason_suoritus.paatason_suoritus_id = osasuoritus.paatason_suoritus_id
         join #${s.name}.r_opiskeluoikeus opiskeluoikeus on paatason_suoritus.opiskeluoikeus_oid = opiskeluoikeus.opiskeluoikeus_oid
-        left join #${s.name}.r_opiskeluoikeus_aikajakso aikajakso
-          on paatason_suoritus.opiskeluoikeus_oid = aikajakso.opiskeluoikeus_oid
-          and (osasuoritus.arviointi_paiva between aikajakso.alku and aikajakso.loppu)
+        join #${s.name}.r_opiskeluoikeus_aikajakso aikajakso on paatason_suoritus.opiskeluoikeus_oid = aikajakso.opiskeluoikeus_oid
         where
           paatason_suoritus.suorituksen_tyyppi = 'lukionoppiaineenoppimaara'
+          and (osasuoritus.arviointi_paiva between aikajakso.alku and aikajakso.loppu)
           and osasuoritus.suorituksen_tyyppi = 'lukionkurssi'
           and (
             osasuoritus.tunnustettu = false

--- a/src/main/scala/fi/oph/koski/raportit/LukioOppiaineenOppimaaranKurssikertymat.scala
+++ b/src/main/scala/fi/oph/koski/raportit/LukioOppiaineenOppimaaranKurssikertymat.scala
@@ -59,11 +59,11 @@ object LukioOppiaineenOppimaaranKurssikertymat extends DatabaseConverters {
             on paatason_suoritus.opiskeluoikeus_oid = opiskeluoikeus.opiskeluoikeus_oid
           join #${s.name}.r_osasuoritus osasuoritus
             on paatason_suoritus.paatason_suoritus_id = osasuoritus.paatason_suoritus_id
-          left join #${s.name}.r_opiskeluoikeus_aikajakso opiskeluoikeus_aikajakso
+          join #${s.name}.r_opiskeluoikeus_aikajakso opiskeluoikeus_aikajakso
             on opiskeluoikeus_aikajakso.opiskeluoikeus_oid = osasuoritus.opiskeluoikeus_oid
-              and (osasuoritus.arviointi_paiva between opiskeluoikeus_aikajakso.alku and opiskeluoikeus_aikajakso.loppu)
         where paatason_suoritus.suorituksen_tyyppi = 'lukionoppiaineenoppimaara'
           and osasuoritus.suorituksen_tyyppi = 'lukionkurssi'
+          and (osasuoritus.arviointi_paiva between opiskeluoikeus_aikajakso.alku and opiskeluoikeus_aikajakso.loppu)
       ) kurssit
     group by
       oppilaitos_oid,

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
@@ -9,7 +9,7 @@ import fi.oph.koski.db.KoskiDatabase._
 import fi.oph.koski.db.PostgresDriverWithJsonSupport.api._
 import fi.oph.koski.db.{KoskiDatabaseConfig, KoskiDatabaseMethods}
 import fi.oph.koski.log.Logging
-import fi.oph.koski.raportit.{LukioOppiaineenOppimaaranKurssikertymat, LukioOppimaaranKussikertymat, PaallekkaisetOpiskeluoikeudet}
+import fi.oph.koski.raportit.{LukioOppiaineRahoitusmuodonMukaan, LukioOppiaineenOppimaaranKurssikertymat, LukioOppimaaranKussikertymat, PaallekkaisetOpiskeluoikeudet}
 import fi.oph.koski.raportointikanta.RaportointiDatabaseSchema._
 import fi.oph.koski.schema.Organisaatio
 import fi.oph.koski.util.DateOrdering.{sqlDateOrdering, sqlTimestampOrdering}
@@ -101,7 +101,9 @@ case class RaportointiDatabase(config: KoskiDatabaseConfig) extends Logging with
       OpiskeluoikeudenUlkopuolellaArvioidutOsasuoritukset.createMaterializedView(schema),
       OpiskeluoikeudenUlkopuolellaArvioidutOsasuoritukset.createIndex(schema),
       LukioOppiaineenOppimaaranKurssikertymat.createMaterializedView(schema),
-      LukioOppiaineenOppimaaranKurssikertymat.createIndex(schema)
+      LukioOppiaineenOppimaaranKurssikertymat.createIndex(schema),
+      LukioOppiaineRahoitusmuodonMukaan.createMaterializedView(schema),
+      LukioOppiaineRahoitusmuodonMukaan.createIndex(schema)
     ), timeout = 120.minutes)
     val duration = (System.currentTimeMillis - started) / 1000
     setStatusLoadCompleted("materialized_views")

--- a/src/test/scala/fi/oph/koski/raportit/LukioKurssikertymaRaporttiSpec.scala
+++ b/src/test/scala/fi/oph/koski/raportit/LukioKurssikertymaRaporttiSpec.scala
@@ -49,10 +49,10 @@ class LukioKurssikertymaRaporttiSpec extends FreeSpec with RaportointikantaTestM
         ressunAineopiskelijat.oppilaitosOid shouldBe(MockOrganisaatiot.ressunLukio)
       }
       "Yhteensä" in {
-        ressunAineopiskelijat.kurssejaYhteensa shouldBe(14)
+        ressunAineopiskelijat.kurssejaYhteensa shouldBe(12)
       }
       "Suoritettuja" in {
-        ressunAineopiskelijat.suoritettujaKursseja shouldBe(8)
+        ressunAineopiskelijat.suoritettujaKursseja shouldBe(6)
       }
       "Tunnustettuja" in {
         ressunAineopiskelijat.tunnustettujaKursseja shouldBe(6)
@@ -61,19 +61,19 @@ class LukioKurssikertymaRaporttiSpec extends FreeSpec with RaportointikantaTestM
         ressunAineopiskelijat.tunnustettujaKursseja_rahoituksenPiirissa shouldBe(3)
       }
       "Pakollisia tai valtakunnallinen ja syventava" in {
-        ressunAineopiskelijat.pakollisia_tai_valtakunnallisiaSyventavia shouldBe(11)
+        ressunAineopiskelijat.pakollisia_tai_valtakunnallisiaSyventavia shouldBe(9)
       }
       "Pakollisia" in {
-        ressunAineopiskelijat.pakollisiaKursseja shouldBe(8)
+        ressunAineopiskelijat.pakollisiaKursseja shouldBe(6)
       }
       "Valtakunnallisia syventavia" in {
         ressunAineopiskelijat.valtakunnallisestiSyventaviaKursseja shouldBe(3)
       }
       "Suoritettuja pakollisia ja suoritettuja valtakunnallisia syventavia" in {
-        ressunAineopiskelijat.suoritettujaPakollisia_ja_suoritettujaValtakunnallisiaSyventavia shouldBe(7)
+        ressunAineopiskelijat.suoritettujaPakollisia_ja_suoritettujaValtakunnallisiaSyventavia shouldBe(5)
       }
       "Suoritettuja pakollisia" in {
-        ressunAineopiskelijat.suoritettujaPakollisiaKursseja shouldBe(6)
+        ressunAineopiskelijat.suoritettujaPakollisiaKursseja shouldBe(4)
       }
       "Suoritettuja valtakunnallisia syventavia" in {
         ressunAineopiskelijat.suoritettujaValtakunnallisiaSyventaviaKursseja shouldBe(1)
@@ -100,7 +100,7 @@ class LukioKurssikertymaRaporttiSpec extends FreeSpec with RaportointikantaTestM
         ressunAineopiskelijat.suoritetutTaiRahoitetut_muutaKauttaRahoitetut shouldBe 1
       }
       "Suoritetut tai rahoituksen piirissä oleviksi merkityt tunnustetut kurssit - rahoitusmuoto ei tiedossa" in {
-        ressunAineopiskelijat.suoritetutTaiRahoitetut_rahoitusmuotoEiTiedossa shouldBe 2
+        ressunAineopiskelijat.suoritetutTaiRahoitetut_rahoitusmuotoEiTiedossa shouldBe 0
       }
       "Suoritetut tai rahoituksen piirissä oleviksi merkityt tunnustetut kurssit – arviointipäivä ei opiskeluoikeuden sisällä" in {
         ressunAineopiskelijat.suoritetutTaiRahoitetut_eiOpiskeluoikeudenSisalla shouldBe 1


### PR DESCRIPTION
View:n luonti kestää ~3min. Itse kysely (ilman view:tä) veisi melkeen yhtä kauan isolla koulutustoimijalla. Raportissa tämä  sama kysely ajetaan kahteen kertaan (opintojen_rahoituksen parametrin vain muuttuu), joten sen nopeuttamisella on vaikutus. Raportissa on myös näiden kahden välilehden lisäksi 3 muuta välilehteä, joten haettavaa dataa on paljon.