### PR TITLE
healthcheck joka tarkistaa vain Kosken yhteyden omaan tietokantaansa

### DIFF
--- a/src/main/scala/fi/oph/koski/healthcheck/HealthCheckApiServlet.scala
+++ b/src/main/scala/fi/oph/koski/healthcheck/HealthCheckApiServlet.scala
@@ -6,7 +6,11 @@ import fi.oph.koski.servlet.{ApiServlet, NoCache}
 
 class HealthCheckApiServlet(implicit val application: KoskiApplication) extends ApiServlet with NoCache with Unauthenticated {
   get("/") {
-    renderStatus(application.healthCheck.healthcheck)
+    renderStatus(application.healthCheck.healthcheckWithExternalSystems)
+  }
+
+  get("/internal") {
+    renderStatus(application.healthCheck.internalHealthcheck)
   }
 }
 

--- a/src/main/scala/fi/oph/koski/healthcheck/HealthCheckHtmlServlet.scala
+++ b/src/main/scala/fi/oph/koski/healthcheck/HealthCheckHtmlServlet.scala
@@ -5,7 +5,7 @@ import fi.oph.koski.servlet.VirkailijaHtmlServlet
 
 class HealthCheckHtmlServlet(implicit val application: KoskiApplication) extends VirkailijaHtmlServlet{
   get("/") {
-    val healthcheck = application.healthCheck.healthcheck
+    val healthcheck = application.healthCheck.healthcheckWithExternalSystems
     val version = buildVersionProperties.map(_.getProperty("version", null)).filter(_ != null).getOrElse("local")
     val buildDate = buildVersionProperties.map(_.getProperty("buildDate", null)).filter(_ != null).getOrElse("")
 

--- a/src/main/scala/fi/oph/koski/healthcheck/HealthChecker.scala
+++ b/src/main/scala/fi/oph/koski/healthcheck/HealthChecker.scala
@@ -47,7 +47,7 @@ trait HealthCheck extends Logging {
   private val ePerusteet = application.ePerusteet
   private def healthcheckOppija: Either[HttpStatus, Oppija] = application.validator.validateAsJson(Oppija(OidHenkilö(oid), List(perustutkintoOpiskeluoikeusValmis())))
 
-  def healthcheck: HttpStatus = {
+  def healthcheckWithExternalSystems: HttpStatus = {
     logger.debug("Performing healthcheck")
     val oppija = findOrCreateOppija
     val checks: List[() => HttpStatus] = List(
@@ -61,7 +61,15 @@ trait HealthCheck extends Logging {
 
     val status = HttpStatus.fold(checks.par.map(_.apply).toList)
     if (status.isError) {
-      logger.warn(s"Healthcheck status failed $status")
+      logger.warn(s"Healthcheck with external systems status failed $status")
+    }
+    status
+  }
+
+  def internalHealthcheck: HttpStatus = {
+    val status = oppijaCheck(findOrCreateOppija)
+    if (status.isError) {
+      logger.warn(s"Internal healtcheck status failed $status")
     }
     status
   }


### PR DESCRIPTION
Kosken alkuperäinen healthcheck on riippuvainen taustajärjestelmien tilasta.
AWS:ssä tämä aiheuttaa mm. sen, että taustajärjestelmän ollessa alhaalla dockerissa ajettava Koski terminoitaisiin.