### PR TITLE
TOR-1210: Kosken ajaminen pelkkää raportointikannan generointia varten

### DIFF
--- a/src/main/scala/fi/oph/koski/config/KoskiApplication.scala
+++ b/src/main/scala/fi/oph/koski/config/KoskiApplication.scala
@@ -45,6 +45,7 @@ object KoskiApplication {
 }
 
 class KoskiApplication(val config: Config, implicit val cacheManager: CacheManager = new CacheManager) extends Logging with UserAuthenticationContext with GlobalExecutionContext {
+  lazy val runMode = RunMode.get
   lazy val organisaatioRepository = OrganisaatioRepository(config, koodistoViitePalvelu)
   lazy val organisaatioService = new OrganisaatioService(this)
   lazy val directoryClient = DirectoryClient(config)

--- a/src/main/scala/fi/oph/koski/config/RunMode.scala
+++ b/src/main/scala/fi/oph/koski/config/RunMode.scala
@@ -1,0 +1,11 @@
+package fi.oph.koski.config
+
+object RunMode extends Enumeration {
+  type RunMode = Value
+  val NORMAL, GENERATE_RAPORTOINTIKANTA = Value
+
+  def get: RunMode = sys.env.get("GENERATE_RAPORTOINTIKANTA") match {
+    case Some(_) => GENERATE_RAPORTOINTIKANTA
+    case None => NORMAL
+  }
+}


### PR DESCRIPTION
Jos ympäristömuuttuja on GENERATE_RAPORTOINTIKANTA=true, Koski-sovellus käynnistyessään menee erikoistilaan, jossa servlettejä ei mountata, raportointikannan generointi lähtee heti käyntiin ja sovellus sammuu sen päätyttyä.