### PR TITLE
Korjaa auditlog-api jos katselijan organisaatio on OPH;

### DIFF
--- a/src/main/scala/fi/oph/koski/omaopintopolkuloki/AuditLogMockData.scala
+++ b/src/main/scala/fi/oph/koski/omaopintopolkuloki/AuditLogMockData.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.model._
 import fi.oph.koski.henkilo.MockOppijat
 import fi.oph.koski.log.Logging
-import fi.oph.koski.organisaatio.MockOrganisaatiot
+import fi.oph.koski.organisaatio.{MockOrganisaatiot, Opetushallitus}
 import fi.oph.koski.omaopintopolkuloki.AuditLogDynamoDB.AuditLogTableName
 
 import scala.collection.JavaConverters._
@@ -140,6 +140,12 @@ object AuditLogMockData extends Logging {
       studentOid = MockOppijat.virtaEiVastaa.oid,
       time = "2000-01-12T20:31:32.104+03",
       organizationOid = List("123123123123123", MockOrganisaatiot.helsinginKaupunki),
+      raw = "{operation: \"OPISKELUOIKEUS_KATSOMINEN\", ...}"
+    ),
+    MockData(
+      studentOid = MockOppijat.aikuisOpiskelija.oid,
+      time = "2000-01-12T20:31:32.104+03",
+      organizationOid = List(Opetushallitus.organisaatioOid),
       raw = "{operation: \"OPISKELUOIKEUS_KATSOMINEN\", ...}"
     )
   )

--- a/src/main/scala/fi/oph/koski/omaopintopolkuloki/AuditLogService.scala
+++ b/src/main/scala/fi/oph/koski/omaopintopolkuloki/AuditLogService.scala
@@ -5,7 +5,7 @@ import java.util
 
 import com.amazonaws.services.dynamodbv2.document.DynamoDB
 import com.amazonaws.services.dynamodbv2.document.spec.QuerySpec
-import fi.oph.koski.organisaatio.OrganisaatioRepository
+import fi.oph.koski.organisaatio.{Opetushallitus, OrganisaatioRepository}
 import fi.oph.koski.http.{HttpStatus, KoskiErrorCategory}
 import fi.oph.koski.log.Logging
 import fi.oph.koski.schema.LocalizedString
@@ -55,9 +55,18 @@ class AuditLogService(organisaatioRepository: OrganisaatioRepository, dynamoDB: 
     val nimi = organisaatioRepository.getOrganisaatio(oid)
       .flatMap(_.nimi)
       .map(name => Organisaatio(oid, name))
+      .orElse(isOpetushallitus(oid))
       .toRight(KoskiErrorCategory.internalError())
     nimi.left.foreach(_ => logger.error(s"AuditLogissa olevaa organisaatiota $oid ei löytynyt organisaatiopalvelusta"))
     nimi
+  }
+
+  private def isOpetushallitus(oid: String) = {
+    if (oid == Opetushallitus.organisaatioOid) {
+      Some(Organisaatio(Opetushallitus.organisaatioOid, Opetushallitus.nimi))
+    } else {
+      None
+    }
   }
 }
 

--- a/src/main/scala/fi/oph/koski/organisaatio/Opetushallitus.scala
+++ b/src/main/scala/fi/oph/koski/organisaatio/Opetushallitus.scala
@@ -1,5 +1,8 @@
 package fi.oph.koski.organisaatio
 
+import fi.oph.koski.schema.{Finnish, LocalizedString}
+
 object Opetushallitus {
   val organisaatioOid = "1.2.246.562.10.00000000001"
+  val nimi: LocalizedString = Finnish("Opetushallitus", sv = Some("Utbildningsstyrelsen"), en = Some("Finnish National Agency for Education"))
 }

--- a/src/test/scala/fi/oph/koski/omaopintopolkuloki/OmaOpintoPolkuLokiServlet.scala
+++ b/src/test/scala/fi/oph/koski/omaopintopolkuloki/OmaOpintoPolkuLokiServlet.scala
@@ -4,7 +4,7 @@ import fi.oph.koski.api.LocalJettyHttpSpecification
 import fi.oph.koski.henkilo.{LaajatOppijaHenkilöTiedot, MockOppijat}
 import fi.oph.koski.http.KoskiErrorCategory
 import fi.oph.koski.json.JsonSerializer
-import fi.oph.koski.organisaatio.MockOrganisaatiot
+import fi.oph.koski.organisaatio.{MockOrganisaatiot, Opetushallitus}
 import org.scalatest.{FreeSpec, Matchers}
 
 class OmaOpintoPolkuLokiServletSpec extends FreeSpec with Matchers with LocalJettyHttpSpecification {
@@ -13,6 +13,11 @@ class OmaOpintoPolkuLokiServletSpec extends FreeSpec with Matchers with LocalJet
       auditlogs(MockOppijat.amis).map(_.organizations.map(_.oid)) should contain theSameElementsAs(List(
         List(MockOrganisaatiot.helsinginKaupunki, MockOrganisaatiot.stadinAmmattiopisto),
         List(MockOrganisaatiot.helsinginKaupunki)
+      ))
+    }
+    "Jos katselijan organisaatio on Opetushallitus" in {
+      auditlogs(MockOppijat.aikuisOpiskelija).map(_.organizations.map(_.oid)) should contain theSameElementsAs(List(
+        List(Opetushallitus.organisaatioOid)
       ))
     }
     "Ei näytetä auditlogeja joissa operaationa on ollut opiskeluoikeuden päivitys/lisäys" in {


### PR DESCRIPTION
Kosken käyttämä organisaatio-cache ei sisällä Opetushallitusta, koska organisaatiopalvelusta käytettävä rajapinta palauttaa annetulle oidille kaikki hierarkiassa alempana olevat organisaatiot. Opetushallitus on organisaatiohierarkian ylin.

Tämä aiheutti ongelman AuditLogien organisaatioiden nimen näyttämisessä, jos katselija on kuulunut Opetushallitukseen.