### PR TITLE
TOR-1203 Korjaa lops2021 laajuuksien yhteenlaskenta validaatioissa

### DIFF
--- a/src/main/scala/fi/oph/koski/documentation/ExamplesLukio2019.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesLukio2019.scala
@@ -261,7 +261,7 @@ object Lukio2019ExampleData {
   def lukiodiplomit(): Lukiodiplomit2019 = Lukiodiplomit2019(Koodistokoodiviite(koodistoUri = "lukionmuutopinnot", koodiarvo= "LD"), None)
   def temaattisetOpinnot(): TemaattisetOpinnot2019 = TemaattisetOpinnot2019(Koodistokoodiviite(koodistoUri = "lukionmuutopinnot", koodiarvo= "TO"), None)
 
-  private def muidenLukioOpintojenSuoritus(koulutusmoduuli: MuutSuorituksetTaiVastaavat2019): MuidenLukioOpintojenSuoritus2019 = MuidenLukioOpintojenSuoritus2019(
+  def muidenLukioOpintojenSuoritus(koulutusmoduuli: MuutSuorituksetTaiVastaavat2019): MuidenLukioOpintojenSuoritus2019 = MuidenLukioOpintojenSuoritus2019(
     koulutusmoduuli = koulutusmoduuli,
     osasuoritukset = None
   )

--- a/src/main/scala/fi/oph/koski/schema/Koulutusmoduuli.scala
+++ b/src/main/scala/fi/oph/koski/schema/Koulutusmoduuli.scala
@@ -103,3 +103,12 @@ trait Äidinkieli extends Kieliaine
 trait Oppimäärä extends Koulutusmoduuli {
   def oppimäärä: Koodistokoodiviite
 }
+
+trait OpintopistelaajuuksienYhteenlaskennallinenKoulutusmoduuli extends KoulutusmoduuliValinnainenLaajuus {
+  def laajuus: Option[LaajuusOpintopisteissä]
+
+  final def withLaajuus(laajuusArvo: Double): OpintopistelaajuuksienYhteenlaskennallinenKoulutusmoduuli = this.withLaajuus(Some(LaajuusOpintopisteissä(laajuusArvo)))
+  final def withLaajuusNone(): OpintopistelaajuuksienYhteenlaskennallinenKoulutusmoduuli = this.withLaajuus(None)
+
+  def withLaajuus(laajuus: Option[LaajuusOpintopisteissä]): OpintopistelaajuuksienYhteenlaskennallinenKoulutusmoduuli
+}

--- a/src/main/scala/fi/oph/koski/schema/Lukio2019.scala
+++ b/src/main/scala/fi/oph/koski/schema/Lukio2019.scala
@@ -175,7 +175,7 @@ case class LukionModuulinSuoritusMuissaOpinnoissa2019(
   tyyppi: Koodistokoodiviite = Koodistokoodiviite(koodiarvo = "lukionvaltakunnallinenmoduuli", koodistoUri = "suorituksentyyppi")
 ) extends LukionModuulinSuoritus2019 with LukionModuulinTaiPaikallisenOpintojaksonSuoritusMuissaOpinnoissa2019
 
-trait MuutSuorituksetTaiVastaavat2019 extends KoodistostaLöytyväKoulutusmoduuliValinnainenLaajuus with PreIBMuutSuorituksetTaiVastaavat2019 {
+trait MuutSuorituksetTaiVastaavat2019 extends KoodistostaLöytyväKoulutusmoduuliValinnainenLaajuus with OpintopistelaajuuksienYhteenlaskennallinenKoulutusmoduuli with PreIBMuutSuorituksetTaiVastaavat2019 {
   @KoodistoUri("lukionmuutopinnot")
   def tunniste: Koodistokoodiviite
 }
@@ -186,7 +186,9 @@ case class MuutLukionSuoritukset2019(
   @KoodistoKoodiarvo("MS")
   tunniste: Koodistokoodiviite,
   laajuus: Option[LaajuusOpintopisteissä]
-) extends MuutSuorituksetTaiVastaavat2019
+) extends MuutSuorituksetTaiVastaavat2019 {
+  def withLaajuus(laajuus: Option[LaajuusOpintopisteissä]): OpintopistelaajuuksienYhteenlaskennallinenKoulutusmoduuli = this.copy(laajuus = laajuus)
+}
 
 @Title("Lukiodiplomit 2019")
 @Description("Kategoria lukiodiplomeille 2019.")
@@ -194,7 +196,9 @@ case class Lukiodiplomit2019(
   @KoodistoKoodiarvo("LD")
   tunniste: Koodistokoodiviite,
   laajuus: Option[LaajuusOpintopisteissä]
-) extends MuutSuorituksetTaiVastaavat2019
+) extends MuutSuorituksetTaiVastaavat2019 {
+  def withLaajuus(laajuus: Option[LaajuusOpintopisteissä]): OpintopistelaajuuksienYhteenlaskennallinenKoulutusmoduuli = this.copy(laajuus = laajuus)
+}
 
 @Title("Temaattiset opinnot 2019")
 @Description("Kategoria temaattisille opinnoille 2019.")
@@ -202,7 +206,9 @@ case class TemaattisetOpinnot2019(
   @KoodistoKoodiarvo("TO")
   tunniste: Koodistokoodiviite,
   laajuus: Option[LaajuusOpintopisteissä]
-) extends MuutSuorituksetTaiVastaavat2019
+) extends MuutSuorituksetTaiVastaavat2019 {
+  def withLaajuus(laajuus: Option[LaajuusOpintopisteissä]): OpintopistelaajuuksienYhteenlaskennallinenKoulutusmoduuli = this.copy(laajuus = laajuus)
+}
 
 @Title("Lukion paikallisen opintojakson suoritus 2019")
 @Description("Lukion paikallisen opintojakson suoritustiedot 2019")
@@ -306,10 +312,9 @@ case class LukionPaikallinenOpintojakso2019(
 ) extends LukionModuuliTaiPaikallinenOpintojakso2019 with PaikallinenKoulutusmoduuli with StorablePreference  with PreIBPaikallinenOpintojakso2019
 
 @Description("Lukion/IB-lukion oppiaineen tunnistetiedot 2019")
-trait LukionOppiaine2019 extends LukionOppiaine with KoulutusmoduuliValinnainenLaajuus with PreIBLukionOppiaine2019 {
+trait LukionOppiaine2019 extends LukionOppiaine with OpintopistelaajuuksienYhteenlaskennallinenKoulutusmoduuli with KoulutusmoduuliValinnainenLaajuus with PreIBLukionOppiaine2019 {
   def laajuus: Option[LaajuusOpintopisteissä]
   override def perusteenDiaarinumero: Option[String] = None
-  def withLaajuus(laajuusArvo: Double): LukionOppiaine2019
 }
 
 @Title("Paikallinen oppiaine 2019")
@@ -321,7 +326,7 @@ case class PaikallinenLukionOppiaine2019(
   @DefaultValue(None)
   laajuus: Option[LaajuusOpintopisteissä] = None
 ) extends LukionOppiaine2019 with PaikallinenKoulutusmoduuli with StorablePreference {
-  def withLaajuus(laajuusArvo: Double): LukionOppiaine2019 = this.copy(laajuus = Some(LaajuusOpintopisteissä(laajuusArvo)))
+  def withLaajuus(laajuus: Option[LaajuusOpintopisteissä]): OpintopistelaajuuksienYhteenlaskennallinenKoulutusmoduuli = this.copy(laajuus = laajuus)
 }
 
 trait LukionValtakunnallinenOppiaine2019 extends LukionOppiaine2019 with YleissivistavaOppiaine
@@ -348,7 +353,7 @@ case class LukionMuuValtakunnallinenOppiaine2019(
   @DefaultValue(None)
   laajuus: Option[LaajuusOpintopisteissä] = None
 ) extends LukionValtakunnallinenOppiaine2019 {
-  def withLaajuus(laajuusArvo: Double): LukionOppiaine2019 = this.copy(laajuus = Some(LaajuusOpintopisteissä(laajuusArvo)))
+  def withLaajuus(laajuus: Option[LaajuusOpintopisteissä]): OpintopistelaajuuksienYhteenlaskennallinenKoulutusmoduuli = this.copy(laajuus = laajuus)
 }
 
 @Title("Uskonto 2019")
@@ -360,7 +365,7 @@ case class LukionUskonto2019(
   laajuus: Option[LaajuusOpintopisteissä] = None,
   uskonnonOppimäärä: Option[Koodistokoodiviite] = None
 ) extends LukionValtakunnallinenOppiaine2019 with Uskonto {
-  def withLaajuus(laajuusArvo: Double): LukionOppiaine2019 = this.copy(laajuus = Some(LaajuusOpintopisteissä(laajuusArvo)))
+  def withLaajuus(laajuus: Option[LaajuusOpintopisteissä]): OpintopistelaajuuksienYhteenlaskennallinenKoulutusmoduuli = this.copy(laajuus = laajuus)
 }
 
 @Title("Äidinkieli ja kirjallisuus 2019")
@@ -377,7 +382,7 @@ case class LukionÄidinkieliJaKirjallisuus2019(
   laajuus: Option[LaajuusOpintopisteissä] = None
 ) extends LukionValtakunnallinenOppiaine2019 with LukionÄidinkieliJaKirjallisuus {
   override def description: LocalizedString = kieliaineDescription
-  def withLaajuus(laajuusArvo: Double): LukionOppiaine2019 = this.copy(laajuus = Some(LaajuusOpintopisteissä(laajuusArvo)))
+  def withLaajuus(laajuus: Option[LaajuusOpintopisteissä]): OpintopistelaajuuksienYhteenlaskennallinenKoulutusmoduuli = this.copy(laajuus = laajuus)
 }
 
 @Title("Vieras tai toinen kotimainen kieli 2019")
@@ -398,7 +403,7 @@ case class VierasTaiToinenKotimainenKieli2019(
   laajuus: Option[LaajuusOpintopisteissä] = None
 ) extends LukionValtakunnallinenOppiaine2019 with Kieliaine {
   override def description = kieliaineDescription
-  def withLaajuus(laajuusArvo: Double): LukionOppiaine2019 = this.copy(laajuus = Some(LaajuusOpintopisteissä(laajuusArvo)))
+  def withLaajuus(laajuus: Option[LaajuusOpintopisteissä]): OpintopistelaajuuksienYhteenlaskennallinenKoulutusmoduuli = this.copy(laajuus = laajuus)
 }
 
 @Title("Matematiikka 2019")
@@ -415,7 +420,7 @@ case class LukionMatematiikka2019(
   laajuus: Option[LaajuusOpintopisteissä] = None
 ) extends LukionValtakunnallinenOppiaine2019 with KoodistostaLöytyväKoulutusmoduuliValinnainenLaajuus with Oppimäärä {
   override def description = oppimäärä.description
-  def withLaajuus(laajuusArvo: Double): LukionOppiaine2019 = this.copy(laajuus = Some(LaajuusOpintopisteissä(laajuusArvo)))
+  def withLaajuus(laajuus: Option[LaajuusOpintopisteissä]): OpintopistelaajuuksienYhteenlaskennallinenKoulutusmoduuli = this.copy(laajuus = laajuus)
 }
 
 trait SuoritettavissaErityisenäTutkintona2019 {

--- a/src/main/scala/fi/oph/koski/schema/VapaaSivistystyö.scala
+++ b/src/main/scala/fi/oph/koski/schema/VapaaSivistystyö.scala
@@ -84,11 +84,9 @@ case class OppivelvollisilleSuunnatunVapaanSivistystyönValinnaistenSuuntautumis
   tyyppi: Koodistokoodiviite = Koodistokoodiviite(koodiarvo = "vstvalinnainensuuntautuminen", koodistoUri = "suorituksentyyppi")
 ) extends OppivelvollisilleSuunnatunVapaanSivistystyönOsasuoritus
 
-trait OppivelvollisilleSuunnatunVapaanSivistystyönOsasuorituksenKoulutusmoduuli extends KoulutusmoduuliValinnainenLaajuus with KoodistostaLöytyväKoulutusmoduuli {
+trait OppivelvollisilleSuunnatunVapaanSivistystyönOsasuorituksenKoulutusmoduuli extends KoulutusmoduuliValinnainenLaajuus with KoodistostaLöytyväKoulutusmoduuli with OpintopistelaajuuksienYhteenlaskennallinenKoulutusmoduuli {
   @Description("Laajuus lasketaan yhteen opintokokonaisuuksien laajuuksista automaattisesti tietoja siirrettäessä")
   def laajuus: Option[LaajuusOpintopisteissä]
-  def withLaajuus(laajuusArvo: Double): OppivelvollisilleSuunnatunVapaanSivistystyönOsasuorituksenKoulutusmoduuli
-  def withLaajuusNone(): OppivelvollisilleSuunnatunVapaanSivistystyönOsasuorituksenKoulutusmoduuli
 }
 
 @Title("Valinnaiset suuntautumisopinnot")
@@ -99,8 +97,7 @@ case class OppivelvollisilleSuunnatunVapaanSivistystyönValinnaisetSuuntautumiso
   laajuus: Option[LaajuusOpintopisteissä] = None
 ) extends OppivelvollisilleSuunnatunVapaanSivistystyönOsasuorituksenKoulutusmoduuli {
   override def nimi: LocalizedString = LocalizedString.empty
-  def withLaajuus(laajuusArvo: Double): OppivelvollisilleSuunnatunVapaanSivistystyönOsasuorituksenKoulutusmoduuli = this.copy(laajuus = Some(LaajuusOpintopisteissä(laajuusArvo)))
-  def withLaajuusNone(): OppivelvollisilleSuunnatunVapaanSivistystyönOsasuorituksenKoulutusmoduuli = this.copy(laajuus = None)
+  def withLaajuus(laajuus: Option[LaajuusOpintopisteissä]): OpintopistelaajuuksienYhteenlaskennallinenKoulutusmoduuli = this.copy(laajuus = laajuus)
 }
 
 @Title("Osaamiskokonaisuus")
@@ -109,8 +106,7 @@ case class OppivelvollisilleSuunnattuVapaanSivistystyönOsaamiskokonaisuus(
   tunniste: Koodistokoodiviite,
   laajuus: Option[LaajuusOpintopisteissä] = None
 ) extends OppivelvollisilleSuunnatunVapaanSivistystyönOsasuorituksenKoulutusmoduuli with KoodistostaLöytyväKoulutusmoduuli {
-  def withLaajuus(laajuusArvo: Double): OppivelvollisilleSuunnatunVapaanSivistystyönOsasuorituksenKoulutusmoduuli = this.copy(laajuus = Some(LaajuusOpintopisteissä(laajuusArvo)))
-  def withLaajuusNone(): OppivelvollisilleSuunnatunVapaanSivistystyönOsasuorituksenKoulutusmoduuli = this.copy(laajuus = None)
+  def withLaajuus(laajuus: Option[LaajuusOpintopisteissä]): OpintopistelaajuuksienYhteenlaskennallinenKoulutusmoduuli = this.copy(laajuus = laajuus)
 }
 
 @Title("Opintokokonaisuuden suoritus")

--- a/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
+++ b/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
@@ -135,20 +135,12 @@ class KoskiValidator(tutkintoRepository: TutkintoRepository, val koodistoPalvelu
     oo.withSuoritukset(oo.suoritukset.map(fillOsasuoritustenLaajuudet))
 
   private def fillOsasuoritustenLaajuudet(suoritus: PäätasonSuoritus): PäätasonSuoritus = suoritus match {
-    case _: LukionPäätasonSuoritus2019 | _: PreIBSuoritus2019 =>
+    case _: LukionPäätasonSuoritus2019 | _: PreIBSuoritus2019 | _: OppivelvollisilleSuunnatunVapaanSivistystyönKoulutuksenSuoritus =>
       suoritus.withOsasuoritukset(suoritus.osasuoritukset.map(_.map { os =>
         lazy val yhteislaajuus = os.osasuoritusLista.map(_.koulutusmoduuli.laajuusArvo(1.0)).map(BigDecimal.decimal).sum.toDouble
         os.withKoulutusmoduuli(os.koulutusmoduuli match {
-          case k: LukionOppiaine2019 if yhteislaajuus > 0 => k.withLaajuus(yhteislaajuus)
-          case k => k
-        })
-      }))
-    case _: OppivelvollisilleSuunnatunVapaanSivistystyönKoulutuksenSuoritus =>
-      suoritus.withOsasuoritukset(suoritus.osasuoritukset.map(_.map { os =>
-        val yhteislaajuus = os.osasuoritusLista.map(_.koulutusmoduuli.laajuusArvo(1.0)).map(BigDecimal.decimal).sum.toDouble
-        os.withKoulutusmoduuli(os.koulutusmoduuli match {
-          case k: OppivelvollisilleSuunnatunVapaanSivistystyönOsasuorituksenKoulutusmoduuli if yhteislaajuus > 0 => k.withLaajuus(yhteislaajuus)
-          case k: OppivelvollisilleSuunnatunVapaanSivistystyönOsasuorituksenKoulutusmoduuli => k.withLaajuusNone()
+          case k: OpintopistelaajuuksienYhteenlaskennallinenKoulutusmoduuli if yhteislaajuus > 0 => k.withLaajuus(yhteislaajuus)
+          case k: OpintopistelaajuuksienYhteenlaskennallinenKoulutusmoduuli => k.withLaajuusNone()
           case k => k
         })
       }))

--- a/validaation_muutoshistoria.md
+++ b/validaation_muutoshistoria.md
@@ -1,5 +1,11 @@
 # Koskeen tallennettavien tietojen validaatiosäännöt
 
+## 8.1.2021
+- Lops2021 laajuuksien laskenta korjattu: Aiemmin laajuudet asetettiin osana validaatioita ainoastaan oppiaineelle sen
+sisältämien moduulien ja paikallisten oppiaineiden laajuuksien perusteella. Lisäksi oppiaineelle mahdollisesti
+siirrettyä laajuutta ei poistettu, jos oppiaineella ei ollut yhtään osasuorituksia. Nyt laajuudet lasketaan myös
+lukion muissa opinnoissa, ja tyhjennetään ylemmältä tasolta, jos osasuorituksia ei ole.
+
 ## 22.12.2020
 - Vapaan sivistystyön oppivelvollisuuslinjan opinnoissa täydennetään osaamiskokonaisuuksien ja valinnaisten
 suuntautumisopintojen laajuus automaattisesti opintokokonaisuuksien laajuuksista

--- a/web/test/spec/omatTiedotLukioSpec.js
+++ b/web/test/spec/omatTiedotLukioSpec.js
@@ -140,11 +140,14 @@ describe('Omat tiedot - lukio', function() {
             'Tanssi ja liike, valinnainen *\n' +
             '(52 opintopistettä) 8\n' +
             '+\n' +
-            'Lukiodiplomit -\n' +
+            'Lukiodiplomit\n' +
+            '(4 opintopistettä) -\n' +
             '+\n' +
-            'Muut suoritukset -\n' +
+            'Muut suoritukset\n' +
+            '(7 opintopistettä) -\n' +
             '+\n' +
-            'Teemaopinnot -'
+            'Teemaopinnot\n' +
+            '(1 opintopistettä) -'
           )
         })
 
@@ -416,17 +419,20 @@ describe('Omat tiedot - lukio', function() {
             'ITT234 *\n' +
             '10 ITT235 *\n' +
             '10\n' +
-            'Lukiodiplomit -\n' +
+            'Lukiodiplomit\n' +
+            '(4 opintopistettä) -\n' +
             'MELD5\n' +
             '7 KÄLD3\n' +
             '9\n' +
-            'Muut suoritukset -\n' +
+            'Muut suoritukset\n' +
+            '(7 opintopistettä) -\n' +
             'KE3\n' +
             '10 HAI765 *\n' +
             'S VKA1\n' +
             '10 ENA1\n' +
             '10\n' +
-            'Teemaopinnot -\n' +
+            'Teemaopinnot\n' +
+            '(1 opintopistettä) -\n' +
             'KAN200 *\n' +
             'S'
           )
@@ -692,15 +698,18 @@ describe('Omat tiedot - lukio', function() {
             'ITT234 *\n' +
             '6 ITT235 *\n' +
             '7\n' +
-            'Muut suoritukset -\n' +
+            'Muut suoritukset\n' +
+            '(6 opintopistettä) -\n' +
             'ÄI1\n' +
             '7 VKAAB31\n' +
             '6 RUB11\n' +
             '6\n' +
-            'Lukiodiplomit -\n' +
+            'Lukiodiplomit\n' +
+            '(2 opintopistettä) -\n' +
             'KULD2\n' +
             '9\n' +
-            'Teemaopinnot -\n' +
+            'Teemaopinnot\n' +
+            '(1 opintopistettä) -\n' +
             'HAI765 *\n' +
             'S'
           )


### PR DESCRIPTION
Aiemmin laajuudet ensimmäiselle osasuoritustasolle laskettiin ainoastaan oppinaineille, joissa oli osasuorituksia. Nyt laajuudet
tyhjennetään, jos osasuorituksia ei ole, ja lasketaan myös lukion muissa suorituksissa.