### PR TITLE
DIA lisää sallittu koodiarvo VT

### DIFF
--- a/src/main/scala/fi/oph/koski/schema/DIA.scala
+++ b/src/main/scala/fi/oph/koski/schema/DIA.scala
@@ -370,6 +370,7 @@ case class DIAOppiaineLisäaine(
   @KoodistoKoodiarvo("VELI")
   @KoodistoKoodiarvo("ELI")
   @KoodistoKoodiarvo("RALI")
+  @KoodistoKoodiarvo("VT")
   tunniste: Koodistokoodiviite,
   laajuus: Option[LaajuusVuosiviikkotunneissa]
 ) extends DIAOppiaine


### PR DESCRIPTION
Tämä on skeeman rikkova muutos, mutta kyseisellä koodiarvolla ei pitäisi olla siirretty suorituksia väärään paikkaan