### PR TITLE
Älä käytä mapping typeä ES-kutsuissa

### DIFF
--- a/src/main/scala/fi/oph/koski/perustiedot/OpiskeluoikeudenPerustiedotIndexer.scala
+++ b/src/main/scala/fi/oph/koski/perustiedot/OpiskeluoikeudenPerustiedotIndexer.scala
@@ -85,7 +85,7 @@ class OpiskeluoikeudenPerustiedotIndexer(
     elastic = elastic,
     name = "perustiedot",
     legacyName = "perustiedot",
-    mappingVersion = 2,
+    mappingVersion = 3,
     mapping = OpiskeluoikeudenPerustiedotIndexer.mapping,
     settings = OpiskeluoikeudenPerustiedotIndexer.settings,
     initialLoader = this.indexAllDocuments

--- a/src/main/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoService.scala
+++ b/src/main/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoService.scala
@@ -79,7 +79,7 @@ class TiedonsiirtoService(
     elastic = elastic,
     name = "tiedonsiirto",
     legacyName = "koski-index",
-    mappingVersion = 1,
+    mappingVersion = 2,
     mapping = TiedonsiirtoService.mapping,
     settings = TiedonsiirtoService.settings,
     initialLoader = () => ???


### PR DESCRIPTION
Vaatii, että indeksit on aiemmin reindeksoitu uusiin indekseihin _doc tyypille.