### PR TITLE
TOR-1248 - step 1 - Mahdollistetu perusteen valinta esiopetuksen opiskeluoikeutta luotaessa

### DIFF
--- a/web/app/uusioppija/UusiEsiopetuksenSuoritus.jsx
+++ b/web/app/uusioppija/UusiEsiopetuksenSuoritus.jsx
@@ -1,0 +1,19 @@
+import React from 'baret'
+import Bacon from 'baconjs'
+import Atom from 'bacon.atom'
+import {makeSuoritus} from './esiopetuksenSuoritus'
+import Peruste from './Peruste'
+import {setPeruste} from '../suoritus/PerusteDropdown'
+
+export default ({suoritusAtom, oppilaitosAtom, organisaatiotyypitAtom, suorituskieliAtom}) => {
+  const perusteAtom = Atom()
+
+  Bacon.combineWith(oppilaitosAtom, organisaatiotyypitAtom, perusteAtom, suorituskieliAtom, makeSuoritus)
+    .onValue(suoritus => suoritusAtom.set(suoritus))
+
+  let suoritusP = Bacon.combineWith(oppilaitosAtom, organisaatiotyypitAtom, perusteAtom, suorituskieliAtom, makeSuoritus)
+  suoritusP.map('.tyyppi').onValue(suoritustyyppi => setPeruste(perusteAtom, suoritustyyppi))
+  suoritusP.filter('.koulutusmoduuli.perusteenDiaarinumero').onValue(suoritus => suoritusAtom.set(suoritus))
+
+  return <Peruste {...{suoritusTyyppiP: suoritusP.map('.tyyppi'), perusteAtom}} />
+}

--- a/web/app/uusioppija/UusiOpiskeluoikeus.jsx
+++ b/web/app/uusioppija/UusiOpiskeluoikeus.jsx
@@ -16,7 +16,7 @@ import {t} from '../i18n/i18n'
 import Text from '../i18n/Text'
 import {sortLanguages} from '../util/sorting'
 import {ift} from '../util/util'
-import {esiopetuksenSuoritus} from './esiopetuksenSuoritus.js'
+import UusiEsiopetuksenSuoritus from './UusiEsiopetuksenSuoritus.jsx'
 import UusiAikuistenPerusopetuksenSuoritus from './UusiAikuistenPerusopetuksenSuoritus'
 import UusiLukionSuoritus from './UusiLukionSuoritus'
 import {sallitutRahoituskoodiarvot} from '../lukio/lukio'
@@ -82,7 +82,7 @@ export default ({opiskeluoikeusAtom}) => {
       tyyppiAtom.map('.koodiarvo').map(tyyppi => {
         if (tyyppi === 'perusopetus') return <UusiNuortenPerusopetuksenSuoritus suoritusAtom={suoritusAtom} oppilaitosAtom={oppilaitosAtom} suorituskieliAtom={suorituskieliAtom} />
         if (tyyppi === 'aikuistenperusopetus') return <UusiAikuistenPerusopetuksenSuoritus suoritusAtom={suoritusAtom} oppilaitosAtom={oppilaitosAtom} suorituskieliAtom={suorituskieliAtom} />
-        if (tyyppi === 'esiopetus') esiopetuksenSuoritus(suoritusAtom, oppilaitosAtom, organisaatiotyypitAtom, suorituskieliAtom) // No need to show the diaarinumero selector as there is only one choice
+        if (tyyppi === 'esiopetus') return <UusiEsiopetuksenSuoritus suoritusAtom={suoritusAtom} oppilaitosAtom={oppilaitosAtom} organisaatiotyypitAtom={organisaatiotyypitAtom} suorituskieliAtom={suorituskieliAtom} />
         if (tyyppi === 'ammatillinenkoulutus') return <UusiAmmatillisenKoulutuksenSuoritus suoritusAtom={suoritusAtom} oppilaitosAtom={oppilaitosAtom} suorituskieliAtom={suorituskieliAtom} />
         if (tyyppi === 'perusopetukseenvalmistavaopetus') return <UusiPerusopetukseenValmistavanOpetuksenSuoritus suoritusAtom={suoritusAtom} oppilaitosAtom={oppilaitosAtom} suorituskieliAtom={suorituskieliAtom} />
         if (tyyppi === 'perusopetuksenlisaopetus') return <UusiPerusopetuksenLisaopetuksenSuoritus suoritusAtom={suoritusAtom} oppilaitosAtom={oppilaitosAtom} suorituskieliAtom={suorituskieliAtom} />

--- a/web/app/uusioppija/esiopetuksenSuoritus.js
+++ b/web/app/uusioppija/esiopetuksenSuoritus.js
@@ -1,31 +1,20 @@
-import Atom from 'bacon.atom'
-import Bacon from 'baconjs'
-import {setPeruste} from '../suoritus/PerusteDropdown'
-
 export const VARHAISKASVATUKSEN_TOIMIPAIKKA = 'VARHAISKASVATUKSEN_TOIMIPAIKKA'
 
-export const esiopetuksenSuoritus = (suoritusAtom, oppilaitosAtom, organisaatiotyypitAtom, suorituskieliAtom) => {
-  const perusteAtom = Atom()
-  const makeSuoritus = (oppilaitos, organisaatiotyypit, peruste, suorituskieli) => {
-    if (oppilaitos) {
-      return {
-        koulutusmoduuli: {
-          tunniste: {
-            koodiarvo: tunnisteenKoodiarvo(organisaatiotyypit),
-            koodistoUri: 'koulutus'
-          },
-          perusteenDiaarinumero: peruste
+export const makeSuoritus = (oppilaitos, organisaatiotyypit, peruste, suorituskieli) => {
+  if (oppilaitos) {
+    return {
+      koulutusmoduuli: {
+        tunniste: {
+          koodiarvo: tunnisteenKoodiarvo(organisaatiotyypit),
+          koodistoUri: 'koulutus'
         },
-        toimipiste: oppilaitos,
-        tyyppi: { koodistoUri: 'suorituksentyyppi', koodiarvo: 'esiopetuksensuoritus'},
-        suorituskieli : suorituskieli
-      }
+        perusteenDiaarinumero: peruste
+      },
+      toimipiste: oppilaitos,
+      tyyppi: { koodistoUri: 'suorituksentyyppi', koodiarvo: 'esiopetuksensuoritus'},
+      suorituskieli : suorituskieli
     }
   }
-
-  let suoritusP = Bacon.combineWith(oppilaitosAtom, organisaatiotyypitAtom, perusteAtom, suorituskieliAtom, makeSuoritus)
-  suoritusP.map('.tyyppi').onValue(suoritustyyppi => setPeruste(perusteAtom, suoritustyyppi))
-  suoritusP.filter('.koulutusmoduuli.perusteenDiaarinumero').onValue(suoritus => suoritusAtom.set(suoritus))
 }
 
 const tunnisteenKoodiarvo = organisaatioTyypit =>


### PR DESCRIPTION
Ongelmia paratiisissa: https://jira.eduuni.fi/browse/TOR-1286

Uusi eperuste-rakenne ei toimi ollenkaan johtuen eperuste-palvelussa olevasta viasta.

Mutta tämä uusi peruste on joka tapauksessa harvinaisempi käyttötapaus kuin tämä vanhempi peruste. Käytetään vanhempaa perustetta defaulttina.

Nyt tässä vaiheessa tehdään ylipäätään mahdolliseksi valita peruste esiopetus-kälissä.