### PR TITLE
TOR-1267: Testi kahden oppija-oidin oppijalle

### DIFF
--- a/src/main/scala/fi/oph/koski/henkilo/MockOppijat.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/MockOppijat.scala
@@ -50,6 +50,11 @@ class MockOppijat(private var oppijat: List[OppijaHenkilöWithMasterInfo] = Nil)
     oppija
   }
 
+  def duplicate(masterOppija: LaajatOppijaHenkilöTiedot): LaajatOppijaHenkilöTiedot = {
+    val oppijaCopy = masterOppija.copy(oid = generateId())
+    addOppija(OppijaHenkilöWithMasterInfo(oppijaCopy, Some(masterOppija))).henkilö.asInstanceOf[LaajatOppijaHenkilöTiedot]
+  }
+
   def getOppijat = oppijat
 
   def generateId(): String = this.synchronized {

--- a/src/main/scala/fi/oph/koski/valpas/fixture/ValpasDatabaseFixtureCreator.scala
+++ b/src/main/scala/fi/oph/koski/valpas/fixture/ValpasDatabaseFixtureCreator.scala
@@ -50,6 +50,8 @@ class ValpasDatabaseFixtureCreator(application: KoskiApplication) extends Databa
     (ValpasMockOppijat.kasiinAstiToisessaKoulussaOllut, ValpasExampleData.kasiluokkaEronnutKeväällä2020Opiskeluoikeus),
     (ValpasMockOppijat.kasiinAstiToisessaKoulussaOllut, ValpasExampleData.pelkkäYsiluokkaKeskenKeväällä2021Opiskeluoikeus),
     (ValpasMockOppijat.lukionAloittanut, ValpasExampleData.valmistunutYsiluokkalainen),
-    (ValpasMockOppijat.lukionAloittanut, ValpasExampleData.lukionOpiskeluoikeusAlkaa2021Syksyllä)
+    (ValpasMockOppijat.lukionAloittanut, ValpasExampleData.lukionOpiskeluoikeusAlkaa2021Syksyllä),
+    (ValpasMockOppijat.oppivelvollinenKahdellaOppijaOidillaMaster, ValpasExampleData.valmistunutYsiluokkalainen),
+    (ValpasMockOppijat.oppivelvollinenKahdellaOppijaOidillaToinen, ValpasExampleData.lukionOpiskeluoikeus),
   )
 }

--- a/src/main/scala/fi/oph/koski/valpas/henkilo/ValpasMockOppijat.scala
+++ b/src/main/scala/fi/oph/koski/valpas/henkilo/ValpasMockOppijat.scala
@@ -21,6 +21,8 @@ object ValpasMockOppijat {
   val luokalleJäänytYsiluokkalainenVaihtanutKouluaMuualta = valpasOppijat.oppija("LuokallejäänytYsiluokkalainenKouluvaihtoMuualta", "Valpas", "021105A624K")
   val kasiinAstiToisessaKoulussaOllut = valpasOppijat.oppija("KasiinAstiToisessaKoulussaOllut", "Valpas", "170805A613F")
   val lukionAloittanut = valpasOppijat.oppija("LukionAloittanut", "Valpas", "290405A871A")
+  val oppivelvollinenKahdellaOppijaOidillaMaster = valpasOppijat.oppija("Kahdella-oppija-oidilla", "Valpas", "150205A490C")
+  val oppivelvollinenKahdellaOppijaOidillaToinen = valpasOppijat.duplicate(oppivelvollinenKahdellaOppijaOidillaMaster)
 
   def defaultOppijat = valpasOppijat.getOppijat
 }

--- a/src/test/scala/fi/oph/koski/valpas/ValpasOppijaServiceSpec.scala
+++ b/src/test/scala/fi/oph/koski/valpas/ValpasOppijaServiceSpec.scala
@@ -64,12 +64,19 @@ class ValpasOppijaServiceSpec extends ValpasTestBase {
         ValpasExampleData.lukionOpiskeluoikeusAlkaa2021Syksyllä,
         ValpasExampleData.valmistunutYsiluokkalainen
       )
+    ),
+    (
+      ValpasMockOppijat.oppivelvollinenKahdellaOppijaOidillaMaster,
+      List(
+        ValpasExampleData.lukionOpiskeluoikeus,
+        ValpasExampleData.valmistunutYsiluokkalainen
+      )
     )
   ).sortBy(item => (item._1.sukunimi, item._1.etunimet))
 
   "getOppija palauttaa vain annetun oppijanumeron mukaisen oppijan" in {
     val (expectedOppija, expectedOpiskeluoikeudet) = oppivelvolliset(1)
-    val oppija = oppijaService.getOppija(expectedOppija.oid)(session(ValpasMockUsers.valpasJklNormaalikoulu))
+    val oppija = oppijaService.getOppija(expectedOppija.oid)(defaultSession())
 
     validateOppija(
       oppija.get,
@@ -77,8 +84,17 @@ class ValpasOppijaServiceSpec extends ValpasTestBase {
       expectedOpiskeluoikeudet)
   }
 
-  "getOppija palauttaa oikeat tulokset" in {
-    val oppijat = oppijaService.getOppijat(oppilaitokset.toSet)(session(ValpasMockUsers.valpasJklNormaalikoulu)).get.toList
+  "getOppija palauttaa oppijan tiedot, vaikka oid ei olisikaan master oid" in {
+    val oppija = oppijaService.getOppija(ValpasMockOppijat.oppivelvollinenKahdellaOppijaOidillaToinen.oid)(defaultSession())
+    validateOppija(
+      oppija.get,
+      ValpasMockOppijat.oppivelvollinenKahdellaOppijaOidillaMaster,
+      List(ValpasExampleData.lukionOpiskeluoikeus, ValpasExampleData.valmistunutYsiluokkalainen)
+    )
+  }
+
+  "getOppijat palauttaa oikeat tulokset" in {
+    val oppijat = oppijaService.getOppijat(oppilaitokset.toSet)(defaultSession()).get.toList
 
     oppijat.map(_.henkilö.oid) shouldBe oppivelvolliset.map(_._1.oid)
 
@@ -163,4 +179,5 @@ class ValpasOppijaServiceSpec extends ValpasTestBase {
       .isDefined
 
   private def session(user: ValpasMockUser)= user.toValpasSession(KoskiApplicationForTests.käyttöoikeusRepository)
+  private def defaultSession() = session(ValpasMockUsers.valpasJklNormaalikoulu)
 }


### PR DESCRIPTION
Lisätty ainoastaan puuttunut testi, koska sen perusteella oppijatietojen haku näyttäisi toimivan oikein.