### PR TITLE
TOR-1267: Nopeuta integraatiotestien alustusta

### DIFF
--- a/src/main/scala/fi/oph/koski/fixture/Fixtures.scala
+++ b/src/main/scala/fi/oph/koski/fixture/Fixtures.scala
@@ -55,6 +55,8 @@ class FixtureCreator(application: KoskiApplication) extends Logging with Timing 
 
   def allOppijaOids: List[String] = (koskiSpecificFixtureState.oppijaOids ++ valpasFixtureState.oppijaOids).distinct // oids that should be considered when deleting fixture data
 
+  def getCurrentFixtureStateName() = currentFixtureState.name
+
   lazy val koskiSpecificFixtureState = new KoskiSpecificFixtureState(application)
   lazy val valpasFixtureState = new ValpasFixtureState(application)
 }

--- a/src/main/scala/fi/oph/koski/valpas/ValpasTestApiServlet.scala
+++ b/src/main/scala/fi/oph/koski/valpas/ValpasTestApiServlet.scala
@@ -4,7 +4,7 @@ import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.http.KoskiErrorCategory
 import fi.oph.koski.koskiuser.Unauthenticated
 import fi.oph.koski.servlet.NoCache
-import fi.oph.koski.valpas.fixture.FixtureUtil
+import fi.oph.koski.valpas.fixture.{FixtureState, FixtureUtil}
 import fi.oph.koski.valpas.repository.MockRajapäivät
 import fi.oph.koski.valpas.servlet.ValpasApiServlet
 
@@ -23,19 +23,18 @@ class ValpasTestApiServlet(implicit val application: KoskiApplication) extends V
   get("/reset-mock-data/:paiva") {
     val tarkasteluPäivä = getLocalDateParam("paiva")
     FixtureUtil.resetMockData(application, new MockRajapäivät(tarkasteluPäivä))
-    contentType = "text/json"
-    response.writer.print("\"Valpas mock data reset\"")
   }
 
   get("/reset-mock-data") {
     FixtureUtil.resetMockData(application)
-    contentType = "text/json"
-    response.writer.print("\"Valpas mock data reset\"")
   }
 
   get("/clear-mock-data") {
     FixtureUtil.clearMockData(application)
-    contentType = "text/json"
-    response.writer.print("\"Valpas mock data cleared\"")
+  }
+
+  get("/current-mock-status") {
+    FixtureState(application)
   }
 }
+

--- a/src/main/scala/fi/oph/koski/valpas/fixture/FixtureUtil.scala
+++ b/src/main/scala/fi/oph/koski/valpas/fixture/FixtureUtil.scala
@@ -6,15 +6,29 @@ import fi.oph.koski.valpas.valpasuser.ValpasMockUsers
 
 
 object FixtureUtil {
-  def resetMockData(app: KoskiApplication, rajapäivät: MockRajapäivät = new MockRajapäivät()): Unit = synchronized {
+  def resetMockData(app: KoskiApplication, rajapäivät: MockRajapäivät = new MockRajapäivät()): FixtureState = synchronized {
     ValpasMockUsers.mockUsersEnabled = true
     Rajapäivät.enableMock(rajapäivät)
     app.fixtureCreator.resetFixtures(app.fixtureCreator.valpasFixtureState)
+    FixtureState(app)
   }
 
-  def clearMockData(app: KoskiApplication): Unit = synchronized {
+  def clearMockData(app: KoskiApplication): FixtureState = synchronized {
     ValpasMockUsers.mockUsersEnabled = false
     Rajapäivät.disableMock()
     app.fixtureCreator.resetFixtures(app.fixtureCreator.koskiSpecificFixtureState)
+    FixtureState(app)
   }
 }
+
+object FixtureState {
+  def apply(application: KoskiApplication): FixtureState = FixtureState(
+    fixture = application.fixtureCreator.getCurrentFixtureStateName(),
+    rajapäivät = Rajapäivät.getCurrent()
+  )
+}
+
+case class FixtureState(
+  fixture: String,
+  rajapäivät: Rajapäivät
+)

--- a/src/main/scala/fi/oph/koski/valpas/repository/Rajapaivat.scala
+++ b/src/main/scala/fi/oph/koski/valpas/repository/Rajapaivat.scala
@@ -37,6 +37,8 @@ object Rajapäivät {
 
   def disableMock(): Unit = mockImplementation = default
 
+  def getCurrent(): Rajapäivät = mockImplementation
+
   def apply(allowMock: Boolean): () => Rajapäivät = {
     () => {
       if (allowMock) {

--- a/valpas-web/devserver/server.js
+++ b/valpas-web/devserver/server.js
@@ -75,7 +75,7 @@ function start(overrides) {
     backend: process.env.BACKEND_HOST || "http://localhost:7021",
     publicUrl: process.env.PUBLIC_URL || "",
     parcelOptions: {
-      cache: false,
+      cache: !!process.env.PARCEL_CACHE,
       watch: false,
       ...(overrides && overrides.parcelOptions),
     },

--- a/valpas-web/src/api/testApi.ts
+++ b/valpas-web/src/api/testApi.ts
@@ -1,10 +1,23 @@
+import { ISODate } from "../state/types"
 import { apiGet } from "./apiFetch"
 
-export const resetMockData = async () =>
-  apiGet<string>("valpas/test/reset-mock-data")
+export type FixtureState = {
+  fixture: string
+  rajapäivät: Rajapäivät
+}
+
+export type Rajapäivät = {
+  tarkasteluPäivä: ISODate
+}
+
+export const resetMockData = () =>
+  apiGet<FixtureState>("valpas/test/reset-mock-data")
 
 export const resetMockDataToDate = (tarkasteluPäivä: string) => () =>
-  apiGet<string>("valpas/test/reset-mock-data/" + tarkasteluPäivä)
+  apiGet<FixtureState>("valpas/test/reset-mock-data/" + tarkasteluPäivä)
 
-export const clearMockData = async () =>
-  apiGet<string>("valpas/test/clear-mock-data")
+export const clearMockData = () =>
+  apiGet<FixtureState>("valpas/test/clear-mock-data")
+
+export const getMockStatus = () =>
+  apiGet<FixtureState>("valpas/test/current-mock-status")

--- a/valpas-web/src/components/navigation/LocalRaamit.less
+++ b/valpas-web/src/components/navigation/LocalRaamit.less
@@ -129,4 +129,17 @@
       background: @color-blue-lighten-2;
     }
   }
+
+  .localraamit__fixture {
+    margin-left: 1rem;
+    padding: 0.2rem 0.5rem;
+    background: @color-white;
+    color: @color-blue;
+    border-radius: 3px;
+    font-size: 80%;
+
+    .localraamit__fixturevalue {
+      font-weight: 600;
+    }
+  }
 }

--- a/valpas-web/src/components/navigation/LocalRaamit.tsx
+++ b/valpas-web/src/components/navigation/LocalRaamit.tsx
@@ -129,7 +129,7 @@ export const SimpleTextField = (props: SimpleTextFieldProps) => (
   <input
     id={props.id}
     className={b("input")}
-    value={props.value}
+    value={props.value || ""}
     onChange={(event) => props.onChange(event.target.value)}
   />
 )

--- a/valpas-web/test/integrationtests-env/browser.ts
+++ b/valpas-web/test/integrationtests-env/browser.ts
@@ -103,6 +103,11 @@ export const setTextInput = async (selector: string, value: string) => {
   await attributeEventuallyEquals(selector, "value", value)
 }
 
+export const getTextInput = async (selector: string) => {
+  const element = await $(selector)
+  return element.getAttribute("value")
+}
+
 // https://stackoverflow.com/questions/53698075/how-to-clear-text-input
 export const clearTextInput = async (selector: string, timeout = 1000) =>
   // Pitää tehdä silmukassa, koska tämä ei aina toimi, välillä BACK_SPACE poistaa vain viimeisen merkin
@@ -159,9 +164,19 @@ export const reset = async (initialPath: string) => {
 }
 
 export const resetMockData = async (tarkasteluPäivä: string = "2019-09-05") => {
-  await setTextInput("#tarkasteluPäivä", tarkasteluPäivä)
-  await clickElement("#resetMockData")
-  await textEventuallyEquals("#resetMockDataState", "success", 15000)
+  const inputSelector = "#tarkasteluPäivä"
+
+  const currentTarkastelupäivä = await getTextInput(inputSelector)
+  const currentFixture = await (await $("#current-fixture")).getText()
+
+  if (
+    currentTarkastelupäivä !== tarkasteluPäivä ||
+    currentFixture !== "VALPAS"
+  ) {
+    await setTextInput(inputSelector, tarkasteluPäivä)
+    await clickElement("#resetMockData")
+    await textEventuallyEquals("#resetMockDataState", "success", 15000)
+  }
 }
 
 export const clearMockData = async () => {


### PR DESCRIPTION
Huom: Rebasettu tällä hetkellä tor-1268_virheenkäsittely päälle.

Muutos: Fikstuureja ei enää ladata, jos backendissa on jo Valpas-fikstuurit sisällä tai tarkastelupäivä ei ole muuttunut sitten viime testin. Tämä muutos ei ota huomioon sitä, että fikstuurin päälle on tehty muutoksia tilaan, mutta koska sellaisia apeja ei muutenkaan vielä ole, tämän ongelman ratkaisu on työnnetty tulevaisuuteen.

Mahdollisia ratkaisuja: 
* muutoksia tekevät testit itse alustavat fikstuurit takaisin alkutilaan (ongelma: jos unohtuu tehdä, muut testit hajoavat --> voi tulla turhaa selvittelytyötä)
* merkataan fikstuurin tila likaiseksi, kun kutsutaan tilaa muuttavaa apia (ongelma: testi- ja tuotantokoodi sekoittuvat keskenään)

Lisätty myös devserverille PARCEL_CACHE -ympäristömuuttuja, jonka avulla saa puristettua käännösajasta helposti 15-16 sekuntia pois. Oletuksena cache on siis pois päältä.