### PR TITLE
tor-1069: Valmistele laajuuden poisto pakollisista oppiaineista, joil…

### DIFF
--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -1,5 +1,6 @@
 import fi.oph.koski.cache.CacheServlet
 import fi.oph.koski.config.{KoskiApplication, RunMode}
+import fi.oph.koski.datamigration.RemovePakollistenOppiainedenLaajuusFromPerusopetus
 import fi.oph.koski.db._
 import fi.oph.koski.documentation.{DocumentationApiServlet, DocumentationServlet, KoodistoServlet}
 import fi.oph.koski.util.Timing
@@ -35,7 +36,7 @@ import fi.oph.koski.sure.SureServlet
 import fi.oph.koski.tiedonsiirto.TiedonsiirtoServlet
 import fi.oph.koski.tutkinto.TutkinnonPerusteetServlet
 import fi.oph.koski.util.Futures
-import fi.oph.koski.valpas.{ValpasRootApiServlet, ValpasBootstrapServlet, ValpasTestApiServlet}
+import fi.oph.koski.valpas.{ValpasBootstrapServlet, ValpasRootApiServlet, ValpasTestApiServlet}
 import fi.oph.koski.valpas.valpasuser.ValpasLogoutServlet
 import fi.oph.koski.valvira.ValviraServlet
 import fi.oph.koski.ytr.{YtrKoesuoritusApiServlet, YtrKoesuoritusServlet}
@@ -49,6 +50,7 @@ class ScalatraBootstrap extends LifeCycle with Logging with Timing with GlobalEx
     application.runMode match {
       case RunMode.NORMAL => initKoskiServices(context)
       case RunMode.GENERATE_RAPORTOINTIKANTA => generateRaportointikanta()
+      case RunMode.REMOVE_LAAJUUDET => RemovePakollistenOppiainedenLaajuusFromPerusopetus.migrate()
     }
   } catch {
     case e: Exception =>

--- a/src/main/scala/fi/oph/koski/config/RunMode.scala
+++ b/src/main/scala/fi/oph/koski/config/RunMode.scala
@@ -2,10 +2,13 @@ package fi.oph.koski.config
 
 object RunMode extends Enumeration {
   type RunMode = Value
-  val NORMAL, GENERATE_RAPORTOINTIKANTA = Value
+  val NORMAL, GENERATE_RAPORTOINTIKANTA, REMOVE_LAAJUUDET = Value
 
   def get: RunMode = sys.env.get("GENERATE_RAPORTOINTIKANTA") match {
     case Some(_) => GENERATE_RAPORTOINTIKANTA
-    case None => NORMAL
+    case None => sys.env.get("REMOVE_LAAJUUDET") match {
+      case Some(_) => REMOVE_LAAJUUDET
+      case None => NORMAL
+    }
   }
 }

--- a/src/main/scala/fi/oph/koski/datamigration/RemovePakollistenOppiainedenLaajuusFromPerusopetus.scala
+++ b/src/main/scala/fi/oph/koski/datamigration/RemovePakollistenOppiainedenLaajuusFromPerusopetus.scala
@@ -1,0 +1,68 @@
+package fi.oph.koski.datamigration
+
+import java.time.LocalDate
+
+import fi.oph.koski.config.KoskiApplication
+import fi.oph.koski.json.JsonDiff
+import fi.oph.koski.koskiuser.KoskiSpecificSession
+import fi.oph.koski.log.Logging
+import fi.oph.koski.schema._
+import rx.lang.scala.Observable
+
+
+object RemovePakollistenOppiainedenLaajuusFromPerusopetus extends Logging {
+  private val batchSize = 50
+  val user = KoskiSpecificSession.systemUser
+
+  def migrate()(implicit application: KoskiApplication) = {
+    logger.info("Remove laajuudet")
+    application.opiskeluoikeusQueryRepository
+      .mapKaikkiOpiskeluoikeudetSivuittain(batchSize, user) {
+        rows => rows.map {row =>
+          try {
+            row.toOpiskeluoikeus
+          } catch {
+            case _: Throwable =>
+          }
+        }
+      }
+      .flatMap {
+        case opiskeluoikeus: PerusopetuksenOpiskeluoikeus if opiskeluoikeus.lähdejärjestelmänId.isDefined =>
+          var changed = false
+          val setChanged = () => changed = true
+
+          val suoritukset = opiskeluoikeus.suoritukset.map {
+            case oppimäärä: NuortenPerusopetuksenOppimääränSuoritus if oppimäärä.vahvistus.exists(_.päivä.isBefore(LocalDate.of(2020, 8, 1))) =>
+              poistaLaajuusPakollisiltaOppiaineilta(oppimäärä)(setChanged)
+            case vuosiluokka: PerusopetuksenVuosiluokanSuoritus if vuosiluokka.vahvistus.exists(_.päivä.isBefore(LocalDate.of(2020, 8, 1))) =>
+              poistaLaajuusPakollisiltaOppiaineilta(vuosiluokka)(setChanged)
+            case suoritus => suoritus
+          }
+
+          if (changed) {
+            Observable.just(Update(original = opiskeluoikeus, updated = opiskeluoikeus.withSuoritukset(suoritukset)))
+          } else {
+            Observable.empty
+          }
+        case _ => Observable.empty
+      }
+     .map { case Update(original, updated) => JsonDiff.objectDiff(original, updated).toString }
+     .foreach(jsondiff => logger.info(jsondiff))
+  }
+
+  private def poistaLaajuusPakollisiltaOppiaineilta(suoritus: PerusopetuksenPäätasonSuoritus)(setChanged: () => Unit) = {
+    val osasuoritukset = suoritus.osasuoritukset.map(_.map {
+      case oppiaine: NuortenPerusopetuksenOppiaineenSuoritus if oppiaine.koulutusmoduuli.pakollinen && oppiaine.koulutusmoduuli.laajuus.isDefined => {
+        setChanged()
+        oppiaine.copy(koulutusmoduuli = oppiaine.koulutusmoduuli.withLaajuus(None))
+      }
+      case oppiaine => oppiaine
+    })
+    suoritus.withOsasuoritukset(osasuoritukset)
+  }
+}
+
+case class Update(
+  original: KoskeenTallennettavaOpiskeluoikeus,
+  updated: KoskeenTallennettavaOpiskeluoikeus
+)

--- a/src/main/scala/fi/oph/koski/schema/NuortenPerusopetus.scala
+++ b/src/main/scala/fi/oph/koski/schema/NuortenPerusopetus.scala
@@ -561,6 +561,12 @@ trait NuortenPerusopetuksenOppiainenTaiEiTiedossaOppiaine extends Koulutusmoduul
 trait NuortenPerusopetuksenOppiaine extends PerusopetuksenOppiaine with NuortenPerusopetuksenOppiainenTaiEiTiedossaOppiaine {
   @Tooltip("Oppiaineen laajuus vuosiviikkotunteina.")
   def laajuus: Option[LaajuusVuosiviikkotunneissa]
+
+
+  final def withLaajuus(laajuus: Option[Laajuus]) = {
+    import mojave._
+    shapeless.lens[NuortenPerusopetuksenOppiaine].field[Option[Laajuus]]("laajuus").set(this)(laajuus)
+  }
 }
 
 trait NuortenPerusopetuksenKoodistostaLöytyväOppiaine extends NuortenPerusopetuksenOppiaine with YleissivistavaOppiaine {


### PR DESCRIPTION
…la ei pitäisi olla laajuutta:

Ennen 1.8.2020 vahvistettujen nuorten perusopetusten päättötodistusten ja vuosiluokan suoritusten pakollisille oppiaineille on virheellisesti siirretty laajuus
Tarkoituksena on käydä kaikki tälläiset opiskeluoikeudet läpi, poistaa pakollisista oppiaineista laajuus ja päivittää opiskeluoikeus