### PR TITLE
TOR-1243 - VIRTA-lukukausimaksutiedot Koski-palveluun

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,12 @@
       <version>2.19.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.22.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <finalName>${finalName}</finalName>

--- a/src/main/resources/localization/koski-default-texts.json
+++ b/src/main/resources/localization/koski-default-texts.json
@@ -1540,5 +1540,6 @@
   "Apuraha" : "Apuraha",
   "Maksettu kokonaan" : "Maksettu kokonaan",
   "description:Korkeakoulun opiskeluoikeuden lukuvuosimaksut" : "Korkeakoulun opiskeluoikeuden lukuvuosimaksut",
-  "Maksettavat lukuvuosimaksut" : "Maksettavat lukuvuosimaksut"
+  "Maksettavat lukuvuosimaksut" : "Maksettavat lukuvuosimaksut",
+  "Virta nimi" : "Virta-datasta saatu nimi"
 }

--- a/src/main/resources/localization/koski-default-texts.json
+++ b/src/main/resources/localization/koski-default-texts.json
@@ -1534,5 +1534,11 @@
   "Kotoutumiskoulutuksen ohjaus" : "Kotoutumiskoulutuksen ohjaus",
   "Kuullun ymmärtämisen taitotaso" : "Kuullun ymmärtämisen taitotaso",
   "Työelämäjakso" : "Työelämäjakso",
-  "Työelämä- ja yhteiskuntataidot" : "Työelämä- ja yhteiskuntataidot"
+  "Työelämä- ja yhteiskuntataidot" : "Työelämä- ja yhteiskuntataidot",
+  "Lukuvuosimaksu" : "Lukuvuosimaksu",
+  "Summa" : "Summa",
+  "Apuraha" : "Apuraha",
+  "Maksettu kokonaan" : "Maksettu kokonaan",
+  "description:Korkeakoulun opiskeluoikeuden lukuvuosimaksut" : "Korkeakoulun opiskeluoikeuden lukuvuosimaksut",
+  "Maksettavat lukuvuosimaksut" : "Maksettavat lukuvuosimaksut"
 }

--- a/src/main/resources/mockdata/virta/opintotiedot/250668-293Y.xml
+++ b/src/main/resources/mockdata/virta/opintotiedot/250668-293Y.xml
@@ -35,6 +35,9 @@
                 <virta:AlkuPvm>2015-10-20</virta:AlkuPvm>
                 <virta:LoppuPvm>2016-04-12</virta:LoppuPvm>
                 <virta:Koulutuskunta>398</virta:Koulutuskunta>
+                <virta:Nimi kieli="fi">Tieto- ja viestintätekniikan tutkinto-ohjelma</virta:Nimi>
+                <virta:Nimi kieli="sv">Examensprogram inom informations- och kommunikationsteknik</virta:Nimi>
+                <virta:Nimi kieli="en">Information Technology Master's Programme</virta:Nimi>
               </virta:Jakso>
               <virta:Koulutusala versio="opmala">2</virta:Koulutusala>
               <virta:Laajuus>

--- a/src/main/resources/mockdata/virta/opintotiedot/250668-293Y.xml
+++ b/src/main/resources/mockdata/virta/opintotiedot/250668-293Y.xml
@@ -40,6 +40,11 @@
               <virta:Laajuus>
                 <virta:Opintopiste>0.000000</virta:Opintopiste>
               </virta:Laajuus>
+              <virta:LukuvuosiMaksu>
+                <virta:AlkuPvm>2015-10-20</virta:AlkuPvm>
+                <virta:LoppuPvm>2016-04-12</virta:LoppuPvm>
+                <virta:Summa>4000</virta:Summa>
+              </virta:LukuvuosiMaksu>
             </virta:Opiskeluoikeus>
           </virta:Opiskeluoikeudet>
           <virta:Opintosuoritukset>
@@ -3214,6 +3219,11 @@
               <virta:LoppuPvm>2008-12-31</virta:LoppuPvm>
               <virta:YlioppilaskuntaJasen>0</virta:YlioppilaskuntaJasen>
               <virta:YTHSMaksu>0</virta:YTHSMaksu>
+              <virta:LukuvuosiMaksu opiskeluoikeusAvain="888999">
+                <virta:Maksettu>1</virta:Maksettu>
+                <virta:Summa>2000</virta:Summa>
+                <virta:Apuraha>2000</virta:Apuraha>
+              </virta:LukuvuosiMaksu>
             </virta:LukukausiIlmoittautuminen>
           </virta:LukukausiIlmoittautumiset>
           <virta:Opintosuoritukset>

--- a/src/main/resources/mockdata/virta/opintotiedot/270191-4208.xml
+++ b/src/main/resources/mockdata/virta/opintotiedot/270191-4208.xml
@@ -23,9 +23,9 @@
                 <virta:Koulutuskunta>049</virta:Koulutuskunta>
                 <virta:Koulutuskieli>fi</virta:Koulutuskieli>
                 <virta:Rahoituslahde>1</virta:Rahoituslahde>
-                <virta:Nimi kieli="fi">Tieto- ja viestintätekniikan tutkinto-ohjelma</virta:Nimi>
-                <virta:Nimi kieli="sv">Examensprogram inom informations- och kommunikationsteknik</virta:Nimi>
-                <virta:Nimi kieli="en">Information Technology Master's Programme</virta:Nimi>
+                <virta:Nimi kieli="fi">Pelialan tutkinto-ohjelma</virta:Nimi>
+                <virta:Nimi kieli="sv">Examensprogram inom spelutveckling</virta:Nimi>
+                <virta:Nimi kieli="en">Game Development Master's Programme</virta:Nimi>
               </virta:Jakso>
               <virta:Koulutusala versio="ohjausala">7</virta:Koulutusala>
               <virta:Laajuus>

--- a/src/main/resources/mockdata/virta/opintotiedot/270191-4208.xml
+++ b/src/main/resources/mockdata/virta/opintotiedot/270191-4208.xml
@@ -28,6 +28,16 @@
               <virta:Laajuus>
                 <virta:Opintopiste>240</virta:Opintopiste>
               </virta:Laajuus>
+              <virta:LukuvuosiMaksu>
+                <virta:AlkuPvm>2015-08-20</virta:AlkuPvm>
+                <virta:LoppuPvm>2016-07-31</virta:LoppuPvm>
+                <virta:Summa>4000</virta:Summa>
+              </virta:LukuvuosiMaksu>
+              <virta:LukuvuosiMaksu>
+                <virta:AlkuPvm>2016-08-20</virta:AlkuPvm>
+                <virta:LoppuPvm>2017-07-31</virta:LoppuPvm>
+                <virta:Summa>5000</virta:Summa>
+              </virta:LukuvuosiMaksu>
             </virta:Opiskeluoikeus>
           </virta:Opiskeluoikeudet>
           <virta:LukukausiIlmoittautumiset>
@@ -37,6 +47,11 @@
               <virta:IlmoittautumisPvm>2015-08-20</virta:IlmoittautumisPvm>
               <virta:AlkuPvm>2015-08-01</virta:AlkuPvm>
               <virta:LoppuPvm>2015-12-31</virta:LoppuPvm>
+              <virta:LukuvuosiMaksu opiskeluoikeusAvain="888999">
+                <virta:Maksettu>1</virta:Maksettu>
+                <virta:Summa>2000</virta:Summa>
+                <virta:Apuraha>2000</virta:Apuraha>
+              </virta:LukuvuosiMaksu>
             </virta:LukukausiIlmoittautuminen>
             <virta:LukukausiIlmoittautuminen opiskelijaAvain="26604" opiskeluoikeusAvain="30759">
               <virta:Myontaja>02629</virta:Myontaja>
@@ -44,6 +59,11 @@
               <virta:IlmoittautumisPvm>2016-01-01</virta:IlmoittautumisPvm>
               <virta:AlkuPvm>2016-01-01</virta:AlkuPvm>
               <virta:LoppuPvm>2016-07-31</virta:LoppuPvm>
+              <virta:LukuvuosiMaksu opiskeluoikeusAvain="888999">
+                <virta:Maksettu>0</virta:Maksettu>
+                <virta:Summa>2000</virta:Summa>
+                <virta:Apuraha>3000</virta:Apuraha>
+              </virta:LukuvuosiMaksu>
             </virta:LukukausiIlmoittautuminen>
             <virta:LukukausiIlmoittautuminen opiskelijaAvain="26604" opiskeluoikeusAvain="30759">
               <virta:Myontaja>02629</virta:Myontaja>

--- a/src/main/resources/mockdata/virta/opintotiedot/270191-4208.xml
+++ b/src/main/resources/mockdata/virta/opintotiedot/270191-4208.xml
@@ -23,6 +23,9 @@
                 <virta:Koulutuskunta>049</virta:Koulutuskunta>
                 <virta:Koulutuskieli>fi</virta:Koulutuskieli>
                 <virta:Rahoituslahde>1</virta:Rahoituslahde>
+                <virta:Nimi kieli="fi">Tieto- ja viestintätekniikan tutkinto-ohjelma</virta:Nimi>
+                <virta:Nimi kieli="sv">Examensprogram inom informations- och kommunikationsteknik</virta:Nimi>
+                <virta:Nimi kieli="en">Information Technology Master's Programme</virta:Nimi>
               </virta:Jakso>
               <virta:Koulutusala versio="ohjausala">7</virta:Koulutusala>
               <virta:Laajuus>

--- a/src/main/scala/fi/oph/koski/omattiedot/OmatTiedotEditorModel.scala
+++ b/src/main/scala/fi/oph/koski/omattiedot/OmatTiedotEditorModel.scala
@@ -77,16 +77,13 @@ object OmatTiedotEditorModel extends Timing {
   private def piilotaLukuvuosimaksutiedot(oppija: Oppija)(implicit koskiSession: KoskiSpecificSession) = {
     val korjatutOpiskeluoikeudet = oppija.opiskeluoikeudet.map {
       case oo: KorkeakoulunOpiskeluoikeus if oo.lisätiedot.nonEmpty => {
-        val korjatutLukukausiIlmottautuminen = oo.lisätiedot.get.lukukausiIlmoittautuminen match {
-          case Some(ilmo) => {
-            Some(ilmo.copy(
-              ilmoittautumisjaksot = ilmo.ilmoittautumisjaksot.map(_.copy(
-                maksetutLukuvuosimaksut = None
-              ))
+        val korjatutLukukausiIlmottautuminen = oo.lisätiedot.get.lukukausiIlmoittautuminen.flatMap(ilmo =>
+          Some(ilmo.copy(
+            ilmoittautumisjaksot = ilmo.ilmoittautumisjaksot.map(_.copy(
+              maksetutLukuvuosimaksut = None
             ))
-          }
-          case None => None
-        }
+          ))
+        )
 
         val korjatutLisätiedot = oo.lisätiedot.get.copy(
           maksettavatLukuvuosimaksut = None,

--- a/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
+++ b/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
@@ -1,9 +1,8 @@
 package fi.oph.koski.schema
 
 import java.time.LocalDate
-
 import fi.oph.koski.schema.annotation._
-import fi.oph.scalaschema.annotation.{Description, Title}
+import fi.oph.scalaschema.annotation.{Description, Discriminator, Title}
 
 case class KorkeakoulunOpiskeluoikeus(
   oid: Option[String] = None,
@@ -48,11 +47,20 @@ case class KorkeakoulunOpiskeluoikeudenLisätiedot(
   @Title("Korkeakoulun opiskeluoikeuden tyyppi")
   @KoodistoUri("virtaopiskeluoikeudentyyppi")
   virtaOpiskeluoikeudenTyyppi: Option[Koodistokoodiviite],
+  @Title("Maksettavat lukuvuosimaksut")
+  maksettavatLukuvuosimaksut: List[KorkeakoulunOpiskeluoikeudenLukuvuosimaksu],
   lukukausiIlmoittautuminen: Option[Lukukausi_Ilmoittautuminen] = None,
   järjestäväOrganisaatio: Option[Oppilaitos] = None
 ) extends OpiskeluoikeudenLisätiedot {
   def ensisijaisuusVoimassa(d: LocalDate): Boolean = ensisijaisuus.exists(_.exists((j: Aikajakso) => j.contains(d)))
 }
+
+@Description("Korkeakoulun opiskeluoikeuden lukuvuosimaksut")
+case class KorkeakoulunOpiskeluoikeudenLukuvuosimaksu(
+  alku: LocalDate,
+  loppu: Option[LocalDate],
+  summa: Option[Int]
+) extends Jakso
 
 trait KorkeakouluSuoritus extends PäätasonSuoritus with MahdollisestiSuorituskielellinen with Toimipisteellinen {
   def toimipiste: Oppilaitos
@@ -167,5 +175,14 @@ case class Lukukausi_Ilmoittautumisjakso(
   @KoodistoUri("virtalukukausiilmtila")
   tila: Koodistokoodiviite,
   ylioppilaskunnanJäsen: Option[Boolean] = None,
-  ythsMaksettu: Option[Boolean] = None
+  ythsMaksettu: Option[Boolean] = None,
+  @Title("Lukuvuosimaksu")
+  maksetutLukuvuosimaksut: Option[Lukuvuosi_IlmottautumisjaksonLukuvuosiMaksu] = None
 ) extends Jakso
+
+case class Lukuvuosi_IlmottautumisjaksonLukuvuosiMaksu(
+  @Title("Maksettu kokonaan")
+  maksettu: Option[Boolean] = None,
+  summa: Option[Int] = None,
+  apuraha: Option[Int] = None
+)

--- a/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
+++ b/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
@@ -140,6 +140,7 @@ case class KorkeakoulunOpiskeluoikeudenTila(
 
 case class KorkeakoulunOpiskeluoikeusjakso(
   alku: LocalDate,
+  nimi: Option[LocalizedString],
   @KoodistoUri("virtaopiskeluoikeudentila")
   tila: Koodistokoodiviite
 ) extends Opiskeluoikeusjakso {

--- a/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
+++ b/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
@@ -48,7 +48,7 @@ case class KorkeakoulunOpiskeluoikeudenLisätiedot(
   @KoodistoUri("virtaopiskeluoikeudentyyppi")
   virtaOpiskeluoikeudenTyyppi: Option[Koodistokoodiviite],
   @Title("Maksettavat lukuvuosimaksut")
-  maksettavatLukuvuosimaksut: List[KorkeakoulunOpiskeluoikeudenLukuvuosimaksu],
+  maksettavatLukuvuosimaksut: Option[List[KorkeakoulunOpiskeluoikeudenLukuvuosimaksu]] = None,
   lukukausiIlmoittautuminen: Option[Lukukausi_Ilmoittautuminen] = None,
   järjestäväOrganisaatio: Option[Oppilaitos] = None
 ) extends OpiskeluoikeudenLisätiedot {

--- a/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
+++ b/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
@@ -1,5 +1,7 @@
 package fi.oph.koski.schema
 
+import fi.oph.koski.schema.LocalizedString.unlocalized
+
 import java.time.LocalDate
 import fi.oph.koski.schema.annotation._
 import fi.oph.scalaschema.annotation.{Description, Discriminator, Title}
@@ -115,8 +117,11 @@ case class MuuKorkeakoulunSuoritus (
 @Description("Korkeakoulututkinnon tunnistetiedot")
 case class Korkeakoulututkinto(
   tunniste: Koodistokoodiviite,
-  koulutustyyppi: Option[Koodistokoodiviite] = None
-) extends Koulutus with Tutkinto with Laajuudeton
+  koulutustyyppi: Option[Koodistokoodiviite] = None,
+  virtaNimi: Option[LocalizedString]
+) extends Koulutus with Tutkinto with Laajuudeton {
+  override def nimi: LocalizedString = virtaNimi.getOrElse(tunniste.nimi.getOrElse(unlocalized(tunniste.koodiarvo)))
+}
 
 @Description("Korkeakoulun opintojakson tunnistetiedot")
 case class KorkeakoulunOpintojakso(
@@ -178,10 +183,10 @@ case class Lukukausi_Ilmoittautumisjakso(
   ylioppilaskunnanJäsen: Option[Boolean] = None,
   ythsMaksettu: Option[Boolean] = None,
   @Title("Lukuvuosimaksu")
-  maksetutLukuvuosimaksut: Option[Lukuvuosi_IlmottautumisjaksonLukuvuosiMaksu] = None
+  maksetutLukuvuosimaksut: Option[Lukuvuosi_IlmoittautumisjaksonLukuvuosiMaksu] = None
 ) extends Jakso
 
-case class Lukuvuosi_IlmottautumisjaksonLukuvuosiMaksu(
+case class Lukuvuosi_IlmoittautumisjaksonLukuvuosiMaksu(
   @Title("Maksettu kokonaan")
   maksettu: Option[Boolean] = None,
   summa: Option[Int] = None,

--- a/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
+++ b/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
@@ -48,7 +48,7 @@ case class KorkeakoulunOpiskeluoikeudenLisätiedot(
   @KoodistoUri("virtaopiskeluoikeudentyyppi")
   virtaOpiskeluoikeudenTyyppi: Option[Koodistokoodiviite],
   @Title("Maksettavat lukuvuosimaksut")
-  maksettavatLukuvuosimaksut: Option[List[KorkeakoulunOpiskeluoikeudenLukuvuosimaksu]] = None,
+  maksettavatLukuvuosimaksut: Option[Seq[KorkeakoulunOpiskeluoikeudenLukuvuosimaksu]] = None,
   lukukausiIlmoittautuminen: Option[Lukukausi_Ilmoittautuminen] = None,
   järjestäväOrganisaatio: Option[Oppilaitos] = None
 ) extends OpiskeluoikeudenLisätiedot {

--- a/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
+++ b/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
@@ -58,7 +58,7 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
           virtaOpiskeluoikeudenTyyppi = Some(opiskeluoikeudenTyyppi(opiskeluoikeusNode)),
           lukukausiIlmoittautuminen = lukukausiIlmoittautuminen(oppilaitos, opiskeluoikeudenTila, avain(opiskeluoikeusNode), virtaXml),
           järjestäväOrganisaatio = järjestäväOrganisaatio(opiskeluoikeusNode, vahvistus.map(_.päivä)),
-          maksettavatLukuvuosimaksut = lukuvuosimaksut
+          maksettavatLukuvuosimaksut = Some(lukuvuosimaksut)
         ))
       )
 

--- a/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
+++ b/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
@@ -34,7 +34,7 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
 
       val opiskeluoikeudenTila: KorkeakoulunOpiskeluoikeudenTila = KorkeakoulunOpiskeluoikeudenTila((opiskeluoikeusNode \ "Tila")
         .sortBy(alkuPvm)
-        .map(tila => KorkeakoulunOpiskeluoikeusjakso(alkuPvm(tila), requiredKoodi("virtaopiskeluoikeudentila", tila \ "Koodi" text)))
+        .map(tila => KorkeakoulunOpiskeluoikeusjakso(alkuPvm(tila), jaksonNimi(opiskeluoikeusNode), requiredKoodi("virtaopiskeluoikeudentila", tila \ "Koodi" text)))
         .toList)
 
       val lukuvuosimaksut: List[KorkeakoulunOpiskeluoikeudenLukuvuosimaksu] = (opiskeluoikeusNode \ "LukuvuosiMaksu").map(lukuvuosiMaksuTiedot).toList
@@ -429,6 +429,11 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
 
   private def nimi(suoritus: Node): LocalizedString = {
     sanitize((suoritus \ "Nimi" map { nimi => (nimi \ "@kieli").text -> nimi.text }).toMap).getOrElse(finnish("Suoritus: " + avain(suoritus)))
+  }
+
+  private def jaksonNimi(opiskeluoikeusNode: Node): Option[LocalizedString] = {
+    val jakso = opiskeluoikeusNode \ "Jakso"
+    sanitize((jakso \ "Nimi" map { nimi => (nimi \ "@kieli").text -> nimi.text }).toMap)
   }
 
   private def oppilaitos(node: Node, vahvistusPäivä: Option[LocalDate]): Oppilaitos =

--- a/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
+++ b/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
@@ -292,7 +292,7 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
     maksetutLukuvuosimaksut = (n \ "LukuvuosiMaksu").headOption.map(lukukausiIlmoLukuvuosiMaksu)
   )
 
-  private def lukukausiIlmoLukuvuosiMaksu(n: Node) = Lukuvuosi_IlmottautumisjaksonLukuvuosiMaksu(
+  private def lukukausiIlmoLukuvuosiMaksu(n: Node) = Lukuvuosi_IlmoittautumisjaksonLukuvuosiMaksu(
     maksettu = (n \ "Maksettu").headOption.map(toBoolean),
     summa = (n \ "Summa").headOption.map(_.text.toInt),
     apuraha = (n \ "Apuraha").headOption.map(_.text.toInt)
@@ -428,12 +428,7 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
   }
 
   private def tutkinto(koulutuskoodi: String, nimi: Option[LocalizedString] = None): Korkeakoulututkinto = {
-    nimi match {
-      case Some(nimi) => Korkeakoulututkinto(requiredKoodi("koulutus", koulutuskoodi).copy(
-        nimi = Some(nimi)
-      ))
-      case _ => Korkeakoulututkinto(requiredKoodi("koulutus", koulutuskoodi))
-    }
+    Korkeakoulututkinto(requiredKoodi("koulutus", koulutuskoodi), virtaNimi = nimi)
   }
 
   private def nimi(node: Node): Option[LocalizedString] = {

--- a/src/test/scala/fi/oph/koski/api/KorkeakouluSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/KorkeakouluSpec.scala
@@ -52,6 +52,12 @@ class KorkeakouluSpec extends FreeSpec with Matchers with OpiskeluoikeusTestMeth
 
         opiskeluoikeus.tila.opiskeluoikeusjaksot.head.nimi.get.values.values.toList should equal (List("Tieto- ja viestintätekniikan tutkinto-ohjelma", "Examensprogram inom informations- och kommunikationsteknik", "Information Technology Master's Programme"))
       }
+
+      "Jos Virran Jakso-tietorakenteessa on määritelty nimi, sitä käytetään myös tutkinnon nimenä" in {
+        val opiskeluoikeus = opiskeluoikeudet("250668-293Y", "02470").head
+
+        opiskeluoikeus.suoritukset.head.koulutusmoduuli.nimi should equal (Finnish("Tieto- ja viestintätekniikan tutkinto-ohjelma",Some("Examensprogram inom informations- och kommunikationsteknik"),Some("Information Technology Master's Programme")))
+      }
     }
 
     "Maksettavat lukuvuosimaksutiedot" - {

--- a/src/test/scala/fi/oph/koski/api/KorkeakouluSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/KorkeakouluSpec.scala
@@ -48,6 +48,17 @@ class KorkeakouluSpec extends FreeSpec with Matchers with OpiskeluoikeusTestMeth
       }
     }
 
+    "Maksettavat lukuvuosimaksutiedot" - {
+      "Koski näyttää maksutiedot" in {
+        val opiskeluoikeus = opiskeluoikeudet("250668-293Y", "02470").head
+
+        val maksettavatLukuvuosimaksut = opiskeluoikeus.lisätiedot.get.maksettavatLukuvuosimaksut.head
+        maksettavatLukuvuosimaksut.alku.toString should equal("2015-10-20")
+        maksettavatLukuvuosimaksut.loppu.get.toString should equal("2016-04-12")
+        maksettavatLukuvuosimaksut.summa.get should equal (4000)
+      }
+    }
+
     "Haettaessa" - {
       "Konvertoidaan Virta-järjestelmän opiskeluoikeus" in {
         val oikeudet = getOpiskeluoikeudet(KoskiSpecificMockOppijat.dippainssi.oid)
@@ -97,6 +108,13 @@ class KorkeakouluSpec extends FreeSpec with Matchers with OpiskeluoikeusTestMeth
             .get
 
           opiskeluoikeus.lisätiedot.get.lukukausiIlmoittautuminen should equal(None)
+        }
+
+        "Lukuvuosimaksutiedot löytyvät" in {
+          val opiskeluoikeus = opiskeluoikeudet("250668-293Y", "10076").head
+
+          val maksutiedot = opiskeluoikeus.lisätiedot.get.lukukausiIlmoittautuminen.get.ilmoittautumisjaksot.map(_.maksetutLukuvuosimaksut.getOrElse("").toString)
+          maksutiedot should equal(List("Lukuvuosi_IlmottautumisjaksonLukuvuosiMaksu(Some(true),Some(2000),Some(2000))", "", "", "", "", ""))
         }
       }
 

--- a/src/test/scala/fi/oph/koski/api/KorkeakouluSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/KorkeakouluSpec.scala
@@ -126,7 +126,7 @@ class KorkeakouluSpec extends FreeSpec with Matchers with OpiskeluoikeusTestMeth
           val opiskeluoikeus = opiskeluoikeudet("250668-293Y", "10076").head
 
           val maksutiedot = opiskeluoikeus.lisätiedot.get.lukukausiIlmoittautuminen.get.ilmoittautumisjaksot.map(_.maksetutLukuvuosimaksut.getOrElse("").toString)
-          maksutiedot should equal(List("Lukuvuosi_IlmottautumisjaksonLukuvuosiMaksu(Some(true),Some(2000),Some(2000))", "", "", "", "", ""))
+          maksutiedot should equal(List("Lukuvuosi_IlmoittautumisjaksonLukuvuosiMaksu(Some(true),Some(2000),Some(2000))", "", "", "", "", ""))
         }
       }
 

--- a/src/test/scala/fi/oph/koski/api/KorkeakouluSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/KorkeakouluSpec.scala
@@ -46,6 +46,12 @@ class KorkeakouluSpec extends FreeSpec with Matchers with OpiskeluoikeusTestMeth
           opiskeluoikeus.suoritukset.head.koulutusmoduuli.nimi.get("fi") should equal("Fil. maist., fysiikka")
         }
       }
+
+      "Opiskeluoikeusjaksoilta voi löytyä tarkentava nimi" in {
+        val opiskeluoikeus = opiskeluoikeudet("250668-293Y", "02470").head
+
+        opiskeluoikeus.tila.opiskeluoikeusjaksot.head.nimi.get.values.values.toList should equal (List("Tieto- ja viestintätekniikan tutkinto-ohjelma", "Examensprogram inom informations- och kommunikationsteknik", "Information Technology Master's Programme"))
+      }
     }
 
     "Maksettavat lukuvuosimaksutiedot" - {

--- a/src/test/scala/fi/oph/koski/api/KorkeakouluSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/KorkeakouluSpec.scala
@@ -58,7 +58,7 @@ class KorkeakouluSpec extends FreeSpec with Matchers with OpiskeluoikeusTestMeth
       "Koski näyttää maksutiedot" in {
         val opiskeluoikeus = opiskeluoikeudet("250668-293Y", "02470").head
 
-        val maksettavatLukuvuosimaksut = opiskeluoikeus.lisätiedot.get.maksettavatLukuvuosimaksut.head
+        val maksettavatLukuvuosimaksut = opiskeluoikeus.lisätiedot.get.maksettavatLukuvuosimaksut.get.head
         maksettavatLukuvuosimaksut.alku.toString should equal("2015-10-20")
         maksettavatLukuvuosimaksut.loppu.get.toString should equal("2016-04-12")
         maksettavatLukuvuosimaksut.summa.get should equal (4000)

--- a/src/test/scala/fi/oph/koski/api/OpiskeluoikeusTestMethodsKorkeakoulu.scala
+++ b/src/test/scala/fi/oph/koski/api/OpiskeluoikeusTestMethodsKorkeakoulu.scala
@@ -15,7 +15,7 @@ trait OpiskeluoikeusTestMethodsKorkeakoulu extends PutOpiskeluoikeusTestMethods[
     suoritukset = Nil,
     tila = KorkeakoulunOpiskeluoikeudenTila(
       List(
-        KorkeakoulunOpiskeluoikeusjakso(date(2012, 9, 1), KorkeakouluTestdata.opiskeluoikeusAktiivinen)
+        KorkeakoulunOpiskeluoikeusjakso(date(2012, 9, 1), nimi = Some(LocalizedString.missing), KorkeakouluTestdata.opiskeluoikeusAktiivinen)
       )
     ),
     tyyppi = koodisto.validateRequired(OpiskeluoikeudenTyyppi.korkeakoulutus)

--- a/src/test/scala/fi/oph/koski/api/SuoritusjakoSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/SuoritusjakoSpec.scala
@@ -7,7 +7,7 @@ import fi.oph.koski.henkilo.KoskiSpecificMockOppijat
 import fi.oph.koski.http.{ErrorMatcher, KoskiErrorCategory}
 import fi.oph.koski.json.JsonSerializer
 import fi.oph.koski.log.{AccessLogTester, AuditLogTester}
-import fi.oph.koski.schema.{KorkeakoulunOpiskeluoikeudenLukuvuosimaksu, Lukuvuosi_IlmottautumisjaksonLukuvuosiMaksu, PerusopetuksenVuosiluokanSuoritus, TäydellisetHenkilötiedot, YlioppilastutkinnonOpiskeluoikeus}
+import fi.oph.koski.schema.{KorkeakoulunOpiskeluoikeudenLukuvuosimaksu, Lukuvuosi_IlmoittautumisjaksonLukuvuosiMaksu, PerusopetuksenVuosiluokanSuoritus, TäydellisetHenkilötiedot, YlioppilastutkinnonOpiskeluoikeus}
 import fi.oph.koski.suoritusjako.{SuoritusIdentifier, Suoritusjako}
 import org.scalatest.{FreeSpec, Matchers}
 
@@ -337,7 +337,7 @@ class SuoritusjakoSpec extends FreeSpec with SuoritusjakoTestMethods with Matche
       getSuoritusjako(secret) {
         val bodyString = new String(response.bodyBytes, StandardCharsets.UTF_8)
 
-        bodyString should not include(Lukuvuosi_IlmottautumisjaksonLukuvuosiMaksu.toString.toLowerCase)
+        bodyString should not include(Lukuvuosi_IlmoittautumisjaksonLukuvuosiMaksu.toString.toLowerCase)
         bodyString should not include(KorkeakoulunOpiskeluoikeudenLukuvuosimaksu.toString.toLowerCase)
       }
     }

--- a/src/test/scala/fi/oph/koski/virta/VirtaXMLConverterSpec.scala
+++ b/src/test/scala/fi/oph/koski/virta/VirtaXMLConverterSpec.scala
@@ -14,7 +14,7 @@ import scala.xml.Elem
 class VirtaXMLConverterSpec extends FreeSpec with Matchers with OptionValues {
 
   val converter = VirtaXMLConverter(MockOppilaitosRepository, MockKoodistoViitePalvelu, MockOrganisaatioRepository)
-  private def convertSuoritus(suoritus: Elem) = converter.convertSuoritus(suoritus, List(suoritus))
+  private def convertSuoritus(suoritus: Elem) = converter.convertSuoritus(None, suoritus, List(suoritus))
 
   def baseSuoritus: Elem = suoritusWithOrganisaatio(None)
   def suoritusWithOrganisaatio(organisaatio: Option[Elem]): Elem = <virta:Opintosuoritus valtakunnallinenKoulutusmoduulitunniste="" opiskeluoikeusAvain="1114082125" opiskelijaAvain="1114082124" koulutusmoduulitunniste="Kul-49.3400" avain="1114935190">

--- a/web/app/suoritus/Koulutusmoduuli.js
+++ b/web/app/suoritus/Koulutusmoduuli.js
@@ -17,4 +17,5 @@ export const koulutusModuuliprototypes = (suoritus) => oneOfPrototypes(modelLook
 export const isIBKurssi = (m) => m && m.value.classes.includes('ibkurssi')
 export const isLukio2019ModuuliTaiOpintojakso = (m) => m && m.value.classes.includes('lukionmoduulitaipaikallinenopintojakso2019')
 export const isLukio2019Oppiaine = m => m.value.classes.includes('lukionoppiaine2019')
-export const tutkinnonNimi = m => modelData(m, 'perusteenNimi') ? modelLookup(m, 'perusteenNimi') : modelLookup(m, 'tunniste')
+export const tutkinnonNimi = m => modelData(m, 'virtaNimi') ? modelLookup(m, 'virtaNimi') :
+  modelData(m, 'perusteenNimi') ? modelLookup(m, 'perusteenNimi') : modelLookup(m, 'tunniste')

--- a/web/app/suoritus/Suoritus.js
+++ b/web/app/suoritus/Suoritus.js
@@ -54,7 +54,7 @@ export const rekursiivisetOsasuoritukset = (suoritus) => flatMapArray(osasuoritu
 export const suorituksenTyyppi = suoritus => suoritus && modelData(suoritus, 'tyyppi').koodiarvo
 
 export const suoritusTitle = (suoritus) => {
-  let title = modelTitle(tutkinnonNimi(modelLookup(suoritus, 'koulutusmoduuli')))
+  const title = modelTitle(tutkinnonNimi(modelLookup(suoritus, 'koulutusmoduuli')))
   switch(suorituksenTyyppi(suoritus)) {
     case 'ammatillinentutkintoosittainen': return title + t(', osittainen')
     case 'lukionaineopinnot':
@@ -64,9 +64,9 @@ export const suoritusTitle = (suoritus) => {
 }
 
 export const newSuoritusProto = (opiskeluoikeus, prototypeKey) => {
-  let suoritukset = modelLookup(opiskeluoikeus, 'suoritukset')
-  let indexForNewItem = modelItems(suoritukset).length
-  let selectedProto = contextualizeSubModel(suoritukset.arrayPrototype, suoritukset, indexForNewItem).oneOfPrototypes.find(p => p.key === prototypeKey)
+  const suoritukset = modelLookup(opiskeluoikeus, 'suoritukset')
+  const indexForNewItem = modelItems(suoritukset).length
+  const selectedProto = contextualizeSubModel(suoritukset.arrayPrototype, suoritukset, indexForNewItem).oneOfPrototypes.find(p => p.key === prototypeKey)
   return contextualizeSubModel(selectedProto, suoritukset, indexForNewItem)
 }
 


### PR DESCRIPTION
VIRTA-lukukausimaksutietoja lisätty kahdelle oppijalle Virta-mockdatoihin.

VIRTA-datasta poimitaan lukukausimaksutiedot, tulevat opiskeluoikeuden lisätietojen alle.