### PR TITLE
Valpas UI-korjauksia

### DIFF
--- a/src/main/resources/valpas/localization/valpas-default-texts.json
+++ b/src/main/resources/valpas/localization/valpas-default-texts.json
@@ -25,6 +25,7 @@
   "hakutilanne__taulu_voimassaolevia_opiskeluoikeuksia": "Voimassaolevia opiskeluoikeuksia",
   "hakutilanne__taulu_data_ei_toteutettu": "Ei toteutettu",
   "hakemuksentila__hakenut": "Hakenut",
+  "hakemuksentila__n_hakua": "hakua",
   "hakemuksentila__ei_hakemusta": "Ei hakemusta",
   "valintatieto__ei_opiskelupaikkaa": "Ei opiskelupaikkaa",
   "valintatieto__varasija": "Varasija",

--- a/src/main/resources/valpas/localization/valpas-default-texts.json
+++ b/src/main/resources/valpas/localization/valpas-default-texts.json
@@ -25,7 +25,7 @@
   "hakutilanne__taulu_voimassaolevia_opiskeluoikeuksia": "Voimassaolevia opiskeluoikeuksia",
   "hakutilanne__taulu_data_ei_toteutettu": "Ei toteutettu",
   "hakemuksentila__hakenut": "Hakenut",
-  "hakemuksentila__n_hakua": "hakua",
+  "hakemuksentila__n_hakua": "{{lukumäärä}} hakua",
   "hakemuksentila__ei_hakemusta": "Ei hakemusta",
   "valintatieto__ei_opiskelupaikkaa": "Ei opiskelupaikkaa",
   "valintatieto__varasija": "Varasija",

--- a/src/main/scala/fi/oph/koski/valpas/fixture/ValpasDatabaseFixtureCreator.scala
+++ b/src/main/scala/fi/oph/koski/valpas/fixture/ValpasDatabaseFixtureCreator.scala
@@ -60,6 +60,7 @@ class ValpasDatabaseFixtureCreator(application: KoskiApplication) extends Databa
     (ValpasMockOppijat.oppivelvollinenAloittanutJaEronnutTarkastelupäivänJälkeen, ValpasExampleData.oppivelvollinenAloittanutJaEronnutTarkastelupäivänJälkeenOpiskeluoikeus),
     (ValpasMockOppijat.useampiYsiluokkaSamassaKoulussa, ValpasExampleData.valmistunutYsiluokkalainen),
     (ValpasMockOppijat.useampiYsiluokkaSamassaKoulussa, ValpasExampleData.kesäYsiluokkaKesken), // Tämä on vähän huono esimerkki, mutta varmistelee sitä, että homma toimii myös sitten, kun aletaan tukea nivelvaihetta, jossa nämä tapaukset voivat olla yleisempiä
-    (ValpasMockOppijat.turvakieltoOppija, ValpasExampleData.oppivelvollinenYsiluokkaKeskenKeväällä2021Opiskeluoikeus)
+    (ValpasMockOppijat.turvakieltoOppija, ValpasExampleData.oppivelvollinenYsiluokkaKeskenKeväällä2021Opiskeluoikeus),
+    (ValpasMockOppijat.hakukohteidenHakuEpäonnistuu, ValpasExampleData.oppivelvollinenYsiluokkaKeskenKeväällä2021Opiskeluoikeus),
   )
 }

--- a/src/main/scala/fi/oph/koski/valpas/hakukooste/HakukoosteExampleData.scala
+++ b/src/main/scala/fi/oph/koski/valpas/hakukooste/HakukoosteExampleData.scala
@@ -60,14 +60,24 @@ object HakukoosteExampleData {
       ))),
     haku(
       ValpasMockOppijat.luokalleJäänytYsiluokkalainen,
-      Vector(Vector(
-        hakutoive(
-          hakukohdeOid = generateOid(),
-          hakukohdeOrganisaatio = "",
-          hakukohdeNimi = "Lukio",
-          koulutusNimi = "Lukiokoulutus"
+      Vector(
+        Vector(
+          hakutoive(
+            hakukohdeOid = generateOid(),
+            hakukohdeOrganisaatio = MockOrganisaatiot.helsinginMedialukio,
+            hakukohdeNimi = "Lukio",
+            koulutusNimi = "Lukiokoulutus"
+          ),
         ),
-      ))),
+        Vector(
+          hakutoive(
+            hakukohdeOid = generateOid(),
+            hakukohdeOrganisaatio = MockOrganisaatiot.varsinaisSuomenKansanopisto,
+            hakukohdeNimi = "Vapaan sivistystyön koulutus oppivelvollisille 2021-2022",
+            koulutusNimi = "Vapaan sivistystyön koulutus oppivelvollisille"
+          ),
+        )
+      )),
   ).flatten
 
   def haku(

--- a/src/main/scala/fi/oph/koski/valpas/hakukooste/HakukoosteExampleData.scala
+++ b/src/main/scala/fi/oph/koski/valpas/hakukooste/HakukoosteExampleData.scala
@@ -13,10 +13,10 @@ object HakukoosteExampleData {
     def toBlankable: BlankableLocalizedString = maybe.getOrElse(BlankLocalizedString())
   }
 
-  lazy val data = List(
+  lazy val data: Seq[Hakukooste] = Vector(
     haku(
       ValpasMockOppijat.oppivelvollinenYsiluokkaKeskenKeväällä2021,
-      List(
+      Vector(Vector(
         hakutoive(
           hakukohdeOid = generateOid(),
           hakukohdeOrganisaatio = MockOrganisaatiot.ressunLukio,
@@ -47,34 +47,34 @@ object HakukoosteExampleData {
           hakukohdeNimi = "Vapaan sivistystyön koulutus oppivelvollisille 2021-2022",
           koulutusNimi = "Vapaan sivistystyön koulutus oppivelvollisille"
         ),
-      )),
+      ))),
     haku(
       ValpasMockOppijat.turvakieltoOppija,
-      List(
+      Vector(Vector(
         hakutoive(
           hakukohdeOid = generateOid(),
           hakukohdeOrganisaatio = MockOrganisaatiot.ressunLukio,
           hakukohdeNimi = "Lukio",
           koulutusNimi = "Lukiokoulutus"
         ).copy(alinValintaPistemaara = Some(9.01), pisteet = Some(9)),
-      )),
+      ))),
     haku(
       ValpasMockOppijat.luokalleJäänytYsiluokkalainen,
-      List(
+      Vector(Vector(
         hakutoive(
           hakukohdeOid = generateOid(),
           hakukohdeOrganisaatio = "",
           hakukohdeNimi = "Lukio",
           koulutusNimi = "Lukiokoulutus"
         ),
-      )),
-  )
+      ))),
+  ).flatten
 
   def haku(
     henkilö: OppijaHenkilö,
-    hakutoiveet: Seq[Hakutoive],
+    hakukoosteidenToiveet: Seq[Seq[Hakutoive]],
     alkamisaika: LocalDateTime = LocalDateTime.of(2020, 3, 9, 12, 0, 0),
-  ): Hakukooste =
+  ): Seq[Hakukooste] = hakukoosteidenToiveet.map(hakutoiveet =>
     Hakukooste(
       oppijaOid = henkilö.oid,
       hakuOid = generateHakuOid(),
@@ -105,6 +105,7 @@ object HakukoosteExampleData {
         }
       ))
     )
+  )
 
   def hakutoive(
     hakukohdeOid: String,

--- a/src/main/scala/fi/oph/koski/valpas/hakukooste/MockHakukoosteService.scala
+++ b/src/main/scala/fi/oph/koski/valpas/hakukooste/MockHakukoosteService.scala
@@ -10,7 +10,7 @@ class MockHakukoosteService extends ValpasHakukoosteService {
   // Näillä oideilla kutsuminen aiheuttaa virhetilanteen (käytetään virhetilanteiden hallinnan testaamiseen)
   private def errorOids = Map(
     "unavailable" -> ValpasErrorCategory.unavailable.sure(),
-    ValpasMockOppijat.lukionAloittanut.oid -> ValpasErrorCategory.unavailable.sure()
+    ValpasMockOppijat.hakukohteidenHakuEpäonnistuu.oid -> ValpasErrorCategory.unavailable.sure()
   )
 
   def getHakukoosteet(oppijaOids: Set[ValpasHenkilö.Oid]): Either[HttpStatus, Seq[Hakukooste]] =

--- a/src/main/scala/fi/oph/koski/valpas/henkilo/ValpasMockOppijat.scala
+++ b/src/main/scala/fi/oph/koski/valpas/henkilo/ValpasMockOppijat.scala
@@ -1,7 +1,6 @@
 package fi.oph.koski.valpas.henkilo
 
-import fi.oph.koski.henkilo.{LaajatOppijaHenkilöTiedot, MockOppijat}
-import fi.oph.koski.schema.UusiHenkilö
+import fi.oph.koski.henkilo.MockOppijat
 
 object ValpasMockOppijat {
   private val valpasOppijat = new MockOppijat
@@ -33,6 +32,7 @@ object ValpasMockOppijat {
   val eronnutOppijaTarkastelupäivänä = valpasOppijat.oppija("Eroaja-samana-päivänä", "Valpas", "270805A084V")
   val eronnutOppijaTarkastelupäivänJälkeen = valpasOppijat.oppija("Eroaja-myöhemmin", "Valpas", "290905A840B")
   val oppivelvollinenAloittanutJaEronnutTarkastelupäivänJälkeen = valpasOppijat.oppija("Aloittanut-ja-eronnut-myöhemmin", "Valpas", "270405A450E")
+  val hakukohteidenHakuEpäonnistuu = valpasOppijat.oppija("Epäonninen", "Valpas", "301005A336J")
 
   def defaultOppijat = valpasOppijat.getOppijat
 }

--- a/src/test/scala/fi/oph/koski/valpas/ValpasOppijaServiceSpec.scala
+++ b/src/test/scala/fi/oph/koski/valpas/ValpasOppijaServiceSpec.scala
@@ -100,6 +100,10 @@ class ValpasOppijaServiceSpec extends ValpasTestBase {
       List(
         ExpectedData(ValpasExampleData.eronnutOpiskeluoikeusTarkastelupäivänJälkeen, "voimassa")
       )
+    ),
+    (
+      ValpasMockOppijat.hakukohteidenHakuEpäonnistuu,
+      List(ExpectedData(ValpasExampleData.oppivelvollinenYsiluokkaKeskenKeväällä2021Opiskeluoikeus, "voimassa"))
     )
   ).sortBy(item => (item._1.sukunimi, item._1.etunimet))
 
@@ -124,15 +128,12 @@ class ValpasOppijaServiceSpec extends ValpasTestBase {
   }
 
   "getOppija palauttaa oppijan tiedot, vaikka hakukoostekysely epäonnistuisi" in {
-    val result = oppijaService.getOppijaLaajatTiedot(ValpasMockOppijat.lukionAloittanut.oid)(defaultSession()).toOption.get
+    val result = oppijaService.getOppijaLaajatTiedot(ValpasMockOppijat.hakukohteidenHakuEpäonnistuu.oid)(defaultSession()).toOption.get
     result.hakutilanneError.get should equal("Hakukoosteita ei juuri nyt saada haettua suoritusrekisteristä. Yritä myöhemmin uudelleen.")
     validateOppijaLaajatTiedot(
       result.oppija,
-      ValpasMockOppijat.lukionAloittanut,
-      List(
-        ExpectedData(ValpasExampleData.lukionOpiskeluoikeusAlkaa2021Syksyllä, "voimassa"),
-        ExpectedData(ValpasExampleData.valmistunutYsiluokkalainen, "valmistunut")
-      )
+      ValpasMockOppijat.hakukohteidenHakuEpäonnistuu,
+      List(ExpectedData(ValpasExampleData.oppivelvollinenYsiluokkaKeskenKeväällä2021Opiskeluoikeus, "voimassa"))
     )
   }
 

--- a/valpas-web/src/views/hakutilanne/HakutilanneTable.tsx
+++ b/valpas-web/src/views/hakutilanne/HakutilanneTable.tsx
@@ -2,7 +2,7 @@ import * as A from "fp-ts/lib/Array"
 import React, { useMemo } from "react"
 import { Link } from "react-router-dom"
 import { ExternalLink } from "../../components/navigation/ExternalLink"
-import { DataTable, Datum } from "../../components/tables/DataTable"
+import { DataTable, Datum, Value } from "../../components/tables/DataTable"
 import { NotImplemented } from "../../components/typography/NoDataMessage"
 import { T, t, Translation } from "../../i18n/i18n"
 import { useBasePath } from "../../state/basePath"
@@ -126,10 +126,10 @@ const oppijaToTableData = (
   }))
 }
 
-export const hakemuksenTila = (
+const hakemuksenTila = (
   hakutilanteet: HakuSuppeatTiedot[],
   hakutilanneError?: string
-) => {
+): Value => {
   const hakemuksenTila = hakemuksenTilaT(hakutilanteet.length, hakutilanneError)
   const component = () => {
     if (hakutilanteet.length == 0) return null
@@ -154,5 +154,5 @@ const hakemuksenTilaT = (
   if (hakutilanneError) return t("oppija__hakuhistoria_virhe")
   else if (hakemusCount == 0) return t("hakemuksentila__ei_hakemusta")
   else if (hakemusCount == 1) return t("hakemuksentila__hakenut")
-  else return `${hakemusCount} ${t("hakemuksentila__n_hakua")}`
+  else return `${t("hakemuksentila__n_hakua", { lukumäärä: hakemusCount })}`
 }

--- a/valpas-web/src/views/oppija/OppijaView.tsx
+++ b/valpas-web/src/views/oppija/OppijaView.tsx
@@ -62,7 +62,10 @@ export const OppijaView = (props: OppijaViewProps) => {
                   </InfoTooltip>
                 </CardHeader>
                 <CardBody>
-                  <OppijanYhteystiedot oppija={oppijaData} />
+                  <OppijanYhteystiedot
+                    henkilö={oppijaData.oppija.henkilö}
+                    yhteystiedot={oppijaData.yhteystiedot}
+                  />
                 </CardBody>
               </BorderlessCard>
             </Column>

--- a/valpas-web/src/views/oppija/OppijanYhteystiedot.tsx
+++ b/valpas-web/src/views/oppija/OppijanYhteystiedot.tsx
@@ -11,7 +11,7 @@ import { TertiaryHeading } from "../../components/typography/headings"
 import { NoDataMessage } from "../../components/typography/NoDataMessage"
 import { getLocalized, t, T } from "../../i18n/i18n"
 import {
-  OppijaHakutilanteillaLaajatTiedot,
+  HenkilöLaajatTiedot,
   Yhteystiedot,
   YhteystietojenAlkuperä,
 } from "../../state/oppijat"
@@ -22,17 +22,18 @@ import "./OppijanYhteystiedot.less"
 const b = bem("oppijanyhteystiedot")
 
 export type OppijanYhteystiedotProps = {
-  oppija: OppijaHakutilanteillaLaajatTiedot
+  henkilö: HenkilöLaajatTiedot
+  yhteystiedot: Yhteystiedot<YhteystietojenAlkuperä>[]
 }
 
 export const OppijanYhteystiedot = (props: OppijanYhteystiedotProps) => {
-  const ilmoitetut = props.oppija.yhteystiedot.filter(Yhteystiedot.isIlmoitettu)
-  const viralliset = props.oppija.yhteystiedot.filter(Yhteystiedot.isVirallinen)
+  const ilmoitetut = props.yhteystiedot.filter(Yhteystiedot.isIlmoitettu)
+  const viralliset = props.yhteystiedot.filter(Yhteystiedot.isVirallinen)
   const viewIlmoitetut = ilmoitetut.length > 0
 
   return (
     <>
-      {props.oppija.oppija.henkilö.turvakielto && (
+      {props.henkilö.turvakielto && (
         <IconSection icon={<WarningIcon />} id="turvakielto-varoitus">
           <T id="oppija__turvakielto_varoitus" />
         </IconSection>
@@ -43,7 +44,7 @@ export const OppijanYhteystiedot = (props: OppijanYhteystiedotProps) => {
             <TertiaryHeading>
               <T id="oppija__ilmoitetut_yhteystiedot" />
             </TertiaryHeading>
-            <YhteistietoAccordion
+            <YhteystietoAccordion
               yhteystiedot={ilmoitetut}
               label={(yt) =>
                 (getLocalized(yt.yhteystietoryhmänNimi) ||
@@ -59,7 +60,7 @@ export const OppijanYhteystiedot = (props: OppijanYhteystiedotProps) => {
           <TertiaryHeading>
             <T id="oppija__viralliset_yhteystiedot" />
           </TertiaryHeading>
-          <YhteistietoAccordion
+          <YhteystietoAccordion
             yhteystiedot={viralliset}
             label={(yt) =>
               uniq(string.Eq)([
@@ -68,7 +69,7 @@ export const OppijanYhteystiedot = (props: OppijanYhteystiedotProps) => {
               ]).join(": ")
             }
             noDataMessage={t(
-              props.oppija.oppija.henkilö.turvakielto
+              props.henkilö.turvakielto
                 ? "oppija__henkilöllä_turvakielto"
                 : "oppija__yhteystietoja_ei_löytynyt"
             )}
@@ -85,7 +86,7 @@ type YhteystietoAccordionProps<T extends YhteystietojenAlkuperä> = {
   noDataMessage?: string
 }
 
-const YhteistietoAccordion = <T extends YhteystietojenAlkuperä>(
+const YhteystietoAccordion = <T extends YhteystietojenAlkuperä>(
   props: YhteystietoAccordionProps<T>
 ) =>
   isNonEmpty(props.yhteystiedot) ? (

--- a/valpas-web/test/integrationtests/oppija.test.ts
+++ b/valpas-web/test/integrationtests/oppija.test.ts
@@ -92,11 +92,11 @@ describe("Oppijakohtainen näkymä", () => {
 
   it("Näyttää oppijan muut tiedot vaikka hakukoostekysely epäonnistuu", async () => {
     await loginAs(
-      "/virkailija/oppijat/1.2.246.562.24.00000000015",
+      "/virkailija/oppijat/1.2.246.562.24.00000000028",
       "valpas-jkl-normaali",
       "valpas-jkl-normaali"
     )
-    await mainHeadingEquals("LukionAloittanut Valpas (290405A871A)")
+    await mainHeadingEquals("Epäonninen Valpas (301005A336J)")
     await hautEquals("Virhe oppijan hakuhistorian hakemisessa")
   })
 

--- a/valpas-web/test/integrationtests/perusopetus.test.ts
+++ b/valpas-web/test/integrationtests/perusopetus.test.ts
@@ -8,7 +8,9 @@ import {
 const selectOrganisaatio = (index: number) =>
   dropdownSelect("#organisaatiovalitsin", index)
 
+// HUOM: Tämä on sarkaimilla (\t) erotettu taulukko:
 const jklNormaalikouluTableContent = `
+  Epäonninen Valpas	30.10.2005	9C	Ei hakemusta	Ei toteutettu	Ei toteutettu	Ei toteutettu
   Eroaja-myöhemmin Valpas	29.9.2005	9C	Ei hakemusta	Ei toteutettu	Ei toteutettu	Ei toteutettu
   Kahdella-oppija-oidilla Valpas	15.2.2005	9C	Ei hakemusta	Ei toteutettu	Ei toteutettu	Ei toteutettu
   KasiinAstiToisessaKoulussaOllut Valpas	17.8.2005	9C	Ei hakemusta	Ei toteutettu	Ei toteutettu	Ei toteutettu
@@ -31,7 +33,7 @@ describe("Perusopetuksen näkymä", () => {
     await loginAs("/virkailija/oppijat", "valpas-jkl-normaali")
     await textEventuallyEquals(
       ".card__header",
-      "Perusopetuksen päättävät 2021 (15)"
+      "Perusopetuksen päättävät 2021 (16)"
     )
     await dataTableEventuallyEquals(
       ".hakutilanne",
@@ -53,7 +55,7 @@ describe("Perusopetuksen näkymä", () => {
     await selectOrganisaatio(0)
     await textEventuallyEquals(
       ".card__header",
-      "Perusopetuksen päättävät 2021 (15)"
+      "Perusopetuksen päättävät 2021 (16)"
     )
     await dataTableEventuallyEquals(
       ".hakutilanne",

--- a/valpas-web/test/integrationtests/perusopetus.test.ts
+++ b/valpas-web/test/integrationtests/perusopetus.test.ts
@@ -17,7 +17,7 @@ const jklNormaalikouluTableContent = `
   Kotiopetus-menneisyydessä Valpas	6.2.2005	9C	Ei hakemusta	Ei toteutettu	Ei toteutettu	Ei toteutettu
   LukionAloittanut Valpas	29.4.2005	9C	Ei hakemusta	Ei toteutettu	Ei toteutettu	Ei toteutettu
   LukionLokakuussaAloittanut Valpas	18.4.2005	9C	Ei hakemusta	Ei toteutettu	Ei toteutettu	Ei toteutettu
-  LuokallejäänytYsiluokkalainen Valpas	2.8.2005	9A	Hakenut open_in_new	Ei toteutettu	Ei toteutettu	Ei toteutettu
+  LuokallejäänytYsiluokkalainen Valpas	2.8.2005	9A	2 hakua	Ei toteutettu	Ei toteutettu	Ei toteutettu
   LuokallejäänytYsiluokkalainenJatkaa Valpas	6.2.2005	9B	Ei hakemusta	Ei toteutettu	Ei toteutettu	Ei toteutettu
   LuokallejäänytYsiluokkalainenKouluvaihtoMuualta Valpas	2.11.2005	9B	Ei hakemusta	Ei toteutettu	Ei toteutettu	Ei toteutettu
   Oppivelvollinen-ysiluokka-kesken-keväällä-2021 Valpas	22.11.2005	9C	Hakenut open_in_new	Ei toteutettu	Ei toteutettu	Ei toteutettu


### PR DESCRIPTION
Yhteystietojen näyttäminen olikin korjattu jo aiemmin. Tässä korjaus lähinnä useamman haun näyttämiseen taulukossa ja pientä siistimistä.

Lisäksi tyylikorjaukset jotka menivät jo masteriin:
0479cf15580facd8ca6cbbcee310ae4d5ee63274
52ab41a26abb85e2814ab73b976711bda3c8d7d6