### PR TITLE
tor-1069: Pakollisille oppiaineiden laajuus käyttöliittymään

### DIFF
--- a/web/app/perusopetus/PerusopetuksenOppiaineetEditor.jsx
+++ b/web/app/perusopetus/PerusopetuksenOppiaineetEditor.jsx
@@ -35,6 +35,7 @@ import {
 import {expandableProperties, PerusopetuksenOppiaineRowEditor} from './PerusopetuksenOppiaineRowEditor'
 import {UusiPerusopetuksenOppiaineDropdown} from './UusiPerusopetuksenOppiaineDropdown'
 import {FootnoteDescriptions} from '../components/footnote'
+import {formatISODate, parseISODate} from '../date/date'
 
 
 export const PerusopetuksenOppiaineetEditor = ({model}) => {
@@ -159,7 +160,15 @@ class Oppiainetaulukko extends React.Component {
     const showArvosana = edit || arvioituTaiVahvistettu(model) || !model.value.classes.includes('perusopetuksenoppimaaransuoritus')
     const uudellaSuorituksellaLaajuus = () => !!modelLookup(uusiOppiaineenSuoritus ? uusiOppiaineenSuoritus : createOppiaineenSuoritus(modelLookup(model, 'osasuoritukset')), 'koulutusmoduuli.laajuus')
     const sisältääLajuudellisiaSuorituksia = !!suoritukset.find(s => modelData(s, 'koulutusmoduuli.laajuus'))
-    const showLaajuus = !pakolliset && (sisältääLajuudellisiaSuorituksia || (edit && uudellaSuorituksellaLaajuus()))
+    const päätasonSuorituksenVahvituspäivä = modelData(model, 'vahvistus.päivä')
+    const vahvistusSalliiLaajuudenNäyttämisen =  päätasonSuorituksenVahvituspäivä && parseISODate(päätasonSuorituksenVahvituspäivä) >= parseISODate('2020-08-01')
+
+    const showLaajuus = edit
+      ? uudellaSuorituksellaLaajuus()
+      : pakolliset
+        ? vahvistusSalliiLaajuudenNäyttämisen && sisältääLajuudellisiaSuorituksia
+        : sisältääLajuudellisiaSuorituksia
+
     const showFootnotes = !edit && !R.isEmpty(footnoteDescriptions(suoritukset))
 
     let addOppiaine = oppiaineenSuoritus => oppiaine => {

--- a/web/app/style/perusopetus.less
+++ b/web/app/style/perusopetus.less
@@ -52,7 +52,7 @@
               color: black;
               padding-right: 4px;
             }
-            min-width: 470px;
+            min-width: 360px;
             .omattiedot-phone({
               min-width: 0;
             });

--- a/web/test/spec/perusopetusSpec.js
+++ b/web/test/spec/perusopetusSpec.js
@@ -1365,9 +1365,10 @@ describe('Perusopetus', function() {
       })
 
       describe('Oppiaineen laajuuden muutos', function() {
-        before(editor.edit, editor.property('laajuus').setValue('1.5'), editor.saveChanges, wait.until(page.isSavedLabelShown))
+        var valinnainenLiikunta = opinnot.oppiaineet.oppiaine('valinnainen.LI')
+        before(editor.edit, valinnainenLiikunta.property('laajuus').setValue('1.5'), editor.saveChanges, wait.until(page.isSavedLabelShown))
         it('muutettu laajuus näytetään', function() {
-          expect(editor.property('laajuus').getValue()).to.equal('1,5')
+          expect(valinnainenLiikunta.property('laajuus').getValue()).to.equal('1,5')
         })
       })
       describe('Oppiaineen arvosanan muutos', function() {
@@ -3547,6 +3548,58 @@ describe('Perusopetus', function() {
             expect(opinnot.getOppilaitos()).to.equal('Jyväskylän normaalikoulu')
             expect(editor.propertyBySelector('.diaarinumero').getValue()).to.equal('57/011/2015')
             expect(opinnot.getSuorituskieli()).to.equal('englanti')
+          })
+        })
+      })
+    })
+  })
+
+  describe('Pakollisen oppiaineen laajuus nuorten päättötodistuksella ja vuosiluokan suorituksella', function () {
+    before(
+      resetFixtures,
+      Authentication().login(),
+      page.openPage,
+      page.oppijaHaku.searchAndSelect('220109-784L'),
+      editor.edit,
+      editor.property('tila').removeItem(0),
+      opinnot.tilaJaVahvistus.merkitseKeskeneräiseksi,
+      editor.saveChanges
+    )
+
+    var matikka = opinnot.oppiaineet.oppiaine('pakollinen.MA')
+    var ennenLeikkuriPäivää = '31.7.2020'
+    var leikkuriPäivä = '1.8.2020'
+
+    describe('Asetetaan pakolliselle oppiaineelle laajuus', function () {
+      before(
+        editor.edit,
+        matikka.property('laajuus').setValue('4'),
+        editor.saveChanges
+      )
+      it('Laajuutta ei näytetä, koska päätason suorituksella ei ole vahvistusta', function () {
+        expect(matikka.property('laajuus').isVisible()).to.equal(false)
+      })
+
+      describe('Asetetaan päätason suoritukselle vahvistus ennen leikkuripäivää', function () {
+        before(editor.edit,
+          tilaJaVahvistus.merkitseValmiiksi,
+          opinnot.tilaJaVahvistus.lisääVahvistus(ennenLeikkuriPäivää),
+          editor.saveChanges
+        )
+        it('Laajuutta ei näytetä, koska vahvistus on ennen leikkuripäivää', function () {
+          expect(matikka.property('laajuus').isVisible()).to.equal(false)
+        })
+
+        describe('Asetetaan päätason suoritukselle vahvistus leikkuripäivälle', function () {
+          before(
+            editor.edit,
+            tilaJaVahvistus.merkitseKeskeneräiseksi,
+            tilaJaVahvistus.merkitseValmiiksi,
+            opinnot.tilaJaVahvistus.lisääVahvistus(leikkuriPäivä),
+            editor.saveChanges
+          )
+          it('Laajuus näytetään', function () {
+            expect(matikka.property('laajuus').isVisible()).to.equal(true)
           })
         })
       })


### PR DESCRIPTION
- Pakollisille oppiaineille voi asettaa laajuuden käyttöliitymästä
- Pakollisen oppiaineen laajuus näytetään käyttöliittymässä vain vahvistetulle päätason suoritukselle, vahvistuspäivän tulee olla 1.8.2020 tai jälkeen.

Päivämäärä rajaus on lisätty sen takia, koska osa oppilashallintojärjestelmistä on siirtänyt pakollisiin oppiaineesiin laajuutta (tätä ei ollu koskessa estetty) ja uuden määräyksen mukaan
laajuutta tulisi siirtää pakollisiin oppiaineisiin vain kyseisen päivämäärän jälkeen. Tästä johtuen laajuus on haluttu piilottaa vanhemmilta suorituksilta hämmennyksen välttämiseksi, sillä niiden oikeellisuuden tarkistamiseen ei ole ollut virkailijoilla mahdollisuutta.