### PR TITLE
Valpas login fiksausta

### DIFF
--- a/src/main/scala/fi/oph/koski/cloudwatch/CloudWatchMetrics.scala
+++ b/src/main/scala/fi/oph/koski/cloudwatch/CloudWatchMetrics.scala
@@ -15,7 +15,7 @@ object CloudWatchMetrics extends Logging {
     val timeInSeconds = (completed.getTime - start.getTime) / 1000.0
 
     if (Environment.isLocalDevelopmentEnvironment) {
-      logger.info(s"Mocking cloudwatch metric: raportointikanta loading took $timeInSeconds seconds")
+      logger.debug(s"Mocking cloudwatch metric: raportointikanta loading took $timeInSeconds seconds")
     } else {
       putRaportointikantaLoadtimeToAWS(timeInSeconds)
     }

--- a/src/main/scala/fi/oph/koski/valpas/valpasuser/ValpasSession.scala
+++ b/src/main/scala/fi/oph/koski/valpas/valpasuser/ValpasSession.scala
@@ -11,7 +11,13 @@ import org.scalatra.servlet.RichRequest
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ValpasSession(user: AuthenticationUser, lang: String, clientIp: InetAddress, userAgent: String, lähdeKäyttöoikeudet: => Set[Käyttöoikeus]) extends Session(user, lang, clientIp, userAgent) with SensitiveDataAllowed {
+class ValpasSession(
+  user: AuthenticationUser,
+  lang: String,
+  clientIp: InetAddress,
+  userAgent: String,
+  lähdeKäyttöoikeudet: => Set[Käyttöoikeus]
+) extends Session(user, lang, clientIp, userAgent) with SensitiveDataAllowed {
   def varhaiskasvatusKoulutustoimijat: Set[Oid] = Set.empty
   def hasKoulutustoimijaVarhaiskasvatuksenJärjestäjäAccess: Boolean = false
 
@@ -19,24 +25,42 @@ class ValpasSession(user: AuthenticationUser, lang: String, clientIp: InetAddres
   def sensitiveDataAllowed(allowedRoles: Set[Role]): Boolean = false
 
   def hasGlobalValpasOikeus(requiredRoles: Set[String]): Boolean = {
-    val käyttäjänGlobaalitValpasOikeudet = globalKäyttöoikeudet.flatMap(_.globalPalveluroolit.filter(_.palveluName == "VALPAS").map(_.rooli))
+    val käyttäjänGlobaalitValpasOikeudet = globalKäyttöoikeudet
+      .flatMap(_.globalPalveluroolit.filter(_.palveluName == "VALPAS").map(_.rooli))
     requiredRoles.subsetOf(käyttäjänGlobaalitValpasOikeudet)
   }
 
   protected def kaikkiKäyttöoikeudet: Set[Käyttöoikeus] = käyttöoikeudet
 
   // Sessio luodaan aina uudestaan jokaisessa API-kutsussa, joten käyttöoikeudet voi tallentaa lazy val:iin eikä hakea ja filteröida aina uudestaan
-  private lazy val käyttöoikeudet: Set[Käyttöoikeus] = Käyttöoikeus.withPalveluroolitFilter(lähdeKäyttöoikeudet, _.palveluName == "VALPAS")
+  private lazy val käyttöoikeudet: Set[Käyttöoikeus] =
+    Käyttöoikeus.withPalveluroolitFilter(lähdeKäyttöoikeudet, _.palveluName == "VALPAS")
 
   Future(lähdeKäyttöoikeudet)(ExecutionContext.global) // haetaan käyttöoikeudet toisessa säikeessä rinnakkain
 }
 
 object ValpasSession {
-  def apply(user: AuthenticationUser, request: RichRequest, käyttöoikeudet: KäyttöoikeusRepository): ValpasSession = {
-    new ValpasSession(user, UserLanguage.getLanguageFromCookie(request), LogUserContext.clientIpFromRequest(request), LogUserContext.userAgent(request), käyttöoikeudet.käyttäjänKäyttöoikeudet(user))
+  def apply(
+    user: AuthenticationUser,
+    request: RichRequest,
+    käyttöoikeudet: KäyttöoikeusRepository
+  ): ValpasSession = {
+    new ValpasSession(
+      user,
+      UserLanguage.getLanguageFromCookie(request),
+      LogUserContext.clientIpFromRequest(request),
+      LogUserContext.userAgent(request),
+      käyttöoikeudet.käyttäjänKäyttöoikeudet(user)
+    )
   }
 
   private val UNTRUSTED_SYSTEM_USER = "Valpas untrusted system user"
 
-  val untrustedUser = new ValpasSession(AuthenticationUser(UNTRUSTED_SYSTEM_USER, UNTRUSTED_SYSTEM_USER, UNTRUSTED_SYSTEM_USER, None), "fi", InetAddress.getLoopbackAddress, "", Set())
+  val untrustedUser = new ValpasSession(
+    AuthenticationUser(UNTRUSTED_SYSTEM_USER, UNTRUSTED_SYSTEM_USER, UNTRUSTED_SYSTEM_USER, None),
+    "fi",
+    InetAddress.getLoopbackAddress,
+    "",
+    Set()
+  )
 }

--- a/valpas-web/src/components/icons/Spinner.less
+++ b/valpas-web/src/components/icons/Spinner.less
@@ -1,7 +1,22 @@
+@import "../../style/zindex";
+
+.loading-modal {
+  position: fixed;
+  z-index: @z-index-modal;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 100vw;
+}
+
+.loading-modal .spinner {
+  min-height: 100vh;
+  min-width: 100vw;
+}
+
 .spinner {
   display: flex;
   align-items: center;
-  position: relative;
   justify-content: center;
   animation: fade-in 1000ms cubic-bezier(0.5, 0, 0.9, 1);
 }

--- a/valpas-web/src/components/icons/Spinner.tsx
+++ b/valpas-web/src/components/icons/Spinner.tsx
@@ -7,3 +7,9 @@ export const Spinner = () => (
     <div className="spinner-circle spinner-circle-blue" />
   </div>
 )
+
+export const LoadingModal = () => (
+  <div className="loading-modal">
+    <Spinner />
+  </div>
+)

--- a/valpas-web/src/components/navigation/LocalRaamit.less
+++ b/valpas-web/src/components/navigation/LocalRaamit.less
@@ -1,5 +1,6 @@
 @import "../../style/colors.less";
 @import "../../style/typography.less";
+@import "../../style/zindex.less";
 
 .Triangle(@size, @color, @direction) {
   display: block;
@@ -17,7 +18,7 @@
   padding-top: 5px;
   color: white;
   box-sizing: border-box;
-  z-index: 100;
+  z-index: @z-index-raamit;
 }
 
 .localraamit {

--- a/valpas-web/src/state/auth.ts
+++ b/valpas-web/src/state/auth.ts
@@ -51,18 +51,15 @@ export const getLogin = (): Login => {
       }
 }
 
-export const storeLoginReturnUrl = () => {
-  if (!Cookies.get(RETURN_URL_KEY)) {
-    Cookies.set(RETURN_URL_KEY, location.href)
-  }
+export const storeLoginReturnUrl = (redirectPath: string) => {
+  Cookies.set(RETURN_URL_KEY, redirectPath)
 }
 
-export const redirectToLoginReturnUrl = (): boolean => {
+export const getLoginRedirectPath = (): string | null => {
   const url = Cookies.get(RETURN_URL_KEY)
   if (url) {
     Cookies.remove(RETURN_URL_KEY)
-    location.href = url
-    return true
+    return url
   }
-  return false
+  return null
 }

--- a/valpas-web/src/style/zindex.less
+++ b/valpas-web/src/style/zindex.less
@@ -1,1 +1,3 @@
 @z-index-tooltip: 10;
+@z-index-raamit: 100;
+@z-index-modal: 1000;

--- a/valpas-web/src/views/VirkailijaApp.tsx
+++ b/valpas-web/src/views/VirkailijaApp.tsx
@@ -4,6 +4,7 @@ import { fetchYlatasonOrganisaatiotJaKayttooikeusroolit } from "../api/api"
 import { useApiOnce } from "../api/apiHooks"
 import { isSuccess } from "../api/apiUtils"
 import { Page } from "../components/containers/Page"
+import { LoadingModal } from "../components/icons/Spinner"
 import { t } from "../i18n/i18n"
 import {
   CurrentUser,
@@ -48,7 +49,7 @@ const VirkailijaRoutes = ({ user }: VirkailijaRoutesProps) => {
   )
 
   if (!isSuccess(organisaatiotJaKayttooikeusroolit)) {
-    return null
+    return <LoadingModal />
   }
 
   return (
@@ -118,7 +119,7 @@ const VirkailijaApp = ({ basePath }: VirkailijaAppProps) => {
   }, [])
 
   if (!user) {
-    return null
+    return <LoadingModal />
   }
 
   const redirectPath = getLoginRedirectPath()


### PR DESCRIPTION
* Robustimpi login-uudelleenohjaus, aiemmassa toteutuksessa saattoi olla blankkoon sivuun johtava tai siihen myötävaikuttava bugi
* On myös mahdollista että virkailija-raamien lataus index.html:ssä aiheuttaa omalta osaltaan tätä ongelmaa. Raamien lataaminen kirjautumatta saattaa aiheuttaa uudelleenohjauksen kirjautumiseen väärällä paluuosoitteella, mutta tästä en ole vielä varma. Aiemmin virkailijan raamit ladattiin vasta kirjautumisen jälkeen - miksikäs tämä muutos olikaan revertoitu?
* Käyttöoikeuksien lataamisessa untuvalla kestää useitakin sekunteja: lisätty spinneri (modaali) myös tähän vaiheeseen, jotta ei sekoiteta tyhjän sivun bugia tyhjältä näyttävään mutta latautuvaan sivuun