### PR TITLE
Valpas login fix 2

### DIFF
--- a/valpas-web/package.json
+++ b/valpas-web/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "node devserver",
     "start:watch": "concurrently npm:start npm:lint:types:watch",
-    "start:raamit": "VIRKAILIJA_RAAMIT_HOST=\"https://virkailija.untuvaopintopolku.fi/\" node devserver",
+    "start:raamit": "npm run clean && VIRKAILIJA_RAAMIT_HOST=\"https://virkailija.untuvaopintopolku.fi/\" node devserver",
     "test": "npm run test:unit && npm run test:integration",
     "test:unit": "jest --runInBand src",
     "test:integration": "jest --config jest.integrationtests.config.js --runInBand test/integrationtests",

--- a/valpas-web/src/components/icons/Spinner.less
+++ b/valpas-web/src/components/icons/Spinner.less
@@ -18,15 +18,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  animation: fade-in 1000ms cubic-bezier(0.5, 0, 0.9, 1);
+  animation: fade-in 300ms ease-in;
 }
 
 @keyframes fade-in {
-  0%,
-  50% {
+  from {
     opacity: 0;
   }
-  100% {
+  to {
     opacity: 1;
   }
 }

--- a/valpas-web/src/index.html
+++ b/valpas-web/src/index.html
@@ -16,10 +16,6 @@
   <body>
     <div id="app"></div>
     <script
-      type="text/javascript"
-      src="/virkailija-raamit/apply-raamit.js"
-    ></script>
-    <script
       id="localization"
       type="text/javascript"
       src="/koski/valpas/localization/set-window-properties.js"

--- a/valpas-web/src/state/auth.ts
+++ b/valpas-web/src/state/auth.ts
@@ -51,17 +51,15 @@ export const getLogin = (): Login => {
       }
 }
 
-export const storeLoginReturnUrl = () => {
-  if (!Cookies.get(RETURN_URL_KEY)) {
-    Cookies.set(RETURN_URL_KEY, location.href)
-  }
+export const storeLoginReturnUrl = (url: string) => {
+  Cookies.set(RETURN_URL_KEY, url)
 }
 
 export const redirectToLoginReturnUrl = (): boolean => {
   const url = Cookies.get(RETURN_URL_KEY)
   if (url) {
     Cookies.remove(RETURN_URL_KEY)
-    location.href = url
+    location.replace(url)
     return true
   }
   return false

--- a/valpas-web/src/views/Raamit.tsx
+++ b/valpas-web/src/views/Raamit.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect } from "react"
+import { Route } from "react-router-dom"
+import { CurrentUser, isLoggedIn } from "../state/auth"
+
+const runningLocally = window.environment == "local"
+const localRaamitEnabled = runningLocally && !process.env.VIRKAILIJA_RAAMIT_HOST
+
+type RaamitProps = {
+  user: CurrentUser
+}
+
+export const Raamit = (props: RaamitProps) => (
+  <Route path="/virkailija">
+    {localRaamitEnabled ? (
+      <LocalRaamit user={props.user} />
+    ) : (
+      isLoggedIn(props.user) && <VirkailijaRaamitLoader />
+    )}
+  </Route>
+)
+
+const VirkailijaRaamitLoader = () => {
+  useEffect(loadExternalRaamitScript, [])
+  return null
+}
+
+const LocalRaamit = React.lazy(
+  () => import("../components/navigation/LocalRaamit")
+)
+
+let externalRaamitLoadInitiated = false
+
+const loadExternalRaamitScript = () => {
+  if (!externalRaamitLoadInitiated) {
+    externalRaamitLoadInitiated = true
+    const script = document.createElement("script")
+    script.src = "/virkailija-raamit/apply-raamit.js"
+    document.head.appendChild(script)
+  }
+}

--- a/valpas-web/src/views/VirkailijaApp.tsx
+++ b/valpas-web/src/views/VirkailijaApp.tsx
@@ -113,7 +113,7 @@ const LocalRaamit = React.lazy(
 
 const Login = () => {
   React.useEffect(() => {
-    storeLoginReturnUrl()
+    storeLoginReturnUrl(location.href)
   }, [])
 
   const config = getLogin()
@@ -147,8 +147,8 @@ const VirkailijaApp = ({ basePath }: VirkailijaAppProps) => {
     return <LoadingModal />
   }
 
-  if (redirectToLoginReturnUrl()) {
-    return null
+  if (isLoggedIn(user) && redirectToLoginReturnUrl()) {
+    return <LoadingModal />
   }
 
   return (
@@ -156,15 +156,17 @@ const VirkailijaApp = ({ basePath }: VirkailijaAppProps) => {
       {runningLocally && !window.virkailija_raamit_set_to_load && (
         <LocalRaamit user={user} />
       )}
-      {hasValpasAccess(user) ? (
-        <Page id="virkailija-app">
-          <VirkailijaRoutes user={user} />
-        </Page>
-      ) : isLoggedIn(user) ? (
-        <ErrorView
-          title={t("login__ei_valpas-oikeuksia_otsikko")}
-          message={t("login__ei_valpas-oikeuksia_viesti")}
-        />
+      {isLoggedIn(user) ? (
+        hasValpasAccess(user) ? (
+          <Page id="virkailija-app">
+            <VirkailijaRoutes user={user} />
+          </Page>
+        ) : (
+          <ErrorView
+            title={t("login__ei_valpas-oikeuksia_otsikko")}
+            message={t("login__ei_valpas-oikeuksia_viesti")}
+          />
+        )
       ) : (
         <Login />
       )}

--- a/valpas-web/src/views/VirkailijaApp.tsx
+++ b/valpas-web/src/views/VirkailijaApp.tsx
@@ -24,13 +24,14 @@ import {
   rootPath,
 } from "../state/paths"
 import { User } from "../state/types"
-import { ErrorView, NotFoundView } from "../views/ErrorView"
+import { ErrorView, NotFoundView } from "./ErrorView"
 import {
   HakutilanneView,
   HakutilanneViewWithoutOrgOid,
 } from "./hakutilanne/HakutilanneView"
 import { HomeView } from "./HomeView"
 import { OppijaView } from "./oppija/OppijaView"
+import { Raamit } from "./Raamit"
 
 const featureFlagName = "valpas-feature"
 const featureFlagEnabledValue = "enabled"
@@ -107,10 +108,6 @@ const VirkailijaRoutes = ({ user }: VirkailijaRoutesProps) => {
   )
 }
 
-const LocalRaamit = React.lazy(
-  () => import("../components/navigation/LocalRaamit")
-)
-
 const Login = () => {
   React.useEffect(() => {
     storeLoginReturnUrl(location.href)
@@ -153,9 +150,7 @@ const VirkailijaApp = ({ basePath }: VirkailijaAppProps) => {
 
   return (
     <BasePathProvider value={basePath}>
-      {runningLocally && !window.virkailija_raamit_set_to_load && (
-        <LocalRaamit user={user} />
-      )}
+      <Raamit user={user} />
       {isLoggedIn(user) ? (
         hasValpasAccess(user) ? (
           <Page id="virkailija-app">


### PR DESCRIPTION
* Vahva hypoteesi: virkailija-raamien lataaminen kirjautumatta johtaa epädeterministiseen käyttäytymiseen: jos raamit ehtii ohjata kirjautumissivulle ennen kuin Valpas ehtii, on kirjautumisen paluuosoite väärä (virkailijan työpöydälle)
* Tehty aiemmin revertoitu uudelleenohjauskäsittely paremmin - nyt pitäisi toimia myös CAS:n kanssa