### PR TITLE
TOR-1335 Vaihda hakutilannenäkymän otsikko paremmaksi

### DIFF
--- a/src/main/resources/valpas/localization/valpas-default-texts.json
+++ b/src/main/resources/valpas/localization/valpas-default-texts.json
@@ -15,7 +15,7 @@
   "tieto_puuttuu": "Tieto puuttuu",
   "localraamit__logout": "Kirjaudu ulos",
   "ylänavi__hakutilanne": "Hakutilanne",
-  "perusopetusnäkymä__otsikko": "Perusopetuksen päättävät {{vuosi}}",
+  "hakutilannenäkymä__otsikko": "Hakeutumisvelvollisia oppijoita",
   "hakutilanne__taulu_nimi": "Nimi",
   "hakutilanne__taulu_syntymäaika": "Syntymäaika",
   "hakutilanne__taulu_ryhma": "Ryhmä",

--- a/valpas-web/src/views/hakutilanne/HakutilanneView.tsx
+++ b/valpas-web/src/views/hakutilanne/HakutilanneView.tsx
@@ -22,7 +22,6 @@ import {
   OrganisaatioHierarkia,
   OrganisaatioJaKayttooikeusrooli,
 } from "../../state/types"
-import { currentYear } from "../../utils/date"
 import { ErrorView } from "../ErrorView"
 import { HakutilanneTable } from "./HakutilanneTable"
 import "./HakutilanneView.less"
@@ -81,10 +80,7 @@ export const HakutilanneView = (props: HakutilanneViewProps) => {
       <VirkailijaNavigation />
       <Card>
         <CardHeader>
-          <T
-            id="perusopetusnäkymä__otsikko"
-            params={{ vuosi: currentYear() }}
-          />
+          <T id="hakutilannenäkymä__otsikko" />
           {isSuccess(oppijatFetch) && (
             <Counter>
               {

--- a/valpas-web/test/integrationtests/hakutilanne.test.ts
+++ b/valpas-web/test/integrationtests/hakutilanne.test.ts
@@ -54,7 +54,7 @@ describe("Hakutilannenäkymä", () => {
     await urlIsEventually(pathToUrl(jklHakutilannePath))
     await textEventuallyEquals(
       ".card__header",
-      "Perusopetuksen päättävät 2021 (16)"
+      "Hakeutumisvelvollisia oppijoita (16)"
     )
     await dataTableEventuallyEquals(
       ".hakutilanne",
@@ -67,7 +67,7 @@ describe("Hakutilannenäkymä", () => {
     await urlIsEventually(pathToUrl(kulosaariHakutilannePath))
     await textEventuallyEquals(
       ".card__header",
-      "Perusopetuksen päättävät 2021 (1)"
+      "Hakeutumisvelvollisia oppijoita (1)"
     )
   })
 
@@ -78,7 +78,7 @@ describe("Hakutilannenäkymä", () => {
     await urlIsEventually(pathToUrl(jklHakutilannePath))
     await textEventuallyEquals(
       ".card__header",
-      "Perusopetuksen päättävät 2021 (16)"
+      "Hakeutumisvelvollisia oppijoita (16)"
     )
     await dataTableEventuallyEquals(
       ".hakutilanne",
@@ -89,7 +89,7 @@ describe("Hakutilannenäkymä", () => {
     await urlIsEventually(pathToUrl(kulosaariHakutilannePath))
     await textEventuallyEquals(
       ".card__header",
-      "Perusopetuksen päättävät 2021 (1)"
+      "Hakeutumisvelvollisia oppijoita (1)"
     )
   })
 


### PR DESCRIPTION
Sama näkymä tulee olemaan muillakin kuin peruskoululla ja lisäksi vuosiluvun näyttäminen otsikossa hajoaa syksyllä.

![image](https://user-images.githubusercontent.com/6376268/114130047-6d736800-9908-11eb-8edd-422240fa90c9.png)
