### PR TITLE
TOR-1335 Hakukoosteen korjaussarja

### DIFF
--- a/src/main/resources/mockdata/koodisto/koodistot/hakutapa.json
+++ b/src/main/resources/mockdata/koodisto/koodistot/hakutapa.json
@@ -1,0 +1,63 @@
+{
+  "koodistoUri": "hakutapa",
+  "resourceUri": "https://virkailija.opintopolku.fi/koodisto-service/rest/codes/hakutapa",
+  "omistaja": "Opetushallitus",
+  "organisaatioOid": "1.2.246.562.10.00000000001",
+  "lukittu": null,
+  "codesGroupUri": "http://haunkoodistot",
+  "version": 0,
+  "versio": 1,
+  "paivitysPvm": "2013-10-28",
+  "paivittajaOid": null,
+  "voimassaAlkuPvm": "2013-01-01",
+  "voimassaLoppuPvm": null,
+  "tila": "LUONNOS",
+  "metadata": [
+    {
+      "kieli": "FI",
+      "nimi": "hakutapa",
+      "kuvaus": "hakutapa",
+      "kayttoohje": null,
+      "kasite": null,
+      "kohdealue": null,
+      "sitovuustaso": null,
+      "kohdealueenOsaAlue": null,
+      "toimintaymparisto": null,
+      "tarkentaaKoodistoa": null,
+      "huomioitavaKoodisto": null,
+      "koodistonLahde": null
+    },
+    {
+      "kieli": "SV",
+      "nimi": "hakutapa",
+      "kuvaus": "hakutapa",
+      "kayttoohje": null,
+      "kasite": null,
+      "kohdealue": null,
+      "sitovuustaso": null,
+      "kohdealueenOsaAlue": null,
+      "toimintaymparisto": null,
+      "tarkentaaKoodistoa": null,
+      "huomioitavaKoodisto": null,
+      "koodistonLahde": null
+    },
+    {
+      "kieli": "EN",
+      "nimi": "hakutapa",
+      "kuvaus": "hakutapa",
+      "kayttoohje": null,
+      "kasite": null,
+      "kohdealue": null,
+      "sitovuustaso": null,
+      "kohdealueenOsaAlue": null,
+      "toimintaymparisto": null,
+      "tarkentaaKoodistoa": null,
+      "huomioitavaKoodisto": null,
+      "koodistonLahde": null
+    }
+  ],
+  "codesVersions": [],
+  "withinCodes": [],
+  "includesCodes": [],
+  "levelsWithCodes": []
+}

--- a/src/main/resources/mockdata/koodisto/koodistot/hakutyyppi.json
+++ b/src/main/resources/mockdata/koodisto/koodistot/hakutyyppi.json
@@ -1,0 +1,63 @@
+{
+  "koodistoUri": "hakutyyppi",
+  "resourceUri": "https://virkailija.opintopolku.fi/koodisto-service/rest/codes/hakutyyppi",
+  "omistaja": "Opetushallitus",
+  "organisaatioOid": "1.2.246.562.10.00000000001",
+  "lukittu": null,
+  "codesGroupUri": "http://haunkoodistot",
+  "version": 0,
+  "versio": 1,
+  "paivitysPvm": "2013-10-28",
+  "paivittajaOid": null,
+  "voimassaAlkuPvm": "2013-01-01",
+  "voimassaLoppuPvm": null,
+  "tila": "LUONNOS",
+  "metadata": [
+    {
+      "kieli": "FI",
+      "nimi": "hakutyyppi",
+      "kuvaus": "hakutyyppi",
+      "kayttoohje": null,
+      "kasite": null,
+      "kohdealue": null,
+      "sitovuustaso": null,
+      "kohdealueenOsaAlue": null,
+      "toimintaymparisto": null,
+      "tarkentaaKoodistoa": null,
+      "huomioitavaKoodisto": null,
+      "koodistonLahde": null
+    },
+    {
+      "kieli": "SV",
+      "nimi": "hakutyyppi",
+      "kuvaus": "hakutyyppi",
+      "kayttoohje": null,
+      "kasite": null,
+      "kohdealue": null,
+      "sitovuustaso": null,
+      "kohdealueenOsaAlue": null,
+      "toimintaymparisto": null,
+      "tarkentaaKoodistoa": null,
+      "huomioitavaKoodisto": null,
+      "koodistonLahde": null
+    },
+    {
+      "kieli": "EN",
+      "nimi": "hakutyyppi",
+      "kuvaus": "hakutyyppi",
+      "kayttoohje": null,
+      "kasite": null,
+      "kohdealue": null,
+      "sitovuustaso": null,
+      "kohdealueenOsaAlue": null,
+      "toimintaymparisto": null,
+      "tarkentaaKoodistoa": null,
+      "huomioitavaKoodisto": null,
+      "koodistonLahde": null
+    }
+  ],
+  "codesVersions": [],
+  "withinCodes": [],
+  "includesCodes": [],
+  "levelsWithCodes": []
+}

--- a/src/main/resources/mockdata/koodisto/koodit/hakutapa.json
+++ b/src/main/resources/mockdata/koodisto/koodit/hakutapa.json
@@ -1,0 +1,65 @@
+[
+  {
+    "koodiUri": "hakutapa_01",
+    "metadata": [
+      {
+        "nimi": "Yhteishaku",
+        "lyhytNimi": "YH",
+        "kieli": "FI"
+      },
+      {
+        "nimi": "Gemensam ansökan",
+        "lyhytNimi": "GA",
+        "kieli": "SV"
+      }
+    ],
+    "versio": 1,
+    "koodiArvo": "01"
+  },
+  {
+    "koodiUri": "hakutapa_04",
+    "metadata": [
+      {
+        "nimi": "Joustava haku",
+        "lyhytNimi": null,
+        "kieli": "FI"
+      }
+    ],
+    "versio": 1,
+    "koodiArvo": "04"
+  },
+  {
+    "koodiUri": "hakutapa_02",
+    "metadata": [
+      {
+        "nimi": "Separata antagningar",
+        "lyhytNimi": "SA",
+        "kieli": "SV"
+      },
+      {
+        "nimi": "Erillishaku",
+        "lyhytNimi": "EH",
+        "kieli": "FI"
+      }
+    ],
+    "versio": 1,
+    "koodiArvo": "02"
+  },
+  {
+    "koodiUri": "hakutapa_03",
+    "metadata": [
+      {
+        "nimi": "Jatkuva haku",
+        "lyhytNimi": "JH",
+        "kieli": "FI"
+      },
+      {
+        "nimi": "Fortgående ansökan",
+        "lyhytNimi": "FA",
+        "kieli": "SV"
+      }
+    ],
+    "versio": 1,
+    "koodiArvo": "03"
+  }
+]

--- a/src/main/resources/mockdata/koodisto/koodit/hakutyyppi.json
+++ b/src/main/resources/mockdata/koodisto/koodit/hakutyyppi.json
@@ -1,0 +1,53 @@
+[
+  {
+    "koodiUri": "hakutyyppi_02",
+    "metadata": [
+      {
+        "nimi": "Täydennyshaku",
+        "lyhytNimi": "TH",
+        "kieli": "FI"
+      },
+      {
+        "nimi": "Tilläggsansögan",
+        "lyhytNimi": "TA",
+        "kieli": "SV"
+      }
+    ],
+    "versio": 1,
+    "koodiArvo": "02"
+  },
+  {
+    "koodiUri": "hakutyyppi_03",
+    "metadata": [
+      {
+        "nimi": "Kompletteringansökan",
+        "lyhytNimi": "KA",
+        "kieli": "SV"
+      },
+      {
+        "nimi": "Lisähaku",
+        "lyhytNimi": "LH",
+        "kieli": "FI"
+      }
+    ],
+    "versio": 1,
+    "koodiArvo": "03"
+  },
+  {
+    "koodiUri": "hakutyyppi_01",
+    "metadata": [
+      {
+        "nimi": "Varsinainen haku",
+        "lyhytNimi": "VH",
+        "kieli": "FI"
+      },
+      {
+        "nimi": "Egentlig ansökan",
+        "lyhytNimi": "EA",
+        "kieli": "SV"
+      }
+    ],
+    "versio": 1,
+    "koodiArvo": "01"
+  }
+]

--- a/src/main/scala/fi/oph/koski/koodisto/Koodistot.scala
+++ b/src/main/scala/fi/oph/koski/koodisto/Koodistot.scala
@@ -86,6 +86,8 @@ object Koodistot {
   private val muutKoodistoAsetukset = List (
     KoodistoAsetus("ammatillisenoppiaineet"),
     KoodistoAsetus("ammatilliseentehtavaanvalmistavakoulutus"),
+    KoodistoAsetus("hakutapa"),
+    KoodistoAsetus("hakutyyppi"),
     KoodistoAsetus("jarjestamismuoto"),
     KoodistoAsetus("kieli"),
     KoodistoAsetus("kielivalikoima"),

--- a/src/main/scala/fi/oph/koski/valpas/hakukooste/Hakukooste.scala
+++ b/src/main/scala/fi/oph/koski/valpas/hakukooste/Hakukooste.scala
@@ -3,6 +3,8 @@ package fi.oph.koski.valpas.hakukooste
 import fi.oph.koski.schema.annotation.{EnumValues, KoodistoKoodiarvo, KoodistoUri}
 import fi.oph.koski.schema.{BlankableLocalizedString, Koodistokoodiviite}
 import fi.oph.koski.valpas.repository.{ValpasHakutilanneLaajatTiedot, ValpasHakutoive, ValpasHenkilö}
+import fi.oph.scalaschema.annotation.SyntheticProperty
+
 import java.time.LocalDateTime
 
 
@@ -45,9 +47,12 @@ case class Hakutoive(
   vastaanottotieto: Option[String],
   @EnumValues(Ilmoittautumistila.values)
   ilmoittautumistila: Option[String],
-  harkinnanvaraisuus: Option[String], // TODO: Arvot?
-  hakukohdeKoulutuskoodi: String // TODO: Arvot?
+  harkinnanvaraisuus: Option[String],
+  // TODO: hakukohdeKoulutuskoodi muuttuu merkkijonosta koodistoarvoksi, kytketty väliaikaisesti pois, ettei hajota parsintaa
+  // hakukohdeKoulutuskoodi: Koodistokoodiviite
 ) {
+  @SyntheticProperty
+  def onHakenutHarkinnanvaraisesti = harkinnanvaraisuus.isDefined
 }
 
 object Vastaanottotieto {

--- a/src/main/scala/fi/oph/koski/valpas/hakukooste/Hakukooste.scala
+++ b/src/main/scala/fi/oph/koski/valpas/hakukooste/Hakukooste.scala
@@ -12,22 +12,10 @@ case class Hakukooste(
   aktiivinenHaku: Option[Boolean],
   hakemusOid: ValpasHakutilanneLaajatTiedot.HakemusOid,
   hakemusUrl: String,
-
   @KoodistoUri("hakutapa")
-  // TODO: Koodiston lataus koskeen
-  @KoodistoKoodiarvo("01") // Yhteishaku
-  @KoodistoKoodiarvo("02") // Erillishaku
-  @KoodistoKoodiarvo("03") // Jatkuva haku
-  @KoodistoKoodiarvo("04") // Joustava haku
   hakutapa: Koodistokoodiviite,
-
   @KoodistoUri("hakutyyppi")
-  // TODO: Koodiston lataus koskeen
-  @KoodistoKoodiarvo("01") // Varsinainen haku
-  @KoodistoKoodiarvo("02") // täydennyshaku
-  @KoodistoKoodiarvo("03") // lisähaku
   hakutyyppi: Koodistokoodiviite,
-
   haunAlkamispaivamaara: LocalDateTime,
   hakuNimi: BlankableLocalizedString,
   email: String,

--- a/src/main/scala/fi/oph/koski/valpas/hakukooste/HakukoosteExampleData.scala
+++ b/src/main/scala/fi/oph/koski/valpas/hakukooste/HakukoosteExampleData.scala
@@ -157,8 +157,8 @@ object HakukoosteExampleData {
       vastaanottotieto = Some("KESKEN"),
       ilmoittautumistila = Some("EI_ILMOITTAUTUNUT"),
       koulutusOid = Some("TODO"),
-      harkinnanvaraisuus = Some("TODO"),
-      hakukohdeKoulutuskoodi = "TODO"
+      harkinnanvaraisuus = None,
+      // hakukohdeKoulutuskoodi = Koodistokoodiviite("000", "hakukohteet")
     )
 
   def yhteishakukoodi = Koodistokoodiviite("01", "hakutapa")

--- a/src/main/scala/fi/oph/koski/valpas/repository/ValpasOppija.scala
+++ b/src/main/scala/fi/oph/koski/valpas/repository/ValpasOppija.scala
@@ -226,7 +226,7 @@ object ValpasHakutoive {
       koulutusNimi = hakutoive.koulutusNimi.toLocalizedString,
       hakutoivenumero = Some(hakutoive.hakutoivenumero),
       pisteet = hakutoive.pisteet,
-      minValintapisteet = hakutoive.alinValintaPistemaara
+      alinValintaPistemaara = hakutoive.alinValintaPistemaara,
     )
   }
 }
@@ -237,12 +237,6 @@ case class ValpasHakutoive(
   koulutusNimi: Option[LocalizedString],
   hakutoivenumero: Option[Int],
   pisteet: Option[BigDecimal],
-  minValintapisteet: Option[BigDecimal]
-) {
-  @SyntheticProperty
-  def hyväksytty: Option[Boolean] = (pisteet, minValintapisteet) match {
-    case (Some(p), Some(min)) => Some(p >= min)
-    case _ => None
-  }
-}
+  alinValintaPistemaara: Option[BigDecimal]
+)
 

--- a/valpas-web/src/components/typography/NoDataMessage.less
+++ b/valpas-web/src/components/typography/NoDataMessage.less
@@ -5,11 +5,12 @@
   color: @color-gray;
 }
 
-table .nodatamessage {
-  display: inline;
-}
-
 .nodatamessage__notimplemented {
   font-style: italic;
   color: @color-gray-lighten-3;
+}
+
+table .nodatamessage,
+table .nodatamessage__notimplemented {
+  display: inline;
 }

--- a/valpas-web/src/state/oppijat.ts
+++ b/valpas-web/src/state/oppijat.ts
@@ -124,8 +124,7 @@ export type Hakutoive = {
   organisaatioNimi?: LocalizedString
   koulutusNimi?: LocalizedString
   pisteet?: number
-  minValintapisteet?: number
-  hyväksytty?: boolean
+  alinValintaPistemaara?: number
 }
 
 export type OpiskeluoikeusLaajatTiedot = {

--- a/valpas-web/src/views/oppija/OppijanHaut.tsx
+++ b/valpas-web/src/views/oppija/OppijanHaut.tsx
@@ -7,7 +7,10 @@ import { ExternalLink } from "../../components/navigation/ExternalLink"
 import { Datum } from "../../components/tables/DataTable"
 import { LeanTable } from "../../components/tables/LeanTable"
 import { TertiaryHeading } from "../../components/typography/headings"
-import { NoDataMessage } from "../../components/typography/NoDataMessage"
+import {
+  NoDataMessage,
+  NotImplemented,
+} from "../../components/typography/NoDataMessage"
 import { formatFixedNumber, getLocalized, t, T } from "../../i18n/i18n"
 import {
   HakuLaajatTiedot,
@@ -106,15 +109,15 @@ const hakutoiveToTableValue = (hakutoive: Hakutoive, index: number): Datum => ({
       ),
     },
     {
-      value:
-        hakutoive.hyväksytty === undefined
-          ? null
-          : hakutoive.hyväksytty === true
-          ? t("oppija__haut_hyvaksytty")
-          : t("oppija__haut_hylatty"),
+      value: t("hakutilanne__taulu_data_ei_toteutettu"),
+      display: (
+        <NotImplemented>
+          <T id="hakutilanne__taulu_data_ei_toteutettu" />
+        </NotImplemented>
+      ),
     },
     { value: formatFixedNumber(hakutoive.pisteet, 2) },
-    { value: formatFixedNumber(hakutoive.minValintapisteet, 2) },
+    { value: formatFixedNumber(hakutoive.alinValintaPistemaara, 2) },
   ],
 })
 

--- a/valpas-web/test/integrationtests/oppija.test.ts
+++ b/valpas-web/test/integrationtests/oppija.test.ts
@@ -84,11 +84,11 @@ describe("Oppijakohtainen näkymä", () => {
         Valinta
         Pisteet
         Alin pistemäärä
-        1. Ressun lukio, Lukio Hylätty 9,00 9,01
-        2. Helsingin medialukio, Lukio Hyväksytty 9,00 8,20
-        3. Omnia, Leipomoala – – –
-        4. Omnia, Puhtaus- ja kiinteistöpalveluala – – –
-        5. Varsinais-Suomen kansanopisto, Vapaan sivistystyön koulutus oppivelvollisille 2021-2022 – – –
+        1. Ressun lukio, Lukio Ei toteutettu 9,00 9,01
+        2. Helsingin medialukio, Lukio Ei toteutettu 9,00 8,20
+        3. Omnia, Leipomoala Ei toteutettu – –
+        4. Omnia, Puhtaus- ja kiinteistöpalveluala Ei toteutettu – –
+        5. Varsinais-Suomen kansanopisto, Vapaan sivistystyön koulutus oppivelvollisille 2021-2022 Ei toteutettu – –
     `)
   })
 
@@ -108,21 +108,21 @@ describe("Oppijakohtainen näkymä", () => {
       Valinta
       Pisteet
       Alin pistemäärä
-      1. Helsingin medialukio, Lukio – – –
+      1. Helsingin medialukio, Lukio Ei toteutettu – –
       list_alt
       Yhteishaku 2021 Hakenut open_in_new
       Hakukohde
       Valinta
       Pisteet
       Alin pistemäärä
-      1. Varsinais-Suomen kansanopisto, Vapaan sivistystyön koulutus oppivelvollisille 2021-2022 – – –
+      1. Varsinais-Suomen kansanopisto, Vapaan sivistystyön koulutus oppivelvollisille 2021-2022 Ei toteutettu – –
       list_alt
       Yhteishaku 2019 Hakenut open_in_new
       Hakukohde
       Valinta
       Pisteet
       Alin pistemäärä
-      1. Varsinais-Suomen kansanopisto, Vapaan sivistystyön koulutus oppivelvollisille 2019-2020 – – –
+      1. Varsinais-Suomen kansanopisto, Vapaan sivistystyön koulutus oppivelvollisille 2019-2020 Ei toteutettu – –
     `)
   })
 


### PR DESCRIPTION
* Pisteet kuntoon
* Oppijanäkymän hakutilannekenttä tilaan "ei toteutettu"
* Hakutapa- ja hakutyyppi-koodistot Koskeen
* Harkinnanvaraisuus-kentän tila "dokumentoitu" koodilla
* hakukohdeKoulutuskoodi piiloon väliaikaisesti, ettei tyypin muuttuminen lähiaikoina riko parsintaa