### PR TITLE
TOR-1132 LOPS 2012 Luva-opinnoissa

### DIFF
--- a/src/main/resources/localization/koski-default-texts.json
+++ b/src/main/resources/localization/koski-default-texts.json
@@ -1548,5 +1548,6 @@
   "Lukutaitokoulutuksen numeeristen taitojen osuus" : "Lukutaitokoulutuksen numeeristen taitojen osuus",
   "Suorituskokonaisuudet" : "Suorituskokonaisuudet",
   "Lukutaitokoulutuksen tekstien kirjoittamisen ja tuottamisen osuus" : "Lukutaitokoulutuksen tekstien kirjoittamisen ja tuottamisen osuus",
-  "Lukutaitokoulutuksen kokonaisuus" : "Lukutaitokoulutuksen kokonaisuus"
+  "Lukutaitokoulutuksen kokonaisuus" : "Lukutaitokoulutuksen kokonaisuus",
+  "description:Lukion oppiaineen 2019 opintojen suoritustiedot..." : "Lukion oppiaineen 2019 opintojen suoritustiedot LUVA-koulutuksessa"
 }

--- a/src/main/resources/mockdata/koodisto/koodit/suorituksentyyppi.json
+++ b/src/main/resources/mockdata/koodisto/koodit/suorituksentyyppi.json
@@ -835,6 +835,27 @@
   "versio" : 1,
   "withinCodeElements" : [ ]
 }, {
+  "koodiUri" : "suorituksentyyppi_luvalukionoppiaine2019",
+  "koodiArvo" : "luvalukionoppiaine2019",
+  "metadata" : [ {
+    "nimi" : "Lukion oppiaineen 2019 opinnnot osana lukioon valmistavaa koulutusta",
+    "lyhytNimi" : "",
+    "kuvaus" : "",
+    "kieli" : "FI"
+  }, {
+    "nimi" : "Studier i ett läroämne i gymnasiet 2019 som en del av förberedande utbildning för gymnasieutbildning",
+    "lyhytNimi" : "",
+    "kuvaus" : "",
+    "kieli" : "SV"
+  }, {
+    "nimi" : "Upper secondary school subject 2019 as part of instruction preparing for general upper secondary education ",
+    "lyhytNimi" : "",
+    "kuvaus" : "",
+    "kieli" : "EN"
+  } ],
+  "versio" : 1,
+  "withinCodeElements" : [ ]
+}, {
   "koodiUri" : "suorituksentyyppi_luvaoppiaine",
   "koodiArvo" : "luvaoppiaine",
   "metadata" : [ {

--- a/src/main/scala/fi/oph/koski/documentation/ExamplesLukioonValmistavaKoulutus.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesLukioonValmistavaKoulutus.scala
@@ -80,15 +80,20 @@ object ExamplesLukioonValmistavaKoulutus {
         ))
       ),
       LukionOppiaineenOpintojenSuoritusLukioonValmistavassaKoulutuksessa2019(
-        lukionKieli2019("A1", "EN"),
+        lukionKieli2019("AOM", "SV"),
         arviointi = numeerinenLukionOppiaineenArviointi(9),
         osasuoritukset = Some(List(
-          moduulinSuoritusOppiaineissa(vieraanKielenModuuliOppiaineissa("VKA1").copy(laajuus = laajuus2019(1))).copy(arviointi = numeerinenArviointi(7)),
-          moduulinSuoritusOppiaineissa(vieraanKielenModuuliOppiaineissa("VKA8").copy(laajuus = laajuus2019(1))).copy(arviointi = numeerinenArviointi(7))
+          moduulinSuoritusOppiaineissa(vieraanKielenModuuliOppiaineissa("RUA4").copy(laajuus = laajuus2019(1))).copy(arviointi = numeerinenArviointi(7))
         ))
       )
     ))
   )
+
+  /*
+  oppiaineenSuoritus(lukionKieli2019("AOM", "SV")).copy(arviointi = numeerinenLukionOppiaineenArviointi(9)).copy(osasuoritukset = Some(List(
+      moduulinSuoritusOppiaineissa(vieraanKielenModuuliOppiaineissa("RUA4").copy(laajuus = laajuus(1))).copy(arviointi = numeerinenArviointi(7))
+    )))
+   */
 
   val lukioonValmistavanKoulutuksenOpiskeluoikeus = LukioonValmistavanKoulutuksenOpiskeluoikeus(
     oppilaitos = Some(jyväskylänNormaalikoulu),

--- a/src/main/scala/fi/oph/koski/documentation/ExamplesLukioonValmistavaKoulutus.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesLukioonValmistavaKoulutus.scala
@@ -1,8 +1,8 @@
 package fi.oph.koski.documentation
 
 import java.time.LocalDate.{of => date}
-
 import fi.oph.koski.documentation.ExampleData._
+import fi.oph.koski.documentation.Lukio2019ExampleData.{lukionKieli2019, moduulinSuoritusOppiaineissa, numeerinenArviointi, numeerinenLukionOppiaineenArviointi, vieraanKielenModuuliOppiaineissa}
 import fi.oph.koski.documentation.LukioExampleData._
 import fi.oph.koski.documentation.YleissivistavakoulutusExampleData._
 import fi.oph.koski.henkilo.KoskiSpecificMockOppijat
@@ -64,7 +64,27 @@ object ExamplesLukioonValmistavaKoulutus {
         lukionKieli("A1", "EN"),
         arviointi = arviointi("S"),
         osasuoritukset = Some(List(
-          kurssisuoritus(valtakunnallinenKurssi("ENA1")).copy(arviointi = numeerinenArviointi(8))
+          kurssisuoritus(valtakunnallinenKurssi("ENA1")).copy(arviointi = LukioExampleData.numeerinenArviointi(8))
+        ))
+      )
+    ))
+  )
+
+  val lukioonValmistavanKoulutuksenSuoritus2019 = lukioonValmistavanKoulutuksenSuoritus.copy(
+    osasuoritukset = Some(List(
+      LukioonValmistavanKoulutuksenOppiaineenSuoritus(
+        PaikallinenLukioonValmistavanKoulutuksenOppiaine(PaikallinenKoodi("LVATK", "Tietojenkäsittely"), "Tietojenkäsittely", pakollinen = false),
+        arviointi = arviointi("S"),
+        osasuoritukset = Some(List(
+          luvaKurssinSuoritus(paikallinenLuvaKurssi("ATK1", "Tietokoneen käytön peruskurssi", "Kurssilla opiskellaan tietokoneen, toimisto-ohjelmien sekä internetin ja sähköpostin peruskäyttöä."))
+        ))
+      ),
+      LukionOppiaineenOpintojenSuoritusLukioonValmistavassaKoulutuksessa2019(
+        lukionKieli2019("A1", "EN"),
+        arviointi = numeerinenLukionOppiaineenArviointi(9),
+        osasuoritukset = Some(List(
+          moduulinSuoritusOppiaineissa(vieraanKielenModuuliOppiaineissa("VKA1").copy(laajuus = laajuus2019(1))).copy(arviointi = numeerinenArviointi(7)),
+          moduulinSuoritusOppiaineissa(vieraanKielenModuuliOppiaineissa("VKA8").copy(laajuus = laajuus2019(1))).copy(arviointi = numeerinenArviointi(7))
         ))
       )
     ))
@@ -87,13 +107,28 @@ object ExamplesLukioonValmistavaKoulutus {
     ))
   )
 
+  val lukioonValmistavanKoulutuksenOpiskeluoikeus2019 = lukioonValmistavanKoulutuksenOpiskeluoikeus.copy(
+    suoritukset = List(lukioonValmistavanKoulutuksenSuoritus2019),
+  )
+
   val luvaTodistus = Oppija(
     asUusiOppija(KoskiSpecificMockOppijat.luva),
     List(
       lukioonValmistavanKoulutuksenOpiskeluoikeus
     )
   )
-  val examples = List(Example("lukioon valmistava koulutus", "Oppija on suorittanut lukioon valmistavan koulutuksen (LUVA)", luvaTodistus, 200))
+
+  val luvaTodistus2019 = Oppija(
+    asUusiOppija(KoskiSpecificMockOppijat.luva2019),
+    List(
+      lukioonValmistavanKoulutuksenOpiskeluoikeus2019
+    )
+  )
+
+  val examples = List(
+    Example("lukioon valmistava koulutus", "Oppija on suorittanut lukioon valmistavan koulutuksen (LUVA)", luvaTodistus, 200),
+    Example("lukioon valmistava koulutus, Lukion 2019-opsilla", "Oppija on suorittanut lukioon valmistavan koulutuksen (LUVA). Mukana lukion 2019 opsin mukaisia osasuorituksia.", luvaTodistus2019, 200)
+  )
 
   private def luvaKurssinSuoritus(kurssi: LukioonValmistavanKoulutuksenKurssi) = LukioonValmistavanKurssinSuoritus(
     koulutusmoduuli = kurssi,
@@ -105,4 +140,6 @@ object ExamplesLukioonValmistavaKoulutus {
 
   private def paikallinenLuvaKurssi(koodi: String, nimi: String, kuvaus: String) =
     PaikallinenLukioonValmistavanKoulutuksenKurssi(PaikallinenKoodi(koodi, LocalizedString.finnish(nimi)), Some(laajuus(1.0f)), LocalizedString.finnish(kuvaus))
+
+  def laajuus2019(arvo: Double): LaajuusOpintopisteissä = LaajuusOpintopisteissä(arvo = arvo, yksikkö = laajuusOpintopisteissä)
 }

--- a/src/main/scala/fi/oph/koski/documentation/ExamplesLukioonValmistavaKoulutus.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesLukioonValmistavaKoulutus.scala
@@ -89,12 +89,6 @@ object ExamplesLukioonValmistavaKoulutus {
     ))
   )
 
-  /*
-  oppiaineenSuoritus(lukionKieli2019("AOM", "SV")).copy(arviointi = numeerinenLukionOppiaineenArviointi(9)).copy(osasuoritukset = Some(List(
-      moduulinSuoritusOppiaineissa(vieraanKielenModuuliOppiaineissa("RUA4").copy(laajuus = laajuus(1))).copy(arviointi = numeerinenArviointi(7))
-    )))
-   */
-
   val lukioonValmistavanKoulutuksenOpiskeluoikeus = LukioonValmistavanKoulutuksenOpiskeluoikeus(
     oppilaitos = Some(jyväskylänNormaalikoulu),
     koulutustoimija = None,

--- a/src/main/scala/fi/oph/koski/henkilo/KoskiSpecificMockOppijat.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/KoskiSpecificMockOppijat.scala
@@ -59,6 +59,7 @@ object KoskiSpecificMockOppijat {
   val aikuisOpiskelijaMuuRahoitus = koskiSpecificOppijat.oppija("Aikuinen", "MuuRahoitus", "241001C4647")
   val kymppiluokkalainen = koskiSpecificOppijat.oppija("Kymppiluokkalainen", "Kaisa", "131025-6573", sukupuoli = Some("2"), kotikunta = Some("Kontu"))
   val luva = koskiSpecificOppijat.oppija("Lukioonvalmistautuja", "Luke", "211007-442N")
+  val luva2019 = koskiSpecificOppijat.oppija("Lukioonvalmistautuja2019", "Luke", "270926-380M")
   val valma = koskiSpecificOppijat.oppija("Amikseenvalmistautuja", "Anneli", "130404-054C")
   val ylioppilas = koskiSpecificOppijat.oppija("Ylioppilas", "Ynjevi", "210244-374K", vanhaHetu = Some("210244-073V"))
   val ylioppilasLukiolainen = koskiSpecificOppijat.oppija("Ylioppilaslukiolainen", "Ynjevi", "080698-967F")

--- a/src/main/scala/fi/oph/koski/http/KoskiErrorCategory.scala
+++ b/src/main/scala/fi/oph/koski/http/KoskiErrorCategory.scala
@@ -119,6 +119,7 @@ object KoskiErrorCategory {
         val deprekoituKielikoodi = subcategory("deprekoituKielikoodi", "Suorituksessa on käytetty deprekoitua kielikoodia")
         val deprekoituOppimäärä = subcategory("deprekoituOppimäärä", "Suorituksessa on käytetty deprekoitua oppimäärää")
         val puuttuvaSuullisenKielitaidonKoe = subcategory("puuttuvaSuullisenKielitaidonKoe", "Suorituksesta puuttuu vaadittava merkintä suullisen kielitaidon kokeesta")
+        val lukioonValmistavassaEriLukioOpsienOsasuorituksia = subcategory("lukioonValmistavassaEriLukioOpsienSuorituksia", "Lukion valmistavan koulutuksen suorituksella ei voi olla sekä lukion 2015 että lukion 2019 opetussuunnitelmien mukaisia osasuorituksia")
       }
       val rakenne = new Rakenne
 

--- a/src/main/scala/fi/oph/koski/schema/Lukio2019.scala
+++ b/src/main/scala/fi/oph/koski/schema/Lukio2019.scala
@@ -161,6 +161,7 @@ trait LukionModuulinSuoritus2019 extends ValtakunnallisenModuulinSuoritus with M
 @Title("Lukion moduulin suoritus oppiaineissa 2019")
 @Description("Lukion moduulin suoritustiedot oppiaineissa 2019")
 @OnlyWhen("../../tyyppi/koodiarvo", "lukionoppiaine")
+@OnlyWhen("../../tyyppi/koodiarvo", "luvalukionoppiaine2019")
 case class LukionModuulinSuoritusOppiaineissa2019(
   koulutusmoduuli: LukionModuuliOppiaineissa2019,
   arviointi: Option[List[LukionModuulinTaiPaikallisenOpintojaksonArviointi2019]] = None,
@@ -318,6 +319,7 @@ trait LukionOppiaine2019 extends LukionOppiaine with OpintopistelaajuuksienYhtee
 
 @Title("Paikallinen oppiaine 2019")
 @OnlyWhen("../tyyppi/koodiarvo", "lukionoppiaine")
+@OnlyWhen("../tyyppi/koodiarvo", "luvalukionoppiaine2019")
 case class PaikallinenLukionOppiaine2019(
   tunniste: PaikallinenKoodi,
   kuvaus: LocalizedString,
@@ -330,6 +332,7 @@ trait LukionValtakunnallinenOppiaine2019 extends LukionOppiaine2019 with Yleissi
 
 @Title("Muu valtakunnallinen oppiaine 2019")
 @OnlyWhen("../tyyppi/koodiarvo", "lukionoppiaine")
+@OnlyWhen("../tyyppi/koodiarvo", "luvalukionoppiaine2019")
 case class LukionMuuValtakunnallinenOppiaine2019(
   @KoodistoKoodiarvo("BI")
   @KoodistoKoodiarvo("ET")
@@ -353,6 +356,7 @@ case class LukionMuuValtakunnallinenOppiaine2019(
 
 @Title("Uskonto 2019")
 @OnlyWhen("../tyyppi/koodiarvo", "lukionoppiaine")
+@OnlyWhen("../tyyppi/koodiarvo", "luvalukionoppiaine2019")
 case class LukionUskonto2019(
   tunniste: Koodistokoodiviite,
   pakollinen: Boolean = true,
@@ -364,6 +368,7 @@ case class LukionUskonto2019(
 @Title("Äidinkieli ja kirjallisuus 2019")
 @Description("Oppiaineena äidinkieli ja kirjallisuus")
 @OnlyWhen("../tyyppi/koodiarvo", "lukionoppiaine")
+@OnlyWhen("../tyyppi/koodiarvo", "luvalukionoppiaine2019")
 case class LukionÄidinkieliJaKirjallisuus2019(
   @KoodistoKoodiarvo("AI")
   tunniste: Koodistokoodiviite = Koodistokoodiviite(koodiarvo = "AI", koodistoUri = "koskioppiaineetyleissivistava"),
@@ -380,6 +385,7 @@ case class LukionÄidinkieliJaKirjallisuus2019(
 @Title("Vieras tai toinen kotimainen kieli 2019")
 @Description("Oppiaineena vieras tai toinen kotimainen kieli 2019")
 @OnlyWhen("../tyyppi/koodiarvo", "lukionoppiaine")
+@OnlyWhen("../tyyppi/koodiarvo", "luvalukionoppiaine2019")
 case class VierasTaiToinenKotimainenKieli2019(
   @KoodistoKoodiarvo("A")
   @KoodistoKoodiarvo("B1")
@@ -400,6 +406,7 @@ case class VierasTaiToinenKotimainenKieli2019(
 @Title("Matematiikka 2019")
 @Description("Oppiaineena matematiikka")
 @OnlyWhen("../tyyppi/koodiarvo", "lukionoppiaine")
+@OnlyWhen("../tyyppi/koodiarvo", "luvalukionoppiaine2019")
 case class LukionMatematiikka2019(
   @KoodistoKoodiarvo("MA")
   tunniste: Koodistokoodiviite = Koodistokoodiviite(koodiarvo = "MA", koodistoUri = "koskioppiaineetyleissivistava"),

--- a/src/main/scala/fi/oph/koski/schema/LukioonValmistavaKoulutus.scala
+++ b/src/main/scala/fi/oph/koski/schema/LukioonValmistavaKoulutus.scala
@@ -95,6 +95,21 @@ case class LukionOppiaineenOpintojenSuoritusLukioonValmistavassaKoulutuksessa(
   tyyppi: Koodistokoodiviite = Koodistokoodiviite(koodiarvo = "luvalukionoppiaine", koodistoUri = "suorituksentyyppi")
 ) extends LukioonValmistavanKoulutuksenOsasuoritus with Vahvistukseton
 
+@Title("Lukion oppiaineen opintojen suoritus 2019")
+@Description("Lukion oppiaineen 2019 opintojen suoritustiedot LUVA-koulutuksessa")
+case class LukionOppiaineenOpintojenSuoritusLukioonValmistavassaKoulutuksessa2019(
+  @Title("Oppiaine")
+  koulutusmoduuli: LukionOppiaine2019,
+  @Description("Lukiokoulutuksen valmistavan koulutuksen todistukseen merkitään opiskelijan opiskelemat oppiaineet, niissä suoritettujen kurssien määrä tai merkintä aineryhmän tai oppiaineen hyväksytystä suorittamisesta (hyväksytty)")
+  arviointi: Option[List[LukionOppiaineenArviointi2019]] = None,
+  suoritettuErityisenäTutkintona: Boolean = false,
+  suorituskieli: Option[Koodistokoodiviite] = None,
+  @Description("Oppiaineeseen kuuluvien kurssien suoritukset")
+  @Title("Kurssit")
+  override val osasuoritukset: Option[List[LukionModuulinTaiPaikallisenOpintojaksonSuoritusOppiaineissa2019]],
+  @KoodistoKoodiarvo("luvalukionoppiaine2019")
+  tyyppi: Koodistokoodiviite = Koodistokoodiviite(koodiarvo = "luvalukionoppiaine2019", koodistoUri = "suorituksentyyppi")
+) extends LukioonValmistavanKoulutuksenOsasuoritus with Vahvistukseton
 
 trait LukioonValmistavanKoulutuksenOppiaine extends KoulutusmoduuliValinnainenLaajuus with Valinnaisuus {
   @Title("Oppiaine")

--- a/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
+++ b/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
@@ -513,7 +513,7 @@ class KoskiValidator(
         :: Lukio2019OsasuoritusValidation.validate(suoritus, parent)
         :: Lukio2019VieraatKieletValidation.validate(suoritus, parent)
         :: Lukio2019ArvosanaValidation.validateOsasuoritus(suoritus)
-        :: validateLukioonValmistava2019(suoritus)
+        :: LukioonValmistavanKoulutuksenValidaatiot.validateLukioonValmistava2019(suoritus)
         :: HttpStatus.validate(!suoritus.isInstanceOf[PäätasonSuoritus])(validateDuplicates(suoritus.osasuoritukset.toList.flatten))
         :: suoritus.osasuoritusLista.map(validateSuoritus(_, opiskeluoikeus, suoritus :: parent))
     )
@@ -1124,23 +1124,5 @@ class KoskiValidator(
           .forall(hankkimistapa => List("koulutussopimus", "oppilaitosmuotoinenkoulutus").contains(hankkimistapa.tunniste.koodiarvo))
       )(KoskiErrorCategory.badRequest.validation.rakenne.deprekoituOsaamisenHankkimistapa())
     case _ => HttpStatus.ok
-  }
-
-  private def validateLukioonValmistava2019(suoritus: Suoritus) = {
-    suoritus match {
-      case s: LukioonValmistavanKoulutuksenSuoritus => validateLukioonValmistava2019Osasuoritukset(s)
-      case _ => HttpStatus.ok
-    }
-  }
-
-  private def validateLukioonValmistava2019Osasuoritukset(suoritus: LukioonValmistavanKoulutuksenSuoritus) = {
-    if (suoritus.osasuoritukset.getOrElse(List()).exists(_.isInstanceOf[LukionOppiaineenOpintojenSuoritusLukioonValmistavassaKoulutuksessa2019]) &&
-      suoritus.osasuoritukset.getOrElse(List()).exists(_.isInstanceOf[LukionOppiaineenOpintojenSuoritusLukioonValmistavassaKoulutuksessa]))
-    {
-      KoskiErrorCategory.badRequest.validation.rakenne.lukioonValmistavassaEriLukioOpsienOsasuorituksia()
-    }
-    else {
-      HttpStatus.ok
-    }
   }
 }

--- a/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
+++ b/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
@@ -513,6 +513,7 @@ class KoskiValidator(
         :: Lukio2019OsasuoritusValidation.validate(suoritus, parent)
         :: Lukio2019VieraatKieletValidation.validate(suoritus, parent)
         :: Lukio2019ArvosanaValidation.validateOsasuoritus(suoritus)
+        :: validateLukioonValmistava2019(suoritus)
         :: HttpStatus.validate(!suoritus.isInstanceOf[PäätasonSuoritus])(validateDuplicates(suoritus.osasuoritukset.toList.flatten))
         :: suoritus.osasuoritusLista.map(validateSuoritus(_, opiskeluoikeus, suoritus :: parent))
     )
@@ -1123,5 +1124,23 @@ class KoskiValidator(
           .forall(hankkimistapa => List("koulutussopimus", "oppilaitosmuotoinenkoulutus").contains(hankkimistapa.tunniste.koodiarvo))
       )(KoskiErrorCategory.badRequest.validation.rakenne.deprekoituOsaamisenHankkimistapa())
     case _ => HttpStatus.ok
+  }
+
+  private def validateLukioonValmistava2019(suoritus: Suoritus) = {
+    suoritus match {
+      case s: LukioonValmistavanKoulutuksenSuoritus => validateLukioonValmistava2019Osasuoritukset(s)
+      case _ => HttpStatus.ok
+    }
+  }
+
+  private def validateLukioonValmistava2019Osasuoritukset(suoritus: LukioonValmistavanKoulutuksenSuoritus) = {
+    if (suoritus.osasuoritukset.getOrElse(List()).exists(_.isInstanceOf[LukionOppiaineenOpintojenSuoritusLukioonValmistavassaKoulutuksessa2019]) &&
+      suoritus.osasuoritukset.getOrElse(List()).exists(_.isInstanceOf[LukionOppiaineenOpintojenSuoritusLukioonValmistavassaKoulutuksessa]))
+    {
+      KoskiErrorCategory.badRequest.validation.rakenne.lukioonValmistavassaEriLukioOpsienOsasuorituksia()
+    }
+    else {
+      HttpStatus.ok
+    }
   }
 }

--- a/src/main/scala/fi/oph/koski/validation/LukioonValmistavanKoulutuksenValidaatiot.scala
+++ b/src/main/scala/fi/oph/koski/validation/LukioonValmistavanKoulutuksenValidaatiot.scala
@@ -1,0 +1,25 @@
+package fi.oph.koski.validation
+
+import fi.oph.koski.http.{HttpStatus, KoskiErrorCategory}
+import fi.oph.koski.schema.{LukionOppiaineenOpintojenSuoritusLukioonValmistavassaKoulutuksessa, LukionOppiaineenOpintojenSuoritusLukioonValmistavassaKoulutuksessa2019, LukioonValmistavanKoulutuksenSuoritus, Suoritus}
+
+object LukioonValmistavanKoulutuksenValidaatiot {
+  def validateLukioonValmistava2019(suoritus: Suoritus) = {
+    suoritus match {
+      case s: LukioonValmistavanKoulutuksenSuoritus => validateLukioonValmistava2019Osasuoritukset(s)
+      case _ => HttpStatus.ok
+    }
+  }
+
+  private def validateLukioonValmistava2019Osasuoritukset(suoritus: LukioonValmistavanKoulutuksenSuoritus) = {
+    if (suoritus.osasuoritukset.getOrElse(List()).exists(_.isInstanceOf[LukionOppiaineenOpintojenSuoritusLukioonValmistavassaKoulutuksessa2019]) &&
+      suoritus.osasuoritukset.getOrElse(List()).exists(_.isInstanceOf[LukionOppiaineenOpintojenSuoritusLukioonValmistavassaKoulutuksessa]))
+    {
+      KoskiErrorCategory.badRequest.validation.rakenne.lukioonValmistavassaEriLukioOpsienOsasuorituksia()
+    }
+    else {
+      HttpStatus.ok
+    }
+  }
+}
+

--- a/src/test/resources/backwardcompatibility/lukioonvalmistavakoulutus,Lukion2019-opsilla_2021-04-09.json
+++ b/src/test/resources/backwardcompatibility/lukioonvalmistavakoulutus,Lukion2019-opsilla_2021-04-09.json
@@ -1,0 +1,360 @@
+{
+  "henkilö" : {
+    "hetu" : "270926-380M",
+    "etunimet" : "Luke",
+    "kutsumanimi" : "Luke",
+    "sukunimi" : "Lukioonvalmistautuja2019"
+  },
+  "opiskeluoikeudet" : [ {
+    "oppilaitos" : {
+      "oid" : "1.2.246.562.10.14613773812",
+      "oppilaitosnumero" : {
+        "koodiarvo" : "00204",
+        "nimi" : {
+          "fi" : "Jyväskylän normaalikoulu",
+          "sv" : "Jyväskylän normaalikoulu",
+          "en" : "Jyväskylän normaalikoulu"
+        },
+        "lyhytNimi" : {
+          "fi" : "Jyväskylän normaalikoulu",
+          "sv" : "Jyväskylän normaalikoulu",
+          "en" : "Jyväskylän normaalikoulu"
+        },
+        "koodistoUri" : "oppilaitosnumero"
+      },
+      "nimi" : {
+        "fi" : "Jyväskylän normaalikoulu",
+        "sv" : "Jyväskylän normaalikoulu",
+        "en" : "Jyväskylän normaalikoulu"
+      },
+      "kotipaikka" : {
+        "koodiarvo" : "179",
+        "nimi" : {
+          "fi" : "Jyväskylä",
+          "sv" : "Jyväskylä"
+        },
+        "koodistoUri" : "kunta"
+      }
+    },
+    "tila" : {
+      "opiskeluoikeusjaksot" : [ {
+        "alku" : "2008-08-15",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        },
+        "opintojenRahoitus" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "opintojenrahoitus"
+        }
+      }, {
+        "alku" : "2016-06-04",
+        "tila" : {
+          "koodiarvo" : "valmistunut",
+          "nimi" : {
+            "fi" : "Valmistunut"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        },
+        "opintojenRahoitus" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "opintojenrahoitus"
+        }
+      } ]
+    },
+    "suoritukset" : [ {
+      "koulutusmoduuli" : {
+        "tunniste" : {
+          "koodiarvo" : "999906",
+          "koodistoUri" : "koulutus"
+        },
+        "perusteenDiaarinumero" : "56/011/2015",
+        "laajuus" : {
+          "arvo" : 2.0,
+          "yksikkö" : {
+            "koodiarvo" : "4",
+            "koodistoUri" : "opintojenlaajuusyksikko"
+          }
+        }
+      },
+      "oppimäärä" : {
+        "koodiarvo" : "nuortenops",
+        "nimi" : {
+          "fi" : "Nuorten ops"
+        },
+        "koodistoUri" : "lukionoppimaara",
+        "koodistoVersio" : 1
+      },
+      "toimipiste" : {
+        "oid" : "1.2.246.562.10.14613773812",
+        "oppilaitosnumero" : {
+          "koodiarvo" : "00204",
+          "nimi" : {
+            "fi" : "Jyväskylän normaalikoulu",
+            "sv" : "Jyväskylän normaalikoulu",
+            "en" : "Jyväskylän normaalikoulu"
+          },
+          "lyhytNimi" : {
+            "fi" : "Jyväskylän normaalikoulu",
+            "sv" : "Jyväskylän normaalikoulu",
+            "en" : "Jyväskylän normaalikoulu"
+          },
+          "koodistoUri" : "oppilaitosnumero"
+        },
+        "nimi" : {
+          "fi" : "Jyväskylän normaalikoulu",
+          "sv" : "Jyväskylän normaalikoulu",
+          "en" : "Jyväskylän normaalikoulu"
+        },
+        "kotipaikka" : {
+          "koodiarvo" : "179",
+          "nimi" : {
+            "fi" : "Jyväskylä",
+            "sv" : "Jyväskylä"
+          },
+          "koodistoUri" : "kunta"
+        }
+      },
+      "vahvistus" : {
+        "päivä" : "2016-06-04",
+        "paikkakunta" : {
+          "koodiarvo" : "179",
+          "nimi" : {
+            "fi" : "Jyväskylä"
+          },
+          "koodistoUri" : "kunta"
+        },
+        "myöntäjäOrganisaatio" : {
+          "oid" : "1.2.246.562.10.14613773812",
+          "oppilaitosnumero" : {
+            "koodiarvo" : "00204",
+            "nimi" : {
+              "fi" : "Jyväskylän normaalikoulu",
+              "sv" : "Jyväskylän normaalikoulu",
+              "en" : "Jyväskylän normaalikoulu"
+            },
+            "lyhytNimi" : {
+              "fi" : "Jyväskylän normaalikoulu",
+              "sv" : "Jyväskylän normaalikoulu",
+              "en" : "Jyväskylän normaalikoulu"
+            },
+            "koodistoUri" : "oppilaitosnumero"
+          },
+          "nimi" : {
+            "fi" : "Jyväskylän normaalikoulu",
+            "sv" : "Jyväskylän normaalikoulu",
+            "en" : "Jyväskylän normaalikoulu"
+          },
+          "kotipaikka" : {
+            "koodiarvo" : "179",
+            "nimi" : {
+              "fi" : "Jyväskylä",
+              "sv" : "Jyväskylä"
+            },
+            "koodistoUri" : "kunta"
+          }
+        },
+        "myöntäjäHenkilöt" : [ {
+          "nimi" : "Reijo Reksi",
+          "titteli" : {
+            "fi" : "rehtori"
+          },
+          "organisaatio" : {
+            "oid" : "1.2.246.562.10.14613773812",
+            "oppilaitosnumero" : {
+              "koodiarvo" : "00204",
+              "nimi" : {
+                "fi" : "Jyväskylän normaalikoulu",
+                "sv" : "Jyväskylän normaalikoulu",
+                "en" : "Jyväskylän normaalikoulu"
+              },
+              "lyhytNimi" : {
+                "fi" : "Jyväskylän normaalikoulu",
+                "sv" : "Jyväskylän normaalikoulu",
+                "en" : "Jyväskylän normaalikoulu"
+              },
+              "koodistoUri" : "oppilaitosnumero"
+            },
+            "nimi" : {
+              "fi" : "Jyväskylän normaalikoulu",
+              "sv" : "Jyväskylän normaalikoulu",
+              "en" : "Jyväskylän normaalikoulu"
+            },
+            "kotipaikka" : {
+              "koodiarvo" : "179",
+              "nimi" : {
+                "fi" : "Jyväskylä",
+                "sv" : "Jyväskylä"
+              },
+              "koodistoUri" : "kunta"
+            }
+          }
+        } ]
+      },
+      "suorituskieli" : {
+        "koodiarvo" : "FI",
+        "nimi" : {
+          "fi" : "suomi"
+        },
+        "koodistoUri" : "kieli"
+      },
+      "osasuoritukset" : [ {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "LVATK",
+            "nimi" : {
+              "fi" : "Tietojenkäsittely"
+            }
+          },
+          "kuvaus" : {
+            "fi" : "Tietojenkäsittely"
+          },
+          "pakollinen" : false
+        },
+        "arviointi" : [ {
+          "arvosana" : {
+            "koodiarvo" : "S",
+            "koodistoUri" : "arviointiasteikkoyleissivistava"
+          },
+          "hyväksytty" : true
+        } ],
+        "osasuoritukset" : [ {
+          "koulutusmoduuli" : {
+            "tunniste" : {
+              "koodiarvo" : "ATK1",
+              "nimi" : {
+                "fi" : "Tietokoneen käytön peruskurssi"
+              }
+            },
+            "laajuus" : {
+              "arvo" : 1.0,
+              "yksikkö" : {
+                "koodiarvo" : "4",
+                "koodistoUri" : "opintojenlaajuusyksikko"
+              }
+            },
+            "kuvaus" : {
+              "fi" : "Kurssilla opiskellaan tietokoneen, toimisto-ohjelmien sekä internetin ja sähköpostin peruskäyttöä."
+            }
+          },
+          "arviointi" : [ {
+            "arvosana" : {
+              "koodiarvo" : "S",
+              "koodistoUri" : "arviointiasteikkoyleissivistava"
+            },
+            "päivä" : "2016-06-04",
+            "hyväksytty" : true
+          } ],
+          "tyyppi" : {
+            "koodiarvo" : "luvakurssi",
+            "koodistoUri" : "suorituksentyyppi"
+          }
+        } ],
+        "tyyppi" : {
+          "koodiarvo" : "luvaoppiaine",
+          "koodistoUri" : "suorituksentyyppi"
+        }
+      }, {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "AOM",
+            "koodistoUri" : "koskioppiaineetyleissivistava"
+          },
+          "kieli" : {
+            "koodiarvo" : "SV",
+            "koodistoUri" : "kielivalikoima"
+          },
+          "pakollinen" : true
+        },
+        "arviointi" : [ {
+          "arvosana" : {
+            "koodiarvo" : "9",
+            "koodistoUri" : "arviointiasteikkoyleissivistava"
+          },
+          "hyväksytty" : true
+        } ],
+        "suoritettuErityisenäTutkintona" : false,
+        "osasuoritukset" : [ {
+          "koulutusmoduuli" : {
+            "tunniste" : {
+              "koodiarvo" : "RUA4",
+              "koodistoUri" : "moduulikoodistolops2021"
+            },
+            "laajuus" : {
+              "arvo" : 1.0,
+              "yksikkö" : {
+                "koodiarvo" : "2",
+                "nimi" : {
+                  "fi" : "opintopistettä",
+                  "sv" : "studiepoäng",
+                  "en" : "ECTS credits"
+                },
+                "lyhytNimi" : {
+                  "fi" : "op",
+                  "sv" : "sp",
+                  "en" : "ECTS cr"
+                },
+                "koodistoUri" : "opintojenlaajuusyksikko"
+              }
+            },
+            "pakollinen" : true
+          },
+          "arviointi" : [ {
+            "arvosana" : {
+              "koodiarvo" : "7",
+              "koodistoUri" : "arviointiasteikkoyleissivistava"
+            },
+            "päivä" : "2021-09-04",
+            "hyväksytty" : true
+          } ],
+          "tyyppi" : {
+            "koodiarvo" : "lukionvaltakunnallinenmoduuli",
+            "koodistoUri" : "suorituksentyyppi"
+          }
+        } ],
+        "tyyppi" : {
+          "koodiarvo" : "luvalukionoppiaine2019",
+          "koodistoUri" : "suorituksentyyppi"
+        }
+      } ],
+      "tyyppi" : {
+        "koodiarvo" : "luva",
+        "koodistoUri" : "suorituksentyyppi"
+      }
+    } ],
+    "tyyppi" : {
+      "koodiarvo" : "luva",
+      "koodistoUri" : "opiskeluoikeudentyyppi"
+    },
+    "lisätiedot" : {
+      "pidennettyPäättymispäivä" : true,
+      "ulkomainenVaihtoopiskelija" : false,
+      "ulkomaanjaksot" : [ {
+        "alku" : "2012-09-01",
+        "loppu" : "2013-09-01",
+        "maa" : {
+          "koodiarvo" : "752",
+          "nimi" : {
+            "fi" : "Ruotsi"
+          },
+          "koodistoUri" : "maatjavaltiot2"
+        },
+        "kuvaus" : {
+          "fi" : "Harjoittelua ulkomailla"
+        }
+      } ],
+      "oikeusMaksuttomaanAsuntolapaikkaan" : true,
+      "sisäoppilaitosmainenMajoitus" : [ {
+        "alku" : "2013-09-01",
+        "loppu" : "2013-12-12"
+      } ]
+    },
+    "alkamispäivä" : "2008-08-15",
+    "päättymispäivä" : "2016-06-04"
+  } ]
+}

--- a/src/test/scala/fi/oph/koski/api/OppijaValidationLukioonValmistavaSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationLukioonValmistavaSpec.scala
@@ -1,12 +1,14 @@
 package fi.oph.koski.api
 
-import fi.oph.koski.documentation.ExamplesLukioonValmistavaKoulutus
-import fi.oph.koski.documentation.ExamplesLukioonValmistavaKoulutus.lukioonValmistavanKoulutuksenSuoritus
+import fi.oph.koski.documentation.{ExamplesLukioonValmistavaKoulutus, Lukio2019ExampleData, LukioExampleData}
+import fi.oph.koski.documentation.ExamplesLukioonValmistavaKoulutus.{lukioonValmistavanKoulutuksenSuoritus, lukioonValmistavanKoulutuksenSuoritus2019}
 import fi.oph.koski.http.KoskiErrorCategory
 import fi.oph.koski.schema._
 import fi.oph.koski.documentation.ExampleData._
-import java.time.LocalDate.{of => date}
+import fi.oph.koski.documentation.Lukio2019ExampleData.{laajuus, moduulinSuoritusOppiaineissa, muuModuuliOppiaineissa, numeerinenArviointi, numeerinenLukionOppiaineenArviointi, vieraanKielenModuuliOppiaineissa}
+import fi.oph.koski.documentation.LukioExampleData.{kurssisuoritus, lukionKieli, valtakunnallinenKurssi}
 
+import java.time.LocalDate.{of => date}
 import scala.reflect.runtime.universe.TypeTag
 
 class OppijaValidationLukioonValmistavaSpec extends TutkinnonPerusteetTest[LukioonValmistavanKoulutuksenOpiskeluoikeus] with LocalJettyHttpSpecification {
@@ -30,6 +32,35 @@ class OppijaValidationLukioonValmistavaSpec extends TutkinnonPerusteetTest[Lukio
       )
       putOpiskeluoikeus(defaultOpiskeluoikeus.copy(tila = tila)) {
         verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.tila.tilaltaPuuttuuRahoitusmuoto("Opiskeluoikeuden tilalta valmistunut puuttuu rahoitusmuoto"))
+      }
+    }
+  }
+
+  "Opintojen osasuoritukset" - {
+    "osasuorituksissa ei voi olla samaan aikaan lukion 2015 ja lukion 2019 opsien mukaisia lukion oppiaineiden suorituksia" in {
+      val opiskeluoikeus = ExamplesLukioonValmistavaKoulutus.lukioonValmistavanKoulutuksenOpiskeluoikeus2019.copy(
+        suoritukset = List(lukioonValmistavanKoulutuksenSuoritus2019.copy(
+          osasuoritukset = Some(List(
+            LukionOppiaineenOpintojenSuoritusLukioonValmistavassaKoulutuksessa(
+              lukionKieli("A1", "EN"),
+              arviointi = LukioExampleData.arviointi("S"),
+              osasuoritukset = Some(List(
+                kurssisuoritus(valtakunnallinenKurssi("ENA1")).copy(arviointi = LukioExampleData.numeerinenArviointi(8))
+              ))
+            ),
+            LukionOppiaineenOpintojenSuoritusLukioonValmistavassaKoulutuksessa2019(
+              koulutusmoduuli = Lukio2019ExampleData.lukionUskonto(Some("MU")),
+              arviointi = numeerinenLukionOppiaineenArviointi(9),
+              osasuoritukset = Some(List(
+                moduulinSuoritusOppiaineissa(muuModuuliOppiaineissa("UE1").copy(laajuus = Lukio2019ExampleData.laajuus(1.5))).copy(arviointi = numeerinenArviointi(4))
+              ))
+            )
+          ))
+        ))
+      )
+
+      putOpiskeluoikeus(opiskeluoikeus) {
+        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.rakenne.lukioonValmistavassaEriLukioOpsienOsasuorituksia())
       }
     }
   }


### PR DESCRIPTION
Aikaisemmin Luva-opinnoissa (Lukioon Valmistava) on toteutettu tuki lukion oppiaineiden opintojen suorituksille siten, että siellä on ollut kopioituna suoraan sama rakenne kuin lukionkin puolella.

Nyt kopioitu myös 2019 opsin mukainen rakenne Luvalle.

Lukio2019:n rakenteissa sallitaan oppiaineiden suoritustyyppinä myös luva2019-oppiaineopinnot.

Sen lisäksi tehty validaatio; Luva-suorituksella ei voi olla sekä lukion 2015 että lukion 2019 opsien mukaisia suorituksia.