### PR TITLE
Valpas taulukon järjestysikonin korjaus Chromessa

### DIFF
--- a/valpas-web/src/components/icons/Icon.tsx
+++ b/valpas-web/src/components/icons/Icon.tsx
@@ -37,7 +37,7 @@ type MaterialDesignIconProps = IconProps & {
 }
 
 const MaterialDesignIcon = (props: MaterialDesignIconProps) => (
-  <i
+  <span
     aria-hidden
     className={joinClassNames(
       "material-icons",
@@ -51,5 +51,5 @@ const MaterialDesignIcon = (props: MaterialDesignIconProps) => (
     )}
   >
     {props.name}
-  </i>
+  </span>
 )

--- a/valpas-web/src/components/tables/Table.less
+++ b/valpas-web/src/components/tables/Table.less
@@ -76,7 +76,7 @@
   margin-left: 0.5ex;
   width: 2ex;
   height: @font-size-medium;
-  overflow-y: hidden;
+  overflow: hidden;
 
   .material-icons {
     font-size: @font-size-large;

--- a/valpas-web/src/components/tables/Table.less
+++ b/valpas-web/src/components/tables/Table.less
@@ -77,7 +77,8 @@
   width: 2ex;
   height: @font-size-medium;
   overflow-y: hidden;
-  i {
+
+  .material-icons {
     font-size: @font-size-large;
   }
 }

--- a/valpas-web/test/snapshots/components/containers/Accordion.test.tsx.snap
+++ b/valpas-web/test/snapshots/components/containers/Accordion.test.tsx.snap
@@ -10,12 +10,12 @@ exports[`Accordion kaikki sivut avatutuvat klikkauksesta 1`] = `
     <h4
       class="accordion__label"
     >
-      <i
+      <span
         aria-hidden="true"
         class="material-icons icon icon--inline"
       >
         keyboard_arrow_right
-      </i>
+      </span>
       Yksi
     </h4>
     <div
@@ -30,12 +30,12 @@ exports[`Accordion kaikki sivut avatutuvat klikkauksesta 1`] = `
     <h4
       class="accordion__label"
     >
-      <i
+      <span
         aria-hidden="true"
         class="material-icons icon icon--inline"
       >
         keyboard_arrow_down
-      </i>
+      </span>
       Kaksi
     </h4>
     <div
@@ -50,12 +50,12 @@ exports[`Accordion kaikki sivut avatutuvat klikkauksesta 1`] = `
     <h4
       class="accordion__label"
     >
-      <i
+      <span
         aria-hidden="true"
         class="material-icons icon icon--inline"
       >
         keyboard_arrow_down
-      </i>
+      </span>
       Kolmas
     </h4>
     <div
@@ -77,12 +77,12 @@ exports[`Accordion renderöityy oikein 1`] = `
     <h4
       class="accordion__label"
     >
-      <i
+      <span
         aria-hidden="true"
         class="material-icons icon icon--inline"
       >
         keyboard_arrow_down
-      </i>
+      </span>
       Yksi
     </h4>
     <div
@@ -97,12 +97,12 @@ exports[`Accordion renderöityy oikein 1`] = `
     <h4
       class="accordion__label"
     >
-      <i
+      <span
         aria-hidden="true"
         class="material-icons icon icon--inline"
       >
         keyboard_arrow_right
-      </i>
+      </span>
       Kaksi
     </h4>
     <div
@@ -117,12 +117,12 @@ exports[`Accordion renderöityy oikein 1`] = `
     <h4
       class="accordion__label"
     >
-      <i
+      <span
         aria-hidden="true"
         class="material-icons icon icon--inline"
       >
         keyboard_arrow_right
-      </i>
+      </span>
       Kolmas
     </h4>
     <div

--- a/valpas-web/test/snapshots/components/tables/DataTable.test.tsx.snap
+++ b/valpas-web/test/snapshots/components/tables/DataTable.test.tsx.snap
@@ -22,12 +22,12 @@ exports[`DataTable Aktiivisen sarakkeen nimen uudelleen klikkaaminen kääntää
           <span
             class="table__sortindicator table__sortindicator--visible"
           >
-            <i
+            <span
               aria-hidden="true"
               class="material-icons icon icon--inline"
             >
               arrow_drop_up
-            </i>
+            </span>
           </span>
         </div>
       </th>
@@ -144,12 +144,12 @@ exports[`DataTable Renderöityy oikein 1`] = `
           <span
             class="table__sortindicator table__sortindicator--visible"
           >
-            <i
+            <span
               aria-hidden="true"
               class="material-icons icon icon--inline"
             >
               arrow_drop_down
-            </i>
+            </span>
           </span>
         </div>
       </th>
@@ -280,12 +280,12 @@ exports[`DataTable Toisen sarakkeen nimen klikkaaminen järjestää sen mukaises
           <span
             class="table__sortindicator table__sortindicator--visible"
           >
-            <i
+            <span
               aria-hidden="true"
               class="material-icons icon icon--inline"
             >
               arrow_drop_down
-            </i>
+            </span>
           </span>
         </div>
       </th>


### PR DESCRIPTION
Chromessa näkyi ikonin sijaan **vierityspalkki**. Korjataan asettamalla molemmat `overflow`:t `hidden`. Olikohan pelkän `overflow-y`:n käyttöön jokin syy tässä?

Laitetaan ikonit semanttisesti oikeampaan `span`-elementtiin `i`-elementin sijaan.