### PR TITLE
TOR-1335 Järjestä haut Valppaan detaljinäkymässä käänteiseen muokkausjärjestykseen

### DIFF
--- a/src/main/scala/fi/oph/koski/valpas/opiskeluoikeusrepository/ValpasOppija.scala
+++ b/src/main/scala/fi/oph/koski/valpas/opiskeluoikeusrepository/ValpasOppija.scala
@@ -181,6 +181,7 @@ object ValpasHakutilanneLaajatTiedot {
       hakemusUrl = hakukooste.hakemusUrl,
       aktiivinenHaku = hakukooste.aktiivinenHaku.getOrElse(true),
       hakuAlkaa = hakukooste.haunAlkamispaivamaara,
+      muokattu = hakukooste.hakemuksenMuokkauksenAikaleima,
       hakutoiveet = hakukooste.hakutoiveet.sortBy(_.hakutoivenumero).map(ValpasHakutoive.apply),
       debugHakukooste = Some(hakukooste)
     )
@@ -193,6 +194,7 @@ case class ValpasHakutilanneLaajatTiedot(
   hakemusUrl: String,
   aktiivinenHaku: Boolean,
   hakuAlkaa: LocalDateTime,
+  muokattu: Option[LocalDateTime],
   hakutoiveet: Seq[ValpasHakutoive],
   debugHakukooste: Option[Hakukooste]
 ) extends ValpasHakutilanne

--- a/valpas-web/src/state/oppijat.ts
+++ b/valpas-web/src/state/oppijat.ts
@@ -99,14 +99,9 @@ export type HakuLaajatTiedot = {
   hakemusOid: Oid
   hakemusUrl: string
   aktiivinenHaku: boolean
-  muokattu: ISODateTime
+  hakuAlkaa: ISODateTime
+  muokattu?: ISODateTime
   hakutoiveet: Hakutoive[]
-  osoite: string
-  puhelinnumero: string
-  sähköposti: string
-  huoltajanNimi?: string
-  huoltajanPuhelinnumero?: string
-  huoltajanSähköposti?: string
 }
 
 export type HakuSuppeatTiedot = Pick<
@@ -117,10 +112,10 @@ export type HakuSuppeatTiedot = Pick<
 }
 
 export type Hakutoive = {
-  hakutoivenumero?: number
   hakukohdeNimi?: LocalizedString
   organisaatioNimi?: LocalizedString
   koulutusNimi?: LocalizedString
+  hakutoivenumero?: number
   pisteet?: number
   alinValintaPistemaara?: number
   valintatila?: KoodistoKoodiviite<
@@ -185,13 +180,14 @@ export const OpiskeluoikeusLaajatTiedot = {
     ]),
 }
 
-const muokkausOrd = Ord.contramap((haku: HakuLaajatTiedot) => haku.muokattu)(
-  string.Ord
-)
+const muokkausOrd = Ord.contramap(
+  (h: HakuLaajatTiedot) => (h["muokattu"] as ISODate) || "0000-00-00"
+)(Ord.reverse(string.Ord))
 
 export const Haku = {
   latest: (haut: HakuLaajatTiedot[]) =>
     pipe(haut, A.sortBy([muokkausOrd]), A.head, O.toNullable),
+  sort: A.sortBy<HakuLaajatTiedot>([muokkausOrd]),
 }
 
 export const Hakutoive = {

--- a/valpas-web/src/views/oppija/OppijanHaut.tsx
+++ b/valpas-web/src/views/oppija/OppijanHaut.tsx
@@ -13,6 +13,7 @@ import {
 } from "../../components/typography/NoDataMessage"
 import { formatFixedNumber, getLocalized, t, T } from "../../i18n/i18n"
 import {
+  Haku,
   HakuLaajatTiedot,
   Hakutoive,
   OppijaHakutilanteillaLaajatTiedot,
@@ -26,7 +27,7 @@ export type OppijanHautProps = {
 }
 
 export const OppijanHaut = (props: OppijanHautProps) => {
-  const haut = props.oppija.hakutilanteet
+  const haut = Haku.sort(props.oppija.hakutilanteet)
   const error = props.oppija.hakutilanneError
   return error ? (
     <NoDataMessage>

--- a/valpas-web/test/integrationtests/login.test.ts
+++ b/valpas-web/test/integrationtests/login.test.ts
@@ -65,6 +65,10 @@ describe("Login / Logout / kirjautuminen", () => {
       "valpas-jkl-normaali"
     )
 
+    await expectElementEventuallyVisible(
+      ".hakutilanne tbody tr td:first-child a"
+    )
+
     // Salavihkainen logout (ei poista selaimesta keksiä)
     await fetch(pathToApiUrl("/test/logout/valpas-jkl-normaali"))
 


### PR DESCRIPTION
Nyt viimeisenä muokattu haku näytetään aina ylimpänä, aiemmin järjestys oli satunnainen eli riippui hakukoostepalvelun palauttamasta järjestyksestä.