### PR TITLE
VST: KOTO- ja Lukutaito -koulutusten arviointiasteikon korjaus

### DIFF
--- a/src/main/scala/fi/oph/koski/documentation/ExamplesVapaaSivistystyö.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesVapaaSivistystyö.scala
@@ -287,7 +287,7 @@ object VapaaSivistystyöExampleData {
         Koodistokoodiviite(koodiarvo = "vstmaahanmuuttajienkotoutumiskoulutuksenohjauksensuoritus", koodistoUri = "vstmaahanmuuttajienkotoutumiskoulutuksenkokonaisuus"),
         Some(LaajuusOpintoviikoissa(5))
       ),
-      arviointi = Some(List(vapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenArviointi))
+      arviointi = Some(List(vstArviointi()))
     )
   }
 
@@ -297,7 +297,7 @@ object VapaaSivistystyöExampleData {
         Koodistokoodiviite(koodiarvo = "vstmaahanmuuttajienkotoutumiskoulutuksentyoelamajayhteiskuntataitojensuoritus", koodistoUri = "vstmaahanmuuttajienkotoutumiskoulutuksenkokonaisuus"),
         Some(LaajuusOpintoviikoissa(15))
       ),
-      arviointi = Some(List(vapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenArviointi)),
+      arviointi = Some(List(vstArviointi())),
       osasuoritukset = Some(List(
         vapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenTyöelämäJaYhteiskuntataitojenTyöelämäJakso,
         vapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenTyöelämäJaYhteiskuntataidot
@@ -308,14 +308,14 @@ object VapaaSivistystyöExampleData {
   def vapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenTyöelämäJaYhteiskuntataitojenTyöelämäJakso() = {
     VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenTyöelämäJaYhteiskuntataitojenTyöelämäJakso(
       koulutusmoduuli = vapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenOpintojenOsasuoritus,
-      arviointi = Some(List(vapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenArviointi))
+      arviointi = Some(List(vstArviointi()))
     )
   }
 
   def vapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenTyöelämäJaYhteiskuntataidot() = {
     VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenTyöelämäJaYhteiskuntataidot(
       koulutusmoduuli = vapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenOpintojenOsasuoritus,
-      arviointi = Some(List(vapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenArviointi))
+      arviointi = Some(List(vstArviointi()))
     )
   }
 
@@ -325,7 +325,7 @@ object VapaaSivistystyöExampleData {
         Koodistokoodiviite(koodiarvo = "vstmaahanmuuttajienkotoutumiskoulutuksenvalinnaistensuoritus", koodistoUri = "vstmaahanmuuttajienkotoutumiskoulutuksenkokonaisuus"),
         Some(LaajuusOpintoviikoissa(4))
       ),
-      arviointi = Some(List(vapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenArviointi)),
+      arviointi = Some(List(vstArviointi())),
       osasuoritukset = Some(List(vapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenValinnaistenOpintojenOsasuoritus))
     )
   }
@@ -333,7 +333,7 @@ object VapaaSivistystyöExampleData {
   def vapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenValinnaistenOpintojenOsasuoritus() = {
     VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenValinnaistenOpintojenOsasuoritus(
       koulutusmoduuli = vapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenOpintojenOsasuoritus,
-      arviointi = Some(List(vapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenArviointi))
+      arviointi = Some(List(vstArviointi()))
     )
   }
 
@@ -342,13 +342,6 @@ object VapaaSivistystyöExampleData {
       tunniste = PaikallinenKoodi("TALO", "Kiinteistöhuollon perusteita"),
       kuvaus = "Omakotitaloasujan kiinteistöhuollon perusteet",
       laajuus = Some(LaajuusOpintoviikoissa(4))
-    )
-  }
-
-  def vapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenArviointi() = {
-    VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenArviointi(
-      arvosana = Koodistokoodiviite("Suoritettu", "arviointiasteikkovstkoto"),
-      päivä = date(2020, 1, 1)
     )
   }
 
@@ -367,7 +360,7 @@ object VapaaSivistystyöExampleData {
         Koodistokoodiviite(koodiarvo = "vstlukutaitokoulutuksenvuorovaikutustilannekokonaisuudensuoritus", koodistoUri = "vstlukutaitokoulutuksenkokonaisuus"),
         Some(LaajuusTunneissa(20))
       ),
-      arviointi = Some(List(vapaanSivistystyönLukutaitokoulutuksenArviointi))
+      arviointi = Some(List(vstArviointi()))
     )
   }
 
@@ -377,7 +370,7 @@ object VapaaSivistystyöExampleData {
         Koodistokoodiviite(koodiarvo = "vstlukutaitokoulutuksentekstienlukemisenkokonaisuudensuoritus", koodistoUri = "vstlukutaitokoulutuksenkokonaisuus"),
         Some(LaajuusTunneissa(20))
       ),
-      arviointi = Some(List(vapaanSivistystyönLukutaitokoulutuksenArviointi))
+      arviointi = Some(List(vstArviointi()))
     )
   }
 
@@ -387,7 +380,7 @@ object VapaaSivistystyöExampleData {
         Koodistokoodiviite(koodiarvo = "vstlukutaitokoulutuksentekstienkirjoittamisenkokonaisuudensuoritus", koodistoUri = "vstlukutaitokoulutuksenkokonaisuus"),
         Some(LaajuusTunneissa(20))
       ),
-      arviointi = Some(List(vapaanSivistystyönLukutaitokoulutuksenArviointi))
+      arviointi = Some(List(vstArviointi()))
     )
   }
 
@@ -397,7 +390,7 @@ object VapaaSivistystyöExampleData {
         Koodistokoodiviite(koodiarvo = "vstlukutaitokoulutuksennumeeristentaitojenkokonaisuudensuoritus", koodistoUri = "vstlukutaitokoulutuksenkokonaisuus"),
         Some(LaajuusTunneissa(20))
       ),
-      arviointi = Some(List(vapaanSivistystyönLukutaitokoulutuksenArviointi))
+      arviointi = Some(List(vstArviointi()))
     )
   }
 
@@ -405,13 +398,6 @@ object VapaaSivistystyöExampleData {
     VapaanSivistystyönLukutaidonKokonaisuus(
       tunniste =  tunniste,
       laajuus = laajuus
-    )
-  }
-
-  def vapaanSivistystyönLukutaitokoulutuksenArviointi() = {
-    VapaanSivistystyönLukutaitokoulutuksenArviointi(
-      taitotaso = Koodistokoodiviite(koodiarvo = "yli_C1.1", koodistoUri = "arviointiasteikkokehittyvankielitaidontasot"),
-      päivä = date(2020, 1, 1)
     )
   }
 }

--- a/src/main/scala/fi/oph/koski/schema/VapaaSivistystyö.scala
+++ b/src/main/scala/fi/oph/koski/schema/VapaaSivistystyö.scala
@@ -236,7 +236,7 @@ case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenOhjauksenSuor
   koulutusmoduuli: OppivelvollisilleSuunnattuVapaanSivistystyönMaahanmuuttajienKotoutumisKokonaisuus,
   @KoodistoKoodiarvo("vstmaahanmuuttajienkotoutumiskoulutuksenohjauksensuoritus")
   tyyppi: Koodistokoodiviite = Koodistokoodiviite(koodiarvo = "vstmaahanmuuttajienkotoutumiskoulutuksenohjauksensuoritus", koodistoUri = "suorituksentyyppi"),
-  override val arviointi: Option[List[VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenArviointi]] = None
+  override val arviointi: Option[List[OppivelvollisilleSuunnatunVapaanSivistystyönOpintokokonaisuudenArviointi]] = None
 ) extends VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenKokonaisuudenSuoritus
 
 @Title("Maahanmuuttajien kotoutumiskoulutuksen työelämä- ja yhteiskuntataitojen opintojen suoritus")
@@ -247,7 +247,7 @@ case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenTyöelämäJa
   override val osasuoritukset: Option[List[VapaanSivistystyönMaahanmuuttajienKuntoutuskoulutuksenTyöelämäJaYhteiskuntataitojenOpintojenOsasuoritus]],
   @KoodistoKoodiarvo("vstmaahanmuuttajienkotoutumiskoulutuksentyoelamajayhteiskuntataitojenkokonaisuudensuoritus")
   tyyppi: Koodistokoodiviite = Koodistokoodiviite(koodiarvo = "vstmaahanmuuttajienkotoutumiskoulutuksentyoelamajayhteiskuntataitojenkokonaisuudensuoritus", koodistoUri = "suorituksentyyppi"),
-  override val arviointi: Option[List[VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenArviointi]] = None
+  override val arviointi: Option[List[OppivelvollisilleSuunnatunVapaanSivistystyönOpintokokonaisuudenArviointi]] = None
 ) extends VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenKokonaisuudenSuoritus
 
 
@@ -259,7 +259,7 @@ case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenValinnaistenO
   override val osasuoritukset: Option[List[VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenValinnaistenOpintojenOsasuoritus]],
   @KoodistoKoodiarvo("vstmaahanmuuttajienkotoutumiskoulutuksenvalinnaistensuoritus")
   tyyppi: Koodistokoodiviite = Koodistokoodiviite(koodiarvo = "vstmaahanmuuttajienkotoutumiskoulutuksenvalinnaistensuoritus", koodistoUri = "suorituksentyyppi"),
-  override val arviointi: Option[List[VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenArviointi]] = None
+  override val arviointi: Option[List[OppivelvollisilleSuunnatunVapaanSivistystyönOpintokokonaisuudenArviointi]] = None
 ) extends VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenKokonaisuudenSuoritus
 
 trait OppivelvollisilleSuunnatunVapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenKokonaisuudenKoulutusmoduuli extends KoulutusmoduuliValinnainenLaajuus with KoodistostaLöytyväKoulutusmoduuli {
@@ -279,7 +279,7 @@ trait VapaanSivistystyönMaahanmuuttajienKuntoutuskoulutuksenValinnaistenOpintoj
 case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenValinnaistenOpintojenOsasuoritus(
   @Title("Valinnaiset opinnot")
   koulutusmoduuli: VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenOpintojenOsasuoritus,
-  arviointi: Option[List[VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenArviointi]],
+  arviointi: Option[List[OppivelvollisilleSuunnatunVapaanSivistystyönOpintokokonaisuudenArviointi]],
   @KoodistoKoodiarvo("vstmaahanmuuttajienkotoutumiskoulutuksenvalinnaistenopintojenosasuoritus")
   override val tyyppi: Koodistokoodiviite = Koodistokoodiviite(koodiarvo = "vstmaahanmuuttajienkotoutumiskoulutuksenvalinnaistenopintojenosasuoritus", koodistoUri = "suorituksentyyppi")
 ) extends VapaanSivistystyönMaahanmuuttajienKuntoutuskoulutuksenValinnaistenOpintojenOsasuoritus
@@ -290,7 +290,7 @@ trait VapaanSivistystyönMaahanmuuttajienKuntoutuskoulutuksenTyöelämäJaYhteis
 case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenTyöelämäJaYhteiskuntataitojenTyöelämäJakso(
   @Title("Työelämäjakso")
   koulutusmoduuli: VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenOpintojenOsasuoritus,
-  arviointi: Option[List[VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenArviointi]],
+  arviointi: Option[List[OppivelvollisilleSuunnatunVapaanSivistystyönOpintokokonaisuudenArviointi]],
   @KoodistoKoodiarvo("vstmaahanmuuttajienkotoutumiskoulutuksentyoelamajayhteiskuntataitojentyoelamajaksonsuoritus")
   override val tyyppi: Koodistokoodiviite = Koodistokoodiviite(koodiarvo = "vstmaahanmuuttajienkotoutumiskoulutuksentyoelamajayhteiskuntataitojentyoelamajaksonsuoritus", koodistoUri = "suorituksentyyppi")
 ) extends VapaanSivistystyönMaahanmuuttajienKuntoutuskoulutuksenTyöelämäJaYhteiskuntataitojenOpintojenOsasuoritus
@@ -299,19 +299,10 @@ case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenTyöelämäJa
 case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenTyöelämäJaYhteiskuntataidot(
   @Title("Työelämä- ja yhteiskuntataidot")
   koulutusmoduuli: VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenOpintojenOsasuoritus,
-  arviointi: Option[List[VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenArviointi]],
+  arviointi: Option[List[OppivelvollisilleSuunnatunVapaanSivistystyönOpintokokonaisuudenArviointi]],
   @KoodistoKoodiarvo("vstmaahanmuuttajienkotoutumiskoulutuksentyoelamajayhteiskuntataitojensuoritus")
   override val tyyppi: Koodistokoodiviite = Koodistokoodiviite(koodiarvo = "vstmaahanmuuttajienkotoutumiskoulutuksentyoelamajayhteiskuntataitojensuoritus", koodistoUri = "suorituksentyyppi")
 ) extends VapaanSivistystyönMaahanmuuttajienKuntoutuskoulutuksenTyöelämäJaYhteiskuntataitojenOpintojenOsasuoritus
-
-
-@Title("Arviointi")
-case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenArviointi(
-  @KoodistoUri("arviointiasteikkovstkoto")
-  @KoodistoKoodiarvo("Suoritettu")
-  arvosana: Koodistokoodiviite = Koodistokoodiviite("Suoritettu", "arviointiasteikkovstkoto"),
-  päivä: LocalDate
-) extends ArviointiPäivämäärällä with VapaanSivistystyönKoulutuksenArviointi
 
 @Title("Maahanmuuttajien kotoutumiskoulutuksen osasuoritus")
 case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenOpintojenOsasuoritus(

--- a/src/main/scala/fi/oph/koski/schema/VapaanSivistystyönLukutaitokoulutus.scala
+++ b/src/main/scala/fi/oph/koski/schema/VapaanSivistystyönLukutaitokoulutus.scala
@@ -35,7 +35,7 @@ case class VapaanSivistystyönLukutaitokoulutuksenKokonaisuudenSuoritus(
   koulutusmoduuli: VapaanSivistystyönLukutaidonKokonaisuus,
   @KoodistoKoodiarvo("vstlukutaitokoulutuksenkokonaisuudensuoritus")
   tyyppi: Koodistokoodiviite = Koodistokoodiviite(koodiarvo = "vstlukutaitokoulutuksenkokonaisuudensuoritus", koodistoUri = "suorituksentyyppi"),
-  override val arviointi: Option[List[VapaanSivistystyönLukutaitokoulutuksenArviointi]] = None
+  override val arviointi: Option[List[OppivelvollisilleSuunnatunVapaanSivistystyönOpintokokonaisuudenArviointi]] = None
 ) extends Suoritus with Vahvistukseton
 
 trait VapaanSivistystyönLukutaitokoulutuksenOsasuoritustenKoulutusmoduuli extends KoulutusmoduuliValinnainenLaajuus with KoodistostaLöytyväKoulutusmoduuli {
@@ -48,13 +48,3 @@ case class VapaanSivistystyönLukutaidonKokonaisuus(
   tunniste: Koodistokoodiviite,
   laajuus: Option[LaajuusTunneissa] = None
 ) extends VapaanSivistystyönLukutaitokoulutuksenOsasuoritustenKoulutusmoduuli with KoodistostaLöytyväKoulutusmoduuli with LaajuuttaEiValidoida
-
-@Title("Arviointi")
-case class VapaanSivistystyönLukutaitokoulutuksenArviointi(
-  @KoodistoUri("arviointiasteikkovstkoto")
-  @KoodistoKoodiarvo("Suoritettu")
-  arvosana: Koodistokoodiviite = Koodistokoodiviite("Suoritettu", "arviointiasteikkovstkoto"),
-  @KoodistoUri("arviointiasteikkokehittyvankielitaidontasot")
-  taitotaso: Koodistokoodiviite,
-  päivä: LocalDate
-) extends ArviointiPäivämäärällä with VapaanSivistystyönKoulutuksenArviointi

--- a/src/test/resources/backwardcompatibility/vapaasivistystyo-lukutaitokoulutus_2021-04-16.json
+++ b/src/test/resources/backwardcompatibility/vapaasivistystyo-lukutaitokoulutus_2021-04-16.json
@@ -168,14 +168,10 @@
         },
         "arviointi" : [ {
           "arvosana" : {
-            "koodiarvo" : "Suoritettu",
-            "koodistoUri" : "arviointiasteikkovstkoto"
+            "koodiarvo" : "Hyväksytty",
+            "koodistoUri" : "arviointiasteikkovst"
           },
-          "taitotaso" : {
-            "koodiarvo" : "yli_C1.1",
-            "koodistoUri" : "arviointiasteikkokehittyvankielitaidontasot"
-          },
-          "päivä" : "2020-01-01",
+          "päivä" : "2021-10-30",
           "hyväksytty" : true
         } ]
       }, {
@@ -208,14 +204,10 @@
         },
         "arviointi" : [ {
           "arvosana" : {
-            "koodiarvo" : "Suoritettu",
-            "koodistoUri" : "arviointiasteikkovstkoto"
+            "koodiarvo" : "Hyväksytty",
+            "koodistoUri" : "arviointiasteikkovst"
           },
-          "taitotaso" : {
-            "koodiarvo" : "yli_C1.1",
-            "koodistoUri" : "arviointiasteikkokehittyvankielitaidontasot"
-          },
-          "päivä" : "2020-01-01",
+          "päivä" : "2021-10-30",
           "hyväksytty" : true
         } ]
       }, {
@@ -248,14 +240,10 @@
         },
         "arviointi" : [ {
           "arvosana" : {
-            "koodiarvo" : "Suoritettu",
-            "koodistoUri" : "arviointiasteikkovstkoto"
+            "koodiarvo" : "Hyväksytty",
+            "koodistoUri" : "arviointiasteikkovst"
           },
-          "taitotaso" : {
-            "koodiarvo" : "yli_C1.1",
-            "koodistoUri" : "arviointiasteikkokehittyvankielitaidontasot"
-          },
-          "päivä" : "2020-01-01",
+          "päivä" : "2021-10-30",
           "hyväksytty" : true
         } ]
       }, {
@@ -288,14 +276,10 @@
         },
         "arviointi" : [ {
           "arvosana" : {
-            "koodiarvo" : "Suoritettu",
-            "koodistoUri" : "arviointiasteikkovstkoto"
+            "koodiarvo" : "Hyväksytty",
+            "koodistoUri" : "arviointiasteikkovst"
           },
-          "taitotaso" : {
-            "koodiarvo" : "yli_C1.1",
-            "koodistoUri" : "arviointiasteikkokehittyvankielitaidontasot"
-          },
-          "päivä" : "2020-01-01",
+          "päivä" : "2021-10-30",
           "hyväksytty" : true
         } ]
       } ]

--- a/src/test/resources/backwardcompatibility/vapaasivistystyo-maahanmuuttajienkotoutuskoulutus_2021-04-16.json
+++ b/src/test/resources/backwardcompatibility/vapaasivistystyo-maahanmuuttajienkotoutuskoulutus_2021-04-16.json
@@ -220,10 +220,10 @@
         },
         "arviointi" : [ {
           "arvosana" : {
-            "koodiarvo" : "Suoritettu",
-            "koodistoUri" : "arviointiasteikkovstkoto"
+            "koodiarvo" : "Hyväksytty",
+            "koodistoUri" : "arviointiasteikkovst"
           },
-          "päivä" : "2020-01-01",
+          "päivä" : "2021-10-30",
           "hyväksytty" : true
         } ]
       }, {
@@ -281,10 +281,10 @@
           },
           "arviointi" : [ {
             "arvosana" : {
-              "koodiarvo" : "Suoritettu",
-              "koodistoUri" : "arviointiasteikkovstkoto"
+              "koodiarvo" : "Hyväksytty",
+              "koodistoUri" : "arviointiasteikkovst"
             },
-            "päivä" : "2020-01-01",
+            "päivä" : "2021-10-30",
             "hyväksytty" : true
           } ],
           "tyyppi" : {
@@ -322,10 +322,10 @@
           },
           "arviointi" : [ {
             "arvosana" : {
-              "koodiarvo" : "Suoritettu",
-              "koodistoUri" : "arviointiasteikkovstkoto"
+              "koodiarvo" : "Hyväksytty",
+              "koodistoUri" : "arviointiasteikkovst"
             },
-            "päivä" : "2020-01-01",
+            "päivä" : "2021-10-30",
             "hyväksytty" : true
           } ],
           "tyyppi" : {
@@ -339,10 +339,10 @@
         },
         "arviointi" : [ {
           "arvosana" : {
-            "koodiarvo" : "Suoritettu",
-            "koodistoUri" : "arviointiasteikkovstkoto"
+            "koodiarvo" : "Hyväksytty",
+            "koodistoUri" : "arviointiasteikkovst"
           },
-          "päivä" : "2020-01-01",
+          "päivä" : "2021-10-30",
           "hyväksytty" : true
         } ]
       }, {
@@ -400,10 +400,10 @@
           },
           "arviointi" : [ {
             "arvosana" : {
-              "koodiarvo" : "Suoritettu",
-              "koodistoUri" : "arviointiasteikkovstkoto"
+              "koodiarvo" : "Hyväksytty",
+              "koodistoUri" : "arviointiasteikkovst"
             },
-            "päivä" : "2020-01-01",
+            "päivä" : "2021-10-30",
             "hyväksytty" : true
           } ],
           "tyyppi" : {
@@ -417,10 +417,10 @@
         },
         "arviointi" : [ {
           "arvosana" : {
-            "koodiarvo" : "Suoritettu",
-            "koodistoUri" : "arviointiasteikkovstkoto"
+            "koodiarvo" : "Hyväksytty",
+            "koodistoUri" : "arviointiasteikkovst"
           },
-          "päivä" : "2020-01-01",
+          "päivä" : "2021-10-30",
           "hyväksytty" : true
         } ]
       } ]


### PR DESCRIPTION
"Suoritettu"-arviointi ei käynytkään, käytetään samaa "Hyväksytty/Hylätty"-arviontirakennetta kuin muukin VST.