### PR TITLE
Perusopetuksen pakollisilta oppiaineilta ei aina vaadita laajuutta

### DIFF
--- a/src/main/scala/fi/oph/koski/schema/NuortenPerusopetus.scala
+++ b/src/main/scala/fi/oph/koski/schema/NuortenPerusopetus.scala
@@ -170,6 +170,7 @@ case class PerusopetuksenOpiskeluoikeudenLisätiedot(
   with OikeusmaksuttomaanAsuntolapaikkaan
   with Majoitusetuinen
   with Kuljetusetuinen
+  with Kotiopetuksellinen
   with Vammainen
   with VaikeastiVammainen {
   override def sisältääOsaAikaisenErityisopetuksen: Boolean =

--- a/src/main/scala/fi/oph/koski/schema/OpiskeluoikeudenLisatiedot.scala
+++ b/src/main/scala/fi/oph/koski/schema/OpiskeluoikeudenLisatiedot.scala
@@ -51,6 +51,10 @@ trait Kuljetusetuinen {
   def kuljetusetu: Option[Aikajakso]
 }
 
+trait Kotiopetuksellinen {
+  def kotiopetus: Option[Aikajakso]
+}
+
 trait MaksuttomuusTieto extends OpiskeluoikeudenLisätiedot {
   import mojave._
   @Title("Koulutuksen maksuttomuus")

--- a/src/main/scala/fi/oph/koski/schema/PerusopetuksenLisaopetus.scala
+++ b/src/main/scala/fi/oph/koski/schema/PerusopetuksenLisaopetus.scala
@@ -137,6 +137,7 @@ case class PerusopetuksenLisäopetuksenOpiskeluoikeudenLisätiedot(
   with OikeusmaksuttomaanAsuntolapaikkaan
   with Majoitusetuinen
   with Kuljetusetuinen
+  with Kotiopetuksellinen
   with Vammainen
   with VaikeastiVammainen
   with MaksuttomuusTieto {


### PR DESCRIPTION
Laajuutta ei vaadita jos:
- Opiskeluoikeudella on voimassa kotiopetus jakso vuosiluokan tai päättötodistuksen vahvistuspäivänä
- Vuosiluokan tai päättötodistuksen suoritustapa on `erityinentutkinto`
- Oppiaineen suoritustapa on `erityinentutkinto`