### PR TITLE
TOR-1352: Opo-pilotin palautetyöpajasta nousseet havainnot

### DIFF
--- a/src/main/resources/valpas/localization/valpas-default-texts.json
+++ b/src/main/resources/valpas/localization/valpas-default-texts.json
@@ -30,6 +30,7 @@
   "hakemuksentila__hakenut": "Hakenut",
   "hakemuksentila__n_hakua": "{{lukumäärä}} hakua",
   "hakemuksentila__ei_hakemusta": "Ei hakemusta",
+  "hakemuksentila__tooltip": "{{haku}}, muokattu {{muokkausPvm}}",
   "valintatieto__ei_opiskelupaikkaa": "Ei opiskelupaikkaa",
   "valintatieto__varasija": "Varasija",
   "valintatieto__ns_varasija": "{{n}}. varasija",

--- a/src/main/resources/valpas/localization/valpas-default-texts.json
+++ b/src/main/resources/valpas/localization/valpas-default-texts.json
@@ -40,7 +40,7 @@
   "vastaanotettu__n_paikkaa": "{{lukumäärä}} paikkaa",
   "opiskeluoikeudet__n_opiskeluoikeutta": "{{lukumäärä}} opiskeluoikeutta",
   "opiskeluoikeudet__pvm_alkaen_kohde": "{{päivämäärä}} alkaen: {{kohde}}",
-  "oppija__muut_oppijat": "Muut oppijat",
+  "oppija__takaisin": "Takaisin",
   "oppija__oletusotsikko": "Oppijan tiedot",
   "oppija__oppija_oid": "Oppija {{oid}}",
   "oppija__ei_löydy": "Oppijaa ei löydy tunnuksella {{oid}}",

--- a/src/main/resources/valpas/localization/valpas-default-texts.json
+++ b/src/main/resources/valpas/localization/valpas-default-texts.json
@@ -16,6 +16,7 @@
   "localraamit__logout": "Kirjaudu ulos",
   "ylänavi__hakutilanne": "Hakutilanne",
   "hakutilannenäkymä__otsikko": "Hakeutumisvelvollisia oppijoita",
+  "taulukko__kaikki": "Kaikki",
   "hakutilanne__taulu_nimi": "Nimi",
   "hakutilanne__taulu_syntymäaika": "Syntymäaika",
   "hakutilanne__taulu_ryhma": "Ryhmä",

--- a/src/main/scala/fi/oph/koski/valpas/opiskeluoikeusrepository/ValpasOppija.scala
+++ b/src/main/scala/fi/oph/koski/valpas/opiskeluoikeusrepository/ValpasOppija.scala
@@ -230,6 +230,7 @@ object ValpasHakutilanneSuppeatTiedot {
       laajatTiedot.hakemusUrl,
       laajatTiedot.aktiivinenHaku,
       laajatTiedot.hakutoiveet.map(ValpasSuppeaHakutoive.apply),
+      laajatTiedot.muokattu,
     )
   }
 }
@@ -241,6 +242,7 @@ case class ValpasHakutilanneSuppeatTiedot(
   hakemusUrl: String,
   aktiivinenHaku: Boolean,
   hakutoiveet: Seq[ValpasSuppeaHakutoive],
+  muokattu: Option[LocalDateTime],
 ) extends ValpasHakutilanne
 
 object ValpasHakutoive {

--- a/valpas-web/src/components/forms/Dropdown.tsx
+++ b/valpas-web/src/components/forms/Dropdown.tsx
@@ -9,7 +9,7 @@ const b = bem("dropdown")
 
 export type DropdownProps<T> = {
   options: DropdownOption<T>[]
-  value: T
+  value?: T
   onChange: (value?: T) => void
   label?: string
   icon?: React.ReactNode

--- a/valpas-web/src/components/tables/DataTable.tsx
+++ b/valpas-web/src/components/tables/DataTable.tsx
@@ -5,7 +5,7 @@ import * as number from "fp-ts/lib/number"
 import * as O from "fp-ts/lib/Option"
 import * as Ord from "fp-ts/lib/Ord"
 import * as string from "fp-ts/lib/string"
-import React, { useMemo, useState } from "react"
+import React, { useEffect, useMemo, useState } from "react"
 import {
   nonStoredState,
   sessionStateStorage,
@@ -39,6 +39,12 @@ export type DataTableProps = {
   columns: Column[]
   data: Datum[]
   storageName?: string
+  onChange?: (event: DataTableChangeEvent) => void
+}
+
+export type DataTableChangeEvent = {
+  filteredRowCount: number
+  unfilteredRowCount: number
 }
 
 export type Column = {
@@ -101,6 +107,13 @@ export const DataTable = (props: DataTableProps) => {
     const ordDatum = Ord.fromCompare(sortAscending ? compare : flip(compare))
     return A.sortBy([ordDatum])(filteredData)
   }, [sortColumnIndex, sortAscending, filteredData])
+
+  useEffect(() => {
+    props.onChange?.({
+      filteredRowCount: sortedData.length,
+      unfilteredRowCount: props.data.length,
+    })
+  }, [sortedData, props.onChange])
 
   const optionsForFilters = useMemo(
     () =>

--- a/valpas-web/src/components/tables/DataTable.tsx
+++ b/valpas-web/src/components/tables/DataTable.tsx
@@ -6,10 +6,16 @@ import * as O from "fp-ts/lib/Option"
 import * as Ord from "fp-ts/lib/Ord"
 import * as string from "fp-ts/lib/string"
 import React, { useMemo, useState } from "react"
+import {
+  nonStoredState,
+  sessionStateStorage,
+  useStoredState,
+} from "../../state/useSessionStoreState"
 // import { update } from "../../utils/arrays"
 import { toFilterableString } from "../../utils/conversions"
 import { ArrowDropDownIcon, ArrowDropUpIcon } from "../icons/Icon"
 import {
+  createFilter,
   DataFilter,
   dataFilterUsesValueList,
   DataTableFilter,
@@ -32,6 +38,7 @@ export type DataTableProps = {
   className?: string
   columns: Column[]
   data: Datum[]
+  storageName?: string
 }
 
 export type Column = {
@@ -60,11 +67,16 @@ export type Value = {
   tooltip?: string
 }
 
+type FilterArray = Array<{ fn: FilterFn | null; value: string | null }>
+
 export const DataTable = (props: DataTableProps) => {
   const [sortColumnIndex, setSortColumnIndex] = useState(0)
   const [sortAscending, setSortAscending] = useState(true)
-  const [filters, setFilters] = useState<Array<FilterFn | null>>(
-    new Array(props.columns.length).fill(null)
+
+  const [filters, setFilters] = useStoredState<FilterArray>(
+    props.storageName
+      ? createFilterStorage(props.storageName, props.columns)
+      : nonStoredState(initialFilters(props.columns.length))
   )
 
   const filteredData = useMemo(
@@ -73,12 +85,12 @@ export const DataTable = (props: DataTableProps) => {
       props.data.filter((datum) =>
         filters.every(
           (filter, index) =>
-            !filter ||
+            !filter?.fn ||
             (datum.values[index]?.filterValues
               ? datum.values[index]?.filterValues?.some((fv) =>
-                  filter(toFilterableString(fv))
+                  filter.fn?.(toFilterableString(fv))
                 )
-              : filter(toFilterableString(datum.values[index]?.value)))
+              : filter.fn?.(toFilterableString(datum.values[index]?.value)))
         )
       ),
     [filters, props.data]
@@ -165,10 +177,11 @@ export const DataTable = (props: DataTableProps) => {
                   <DataTableFilter
                     type={col.filter}
                     values={optionsForFilters[index] || []}
-                    onChange={(filter) =>
+                    initialValue={filters[index]?.value}
+                    onChange={(filter, value) =>
                       pipe(
                         filters,
-                        A.updateAt(index, filter),
+                        A.updateAt(index, { fn: filter, value }),
                         O.map(setFilters)
                       )
                     }
@@ -234,3 +247,18 @@ const selectFilterValues = (index: number) => (datum: Datum) => {
   const item = datum.values[index]
   return item?.filterValues || (item?.value ? [item.value] : [])
 }
+
+const createFilterStorage = (storageName: string, columns: Column[]) =>
+  sessionStateStorage<FilterArray, Array<string | null>>(
+    `${storageName}-${columns.map((c) => c.filter?.slice(0, 2)).join(".")}`,
+    initialFilters(columns.length),
+    (filts) => filts.map((f) => f.value),
+    (values) =>
+      values.map((value, index) => ({
+        value,
+        fn: createFilter(columns[index]?.filter, value),
+      }))
+  )
+
+const initialFilters = (length: number): FilterArray =>
+  new Array(length).fill({ value: null, fn: null })

--- a/valpas-web/src/state/apitypes/haku.ts
+++ b/valpas-web/src/state/apitypes/haku.ts
@@ -21,7 +21,12 @@ export type HakuLaajatTiedot = {
 
 export type HakuSuppeatTiedot = Pick<
   HakuLaajatTiedot,
-  "hakuOid" | "hakuNimi" | "hakemusOid" | "hakemusUrl" | "aktiivinenHaku"
+  | "hakuOid"
+  | "hakuNimi"
+  | "hakemusOid"
+  | "hakemusUrl"
+  | "aktiivinenHaku"
+  | "muokattu"
 > & {
   hakutoiveet: SuppeaHakutoive[]
 }

--- a/valpas-web/src/state/useSessionStoreState.ts
+++ b/valpas-web/src/state/useSessionStoreState.ts
@@ -1,0 +1,49 @@
+import { Dispatch, SetStateAction, useMemo, useState } from "react"
+
+export type StateStorage<S> = {
+  get: () => S
+  set: (value: S) => void
+}
+
+export const nonStoredState = <S>(initialState: S): StateStorage<S> => ({
+  get() {
+    return initialState
+  },
+  set(_) {},
+})
+
+export const sessionStateStorage = <S, T>(
+  name: string,
+  initialState: S,
+  mapSave: (a: S) => T = (a: unknown) => a as T,
+  mapRestore: (a: T) => S = (a: unknown) => a as S
+): StateStorage<S> => {
+  return {
+    get() {
+      const storedState = sessionStorage.getItem(name)
+      return storedState ? mapRestore(JSON.parse(storedState)) : initialState
+    },
+    set(value) {
+      sessionStorage.setItem(name, JSON.stringify(mapSave(value)))
+    },
+  }
+}
+
+export const useStoredState = <S>(
+  storage: StateStorage<S>
+): [S, Dispatch<SetStateAction<S>>] => {
+  const initialState = useMemo(() => storage.get(), [])
+
+  const [state, setState] = useState(initialState)
+
+  const setAndStoreState = (value: SetStateAction<S>): void => {
+    const newState: S = isFunction(value) ? value(state) : value
+    setState(newState)
+    storage.set(newState)
+  }
+
+  return [state, setAndStoreState]
+}
+
+const isFunction = <S>(s: SetStateAction<S>): s is (value: S) => S =>
+  typeof s === "function"

--- a/valpas-web/src/views/hakutilanne/HakutilanneTable.tsx
+++ b/valpas-web/src/views/hakutilanne/HakutilanneTable.tsx
@@ -53,6 +53,7 @@ export const HakutilanneTable = (props: HakutilanneTableProps) => {
 
   return (
     <DataTable
+      storageName="hakutilannetaulu"
       className="hakutilanne"
       columns={[
         {

--- a/valpas-web/src/views/hakutilanne/HakutilanneTable.tsx
+++ b/valpas-web/src/views/hakutilanne/HakutilanneTable.tsx
@@ -153,6 +153,7 @@ const hakemuksenTila = (
       oppijaOid,
       basePath
     ),
+    tooltip: hakutilanteet.map(hakuTooltip).join("\n"),
   }
 }
 
@@ -187,6 +188,12 @@ const hakemuksenTilaDisplay = (
     ),
     O.toNullable
   )
+
+const hakuTooltip = (haku: HakuSuppeatTiedot): string =>
+  t("hakemuksentila__tooltip", {
+    haku: getLocalized(haku.hakuNimi) || "?",
+    muokkausPvm: formatNullableDate(haku.muokattu),
+  })
 
 const fromNullableValue = (value: Value | null): Value =>
   value || {

--- a/valpas-web/src/views/hakutilanne/HakutilanneTable.tsx
+++ b/valpas-web/src/views/hakutilanne/HakutilanneTable.tsx
@@ -10,7 +10,12 @@ import {
   WarningIcon,
 } from "../../components/icons/Icon"
 import { ExternalLink } from "../../components/navigation/ExternalLink"
-import { DataTable, Datum, Value } from "../../components/tables/DataTable"
+import {
+  DataTable,
+  DataTableProps,
+  Datum,
+  Value,
+} from "../../components/tables/DataTable"
 import { getLocalized, t, Translation } from "../../i18n/i18n"
 import { HakuSuppeatTiedot, selectByHakutoive } from "../../state/apitypes/haku"
 import {
@@ -39,6 +44,7 @@ import { formatDate, formatNullableDate } from "../../utils/date"
 export type HakutilanneTableProps = {
   data: OppijaHakutilanteillaSuppeatTiedot[]
   organisaatioOid: string
+  onChange?: DataTableProps["onChange"]
 }
 
 export const HakutilanneTable = (props: HakutilanneTableProps) => {
@@ -91,6 +97,7 @@ export const HakutilanneTable = (props: HakutilanneTableProps) => {
         },
       ]}
       data={data}
+      onChange={props.onChange}
     />
   )
 }

--- a/valpas-web/src/views/hakutilanne/HakutilanneView.tsx
+++ b/valpas-web/src/views/hakutilanne/HakutilanneView.tsx
@@ -2,7 +2,7 @@ import bem from "bem-ts"
 import * as A from "fp-ts/Array"
 import * as Eq from "fp-ts/Eq"
 import { pipe } from "fp-ts/lib/function"
-import React from "react"
+import React, { useState } from "react"
 import { Redirect, useHistory } from "react-router"
 import { fetchOppijat, fetchOppijatCache } from "../../api/api"
 import { useApiWithParams } from "../../api/apiHooks"
@@ -10,9 +10,9 @@ import { isLoading, isSuccess } from "../../api/apiUtils"
 import { Card, CardBody, CardHeader } from "../../components/containers/cards"
 import { Dropdown } from "../../components/forms/Dropdown"
 import { Spinner } from "../../components/icons/Spinner"
+import { DataTableChangeEvent } from "../../components/tables/DataTable"
 import { Counter } from "../../components/typography/Counter"
 import { getLocalized, t, T } from "../../i18n/i18n"
-import { valvottavatOpiskeluoikeudet } from "../../state/apitypes/opiskeluoikeus"
 import { useBasePath } from "../../state/basePath"
 import {
   Oid,
@@ -59,6 +59,10 @@ export const HakutilanneView = (props: HakutilanneViewProps) => {
     organisaatioOid ? [organisaatioOid] : undefined,
     fetchOppijatCache
   )
+  const [counters, setCounters] = useState<DataTableChangeEvent>({
+    filteredRowCount: 0,
+    unfilteredRowCount: 0,
+  })
 
   const orgOptions = getOrgOptions(organisaatiot)
 
@@ -84,16 +88,9 @@ export const HakutilanneView = (props: HakutilanneViewProps) => {
           <T id="hakutilannenäkymä__otsikko" />
           {isSuccess(oppijatFetch) && (
             <Counter>
-              {
-                A.flatten(
-                  oppijatFetch.data.map((d) =>
-                    valvottavatOpiskeluoikeudet(
-                      organisaatioOid,
-                      d.oppija.opiskeluoikeudet
-                    )
-                  )
-                ).length
-              }
+              {counters.filteredRowCount === counters.unfilteredRowCount
+                ? counters.filteredRowCount
+                : `${counters.filteredRowCount} / ${counters.unfilteredRowCount}`}
             </Counter>
           )}
         </CardHeader>
@@ -103,6 +100,7 @@ export const HakutilanneView = (props: HakutilanneViewProps) => {
             <HakutilanneTable
               data={oppijatFetch.data}
               organisaatioOid={organisaatioOid}
+              onChange={setCounters}
             />
           )}
         </CardBody>

--- a/valpas-web/src/views/oppija/OppijaView.tsx
+++ b/valpas-web/src/views/oppija/OppijaView.tsx
@@ -127,7 +127,7 @@ const BackNav = (props: BackNavProps) => {
       <FlatLink to={targetPath}>
         <BackIcon />
         <ButtonLabel>
-          <T id="oppija__muut_oppijat" />
+          <T id="oppija__takaisin" />
         </ButtonLabel>
       </FlatLink>
     </div>


### PR DESCRIPTION
- kun tehdään valinta suodatuksessa, pitäisi näkyä selkeästi ”kaikki”  eikä tyhjä, esim. ryhmästä 9a -> selkeästi valikossa ”kaikki”
- parempi nimi: muut oppijat -> takaisin
- hakemuksiin listanäkymässä lisätietoa: hakemusta on muokattu,  tuodaan päivämäärä koska viimeksi muokattu (hover / tooltip tms.),  tietona missä haussa on hakenut (hover / tooltip tms.)
- jos valitsee vain yhden ysin ryhmän/luokan tarkasteluun, esim. 9A,  niin nopeuttaisi tarkistusta, mikäli yhden ryhmän kokonaislukumäärä  olisi nopeasti nähtävillä. Tällä hetkellä näyttää vain kaikkien ysien  kokonaislukumäärän. Tämä on tärkeää varsinkin, jos ryhmät on jaettu eri  opojen vastuulle.- suodatetut lukumäärä / oppivelvollisten  kokonaislukumäärä
- filttereiden tilat pysyvät tallessa, kun käydään detskunäkymässä
