### PR TITLE
TOR-1362: Näytä esimerkinomaiset muu haku -valitsimet taulussa, jos ilmoittaminen-featureflag on päällä

### DIFF
--- a/src/main/resources/valpas/localization/valpas-default-texts.json
+++ b/src/main/resources/valpas/localization/valpas-default-texts.json
@@ -25,6 +25,7 @@
   "hakutilanne__taulu_opiskelupaikka_vastaanotettu": "Opiskelupaikka vastaanotettu",
   "hakutilanne__taulu_voimassaolevia_opiskeluoikeuksia": "Voimassaolevia opiskeluoikeuksia",
   "hakutilanne__taulu_data_ei_toteutettu": "Ei toteutettu",
+  "hakutilanne__taulu_muu_haku": "Muu haku",
   "hakutilanne__ei_oikeuksia_title": "Virhe",
   "hakutilanne__ei_oikeuksia_teksti": "Sinulla ei ole oikeuksia nähdä yhdenkään oppilaitoksen tietoja",
   "ilmoittaminen_drawer__title": "Oppilaiden ilmoittaminen asuinkunnalle",

--- a/src/main/resources/valpas/localization/valpas-default-texts.json
+++ b/src/main/resources/valpas/localization/valpas-default-texts.json
@@ -26,6 +26,7 @@
   "hakutilanne__taulu_voimassaolevia_opiskeluoikeuksia": "Voimassaolevia opiskeluoikeuksia",
   "hakutilanne__taulu_data_ei_toteutettu": "Ei toteutettu",
   "hakutilanne__taulu_muu_haku": "Muu haku",
+  "hakutilanne__taulu_muu_haku_tooltip": "Voit halutessasi merkitä tähän jos hakija on hakenut opintopolun ulkopuolella, esimerkiksi ulkomaille tai Ahvenanmaalle. Tieto näkyy vain omalle organisaatiolle, sekä ilmoittaessa asuinkunnalle",
   "hakutilanne__ei_oikeuksia_title": "Virhe",
   "hakutilanne__ei_oikeuksia_teksti": "Sinulla ei ole oikeuksia nähdä yhdenkään oppilaitoksen tietoja",
   "ilmoittaminen_drawer__title": "Oppilaiden ilmoittaminen asuinkunnalle",

--- a/valpas-web/src/components/buttons/ToggleSwitch.less
+++ b/valpas-web/src/components/buttons/ToggleSwitch.less
@@ -1,0 +1,55 @@
+@import "../../style/colors.less";
+@import "../../style/utils.less";
+
+@toggleswitch-width: .pxToRem(42) [];
+@toggleswitch-height: .pxToRem(22) [];
+@toggleswitch-slider-size: .pxToRem(18) [];
+@toggleswitch-margin: (@toggleswitch-height - @toggleswitch-slider-size) * 0.5;
+
+.toggleswitch__container {
+  position: relative;
+  display: inline-block;
+  width: @toggleswitch-width;
+  height: @toggleswitch-height;
+
+  border-radius: @toggleswitch-height * 0.5;
+
+  input:checked + .toggleswitch__slider {
+    background-color: @color-blue;
+  }
+
+  input:checked + .toggleswitch__slider::before {
+    transform: translateX(
+      @toggleswitch-width - @toggleswitch-margin * 2 - @toggleswitch-slider-size
+    );
+  }
+
+  .toggleswitch__slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+
+    background: @color-gray-lighten-2;
+    border-radius: 99999px;
+
+    transition: 200ms;
+
+    &::before {
+      position: absolute;
+      content: "";
+
+      width: @toggleswitch-slider-size;
+      height: @toggleswitch-slider-size;
+      left: @toggleswitch-margin;
+      top: @toggleswitch-margin;
+
+      background-color: @color-white;
+      border-radius: 99999px;
+      transform: translateX(0px);
+      transition: 200ms;
+    }
+  }
+}

--- a/valpas-web/src/components/buttons/ToggleSwitch.tsx
+++ b/valpas-web/src/components/buttons/ToggleSwitch.tsx
@@ -1,0 +1,17 @@
+import bem from "bem-ts"
+import React from "react"
+import "./ToggleSwitch.less"
+
+const b = bem("toggleswitch")
+
+export type ToggleSwitchProps = {
+  // checked: boolean
+  // onChanged: (checked: boolean) => void
+}
+
+export const ToggleSwitch = (_props: ToggleSwitchProps) => (
+  <label className={b("container")}>
+    <input type="checkbox" />
+    <span className={b("slider")} />
+  </label>
+)

--- a/valpas-web/src/views/hakutilanne/HakutilanneTable.tsx
+++ b/valpas-web/src/views/hakutilanne/HakutilanneTable.tsx
@@ -23,7 +23,8 @@ import {
   SelectableDataTable,
   SelectableDataTableProps,
 } from "../../components/tables/SelectableDataTable"
-import { getLocalized, t, Translation } from "../../i18n/i18n"
+import { InfoTooltip } from "../../components/tooltip/InfoTooltip"
+import { getLocalized, T, t, Translation } from "../../i18n/i18n"
 import { HakuSuppeatTiedot, selectByHakutoive } from "../../state/apitypes/haku"
 import {
   isEiPaikkaa,
@@ -110,7 +111,14 @@ export const HakutilanneTable = (props: HakutilanneTableProps) => {
 
   if (isFeatureFlagEnabled("ilmoittaminen")) {
     columns.push({
-      label: t("hakutilanne__taulu_muu_haku"),
+      label: (
+        <>
+          <T id="hakutilanne__taulu_muu_haku" />
+          <InfoTooltip>
+            <T id="hakutilanne__taulu_muu_haku_tooltip" />
+          </InfoTooltip>
+        </>
+      ),
     })
   }
 

--- a/valpas-web/src/views/hakutilanne/HakutilanneTable.tsx
+++ b/valpas-web/src/views/hakutilanne/HakutilanneTable.tsx
@@ -5,6 +5,7 @@ import * as O from "fp-ts/lib/Option"
 import * as string from "fp-ts/string"
 import React, { useMemo } from "react"
 import { Link } from "react-router-dom"
+import { ToggleSwitch } from "../../components/buttons/ToggleSwitch"
 import {
   FutureSuccessIcon,
   SuccessIcon,
@@ -12,6 +13,7 @@ import {
 } from "../../components/icons/Icon"
 import { ExternalLink } from "../../components/navigation/ExternalLink"
 import {
+  Column,
   DataTable,
   Datum,
   DatumKey,
@@ -70,45 +72,53 @@ export const HakutilanneTable = (props: HakutilanneTableProps) => {
     ? SelectableDataTable
     : DataTable
 
+  const columns: Column[] = [
+    {
+      label: t("hakutilanne__taulu_nimi"),
+      filter: "freetext",
+      size: "large",
+    },
+    {
+      label: t("hakutilanne__taulu_syntymäaika"),
+      size: "small",
+    },
+    {
+      label: t("hakutilanne__taulu_ryhma"),
+      filter: "dropdown",
+      size: "xsmall",
+    },
+    {
+      label: t("hakutilanne__taulu_hakemuksen_tila"),
+      filter: "dropdown",
+    },
+    {
+      label: t("hakutilanne__taulu_valintatieto"),
+      filter: "dropdown",
+      indicatorSpace: "auto",
+    },
+    {
+      label: t("hakutilanne__taulu_opiskelupaikka_vastaanotettu"),
+      filter: "dropdown",
+      indicatorSpace: "auto",
+    },
+    {
+      label: t("hakutilanne__taulu_voimassaolevia_opiskeluoikeuksia"),
+      filter: "dropdown",
+      indicatorSpace: "auto",
+    },
+  ]
+
+  if (isFeatureFlagEnabled("ilmoittaminen")) {
+    columns.push({
+      label: t("hakutilanne__taulu_muu_haku"),
+    })
+  }
+
   return (
     <TableComponent
       storageName="hakutilannetaulu"
       className="hakutilanne"
-      columns={[
-        {
-          label: t("hakutilanne__taulu_nimi"),
-          filter: "freetext",
-          size: "large",
-        },
-        {
-          label: t("hakutilanne__taulu_syntymäaika"),
-          size: "small",
-        },
-        {
-          label: t("hakutilanne__taulu_ryhma"),
-          filter: "dropdown",
-          size: "xsmall",
-        },
-        {
-          label: t("hakutilanne__taulu_hakemuksen_tila"),
-          filter: "dropdown",
-        },
-        {
-          label: t("hakutilanne__taulu_valintatieto"),
-          filter: "dropdown",
-          indicatorSpace: "auto",
-        },
-        {
-          label: t("hakutilanne__taulu_opiskelupaikka_vastaanotettu"),
-          filter: "dropdown",
-          indicatorSpace: "auto",
-        },
-        {
-          label: t("hakutilanne__taulu_voimassaolevia_opiskeluoikeuksia"),
-          filter: "dropdown",
-          indicatorSpace: "auto",
-        },
-      ]}
+      columns={columns}
       data={data}
       onCountChange={props.onCountChange}
       peerEquality={oppijaOidsEqual}
@@ -169,7 +179,13 @@ const oppijaToTableData = (basePath: string, organisaatioOid: string) => (
       fromNullableValue(valintatila(oppija.hakutilanteet)),
       fromNullableValue(vastaanottotieto(oppija.hakutilanteet)),
       fromNullableValue(opiskeluoikeustiedot(oppija.oppija.opiskeluoikeudet)),
-    ],
+      isFeatureFlagEnabled("ilmoittaminen")
+        ? {
+            value: null,
+            display: <ToggleSwitch />,
+          }
+        : null,
+    ].filter(nonNull),
   }))
 }
 

--- a/valpas-web/test/integrationtests/hakutilanne.test.ts
+++ b/valpas-web/test/integrationtests/hakutilanne.test.ts
@@ -21,22 +21,22 @@ const clickOppija = (index: number) =>
   clickElement(`.hakutilanne tr:nth-child(${index + 1}) td:first-child a`)
 
 const jklNormaalikouluTableContent = `
-  Epäonninen Valpas                                       | 30.10.2005  | 9C | Ei hakemusta         | –                           | –                         | doneJyväskylän normaalikoulu, Perusopetus
-  Eroaja-myöhemmin Valpas                                 | 29.9.2005   | 9C | Ei hakemusta         | –                           | –                         | doneJyväskylän normaalikoulu, Perusopetus
-  Kahdella-oppija-oidilla Valpas                          | 15.2.2005   | 9C | Hakenut open_in_new  | Varasija: Ressun lukio      | –                         | doneJyväskylän normaalikoulu, Lukiokoulutus
-  KasiinAstiToisessaKoulussaOllut Valpas                  | 17.8.2005   | 9C | Ei hakemusta         | –                           | –                         | doneJyväskylän normaalikoulu, Perusopetus
-  Kotiopetus-menneisyydessä Valpas                        | 6.2.2005    | 9C | Ei hakemusta         | –                           | –                         | doneJyväskylän normaalikoulu, Perusopetus
-  LukionAloittanut Valpas                                 | 29.4.2005   | 9C | Ei hakemusta         | –                           | –                         | doneJyväskylän normaalikoulu, Lukiokoulutus
-  LukionLokakuussaAloittanut Valpas                       | 18.4.2005   | 9C | Ei hakemusta         | –                           | –                         | hourglass_empty3.10.2021 alkaen: Jyväskylän normaalikoulu, Lukiokoulutus
-  LuokallejäänytYsiluokkalainen Valpas                    | 2.8.2005    | 9A | 2 hakua              | –                           | –                         | doneJyväskylän normaalikoulu, Perusopetus
-  LuokallejäänytYsiluokkalainenJatkaa Valpas              | 6.2.2005    | 9B | Ei hakemusta         | –                           | –                         | doneJyväskylän normaalikoulu, Perusopetus
-  LuokallejäänytYsiluokkalainenKouluvaihtoMuualta Valpas  | 2.11.2005   | 9B | Ei hakemusta         | –                           | –                         | doneJyväskylän normaalikoulu, Perusopetus
-  Oppivelvollinen-ysiluokka-kesken-keväällä-2021 Valpas   | 22.11.2005  | 9C | Hakenut open_in_new  | 2. Helsingin medialukio     | doneHelsingin medialukio  | doneJyväskylän normaalikoulu, Perusopetus
-  Päällekkäisiä Oppivelvollisuuksia                       | 6.6.2005    | 9B | Hakenut open_in_new  | Hyväksytty (2 hakukohdetta) | doneOmnia                 | done2 opiskeluoikeutta
-  Turvakielto Valpas                                      | 29.9.2004   | 9C | Hakenut open_in_new  | warningEi opiskelupaikkaa   | –                         | doneJyväskylän normaalikoulu, Perusopetus
-  UseampiYsiluokkaSamassaKoulussa Valpas                  | 25.8.2005   | 9D | Ei hakemusta         | –                           | –                         | doneJyväskylän normaalikoulu, Perusopetus
-  UseampiYsiluokkaSamassaKoulussa Valpas                  | 25.8.2005   | 9C | Ei hakemusta         | –                           | –                         | doneJyväskylän normaalikoulu, Perusopetus
-  Ysiluokka-valmis-keväällä-2021 Valpas                   | 19.6.2005   | 9C | Ei hakemusta         | –                           | –                         | –
+  Epäonninen Valpas                                       | 30.10.2005  | 9C | Ei hakemusta         | –                           | –                         | doneJyväskylän normaalikoulu, Perusopetus                                   |
+  Eroaja-myöhemmin Valpas                                 | 29.9.2005   | 9C | Ei hakemusta         | –                           | –                         | doneJyväskylän normaalikoulu, Perusopetus                                   |
+  Kahdella-oppija-oidilla Valpas                          | 15.2.2005   | 9C | Hakenut open_in_new  | Varasija: Ressun lukio      | –                         | doneJyväskylän normaalikoulu, Lukiokoulutus                                 |
+  KasiinAstiToisessaKoulussaOllut Valpas                  | 17.8.2005   | 9C | Ei hakemusta         | –                           | –                         | doneJyväskylän normaalikoulu, Perusopetus                                   |
+  Kotiopetus-menneisyydessä Valpas                        | 6.2.2005    | 9C | Ei hakemusta         | –                           | –                         | doneJyväskylän normaalikoulu, Perusopetus                                   |
+  LukionAloittanut Valpas                                 | 29.4.2005   | 9C | Ei hakemusta         | –                           | –                         | doneJyväskylän normaalikoulu, Lukiokoulutus                                 |
+  LukionLokakuussaAloittanut Valpas                       | 18.4.2005   | 9C | Ei hakemusta         | –                           | –                         | hourglass_empty3.10.2021 alkaen: Jyväskylän normaalikoulu, Lukiokoulutus    |
+  LuokallejäänytYsiluokkalainen Valpas                    | 2.8.2005    | 9A | 2 hakua              | –                           | –                         | doneJyväskylän normaalikoulu, Perusopetus                                   |
+  LuokallejäänytYsiluokkalainenJatkaa Valpas              | 6.2.2005    | 9B | Ei hakemusta         | –                           | –                         | doneJyväskylän normaalikoulu, Perusopetus                                   |
+  LuokallejäänytYsiluokkalainenKouluvaihtoMuualta Valpas  | 2.11.2005   | 9B | Ei hakemusta         | –                           | –                         | doneJyväskylän normaalikoulu, Perusopetus                                   |
+  Oppivelvollinen-ysiluokka-kesken-keväällä-2021 Valpas   | 22.11.2005  | 9C | Hakenut open_in_new  | 2. Helsingin medialukio     | doneHelsingin medialukio  | doneJyväskylän normaalikoulu, Perusopetus                                   |
+  Päällekkäisiä Oppivelvollisuuksia                       | 6.6.2005    | 9B | Hakenut open_in_new  | Hyväksytty (2 hakukohdetta) | doneOmnia                 | done2 opiskeluoikeutta                                                      |
+  Turvakielto Valpas                                      | 29.9.2004   | 9C | Hakenut open_in_new  | warningEi opiskelupaikkaa   | –                         | doneJyväskylän normaalikoulu, Perusopetus                                   |
+  UseampiYsiluokkaSamassaKoulussa Valpas                  | 25.8.2005   | 9D | Ei hakemusta         | –                           | –                         | doneJyväskylän normaalikoulu, Perusopetus                                   |
+  UseampiYsiluokkaSamassaKoulussa Valpas                  | 25.8.2005   | 9C | Ei hakemusta         | –                           | –                         | doneJyväskylän normaalikoulu, Perusopetus                                   |
+  Ysiluokka-valmis-keväällä-2021 Valpas                   | 19.6.2005   | 9C | Ei hakemusta         | –                           | –                         | –                                                                           |
 `
 
 const hakutilannePath = createHakutilannePathWithoutOrg("/virkailija")


### PR DESCRIPTION
Huom! Sarakkeelle lisätty tooltip asemoituu väärin (menee ruudun ulkopuolelle), mutta tämä bugi korjautuu pullarissa https://github.com/Opetushallitus/koski/pull/1341 olevan korjauksen myötä.