### PR TITLE
Raportointikannan aikajakso riveihin esiopetuksen vammaisuus-tiedot e…

### DIFF
--- a/src/main/scala/fi/oph/koski/raportointikanta/AikajaksoRowBuilder.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/AikajaksoRowBuilder.scala
@@ -267,6 +267,7 @@ object AikajaksoRowBuilder {
         )
       case eol: EsiopetuksenOpiskeluoikeudenLisätiedot =>
         toSeq(
+          eol.vammainen,
           eol.vaikeastiVammainen,
           eol.sisäoppilaitosmainenMajoitus,
           eol.koulukoti


### PR DESCRIPTION
…ivät muodostuneet oikein, koska vammaisuus-jakson alkupäiviä ei otettu huomioon rivejä luodessa