### PR TITLE
TOR-1228: Taulukon parempi responsiivisuus

### DIFF
--- a/valpas-web/src/components/tables/DataTable.tsx
+++ b/valpas-web/src/components/tables/DataTable.tsx
@@ -14,6 +14,7 @@ import {
 // import { update } from "../../utils/arrays"
 import { toFilterableString } from "../../utils/conversions"
 import { ArrowDropDownIcon, ArrowDropUpIcon } from "../icons/Icon"
+import { InfoTooltip } from "../tooltip/InfoTooltip"
 import {
   createFilter,
   DataFilter,
@@ -48,7 +49,8 @@ export type DataTableCountChangeEvent = {
 }
 
 export type Column = {
-  label: React.ReactNode
+  label: string
+  tooltip?: string
   filter?: DataFilter
   size?: TableCellSize
   indicatorSpace?: true | false | "auto"
@@ -153,12 +155,15 @@ export const DataTable = (props: DataTableProps) => {
               onClick={() => sortByColumn(index)}
               className={b("label")}
             >
-              <div className={b("labeltext")}>
-                <span>{col.label}</span>
+              <div className={b("labelcontent")}>
+                <div className={b("labeltext")} title={col.label}>
+                  {col.label}
+                </div>
                 <SortIndicator
                   visible={sortColumnIndex === index}
                   ascending={sortAscending}
                 />
+                {col.tooltip && <InfoTooltip>{col.tooltip}</InfoTooltip>}
               </div>
             </HeaderCell>
           ))}
@@ -256,10 +261,10 @@ type SortIndicatorProps = {
 }
 
 const SortIndicator = ({ visible, ascending }: SortIndicatorProps) => (
-  <span className={b("sortindicator", { visible })}>
+  <div className={b("sortindicator", { visible })}>
     {visible &&
       (ascending ? <ArrowDropDownIcon inline /> : <ArrowDropUpIcon inline />)}
-  </span>
+  </div>
 )
 
 const compareDatum = (index: number) => (a: Datum, b: Datum) => {

--- a/valpas-web/src/components/tables/Table.less
+++ b/valpas-web/src/components/tables/Table.less
@@ -5,9 +5,18 @@
 @table-h-padding: 0.75rem;
 @table-v-padding: 0.5rem;
 
+.table__container {
+  @media screen and (max-width: 1600px) {
+    overflow: scroll;
+    table {
+      width: auto;
+    }
+  }
+}
+
 .table {
   table-layout: fixed;
-  min-width: 100%;
+  width: 100%;
 }
 
 .table__body .table__row:nth-child(odd) {
@@ -45,6 +54,17 @@
   border-bottom: 1px solid @color-gray-lighten-3;
 }
 
+.table__labelcontent {
+  width: 100%;
+  display: flex;
+
+  .table__labeltext {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    flex: 1;
+  }
+}
+
 .table__th--xsmall {
   width: 6rem;
 }
@@ -80,19 +100,15 @@
 }
 
 .table__sortindicator {
-  display: inline-block;
-  margin-left: 0.5ex;
-  width: 2ex;
+  display: block;
   height: @font-size-medium;
-  overflow: hidden;
-
   .material-icons {
     font-size: @font-size-large;
   }
 }
 
 .card__body {
-  .table {
+  .table__container {
     margin-left: -@table-h-padding;
     margin-right: -@table-h-padding;
 

--- a/valpas-web/src/components/tables/Table.tsx
+++ b/valpas-web/src/components/tables/Table.tsx
@@ -29,9 +29,11 @@ export type TableCellSize =
 export type TableProps = React.HTMLAttributes<HTMLTableElement>
 
 export const Table = ({ children, className, ...rest }: TableProps) => (
-  <table {...rest} className={joinClassNames(b(), className)}>
-    {children}
-  </table>
+  <div className={b("container")}>
+    <table {...rest} className={joinClassNames(b(), className)}>
+      {children}
+    </table>
+  </div>
 )
 
 export const TableHeader = ({

--- a/valpas-web/src/views/hakutilanne/HakutilanneTable.tsx
+++ b/valpas-web/src/views/hakutilanne/HakutilanneTable.tsx
@@ -23,8 +23,7 @@ import {
   SelectableDataTable,
   SelectableDataTableProps,
 } from "../../components/tables/SelectableDataTable"
-import { InfoTooltip } from "../../components/tooltip/InfoTooltip"
-import { getLocalized, T, t, Translation } from "../../i18n/i18n"
+import { getLocalized, t, Translation } from "../../i18n/i18n"
 import { HakuSuppeatTiedot, selectByHakutoive } from "../../state/apitypes/haku"
 import {
   isEiPaikkaa,
@@ -107,14 +106,8 @@ export const HakutilanneTable = (props: HakutilanneTableProps) => {
       indicatorSpace: "auto",
     },
     {
-      label: (
-        <>
-          <T id="hakutilanne__taulu_voimassaolevia_opiskeluoikeuksia" />
-          <InfoTooltip>
-            <T id="hakutilanne__taulu_voimassaolevia_opiskeluoikeuksia_tooltip" />
-          </InfoTooltip>
-        </>
-      ),
+      label: t("hakutilanne__taulu_voimassaolevia_opiskeluoikeuksia"),
+      tooltip: t("hakutilanne__taulu_voimassaolevia_opiskeluoikeuksia_tooltip"),
       filter: "dropdown",
       indicatorSpace: "auto",
     },
@@ -122,14 +115,8 @@ export const HakutilanneTable = (props: HakutilanneTableProps) => {
 
   if (isFeatureFlagEnabled("ilmoittaminen")) {
     columns.push({
-      label: (
-        <>
-          <T id="hakutilanne__taulu_muu_haku" />
-          <InfoTooltip>
-            <T id="hakutilanne__taulu_muu_haku_tooltip" />
-          </InfoTooltip>
-        </>
-      ),
+      label: t("hakutilanne__taulu_muu_haku"),
+      tooltip: t("hakutilanne__taulu_muu_haku_tooltip"),
     })
   }
 

--- a/valpas-web/test/snapshots/components/tables/DataTable.test.tsx.snap
+++ b/valpas-web/test/snapshots/components/tables/DataTable.test.tsx.snap
@@ -1,367 +1,397 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataTable Aktiivisen sarakkeen nimen uudelleen klikkaaminen kääntää järjestyksen 1`] = `
-<table
-  class="table"
+<div
+  class="table__container"
 >
-  <thead
-    class="table__head"
+  <table
+    class="table"
   >
-    <tr
-      class="table__row"
+    <thead
+      class="table__head"
     >
-      <th
-        class="table__th table__label"
+      <tr
+        class="table__row"
       >
-        <div
-          class="table__labeltext"
+        <th
+          class="table__th table__label"
         >
-          <span>
-            Nimi
-          </span>
-          <span
-            class="table__sortindicator table__sortindicator--visible"
+          <div
+            class="table__labelcontent"
           >
-            <span
-              aria-hidden="true"
-              class="material-icons icon icon--inline"
+            <div
+              class="table__labeltext"
+              title="Nimi"
             >
-              arrow_drop_up
-            </span>
-          </span>
-        </div>
-      </th>
-      <th
-        class="table__th table__label"
-      >
-        <div
-          class="table__labeltext"
+              Nimi
+            </div>
+            <div
+              class="table__sortindicator table__sortindicator--visible"
+            >
+              <span
+                aria-hidden="true"
+                class="material-icons icon icon--inline"
+              >
+                arrow_drop_up
+              </span>
+            </div>
+          </div>
+        </th>
+        <th
+          class="table__th table__label"
         >
-          <span>
-            Oppilaitos
-          </span>
-          <span
-            class="table__sortindicator"
-          />
-        </div>
-      </th>
-    </tr>
-  </thead>
-  <tbody
-    class="table__body"
-  >
-    <tr
-      class="table__row"
-      data-row="4"
+          <div
+            class="table__labelcontent"
+          >
+            <div
+              class="table__labeltext"
+              title="Oppilaitos"
+            >
+              Oppilaitos
+            </div>
+            <div
+              class="table__sortindicator"
+            />
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="table__body"
     >
-      <td
-        class="table__td"
-        title="Osmo"
+      <tr
+        class="table__row"
+        data-row="4"
       >
-        Osmo
-      </td>
-      <td
-        class="table__td"
-        title="Celsiuksen koulu"
+        <td
+          class="table__td"
+          title="Osmo"
+        >
+          Osmo
+        </td>
+        <td
+          class="table__td"
+          title="Celsiuksen koulu"
+        >
+          Celsiuksen koulu
+        </td>
+      </tr>
+      <tr
+        class="table__row"
+        data-row="2"
       >
-        Celsiuksen koulu
-      </td>
-    </tr>
-    <tr
-      class="table__row"
-      data-row="2"
-    >
-      <td
-        class="table__td"
-        title="Heli"
+        <td
+          class="table__td"
+          title="Heli"
+        >
+          Heli
+        </td>
+        <td
+          class="table__td"
+          title="Beetakaroteenikoulu"
+        >
+          Beetakaroteenikoulu
+        </td>
+      </tr>
+      <tr
+        class="table__row"
+        data-row="1"
       >
-        Heli
-      </td>
-      <td
-        class="table__td"
-        title="Beetakaroteenikoulu"
+        <td
+          class="table__td"
+          title="Heikki"
+        >
+          Heikki
+        </td>
+        <td
+          class="table__td"
+          title="Aakkoskoulu"
+        >
+          Aakkoskoulu
+        </td>
+      </tr>
+      <tr
+        class="table__row"
+        data-row="3"
       >
-        Beetakaroteenikoulu
-      </td>
-    </tr>
-    <tr
-      class="table__row"
-      data-row="1"
-    >
-      <td
-        class="table__td"
-        title="Heikki"
-      >
-        Heikki
-      </td>
-      <td
-        class="table__td"
-        title="Aakkoskoulu"
-      >
-        Aakkoskoulu
-      </td>
-    </tr>
-    <tr
-      class="table__row"
-      data-row="3"
-    >
-      <td
-        class="table__td"
-        title="Aatu"
-      >
-        Aatu
-      </td>
-      <td
-        class="table__td"
-        title="Deltakoulu"
-      >
-        Deltakoulu
-      </td>
-    </tr>
-  </tbody>
-</table>
+        <td
+          class="table__td"
+          title="Aatu"
+        >
+          Aatu
+        </td>
+        <td
+          class="table__td"
+          title="Deltakoulu"
+        >
+          Deltakoulu
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 `;
 
 exports[`DataTable Renderöityy oikein 1`] = `
-<table
-  class="table"
+<div
+  class="table__container"
 >
-  <thead
-    class="table__head"
+  <table
+    class="table"
   >
-    <tr
-      class="table__row"
+    <thead
+      class="table__head"
     >
-      <th
-        class="table__th table__label"
+      <tr
+        class="table__row"
       >
-        <div
-          class="table__labeltext"
+        <th
+          class="table__th table__label"
         >
-          <span>
-            Nimi
-          </span>
-          <span
-            class="table__sortindicator table__sortindicator--visible"
+          <div
+            class="table__labelcontent"
           >
-            <span
-              aria-hidden="true"
-              class="material-icons icon icon--inline"
+            <div
+              class="table__labeltext"
+              title="Nimi"
             >
-              arrow_drop_down
-            </span>
-          </span>
-        </div>
-      </th>
-      <th
-        class="table__th table__label"
-      >
-        <div
-          class="table__labeltext"
+              Nimi
+            </div>
+            <div
+              class="table__sortindicator table__sortindicator--visible"
+            >
+              <span
+                aria-hidden="true"
+                class="material-icons icon icon--inline"
+              >
+                arrow_drop_down
+              </span>
+            </div>
+          </div>
+        </th>
+        <th
+          class="table__th table__label"
         >
-          <span>
-            Oppilaitos
-          </span>
-          <span
-            class="table__sortindicator"
-          />
-        </div>
-      </th>
-    </tr>
-  </thead>
-  <tbody
-    class="table__body"
-  >
-    <tr
-      class="table__row"
-      data-row="3"
+          <div
+            class="table__labelcontent"
+          >
+            <div
+              class="table__labeltext"
+              title="Oppilaitos"
+            >
+              Oppilaitos
+            </div>
+            <div
+              class="table__sortindicator"
+            />
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="table__body"
     >
-      <td
-        class="table__td"
-        title="Aatu"
+      <tr
+        class="table__row"
+        data-row="3"
       >
-        Aatu
-      </td>
-      <td
-        class="table__td"
-        title="Deltakoulu"
+        <td
+          class="table__td"
+          title="Aatu"
+        >
+          Aatu
+        </td>
+        <td
+          class="table__td"
+          title="Deltakoulu"
+        >
+          Deltakoulu
+        </td>
+      </tr>
+      <tr
+        class="table__row"
+        data-row="1"
       >
-        Deltakoulu
-      </td>
-    </tr>
-    <tr
-      class="table__row"
-      data-row="1"
-    >
-      <td
-        class="table__td"
-        title="Heikki"
+        <td
+          class="table__td"
+          title="Heikki"
+        >
+          Heikki
+        </td>
+        <td
+          class="table__td"
+          title="Aakkoskoulu"
+        >
+          Aakkoskoulu
+        </td>
+      </tr>
+      <tr
+        class="table__row"
+        data-row="2"
       >
-        Heikki
-      </td>
-      <td
-        class="table__td"
-        title="Aakkoskoulu"
+        <td
+          class="table__td"
+          title="Heli"
+        >
+          Heli
+        </td>
+        <td
+          class="table__td"
+          title="Beetakaroteenikoulu"
+        >
+          Beetakaroteenikoulu
+        </td>
+      </tr>
+      <tr
+        class="table__row"
+        data-row="4"
       >
-        Aakkoskoulu
-      </td>
-    </tr>
-    <tr
-      class="table__row"
-      data-row="2"
-    >
-      <td
-        class="table__td"
-        title="Heli"
-      >
-        Heli
-      </td>
-      <td
-        class="table__td"
-        title="Beetakaroteenikoulu"
-      >
-        Beetakaroteenikoulu
-      </td>
-    </tr>
-    <tr
-      class="table__row"
-      data-row="4"
-    >
-      <td
-        class="table__td"
-        title="Osmo"
-      >
-        Osmo
-      </td>
-      <td
-        class="table__td"
-        title="Celsiuksen koulu"
-      >
-        Celsiuksen koulu
-      </td>
-    </tr>
-  </tbody>
-</table>
+        <td
+          class="table__td"
+          title="Osmo"
+        >
+          Osmo
+        </td>
+        <td
+          class="table__td"
+          title="Celsiuksen koulu"
+        >
+          Celsiuksen koulu
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 `;
 
 exports[`DataTable Toisen sarakkeen nimen klikkaaminen järjestää sen mukaisesti 1`] = `
-<table
-  class="table"
+<div
+  class="table__container"
 >
-  <thead
-    class="table__head"
+  <table
+    class="table"
   >
-    <tr
-      class="table__row"
+    <thead
+      class="table__head"
     >
-      <th
-        class="table__th table__label"
+      <tr
+        class="table__row"
       >
-        <div
-          class="table__labeltext"
+        <th
+          class="table__th table__label"
         >
-          <span>
-            Nimi
-          </span>
-          <span
-            class="table__sortindicator"
-          />
-        </div>
-      </th>
-      <th
-        class="table__th table__label"
-      >
-        <div
-          class="table__labeltext"
-        >
-          <span>
-            Oppilaitos
-          </span>
-          <span
-            class="table__sortindicator table__sortindicator--visible"
+          <div
+            class="table__labelcontent"
           >
-            <span
-              aria-hidden="true"
-              class="material-icons icon icon--inline"
+            <div
+              class="table__labeltext"
+              title="Nimi"
             >
-              arrow_drop_down
-            </span>
-          </span>
-        </div>
-      </th>
-    </tr>
-  </thead>
-  <tbody
-    class="table__body"
-  >
-    <tr
-      class="table__row"
-      data-row="1"
+              Nimi
+            </div>
+            <div
+              class="table__sortindicator"
+            />
+          </div>
+        </th>
+        <th
+          class="table__th table__label"
+        >
+          <div
+            class="table__labelcontent"
+          >
+            <div
+              class="table__labeltext"
+              title="Oppilaitos"
+            >
+              Oppilaitos
+            </div>
+            <div
+              class="table__sortindicator table__sortindicator--visible"
+            >
+              <span
+                aria-hidden="true"
+                class="material-icons icon icon--inline"
+              >
+                arrow_drop_down
+              </span>
+            </div>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="table__body"
     >
-      <td
-        class="table__td"
-        title="Heikki"
+      <tr
+        class="table__row"
+        data-row="1"
       >
-        Heikki
-      </td>
-      <td
-        class="table__td"
-        title="Aakkoskoulu"
+        <td
+          class="table__td"
+          title="Heikki"
+        >
+          Heikki
+        </td>
+        <td
+          class="table__td"
+          title="Aakkoskoulu"
+        >
+          Aakkoskoulu
+        </td>
+      </tr>
+      <tr
+        class="table__row"
+        data-row="2"
       >
-        Aakkoskoulu
-      </td>
-    </tr>
-    <tr
-      class="table__row"
-      data-row="2"
-    >
-      <td
-        class="table__td"
-        title="Heli"
+        <td
+          class="table__td"
+          title="Heli"
+        >
+          Heli
+        </td>
+        <td
+          class="table__td"
+          title="Beetakaroteenikoulu"
+        >
+          Beetakaroteenikoulu
+        </td>
+      </tr>
+      <tr
+        class="table__row"
+        data-row="4"
       >
-        Heli
-      </td>
-      <td
-        class="table__td"
-        title="Beetakaroteenikoulu"
+        <td
+          class="table__td"
+          title="Osmo"
+        >
+          Osmo
+        </td>
+        <td
+          class="table__td"
+          title="Celsiuksen koulu"
+        >
+          Celsiuksen koulu
+        </td>
+      </tr>
+      <tr
+        class="table__row"
+        data-row="3"
       >
-        Beetakaroteenikoulu
-      </td>
-    </tr>
-    <tr
-      class="table__row"
-      data-row="4"
-    >
-      <td
-        class="table__td"
-        title="Osmo"
-      >
-        Osmo
-      </td>
-      <td
-        class="table__td"
-        title="Celsiuksen koulu"
-      >
-        Celsiuksen koulu
-      </td>
-    </tr>
-    <tr
-      class="table__row"
-      data-row="3"
-    >
-      <td
-        class="table__td"
-        title="Aatu"
-      >
-        Aatu
-      </td>
-      <td
-        class="table__td"
-        title="Deltakoulu"
-      >
-        Deltakoulu
-      </td>
-    </tr>
-  </tbody>
-</table>
+        <td
+          class="table__td"
+          title="Aatu"
+        >
+          Aatu
+        </td>
+        <td
+          class="table__td"
+          title="Deltakoulu"
+        >
+          Deltakoulu
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 `;


### PR DESCRIPTION
* Kolmella pisteellä lyhennys toimii taas
* Jos ikkuna on alle 1600 pikseliä, ei yritetä ahtaa taulukkoa enää laatikon sisään, vaan se saa olla niin leveä kuin tarve on ja laatikko sen ympärillä muuttuu vaakatasossa skrollattavaksi﻿
* Otsikkorivit on siivottu ja nyt järjestysindikaattori on aina tekstin vieressä (meni ennen joskus uudelle riville)
* Tooltip-nappi on nyt aina solun oikeassa reunassa
