### PR TITLE
Tor-1229 valpas kantakonffin korjaus

### DIFF
--- a/src/main/scala/fi/oph/koski/config/SecretsManager.scala
+++ b/src/main/scala/fi/oph/koski/config/SecretsManager.scala
@@ -11,7 +11,6 @@ import fi.oph.koski.log.{Logging, NotLoggable}
 case class DatabaseConnectionConfig(
   host: String,
   port: Int,
-  dbname: String,
   username: String,
   password: String
 ) extends NotLoggable

--- a/src/main/scala/fi/oph/koski/db/DatabaseConfig.scala
+++ b/src/main/scala/fi/oph/koski/db/DatabaseConfig.scala
@@ -74,7 +74,6 @@ trait DatabaseConfig extends NotLoggable with Logging {
       config
         .withValue("host", fromAnyRef(secretConfig.host))
         .withValue("port", fromAnyRef(secretConfig.port))
-        .withValue("name", fromAnyRef(secretConfig.dbname))
         .withValue("user", fromAnyRef(secretConfig.username))
         .withValue("password", fromAnyRef(secretConfig.password))
         .withValue("secretId", fromAnyRef(secretId))

--- a/src/main/scala/fi/oph/koski/valpas/hakukooste/SureHakukoosteService.scala
+++ b/src/main/scala/fi/oph/koski/valpas/hakukooste/SureHakukoosteService.scala
@@ -7,7 +7,7 @@ import fi.oph.koski.json.Json4sHttp4s.json4sEncoderOf
 import fi.oph.koski.log.Logging
 import fi.oph.koski.util.Timing
 import fi.oph.koski.valpas.ValpasErrorCategory
-import fi.oph.koski.valpas.opiskeluoikeusrepository.{ValpasHenkilö, ValpasHenkilöLaajatTiedot}
+import fi.oph.koski.valpas.opiskeluoikeusrepository.ValpasHenkilö
 
 
 class SureHakukoosteService(config: Config) extends ValpasHakukoosteService with Logging with Timing {
@@ -15,7 +15,9 @@ class SureHakukoosteService(config: Config) extends ValpasHakukoosteService with
 
   private val http = VirkailijaHttpClient(ServiceConfig.apply(config, "opintopolku.virkailija"), baseUrl)
 
-  def getHakukoosteet(oppijaOids: Set[ValpasHenkilö.Oid], ainoastaanAktiivisetHaut: Boolean = false, errorClue: String = ""): Either[HttpStatus, Seq[Hakukooste]] = {
+  def getHakukoosteet
+    (oppijaOids: Set[ValpasHenkilö.Oid], ainoastaanAktiivisetHaut: Boolean = false, errorClue: String = "")
+  : Either[HttpStatus, Seq[Hakukooste]] = {
     val encoder = json4sEncoderOf[Seq[ValpasHenkilö.Oid]]
     val decoder = parseJson[Seq[Hakukooste]] _
 


### PR DESCRIPTION
Käytetään kannan nimeä konffitiedostosta eikä aws:n salaisuudesta