### PR TITLE
vst-koto - käytetään vst-käyttöliittymäkoodia myös kotoutuskoulutukselle

### DIFF
--- a/src/main/scala/fi/oph/koski/schema/VapaaSivistystyö.scala
+++ b/src/main/scala/fi/oph/koski/schema/VapaaSivistystyö.scala
@@ -1,6 +1,6 @@
 package fi.oph.koski.schema
 
-import fi.oph.scalaschema.annotation.{Description, MaxItems, MinItems, OnlyWhen, Title}
+import fi.oph.scalaschema.annotation.{Description, MaxItems, MinItems, Title}
 
 import java.time.{LocalDate, LocalDateTime}
 import fi.oph.koski.schema.annotation.{KoodistoKoodiarvo, KoodistoUri, MultiLineString, OksaUri, Representative, Tooltip}
@@ -205,7 +205,6 @@ case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutus(
 trait VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenKokonaisuudenSuoritus extends Suoritus with Vahvistukseton
 
 @Title("Maahanmuuttajien kotoutumiskoulutuksen kieliopintojen suoritus")
-@OnlyWhen("koulutusmoduuli/tunniste/koodiarvo","vstmaahanmuuttajienkotoutumiskoulutuksenkieliopintojensuoritus")
 case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenKieliopintojenSuoritus(
  @Title("Kotoutumiskoulutuksen kieliopinnot")
  koulutusmoduuli: OppivelvollisilleSuunnattuVapaanSivistystyönMaahanmuuttajienKotoutumisKokonaisuus,
@@ -217,9 +216,9 @@ case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenKieliopintoje
 
 @Title("Kieliopintojen arviointi")
 case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenKieliopintojenArviointi(
-  @KoodistoUri("arviointiasteikkovstkoto")
-  @KoodistoKoodiarvo("Suoritettu")
-  arvosana: Koodistokoodiviite = Koodistokoodiviite("Suoritettu", "arviointiasteikkovstkoto"),
+  @KoodistoKoodiarvo("Hyväksytty")
+  @KoodistoKoodiarvo("Hylätty")
+  arvosana: Koodistokoodiviite = Koodistokoodiviite("Hyväksytty", "arviointiasteikkovst"),
   @KoodistoUri("arviointiasteikkokehittyvankielitaidontasot")
   kuullunYmmärtämisenTaitotaso: Koodistokoodiviite,
   @KoodistoUri("arviointiasteikkokehittyvankielitaidontasot")
@@ -232,7 +231,6 @@ case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenKieliopintoje
 ) extends ArviointiPäivämäärällä with VapaanSivistystyönKoulutuksenArviointi
 
 @Title("Maahanmuuttajien kotoutumiskoulutuksen opinto-ohjauksen suoritus")
-@OnlyWhen("koulutusmoduuli/tunniste/koodiarvo","vstmaahanmuuttajienkotoutumiskoulutuksenohjauksensuoritus")
 case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenOhjauksenSuoritus(
   @Title("Kotoutumiskoulutuksen ohjaus")
   koulutusmoduuli: OppivelvollisilleSuunnattuVapaanSivistystyönMaahanmuuttajienKotoutumisKokonaisuus,
@@ -242,7 +240,6 @@ case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenOhjauksenSuor
 ) extends VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenKokonaisuudenSuoritus
 
 @Title("Maahanmuuttajien kotoutumiskoulutuksen työelämä- ja yhteiskuntataitojen opintojen suoritus")
-@OnlyWhen("koulutusmoduuli/tunniste/koodiarvo","vstmaahanmuuttajienkotoutumiskoulutuksentyoelamajayhteiskuntataitojensuoritus")
 case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenTyöelämäJaYhteiskuntataitojenOpintojenSuoritus(
   @Title("Kotoutumiskoulutuksen työelämä- ja yhteiskuntaopinnot")
   koulutusmoduuli: OppivelvollisilleSuunnattuVapaanSivistystyönMaahanmuuttajienKotoutumisKokonaisuus,
@@ -254,7 +251,6 @@ case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenTyöelämäJa
 
 
 @Title("Maahanmuuttajien kotoutumiskoulutuksen valinnaisten opintojen suoritus")
-@OnlyWhen("koulutusmoduuli/tunniste/koodiarvo","vstmaahanmuuttajienkotoutumiskoulutuksenvalinnaistensuoritus")
 case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenValinnaistenOpintojenSuoritus(
   @Title("Kotoutumiskoulutuksen valinnaiset opinnot")
   koulutusmoduuli: OppivelvollisilleSuunnattuVapaanSivistystyönMaahanmuuttajienKotoutumisKokonaisuus,
@@ -275,8 +271,6 @@ case class OppivelvollisilleSuunnattuVapaanSivistystyönMaahanmuuttajienKotoutum
   laajuus: Option[LaajuusOpintopisteissä] = None
 ) extends OppivelvollisilleSuunnatunVapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenKokonaisuudenKoulutusmoduuli with KoodistostaLöytyväKoulutusmoduuli with LaajuuttaEiValidoida
 
-trait VapaanSivistystyönMaahanmuuttajienKuntoutuskoulutuksenValinnaistenOpintojenOsasuoritus extends Suoritus with Vahvistukseton
-
 @Title("Valinnaisten opintojen osasuoritus")
 case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenValinnaistenOpintojenOsasuoritus(
   @Title("Valinnaiset opinnot")
@@ -284,7 +278,7 @@ case class VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenValinnaistenO
   arviointi: Option[List[OppivelvollisilleSuunnatunVapaanSivistystyönOpintokokonaisuudenArviointi]],
   @KoodistoKoodiarvo("vstmaahanmuuttajienkotoutumiskoulutuksenvalinnaistenopintojenosasuoritus")
   override val tyyppi: Koodistokoodiviite = Koodistokoodiviite(koodiarvo = "vstmaahanmuuttajienkotoutumiskoulutuksenvalinnaistenopintojenosasuoritus", koodistoUri = "suorituksentyyppi")
-) extends VapaanSivistystyönMaahanmuuttajienKuntoutuskoulutuksenValinnaistenOpintojenOsasuoritus
+) extends Suoritus with Vahvistukseton
 
 trait VapaanSivistystyönMaahanmuuttajienKuntoutuskoulutuksenTyöelämäJaYhteiskuntataitojenOpintojenOsasuoritus extends Suoritus with Vahvistukseton
 

--- a/src/test/resources/backwardcompatibility/vapaasivistystyo-maahanmuuttajienkotoutuskoulutus_2021-06-10.json
+++ b/src/test/resources/backwardcompatibility/vapaasivistystyo-maahanmuuttajienkotoutuskoulutus_2021-06-10.json
@@ -168,8 +168,8 @@
         },
         "arviointi" : [ {
           "arvosana" : {
-            "koodiarvo" : "Suoritettu",
-            "koodistoUri" : "arviointiasteikkovstkoto"
+            "koodiarvo" : "Hyväksytty",
+            "koodistoUri" : "arviointiasteikkovst"
           },
           "kuullunYmmärtämisenTaitotaso" : {
             "koodiarvo" : "yli_C1.1",

--- a/web/app/suoritus/SuoritustaulukkoCommon.jsx
+++ b/web/app/suoritus/SuoritustaulukkoCommon.jsx
@@ -20,7 +20,8 @@ export const isMuunAmmatillisenKoulutuksenOsasuorituksenSuoritus = suoritus => s
 export const isTutkinnonOsaaPienemmistäKokonaisuuksistaKoostuvaSuoritus = suoritus => suoritus.value.classes.includes('tutkinnonosaapienemmistakokonaisuuksistakoostuvasuoritus')
 export const isNäyttötutkintoonValmistava = suoritus => suoritus.value.classes.includes('nayttotutkintoonvalmistavankoulutuksensuoritus')
 export const isYlioppilastutkinto = suoritus => suoritus.value.classes.includes('ylioppilastutkinnonsuoritus')
-export const isVapaanSivistystyönOppivelvollisitenSuoritus =  suoritus => suoritus.value.classes.includes('oppivelvollisillesuunnattuvapaansivistystyonkoulutuksensuoritus')
+export const isVapaanSivistystyönOppivelvollistenSuoritus = suoritus => suoritus.value.classes.includes('oppivelvollisillesuunnattuvapaansivistystyonkoulutuksensuoritus')
+export const isMaahanmuuttajienKotoutumiskoulutuksenSuoritus = suoritus => suoritus.value.classes.includes('oppivelvollisillesuunnattumaahanmuuttajienkotoutumiskoulutuksensuoritus')
 
 export const getLaajuusYksikkö = (suoritus) => {
   const laajuusModel = modelLookup(suoritus, 'koulutusmoduuli.laajuus')
@@ -83,12 +84,17 @@ export const suoritusProperties = suoritus => {
     const showPakollinen = (tyyppi !== 'nayttotutkintoonvalmistavakoulutus') && modelData(suoritus, 'koulutusmoduuli.pakollinen') !== undefined
     const pakollinen = showPakollinen ? modelProperties(modelLookup(suoritus, 'koulutusmoduuli'), p => p.key === 'pakollinen') : []
 
+    const taitotasot = modelProperties(modelLookup(suoritus, 'arviointi.-1'),
+      p => isEdit && ['kuullunYmmärtämisenTaitotaso', 'puhumisenTaitotaso', 'luetunYmmärtämisenTaitotaso', 'kirjoittamisenTaitotaso'].includes(p.key))
+
     const defaultsForEdit = pakollinen
       .concat(arviointipäivä)
+      .concat(taitotasot)
       .concat(includeProperties('näyttö', 'tunnustettu', 'lisätiedot', 'liittyyTutkinnonOsaan'))
 
     const defaultsForView = pakollinen
       .concat(excludeProperties('koulutusmoduuli', 'arviointi', 'tutkinnonOsanRyhmä', 'tutkintokerta'))
+      .concat(taitotasot)
       .concat(simplifiedArviointi)
 
     switch (tyyppi) {
@@ -180,7 +186,7 @@ export const LaajuusColumn = {
   shouldShow: ({parentSuoritus, suoritukset, suorituksetModel, context}) => {
     if (isNäyttötutkintoonValmistava(parentSuoritus)) {
       return false
-    } else if (isVapaanSivistystyönOppivelvollisitenSuoritus(parentSuoritus) && context.edit) {
+    } else if (isVapaanSivistystyönOppivelvollistenSuoritus(parentSuoritus) && context.edit) {
       return false
     } else {
       return context.edit
@@ -197,7 +203,7 @@ export const LaajuusColumn = {
 export const ArvosanaColumn = {
   shouldShow: ({parentSuoritus, suoritukset, context}) => (
     !isNäyttötutkintoonValmistava(parentSuoritus)
-    && !isVapaanSivistystyönOppivelvollisitenSuoritus(parentSuoritus)
+    && !isVapaanSivistystyönOppivelvollistenSuoritus(parentSuoritus)
     && (context.edit || suoritukset.find(hasArvosana) !== undefined)
   ),
   renderHeader: () => <th key='arvosana' className='arvosana' scope='col'><Text name='Arvosana'/></th>,

--- a/web/app/suoritus/suoritusEditorMapping.jsx
+++ b/web/app/suoritus/suoritusEditorMapping.jsx
@@ -55,7 +55,7 @@ export const resolveOsasuorituksetEditor = (mdl) => {
     const SuoritustaulukkoComponent = kansalainen ? OmatTiedotSuoritustaulukko : Suoritustaulukko
     return <SuoritustaulukkoComponent suorituksetModel={modelLookup(mdl, 'osasuoritukset')} />
   }
-  if (oneOf('oppivelvollisillesuunnattuvapaansivistystyonkoulutuksensuoritus')) {
+  if (oneOf('oppivelvollisillesuunnattuvapaansivistystyonkoulutuksensuoritus', 'oppivelvollisillesuunnattumaahanmuuttajienkotoutumiskoulutuksensuoritus')) {
     return <VapaanSivistystyonSuoritustaulukko parentSuoritus={mdl} suorituksetModel={modelLookup(mdl, 'osasuoritukset')}/>
   }
   if (oneOf('lukionoppimaaransuoritus2015')) {

--- a/web/app/vapaasivistystyo/UusiVapaanSivistystyonOsasuoritus.jsx
+++ b/web/app/vapaasivistystyo/UusiVapaanSivistystyonOsasuoritus.jsx
@@ -22,6 +22,11 @@ export const UusiVapaanSivistystyonOsasuoritus = ({suoritusPrototypes, setExpand
   const muuallaSuoritettuOpinto = suoritusPrototypes.find(s => s.value.classes.includes('muuallasuoritettuoppivelvollisillesuunnatunvapaansivistystyonopintojensuoritus'))
   const opintokokonaisuus = suoritusPrototypes.find(s => s.value.classes.includes('oppivelvollisillesuunnatunvapaansivistystyonopintokokonaisuudensuoritus'))
 
+  const kotoOsaAlue = suoritusPrototypes.find(s => s.value.classes.includes('vapaansivistystyonmaahanmuuttajienkotoutumiskoulutuksenkokonaisuudensuoritus'))
+  const kotoTyöelämäJaYhteiskuntataidot = suoritusPrototypes.find(s => s.value.classes.includes('vapaansivistystyonmaahanmuuttajienkotoutumiskoulutuksentyoelamajayhteiskuntataidot'))
+  const kotoTyöelämäJaYhteiskuntataidotTyöelämäjakso = suoritusPrototypes.find(s => s.value.classes.includes('vapaansivistystyonmaahanmuuttajienkotoutumiskoulutuksentyoelamajayhteiskuntataitojentyoelamajakso'))
+  const kotoValinnaisetOpinnot= suoritusPrototypes.find(s => s.value.classes.includes('vapaansivistystyonmaahanmuuttajienkotoutumiskoulutuksenvalinnaistenopintojenosasuoritus'))
+
   return (
     <>
       {
@@ -54,6 +59,41 @@ export const UusiVapaanSivistystyonOsasuoritus = ({suoritusPrototypes, setExpand
       {
         opintokokonaisuus &&
         <LisääPaikallinen suoritusPrototype={opintokokonaisuus}
+                          setExpanded={setExpanded}
+                          lisääText={'Lisää paikallinen opintokokonaisuus'}
+                          lisääTitle={'Paikallisen opintokokonaisuuden lisäys'}
+        />
+      }
+      {
+        kotoTyöelämäJaYhteiskuntataidot &&
+        <LisääPaikallinen suoritusPrototype={kotoTyöelämäJaYhteiskuntataidotTyöelämäjakso}
+                          setExpanded={setExpanded}
+                          lisääText={'Lisää työelämäjakso'}
+                          lisääTitle={'Työelämäjakson lisäys'}
+        />
+      }
+      {
+        kotoTyöelämäJaYhteiskuntataidot &&
+        <LisääPaikallinen suoritusPrototype={kotoTyöelämäJaYhteiskuntataidot}
+                          setExpanded={setExpanded}
+                          lisääText={'Lisää työelämä- ja yhteiskuntataidon opintokokonaisuus'}
+                          lisääTitle={'Työelämä- ja yhteiskuntataidon opintokokonaisuuden lisäys'}
+        />
+      }
+      {
+        kotoValinnaisetOpinnot &&
+        <LisääPaikallinen suoritusPrototype={kotoValinnaisetOpinnot}
+                          setExpanded={setExpanded}
+                          lisääText={'Lisää valinnainen opintosuoritus'}
+                          lisääTitle={'Valinnaisen opintosuorituksen lisäys'}
+        />
+      }
+      {
+        kotoOsaAlue &&
+        <LisääKoodistosta koodistoUri={'vstmaahanmuuttajienkotoutumiskoulutuksenkokonaisuus'}
+                          suoritusPrototype={kotoOsaAlue}
+                          className={'vst-osaamiskokonaisuus'}
+                          selectionText={'Lisää osa-alue'}
                           setExpanded={setExpanded}
         />
       }
@@ -90,7 +130,7 @@ const LisääKoodistosta = ({
   )
 }
 
-const LisääPaikallinen = ({suoritusPrototype, setExpanded}) => {
+const LisääPaikallinen = ({suoritusPrototype, setExpanded, lisääText, lisääTitle}) => {
   const showModal = Atom(false)
   const inputState = Atom('')
   const validP = inputState
@@ -119,16 +159,16 @@ const LisääPaikallinen = ({suoritusPrototype, setExpanded}) => {
       <span className="lisaa-paikallinen-suoritus">
         <a className='add-link'
            onClick={() => showModal.set(true)}>
-          <Text name={'Lisää paikallinen opintokokonaisuus'}/>
+          <Text name={lisääText}/>
         </a>
       {
         ift(showModal,
           <ModalDialog className="lisaa-paikallinen-vst-suoritus-modal"
                        onDismiss={closeModal}
                        onSubmit={addNewSuoritus}
-                       okTextKey={'Lisää paikallinen opintokokonaisuus'}
+                       okTextKey={lisääText}
                        validP={validP}>
-            <h2><Text name={'Paikallisen opintokokonaisuuden lisäys'}/></h2>
+            <h2><Text name={lisääTitle}/></h2>
             <label>
               <Text name={'Opintokokonaisuuden nimi'} />
               <input className='paikallinen-koulutusmoduuli-nimi'

--- a/web/app/vapaasivistystyo/VapaanSivistystyonSuoritustaulukko.jsx
+++ b/web/app/vapaasivistystyo/VapaanSivistystyonSuoritustaulukko.jsx
@@ -17,8 +17,9 @@ export class VapaanSivistystyonSuoritustaulukko extends React.Component {
     const {parentSuoritus, suorituksetModel, nestedLevel = 0} = this.props
     const context = parentSuoritus.context
     const suoritukset = modelItems(suorituksetModel) || []
+    const parentOneOf = (...classes) => classes.some(c => parentSuoritus.value.classes.includes(c))
 
-    if (suoritukset.length === 0 && !context.edit || nestedLevel >= MAX_NESTED_LEVEL) {
+    if (suoritukset.length === 0 && !context.edit || nestedLevel >= MAX_NESTED_LEVEL || suorituksetModel === undefined) {
       return null
     }
 
@@ -26,7 +27,8 @@ export class VapaanSivistystyonSuoritustaulukko extends React.Component {
 
     const suoritusProtos = tutkinnonOsaPrototypes(suorituksetModel)
     const laajuusYksikkö = getLaajuusYksikkö(suoritusProtos[0])
-    const suoritusTitle = nestedLevel === 0 ? t('Osaamiskokonaisuus') : t('Opintokokonaisuus')
+    const osaAlueTitle = parentOneOf('oppivelvollisillesuunnattuvapaansivistystyonkoulutuksensuoritus') ? t('Osaamiskokonaisuus') : t('Osa-alue')
+    const suoritusTitle = nestedLevel === 0 ? osaAlueTitle : t('Opintokokonaisuus')
 
     const columns = [SuoritusColumn, LaajuusColumn, ArvosanaColumn].filter(column => column.shouldShow({parentSuoritus, suoritukset, suorituksetModel, context}))
 

--- a/web/test/spec/vapaaSivistystyoSpec.js
+++ b/web/test/spec/vapaaSivistystyoSpec.js
@@ -3,6 +3,7 @@ describe('VST', function () {
   var vst = VSTSuoritukset()
   var editor = opinnot.opiskeluoikeusEditor()
   var addOppija = AddOppijaPage()
+  var page = KoskiPage()
 
   describe('Opiskeluoikeuden lisääminen oppivelollisten suorituksella', function () {
     before(
@@ -106,6 +107,22 @@ describe('VST', function () {
           expect(extractAsText(S('.yhteislaajuus'))).to.equal('Yhteensä 55 op')
         })
       })
+    })
+  })
+
+  describe('Kotoutuskoulutus', function () {
+    before(
+      Authentication().login(),
+      page.openPage,
+      page.oppijaHaku.searchAndSelect('260769-598H'),
+      opinnot.avaaKaikki
+    )
+
+    it('kielisuorituksen arvioinnin taitotasot näkyvät', function () {
+      expect(extractAsText(S('.kuullunYmmärtämisenTaitotaso'))).to.equal('Kuullun ymmärtämisen taitotaso Yli C1.1')
+      expect(extractAsText(S('.puhumisenTaitotaso'))).to.equal('Puhumisen taitotaso Yli C1.1')
+      expect(extractAsText(S('.luetunYmmärtämisenTaitotaso'))).to.equal('Luetun ymmärtämisen taitotaso Yli C1.1')
+      expect(extractAsText(S('.kirjoittamisenTaitotaso'))).to.equal('Kirjoittamisen taitotaso Yli C1.1')
     })
   })
 })


### PR DESCRIPTION
Käytetään VST:n käliä myös maahanmuuttajien kotoutumiskoulutusta varten, valtaosa koodista on samaa.

Lisätty testi tarkistamaan, että uusi funktionaalisuus on oikein (kieliopiskelujen taitotasojen näyttäminen).

Fiksattu myös Koton kieliopintosuorituksen arvioinnin koodistotyyppi samaksi kuin muilla saman tason osasuorituksilla.