### PR TITLE
Tor-1229 indeksejä valpas-kyselyjä varten

### DIFF
--- a/src/main/scala/fi/oph/koski/oppija/OppijaServlet.scala
+++ b/src/main/scala/fi/oph/koski/oppija/OppijaServlet.scala
@@ -138,7 +138,7 @@ case class UpdateContext(user: KoskiSpecificSession, application: KoskiApplicati
     val result: Either[HttpStatus, HenkilönOpiskeluoikeusVersiot] = validationResult.flatMap(application.oppijaFacade.createOrUpdate(_, allowUpdate)(user))
 
     result.left.foreach { case HttpStatus(code, errors) =>
-      logger(user).warn("Opiskeluoikeuden lisäys/päivitys estetty: " + code + " " + errors + " for request " + logSafeDescription(request))
+      logger(user).info("Opiskeluoikeuden lisäys/päivitys estetty: " + code + " " + errors + " for request " + logSafeDescription(request))
     }
 
     val error = result.left.toOption.map(status => TiedonsiirtoError(oppijaJsonFromRequest, status.errors))

--- a/src/main/scala/fi/oph/koski/oppija/OppijaServletV2.scala
+++ b/src/main/scala/fi/oph/koski/oppija/OppijaServletV2.scala
@@ -55,7 +55,7 @@ case class UpdateContextV2(user: KoskiSpecificSession, application: KoskiApplica
     val result: Either[HttpStatus, HenkilönOpiskeluoikeusVersiot] = validationResult.flatMap(application.oppijaFacadeV2.createOrUpdate(_, allowUpdate)(user))
 
     result.left.foreach { case HttpStatus(code, errors) =>
-      logger(user).warn("Opiskeluoikeuden lisäys/päivitys estetty: " + code + " " + errors + " for request " + logSafeDescription(request))
+      logger(user).info("Opiskeluoikeuden lisäys/päivitys estetty: " + code + " " + errors + " for request " + logSafeDescription(request))
     }
 
     val error = result.left.toOption.map(status => TiedonsiirtoError(oppijaJsonFromRequest, status.errors))

--- a/src/main/scala/fi/oph/koski/oppivelvollisuustieto/Oppivelvollisuustiedot.scala
+++ b/src/main/scala/fi/oph/koski/oppivelvollisuustieto/Oppivelvollisuustiedot.scala
@@ -115,6 +115,15 @@ object Oppivelvollisuustiedot {
       """
   }
 
+  def createIndexes(s: Schema) = {
+    sqlu"""
+          create index on #${s.name}.oppivelvollisuustiedot (
+               oppija_oid,
+               oppivelvollisuusvoimassaasti,
+               oikeuskoulutuksenmaksuttomuuteenvoimassaasti
+          )"""
+  }
+
   implicit private val oppivelvollisuustietoGetResult: GetResult[Oppivelvollisuustieto] = GetResult(row =>
     Oppivelvollisuustieto(
       oid = row.rs.getString("oppija_oid"),

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
@@ -100,7 +100,8 @@ class RaportointiDatabase(config: RaportointiDatabaseConfig) extends Logging wit
       LukioOppiaineRahoitusmuodonMukaan.createIndex(schema),
       LukioOppiaineEriVuonnaKorotetutKurssit.createMaterializedView(schema),
       LukioOppiaineEriVuonnaKorotetutKurssit.createIndex(schema),
-      Oppivelvollisuustiedot.createMaterializedView(schema, config)
+      Oppivelvollisuustiedot.createMaterializedView(schema, config),
+      Oppivelvollisuustiedot.createIndexes(schema)
     ), timeout = 120.minutes)
     val duration = (System.currentTimeMillis - started) / 1000
     setStatusLoadCompleted("materialized_views")

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabaseSchema.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabaseSchema.scala
@@ -61,6 +61,7 @@ object RaportointiDatabaseSchema {
     sqlu"CREATE INDEX ON #${s.name}.r_henkilo(hetu)",
     sqlu"CREATE INDEX ON #${s.name}.r_henkilo(oppija_oid, aidinkieli)",
     sqlu"CREATE INDEX ON #${s.name}.r_henkilo(linkitetyt_oidit)",
+    sqlu"CREATE INDEX ON #${s.name}.r_henkilo(master_oid)",
 
     sqlu"CREATE INDEX ON #${s.name}.r_organisaatio(oppilaitosnumero)",
 

--- a/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
+++ b/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
@@ -162,7 +162,7 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
       addKeskeneräinenTutkinnonSuoritus(tila, suoritukset, opiskeluoikeusNode, viimeisinTutkinto)
     } else {
       val opiskeluoikeusTila = tila.opiskeluoikeusjaksot.lastOption.map(_.tila)
-      logger.warn(s"Tutkintoon johtavaa päätason suoritusta ei löydy tai opiskeluoikeus on päättynyt. Opiskeluoikeus(avain: ${avain(opiskeluoikeusNode)}, tila: $opiskeluoikeusTila, jaksot: ${opiskeluoikeusJaksot.map(_.koulutuskoodi)}, laji: '${laji(opiskeluoikeusNode)}')")
+      logger.info(s"Tutkintoon johtavaa päätason suoritusta ei löydy tai opiskeluoikeus on päättynyt. Opiskeluoikeus(avain: ${avain(opiskeluoikeusNode)}, tila: $opiskeluoikeusTila, jaksot: ${opiskeluoikeusJaksot.map(_.koulutuskoodi)}, laji: '${laji(opiskeluoikeusNode)}')")
       addMuuKorkeakoulunSuoritus(tila, suoritukset, opiskeluoikeusNode)
     }
   }
@@ -239,7 +239,7 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
       case "2" => // opintojakso
         Some(convertOpintojaksonSuoritus(suoritus, allNodes))
       case laji: String =>
-        logger.warn("Tuntematon laji: " + laji)
+        logger.info("Tuntematon laji: " + laji)
         None
     }
   } catch {


### PR DESCRIPTION
Kyselyyn noin 20-40x nopeutus riippuen välimuistien tilasta, ja noin 10x pienempi IO-kuorma (buffer hitteinä mitattuna).

Ilman näitä indeksejä pg12 on noin 2x nopeampi (2x pienemmällä IO-kuormalla) kuin pg10, mutta indeksien kanssa eroa ei käytännössä ole, joten suurta painetta postgres-version päivitykseen ei tästä vielä tule. Tosin käytännön suorituskyky perffitestikuormalla on vielä testattava (merkittävästi pienempi IO-kuorma kyllä enteilee hyvää myös siltä osin).