### PR TITLE
Sisäinen healthcheck tarkistaa vain kantayhteydet

### DIFF
--- a/src/main/scala/fi/oph/koski/db/DatabaseUtilQueries.scala
+++ b/src/main/scala/fi/oph/koski/db/DatabaseUtilQueries.scala
@@ -1,9 +1,11 @@
 package fi.oph.koski.db
 
+import fi.oph.koski.db.PostgresDriverWithJsonSupport.api.actionBasedSQLInterpolation
 import fi.oph.koski.util.RegexUtils.StringWithRegex
-
 import org.postgresql.util.PSQLException
 import slick.dbio.{DBIOAction, NoStream}
+
+import scala.concurrent.duration.DurationInt
 
 object DatabaseUtilQueries {
   type SizeQuery = DBIOAction[Int, NoStream, Nothing]
@@ -14,6 +16,10 @@ class DatabaseUtilQueries(
   sizeQuery: DatabaseUtilQueries.SizeQuery,
   smallDatabaseMaxRows: Int
 ) extends QueryMethods {
+  def databaseIsOnline: Boolean = {
+    runDbSync(sql"select true".as[Boolean], timeout = 5.seconds).head
+  }
+
   def databaseIsLarge: Boolean = {
     try {
       val count: Int = runDbSync(sizeQuery)

--- a/src/main/scala/fi/oph/koski/elasticsearch/ElasticSearchIndex.scala
+++ b/src/main/scala/fi/oph/koski/elasticsearch/ElasticSearchIndex.scala
@@ -10,6 +10,8 @@ import org.http4s.EntityEncoder
 import org.json4s._
 import org.json4s.jackson.JsonMethods
 
+import scala.concurrent.duration.DurationInt
+
 class ElasticSearchIndex(
   val name: String,
   private val elastic: ElasticSearch,
@@ -80,8 +82,10 @@ class ElasticSearchIndex(
 
   def migrateWriteAlias(toVersion: Int, fromVersion: Option[Int] = None): String = migrateAlias(writeAlias, toVersion, fromVersion)
 
+  def isOnline: Boolean = indexExists(currentIndexName)
+
   private def indexExists(indexName: String): Boolean = {
-    Http.runTask(http.head(uri"/$indexName")(Http.statusCode)) match {
+    Http.runTask(http.head(uri"/$indexName")(Http.statusCode), timeout = 5.seconds) match {
       case 200 => true
       case 404 => false
       case statusCode: Int => throw new RuntimeException("Unexpected status code from elasticsearch: " + statusCode)

--- a/src/main/scala/fi/oph/koski/healthcheck/HealthCheckApiServlet.scala
+++ b/src/main/scala/fi/oph/koski/healthcheck/HealthCheckApiServlet.scala
@@ -13,4 +13,3 @@ class HealthCheckApiServlet(implicit val application: KoskiApplication) extends 
     renderStatus(application.healthCheck.internalHealthcheck)
   }
 }
-

--- a/src/main/scala/fi/oph/koski/http/Http.scala
+++ b/src/main/scala/fi/oph/koski/http/Http.scala
@@ -15,7 +15,7 @@ import org.http4s.client.{Client, blaze}
 import org.http4s.headers.`Content-Type`
 import org.json4s.jackson.JsonMethods.parse
 
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.{Duration, DurationInt}
 import scala.reflect.runtime.universe.TypeTag
 import scala.xml.Elem
 import scalaz.concurrent.Task
@@ -116,7 +116,7 @@ object Http extends Logging {
   }
 
   // Http task runner: runs at most 2 minutes. We must avoid using the timeout-less run method, that may block forever.
-  def runTask[A](task: Task[A]): A = task.unsafePerformSyncFor(2.minutes)
+  def runTask[A](task: Task[A], timeout: Duration = 2.minutes): A = task.unsafePerformSyncFor(timeout)
 
   type Decode[ResultType] = (Int, String, Request) => ResultType
 

--- a/src/main/scala/fi/oph/koski/perustiedot/OpiskeluoikeudenPerustiedotIndexer.scala
+++ b/src/main/scala/fi/oph/koski/perustiedot/OpiskeluoikeudenPerustiedotIndexer.scala
@@ -82,7 +82,7 @@ class OpiskeluoikeudenPerustiedotIndexer(
   perustiedotSyncRepository: PerustiedotSyncRepository
 ) extends Logging {
 
-  var index = new ElasticSearchIndex(
+  val index = new ElasticSearchIndex(
     elastic = elastic,
     name = "perustiedot",
     mappingVersion = 3,

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
@@ -6,9 +6,9 @@ import java.time.LocalDateTime.now
 import java.time._
 
 import fi.oph.koski.db.PostgresDriverWithJsonSupport.api._
-import fi.oph.koski.db.{DB, QueryMethods, RaportointiDatabaseConfig}
+import fi.oph.koski.db.{DB, DatabaseUtilQueries, QueryMethods, RaportointiDatabaseConfig}
 import fi.oph.koski.log.Logging
-import fi.oph.koski.oppivelvollisuustieto.{Oppivelvollisuustiedot}
+import fi.oph.koski.oppivelvollisuustieto.Oppivelvollisuustiedot
 import fi.oph.koski.raportit.PaallekkaisetOpiskeluoikeudet
 import fi.oph.koski.raportit.lukio.{LukioOppiaineEriVuonnaKorotetutKurssit, LukioOppiaineRahoitusmuodonMukaan, LukioOppiaineenOppimaaranKurssikertymat, LukioOppimaaranKussikertymat}
 import fi.oph.koski.raportointikanta.RaportointiDatabaseSchema._
@@ -23,9 +23,15 @@ import scala.concurrent.duration.DurationInt
 
 class RaportointiDatabase(config: RaportointiDatabaseConfig) extends Logging with QueryMethods {
   val schema: Schema = config.schema
+
   logger.info(s"Instantiating RaportointiDatabase for ${schema.name}")
 
   val db: DB = config.toSlickDatabase
+
+  final val smallDatabaseMaxRows = 500
+
+  val util = new DatabaseUtilQueries(db, ROpiskeluoikeudet.length.result, smallDatabaseMaxRows)
+
   val tables = List(
     ROpiskeluoikeudet,
     ROrganisaatioHistoriat,


### PR DESCRIPTION
Aiempi toteutus oli riippuvainen ulkoisesta oppijanumerorekisteristä.