### PR TITLE
Valpas Sure-API parsintakorjaus

### DIFF
--- a/src/main/scala/fi/oph/koski/config/KoskiApplication.scala
+++ b/src/main/scala/fi/oph/koski/config/KoskiApplication.scala
@@ -63,11 +63,7 @@ class KoskiApplication(
   lazy val oppilaitosRepository = OppilaitosRepository(config, organisaatioRepository)
   lazy val koodistoPalvelu = KoodistoPalvelu.apply(config)
   lazy val koodistoViitePalvelu = KoodistoViitePalvelu(koodistoPalvelu)
-  lazy val validatingAndResolvingExtractor = new ValidatingAndResolvingExtractor(
-    koodistoViitePalvelu,
-    organisaatioRepository,
-    KoskiSchema.deserializationContext
-  )
+  lazy val validatingAndResolvingExtractor = new ValidatingAndResolvingExtractor(koodistoViitePalvelu, organisaatioRepository)
   lazy val opintopolkuHenkilöFacade = OpintopolkuHenkilöFacade(config, masterDatabase.db, perustiedotRepository, perustiedotIndexer)
   lazy val käyttöoikeusRepository = new KäyttöoikeusRepository(organisaatioRepository, directoryClient)
   lazy val masterDatabase = KoskiDatabase.master(config)

--- a/src/main/scala/fi/oph/koski/editor/EditorServlet.scala
+++ b/src/main/scala/fi/oph/koski/editor/EditorServlet.scala
@@ -7,6 +7,7 @@ import fi.oph.koski.http.{HttpStatus, KoskiErrorCategory}
 import fi.oph.koski.koskiuser.{AccessType, RequiresVirkailijaOrPalvelukäyttäjä}
 import fi.oph.koski.organisaatio.OrganisaatioOid
 import fi.oph.koski.preferences.PreferencesService
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import fi.oph.koski.schema.{PäätasonSuoritus, SuoritusVaatiiMahdollisestiMaksuttomuusTiedonOpiskeluoikeudelta}
 import fi.oph.koski.servlet.NoCache
 import fi.oph.koski.util.WithWarnings
@@ -83,7 +84,7 @@ class EditorServlet(implicit val application: KoskiApplication)
   post("/check-vaatiiko-suoritus-maksuttomuus-tiedon") {
     withJsonBody { body =>
       render[Boolean](
-        application.validatingAndResolvingExtractor.extract[PäätasonSuoritus](body)
+        application.validatingAndResolvingExtractor.extract[PäätasonSuoritus](strictDeserialization)(body)
         .map(_.isInstanceOf[SuoritusVaatiiMahdollisestiMaksuttomuusTiedonOpiskeluoikeudelta])
         .getOrElse(false)
       )

--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/OpiskeluoikeusServlet.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/OpiskeluoikeusServlet.scala
@@ -8,9 +8,10 @@ import fi.oph.koski.log.KoskiAuditLogMessageField.{apply => _, _}
 import fi.oph.koski.log.KoskiOperation._
 import fi.oph.koski.log.{AuditLog, KoskiAuditLogMessage, Logging}
 import fi.oph.koski.oppija.HenkilönOpiskeluoikeusVersiot
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import fi.oph.koski.schema.{KoskeenTallennettavaOpiskeluoikeus, PäätasonSuoritus}
 import fi.oph.koski.servlet.{KoskiSpecificApiServlet, NoCache}
-import fi.oph.scalaschema.SchemaValidatingExtractor
+import fi.oph.scalaschema.{ExtractionContext, SchemaValidatingExtractor}
 import fi.oph.scalaschema.extraction.ValidationError
 import org.json4s.JValue
 
@@ -23,8 +24,7 @@ class OpiskeluoikeusServlet(implicit val application: KoskiApplication) extends 
 
   post("/:oid/:versionumero/delete-paatason-suoritus") {
     withJsonBody { oppijaJson: JValue =>
-      import fi.oph.koski.schema.KoskiSchema.deserializationContext
-
+      implicit val context: ExtractionContext = strictDeserialization
       val validationResult = SchemaValidatingExtractor.extract[PäätasonSuoritus](oppijaJson) match {
         case Right(t) => Right(t)
         case Left(errors: List[ValidationError]) => Left(KoskiErrorCategory.badRequest.validation.jsonSchema.apply(JsonErrorMessage(errors)))

--- a/src/main/scala/fi/oph/koski/preferences/PreferencesService.scala
+++ b/src/main/scala/fi/oph/koski/preferences/PreferencesService.scala
@@ -1,13 +1,14 @@
 package fi.oph.koski.preferences
 
 import fi.oph.koski.db.DB
-import fi.oph.koski.db.{QueryMethods, PreferenceRow, KoskiTables}
+import fi.oph.koski.db.{KoskiTables, PreferenceRow, QueryMethods}
 import fi.oph.koski.http.{HttpStatus, JsonErrorMessage, KoskiErrorCategory}
 import fi.oph.koski.koskiuser.KoskiSpecificSession
 import fi.oph.koski.log.Logging
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import fi.oph.koski.schema._
 import fi.oph.koski.servlet.InvalidRequestException
-import fi.oph.scalaschema.SchemaValidatingExtractor
+import fi.oph.scalaschema.{ExtractionContext, SchemaValidatingExtractor}
 import fi.oph.scalaschema.extraction.ValidationError
 import org.json4s._
 
@@ -66,7 +67,7 @@ case class PreferencesService(protected val db: DB) extends Logging with QueryMe
   }
 
   private def extract[T : TypeTag](value: JValue, klass: Class[_ <: T]): Either[List[ValidationError], T] = {
-    import fi.oph.koski.schema.KoskiSchema.deserializationContext
+    implicit val context: ExtractionContext = strictDeserialization
     SchemaValidatingExtractor.extract(value, klass).right.map(_.asInstanceOf[T])
   }
 

--- a/src/main/scala/fi/oph/koski/schema/KoskiSchema.scala
+++ b/src/main/scala/fi/oph/koski/schema/KoskiSchema.scala
@@ -10,6 +10,7 @@ object KoskiSchema {
   lazy val schemaJson: JValue = SchemaToJson.toJsonSchema(schema)
   lazy val schemaJsonString = JsonMethods.compact(schemaJson)
   lazy val strictDeserialization = ExtractionContext(schemaFactory, allowEmptyStrings = false)
+  lazy val lenientDeserialization = ExtractionContext(schemaFactory, ignoreUnexpectedProperties = true)
 
   def createSchema(clazz: Class[_]) = schemaFactory.createSchema(clazz) match {
     case s: AnyOfSchema => s

--- a/src/main/scala/fi/oph/koski/schema/KoskiSchema.scala
+++ b/src/main/scala/fi/oph/koski/schema/KoskiSchema.scala
@@ -9,7 +9,7 @@ object KoskiSchema {
   lazy val schema = createSchema(classOf[Oppija]).asInstanceOf[ClassSchema]
   lazy val schemaJson: JValue = SchemaToJson.toJsonSchema(schema)
   lazy val schemaJsonString = JsonMethods.compact(schemaJson)
-  lazy implicit val deserializationContext = ExtractionContext(schemaFactory, allowEmptyStrings = false)
+  lazy implicit val strictDeserialization = ExtractionContext(schemaFactory, allowEmptyStrings = false)
 
   def createSchema(clazz: Class[_]) = schemaFactory.createSchema(clazz) match {
     case s: AnyOfSchema => s

--- a/src/main/scala/fi/oph/koski/schema/KoskiSchema.scala
+++ b/src/main/scala/fi/oph/koski/schema/KoskiSchema.scala
@@ -9,7 +9,7 @@ object KoskiSchema {
   lazy val schema = createSchema(classOf[Oppija]).asInstanceOf[ClassSchema]
   lazy val schemaJson: JValue = SchemaToJson.toJsonSchema(schema)
   lazy val schemaJsonString = JsonMethods.compact(schemaJson)
-  lazy implicit val strictDeserialization = ExtractionContext(schemaFactory, allowEmptyStrings = false)
+  lazy val strictDeserialization = ExtractionContext(schemaFactory, allowEmptyStrings = false)
 
   def createSchema(clazz: Class[_]) = schemaFactory.createSchema(clazz) match {
     case s: AnyOfSchema => s

--- a/src/main/scala/fi/oph/koski/suoritusjako/SuoritusjakoServlet.scala
+++ b/src/main/scala/fi/oph/koski/suoritusjako/SuoritusjakoServlet.scala
@@ -7,7 +7,7 @@ import fi.oph.koski.json.JsonSerializer
 import fi.oph.koski.koskiuser.{KoskiSpecificAuthenticationSupport, KoskiSpecificSession}
 import fi.oph.koski.log.Logging
 import fi.oph.koski.omattiedot.OmatTiedotEditorModel
-import fi.oph.koski.schema.KoskiSchema.deserializationContext
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import fi.oph.koski.servlet.NoCache
 import org.json4s.JValue
 
@@ -72,7 +72,7 @@ class SuoritusjakoServlet(implicit val application: KoskiApplication) extends Ed
   private def user = koskiSessionOption.get
 
   private def extract[T: TypeTag](body: JValue) = {
-    application.validatingAndResolvingExtractor.extract[T](body, deserializationContext.copy(allowEmptyStrings = true))
+    application.validatingAndResolvingExtractor.extract[T](body, strictDeserialization.copy(allowEmptyStrings = true))
   }
 }
 

--- a/src/main/scala/fi/oph/koski/suoritusjako/SuoritusjakoServletV2.scala
+++ b/src/main/scala/fi/oph/koski/suoritusjako/SuoritusjakoServletV2.scala
@@ -6,7 +6,7 @@ import fi.oph.koski.editor.{EditorApiServlet, EditorModel}
 import fi.oph.koski.http.{HttpStatus, KoskiErrorCategory}
 import fi.oph.koski.koskiuser.{KoskiSpecificAuthenticationSupport, KoskiSpecificSession}
 import fi.oph.koski.log.Logging
-import fi.oph.koski.schema.KoskiSchema.deserializationContext
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import fi.oph.koski.schema._
 import fi.oph.koski.servlet.NoCache
 import org.json4s.JValue
@@ -64,7 +64,7 @@ class SuoritusjakoServletV2(implicit val application: KoskiApplication) extends 
   }
 
   private def extract[T: TypeTag](body: JValue) =
-    application.validatingAndResolvingExtractor.extract[T](body, deserializationContext.copy(allowEmptyStrings = true))
+    application.validatingAndResolvingExtractor.extract[T](body, strictDeserialization.copy(allowEmptyStrings = true))
       .left.map(_ => KoskiErrorCategory.badRequest())
 
   private def user = koskiSessionOption.get

--- a/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
+++ b/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
@@ -13,6 +13,7 @@ import fi.oph.koski.koskiuser.{AccessType, KoskiSpecificSession}
 import fi.oph.koski.opiskeluoikeus.KoskiOpiskeluoikeusRepository
 import fi.oph.koski.organisaatio.OrganisaatioRepository
 import fi.oph.koski.schema.Henkilö.Oid
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import fi.oph.koski.schema.Opiskeluoikeus.{koulutustoimijaTraversal, oppilaitosTraversal, toimipisteetTraversal}
 import fi.oph.koski.schema.{VapaanSivistystyönPäätasonSuoritus, _}
 import fi.oph.koski.tutkinto.Koulutustyyppi._
@@ -52,7 +53,7 @@ class KoskiValidator(
   def extractAndValidateOppija(parsedJson: JValue)(implicit user: KoskiSpecificSession, accessType: AccessType.Value): Either[HttpStatus, Oppija] = {
     timed("extractAndValidateOppija", 200) {
       val extractionResult: Either[HttpStatus, Oppija] = {
-        validatingAndResolvingExtractor.extract[Oppija](parsedJson)
+        validatingAndResolvingExtractor.extract[Oppija](strictDeserialization)(parsedJson)
       }
       extractionResult.right.flatMap(validateOpiskeluoikeudet)
     }
@@ -68,7 +69,7 @@ class KoskiValidator(
 
   def extractOpiskeluoikeus(parsedJson: JValue): Either[HttpStatus, Opiskeluoikeus] = {
     timed("extract")(
-      validatingAndResolvingExtractor.extract[Opiskeluoikeus](parsedJson)
+      validatingAndResolvingExtractor.extract[Opiskeluoikeus](strictDeserialization)(parsedJson)
     )
   }
 

--- a/src/main/scala/fi/oph/koski/validation/ValidatingAndResolvingExtractor.scala
+++ b/src/main/scala/fi/oph/koski/validation/ValidatingAndResolvingExtractor.scala
@@ -12,13 +12,12 @@ import scala.reflect.runtime.universe.TypeTag
 
 class ValidatingAndResolvingExtractor(
   koodistoPalvelu: KoodistoViitePalvelu,
-  organisaatioRepository: OrganisaatioRepository,
-  deserializationContext: ExtractionContext
+  organisaatioRepository: OrganisaatioRepository
 ) {
   /**
    * Extracts object from json value, and validates/resolves all KoodistoKoodiViite objects on the way.
    */
-  def extract[T](json: JValue)(implicit tag: TypeTag[T])
+  def extract[T](deserializationContext: ExtractionContext)(json: JValue)(implicit tag: TypeTag[T])
   : Either[HttpStatus, T] = {
     val customDeserializers = List(
       OrganisaatioResolvingCustomDeserializer(organisaatioRepository),

--- a/src/main/scala/fi/oph/koski/valpas/ValpasKuntailmoitusApiServlet.scala
+++ b/src/main/scala/fi/oph/koski/valpas/ValpasKuntailmoitusApiServlet.scala
@@ -2,6 +2,7 @@ package fi.oph.koski.valpas
 
 import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.http.HttpStatus
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import fi.oph.koski.servlet.NoCache
 import fi.oph.koski.util.ChainingSyntax._
 import fi.oph.koski.valpas.log.ValpasAuditLog.{auditLogOppijaKatsominen, auditLogOppijaKuntailmoitus}
@@ -34,7 +35,8 @@ class ValpasKuntailmoitusApiServlet(implicit val application: KoskiApplication)
   }
 
   private def extractAndValidateKuntailmoitus(kuntailmoitusInputJson: JValue) = {
-    application.validatingAndResolvingExtractor.extract[ValpasKuntailmoitusLaajatTiedotJaOppijaOid](kuntailmoitusInputJson)
+    application.validatingAndResolvingExtractor
+      .extract[ValpasKuntailmoitusLaajatTiedotJaOppijaOid](strictDeserialization)(kuntailmoitusInputJson)
       .flatMap(kuntailmoitusInput =>
         Either.cond(
           kuntailmoitusInput.kuntailmoitus.id.isEmpty,
@@ -57,7 +59,8 @@ class ValpasKuntailmoitusApiServlet(implicit val application: KoskiApplication)
   }
 
   private def extractAndValidatePohjatiedot(pohjatiedotInputJson: JValue): Either[HttpStatus, ValpasKuntailmoitusPohjatiedotInput] = {
-    application.validatingAndResolvingExtractor.extract[ValpasKuntailmoitusPohjatiedotInput](pohjatiedotInputJson)
+    application.validatingAndResolvingExtractor
+      .extract[ValpasKuntailmoitusPohjatiedotInput](strictDeserialization)(pohjatiedotInputJson)
   }
 
   private def handleUnparseableJson(status: HttpStatus) = {

--- a/src/main/scala/fi/oph/koski/valpas/ValpasOppijaService.scala
+++ b/src/main/scala/fi/oph/koski/valpas/ValpasOppijaService.scala
@@ -5,6 +5,7 @@ import fi.oph.koski.henkilo.{Hetu, Yhteystiedot}
 import fi.oph.koski.http.HttpStatus
 import fi.oph.koski.koodisto.KoodistoViitePalvelu
 import fi.oph.koski.log.Logging
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import fi.oph.koski.schema.LocalizedString
 import fi.oph.koski.util.DateOrdering.localDateTimeOrdering
 import fi.oph.koski.util.Timing
@@ -185,7 +186,7 @@ class ValpasOppijaService(
 
   private def asValpasOppijaLaajatTiedot(dbRow: ValpasOppijaRow): Either[HttpStatus, ValpasOppijaLaajatTiedot] = {
     validatingAndResolvingExtractor
-      .extract[List[ValpasOpiskeluoikeusLaajatTiedot]](dbRow.opiskeluoikeudet)
+      .extract[List[ValpasOpiskeluoikeusLaajatTiedot]](strictDeserialization)(dbRow.opiskeluoikeudet)
       .map(opiskeluoikeudet =>
         ValpasOppijaLaajatTiedot(
           henkilö = ValpasHenkilöLaajatTiedot(

--- a/src/main/scala/fi/oph/koski/valpas/hakukooste/SureHakukoosteService.scala
+++ b/src/main/scala/fi/oph/koski/valpas/hakukooste/SureHakukoosteService.scala
@@ -5,7 +5,7 @@ import fi.oph.koski.http.Http.{StringToUriConverter, parseJsonWithDeserialize}
 import fi.oph.koski.http.{HttpStatus, HttpStatusException, ServiceConfig, VirkailijaHttpClient}
 import fi.oph.koski.json.Json4sHttp4s.json4sEncoderOf
 import fi.oph.koski.log.Logging
-import fi.oph.koski.schema.KoskiSchema.strictDeserialization
+import fi.oph.koski.schema.KoskiSchema.lenientDeserialization
 import fi.oph.koski.util.Timing
 import fi.oph.koski.validation.ValidatingAndResolvingExtractor
 import fi.oph.koski.valpas.ValpasErrorCategory
@@ -24,7 +24,7 @@ class SureHakukoosteService(config: Config, validatingAndResolvingExtractor: Val
     val encoder = json4sEncoderOf[Seq[ValpasHenkilö.Oid]]
 
     def deserialize(parsedJson: JValue): Either[HttpStatus, Seq[Hakukooste]] =
-      validatingAndResolvingExtractor.extract[Seq[Hakukooste]](strictDeserialization)(parsedJson)
+      validatingAndResolvingExtractor.extract[Seq[Hakukooste]](lenientDeserialization)(parsedJson)
         .left.map(e => {
           logger.error(s"Error deserializing JSON response from Suoritusrekisteri for ${errorClue}: " + e.toString)
           ValpasErrorCategory.badGateway.sure()

--- a/src/main/scala/fi/oph/koski/valpas/hakukooste/SureHakukoosteService.scala
+++ b/src/main/scala/fi/oph/koski/valpas/hakukooste/SureHakukoosteService.scala
@@ -5,6 +5,7 @@ import fi.oph.koski.http.Http.{StringToUriConverter, parseJsonWithDeserialize}
 import fi.oph.koski.http.{HttpStatus, HttpStatusException, ServiceConfig, VirkailijaHttpClient}
 import fi.oph.koski.json.Json4sHttp4s.json4sEncoderOf
 import fi.oph.koski.log.Logging
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import fi.oph.koski.util.Timing
 import fi.oph.koski.validation.ValidatingAndResolvingExtractor
 import fi.oph.koski.valpas.ValpasErrorCategory
@@ -23,7 +24,7 @@ class SureHakukoosteService(config: Config, validatingAndResolvingExtractor: Val
     val encoder = json4sEncoderOf[Seq[ValpasHenkilö.Oid]]
 
     def deserialize(parsedJson: JValue): Either[HttpStatus, Seq[Hakukooste]] =
-      validatingAndResolvingExtractor.extract[Seq[Hakukooste]](parsedJson)
+      validatingAndResolvingExtractor.extract[Seq[Hakukooste]](strictDeserialization)(parsedJson)
         .left.map(e => {
           logger.error(s"Error deserializing JSON response from Suoritusrekisteri for ${errorClue}: " + e.toString)
           ValpasErrorCategory.badGateway.sure()

--- a/src/main/scala/fi/oph/koski/valpas/valpasrepository/ValpasKuntailmoitusRepository.scala
+++ b/src/main/scala/fi/oph/koski/valpas/valpasrepository/ValpasKuntailmoitusRepository.scala
@@ -4,7 +4,7 @@ import fi.oph.koski.db.PostgresDriverWithJsonSupport.api._
 import fi.oph.koski.db.{DB, QueryMethods}
 import fi.oph.koski.http.HttpStatus
 import fi.oph.koski.log.Logging
-import fi.oph.koski.schema.KoskiSchema.skipSyntheticProperties
+import fi.oph.koski.schema.KoskiSchema.{skipSyntheticProperties, strictDeserialization}
 import fi.oph.koski.schema.{Koodistokoodiviite, KoskiSchema}
 import fi.oph.koski.validation.ValidatingAndResolvingExtractor
 import fi.oph.koski.valpas.ValpasErrorCategory
@@ -15,7 +15,6 @@ import fi.oph.scalaschema.{SerializationContext, Serializer}
 import org.json4s.JValue
 
 import java.time.LocalTime
-import java.util.UUID
 
 class ValpasKuntailmoitusRepository(
   valpasDatabase: ValpasDatabase,
@@ -29,7 +28,7 @@ class ValpasKuntailmoitusRepository(
     Serializer.serialize(model, SerializationContext(KoskiSchema.schemaFactory, skipSyntheticProperties))
 
   private def deserialize(data: JValue): Either[HttpStatus, IlmoitusLisätiedotData] =
-    deserializer.extract[IlmoitusLisätiedotData](data)
+    deserializer.extract[IlmoitusLisätiedotData](strictDeserialization)(data)
 
   private def toDbRows(data: ValpasKuntailmoitusLaajatTiedotJaOppijaOid)(tekijäHenkilöOid: String)
   : Either[HttpStatus, (IlmoitusRow, IlmoitusLisätiedotRow)] = {

--- a/src/test/scala/fi/oph/koski/api/HistoryTestMethods.scala
+++ b/src/test/scala/fi/oph/koski/api/HistoryTestMethods.scala
@@ -2,11 +2,12 @@ package fi.oph.koski.api
 
 import fi.oph.koski.history.OpiskeluoikeusHistoryPatch
 import fi.oph.koski.koskiuser.{MockUsers, UserWithPassword}
-import fi.oph.scalaschema.SchemaValidatingExtractor
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
+import fi.oph.scalaschema.{ExtractionContext, SchemaValidatingExtractor}
 import org.json4s.jackson.JsonMethods
 
 trait HistoryTestMethods extends OpiskeluoikeusTestMethods {
-  import fi.oph.koski.schema.KoskiSchema.deserializationContext
+  private implicit val context: ExtractionContext = strictDeserialization
 
   def readHistory = SchemaValidatingExtractor.extract[List[OpiskeluoikeusHistoryPatch]](JsonMethods.parse(body)).right.get
 

--- a/src/test/scala/fi/oph/koski/api/KäyttöoikeusryhmätSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/KäyttöoikeusryhmätSpec.scala
@@ -11,9 +11,10 @@ import fi.oph.koski.koskiuser.MockUsers.{evira, korkeakouluViranomainen, perusop
 import fi.oph.koski.koskiuser.{KoskiSpecificSession, MockUser, MockUsers, UserWithPassword}
 import fi.oph.koski.luovutuspalvelu.{HetuRequestV1, LuovutuspalveluResponseV1}
 import fi.oph.koski.organisaatio.MockOrganisaatiot
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import fi.oph.koski.schema._
 import fi.oph.koski.{DatabaseTestMethods, DirtiesFixtures, KoskiHttpSpec}
-import fi.oph.scalaschema.SchemaValidatingExtractor
+import fi.oph.scalaschema.{ExtractionContext, SchemaValidatingExtractor}
 import org.scalatest.FreeSpec
 
 import java.time.LocalDate
@@ -425,7 +426,7 @@ class KäyttöoikeusryhmätSpec
   private def readLisätiedot(opiskeluoikeudet: Seq[Opiskeluoikeus]) = opiskeluoikeudet.head.lisätiedot.get.asInstanceOf[AmmatillisenOpiskeluoikeudenLisätiedot]
 
   private def getLuovutuspalveluOpiskeluoikeudet = {
-    import fi.oph.koski.schema.KoskiSchema.deserializationContext
+    implicit val context: ExtractionContext = strictDeserialization
     SchemaValidatingExtractor.extract[LuovutuspalveluResponseV1](body).right.get.opiskeluoikeudet
   }
 

--- a/src/test/scala/fi/oph/koski/api/OpiskeluoikeusTestMethods.scala
+++ b/src/test/scala/fi/oph/koski/api/OpiskeluoikeusTestMethods.scala
@@ -6,13 +6,14 @@ import fi.oph.koski.json.JsonSerializer
 import fi.oph.koski.koskiuser.MockUsers.paakayttajaMitatoidytOpiskeluoikeudet
 import fi.oph.koski.koskiuser.UserWithPassword
 import fi.oph.koski.schema.Henkilö.Oid
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import fi.oph.koski.schema._
-import fi.oph.scalaschema.SchemaValidatingExtractor
+import fi.oph.scalaschema.{ExtractionContext, SchemaValidatingExtractor}
 import org.json4s.jackson.JsonMethods
 import org.scalatest.Matchers
 
 trait OpiskeluoikeusTestMethods extends HttpSpecification with Matchers {
-  import fi.oph.koski.schema.KoskiSchema.deserializationContext
+  private implicit val context: ExtractionContext = strictDeserialization
 
   def lastOpiskeluoikeusByHetu(oppija: Henkilö, user: UserWithPassword = defaultUser): KoskeenTallennettavaOpiskeluoikeus = {
     val hetu = oppija match {

--- a/src/test/scala/fi/oph/koski/api/PermissionCheckSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/PermissionCheckSpec.scala
@@ -5,8 +5,9 @@ import fi.oph.koski.henkilo.KoskiSpecificMockOppijat
 import fi.oph.koski.json.JsonSerializer
 import fi.oph.koski.organisaatio.MockOrganisaatiot
 import fi.oph.koski.permission.PermissionCheckResponse
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import fi.oph.koski.schema.{Henkilö, Organisaatio}
-import fi.oph.scalaschema.SchemaValidatingExtractor
+import fi.oph.scalaschema.{ExtractionContext, SchemaValidatingExtractor}
 import org.scalatest.{FreeSpec, Matchers}
 
 class PermissionCheckSpec extends FreeSpec with KoskiHttpSpec with Matchers {
@@ -38,8 +39,6 @@ class PermissionCheckSpec extends FreeSpec with KoskiHttpSpec with Matchers {
     }
   }
 
-  import fi.oph.koski.schema.KoskiSchema.deserializationContext
-
   def permissionCheck(personOidsForSamePerson: List[Henkilö.Oid], organisationOids: List[Organisaatio.Oid], loggedInUserRoles: List[String] = List("ROLE_APP_KOSKI", "ROLE_APP_OPPIJANUMEROREKISTERI_HENKILON_RU")): Boolean = {
     post(
       "api/permission/checkpermission",
@@ -51,6 +50,7 @@ class PermissionCheckSpec extends FreeSpec with KoskiHttpSpec with Matchers {
       headers = jsonContent
     ) {
       verifyResponseStatusOk()
+      implicit val context: ExtractionContext = strictDeserialization
       SchemaValidatingExtractor.extract[PermissionCheckResponse](body).right.get.accessAllowed
     }
   }

--- a/src/test/scala/fi/oph/koski/api/PutOpiskeluOikeusTestMethods.scala
+++ b/src/test/scala/fi/oph/koski/api/PutOpiskeluOikeusTestMethods.scala
@@ -4,8 +4,9 @@ import fi.oph.koski.henkilo.{LaajatOppijaHenkilöTiedot, OppijaHenkilö}
 import fi.oph.koski.json.JsonSerializer
 import fi.oph.koski.koodisto.{KoodistoViitePalvelu, MockKoodistoViitePalvelu}
 import fi.oph.koski.koskiuser.{KoskiSpecificSession, UserWithPassword}
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import fi.oph.koski.schema._
-import fi.oph.scalaschema.SchemaValidatingExtractor
+import fi.oph.scalaschema.{ExtractionContext, SchemaValidatingExtractor}
 import org.json4s._
 import org.json4s.jackson.JsonMethods
 
@@ -13,6 +14,8 @@ import scala.language.implicitConversions
 import scala.reflect.runtime.universe.TypeTag
 
 trait PutOpiskeluoikeusTestMethods[Oikeus <: Opiskeluoikeus] extends OpiskeluoikeusTestMethods with OpiskeluoikeusData[Oikeus] {
+  private implicit val context: ExtractionContext = strictDeserialization
+
   def tag: TypeTag[Oikeus]
 
   val koodisto: KoodistoViitePalvelu = MockKoodistoViitePalvelu
@@ -31,7 +34,6 @@ trait PutOpiskeluoikeusTestMethods[Oikeus <: Opiskeluoikeus] extends Opiskeluoik
   }
 
   def putHenkilö[A](henkilö: Henkilö)(f: => A): Unit = {
-    import fi.oph.koski.schema.KoskiSchema.deserializationContext
     putOppija(JsonSerializer.serializeWithRoot(SchemaValidatingExtractor.extract[Oppija](makeOppija(opiskeluOikeudet = List(defaultOpiskeluoikeus))(tag)).right.get.copy(henkilö = henkilö)))(f)
   }
 
@@ -62,7 +64,6 @@ trait PutOpiskeluoikeusTestMethods[Oikeus <: Opiskeluoikeus] extends Opiskeluoik
     "opiskeluoikeudet" -> JsonSerializer.serializeWithRoot(opiskeluOikeudet)
   )
 
-  import fi.oph.koski.schema.KoskiSchema.deserializationContext
   def readPutOppijaResponse: PutOppijaResponse = {
     SchemaValidatingExtractor.extract[PutOppijaResponse](JsonMethods.parse(body)).right.get
   }

--- a/src/test/scala/fi/oph/koski/api/QueryTestMethods.scala
+++ b/src/test/scala/fi/oph/koski/api/QueryTestMethods.scala
@@ -2,14 +2,15 @@ package fi.oph.koski.api
 
 import fi.oph.koski.http.HttpSpecification
 import fi.oph.koski.koskiuser.UserWithPassword
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import fi.oph.koski.schema.Oppija
-import fi.oph.scalaschema.SchemaValidatingExtractor
+import fi.oph.scalaschema.{ExtractionContext, SchemaValidatingExtractor}
 
 trait QueryTestMethods extends HttpSpecification {
-  import fi.oph.koski.schema.KoskiSchema.deserializationContext
   def queryOppijat(queryString: String = "", user: UserWithPassword = defaultUser): List[Oppija] = {
     authGet ("api/oppija" + queryString, user = user) {
       verifyResponseStatusOk()
+      implicit val context: ExtractionContext = strictDeserialization
       SchemaValidatingExtractor.extract[List[Oppija]](body).right.get
     }
   }

--- a/src/test/scala/fi/oph/koski/api/SuoritusjakoV2Spec.scala
+++ b/src/test/scala/fi/oph/koski/api/SuoritusjakoV2Spec.scala
@@ -7,18 +7,16 @@ import fi.oph.koski.henkilo.{KoskiSpecificMockOppijat, OppijaHenkilö}
 import fi.oph.koski.http.KoskiErrorCategory
 import fi.oph.koski.json.JsonSerializer
 import fi.oph.koski.log.AuditLogTester
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import fi.oph.koski.schema._
 import fi.oph.koski.suoritusjako.{Suoritusjako, SuoritusjakoDeleteRequest, SuoritusjakoRequest, SuoritusjakoUpdateRequest}
-import fi.oph.scalaschema.SchemaValidatingExtractor
+import fi.oph.scalaschema.{ExtractionContext, SchemaValidatingExtractor}
 import org.json4s.jackson.JsonMethods
 import org.scalatest.{FreeSpec, Matchers}
 
 import java.time.LocalDate
 
 class SuoritusjakoV2Spec extends FreeSpec with Matchers with OpiskeluoikeusTestMethodsAmmatillinen with KoskiHttpSpec {
-
-  import fi.oph.koski.schema.KoskiSchema.deserializationContext
-
   "Voi jakaa koko opiskeluoikeuden" in {
     val oppija = KoskiSpecificMockOppijat.lukiolainen
     val oppimääränOpiskeluoikeus = getOpiskeluoikeudet(oppija.oid).collectFirst {
@@ -172,6 +170,7 @@ class SuoritusjakoV2Spec extends FreeSpec with Matchers with OpiskeluoikeusTestM
   def getSuoritusjaot(oppija: OppijaHenkilö) = {
     get("api/suoritusjakoV2/available", headers = kansalainenLoginHeaders(oppija.hetu.get)) {
       verifyResponseStatusOk()
+      implicit val context: ExtractionContext = strictDeserialization
       SchemaValidatingExtractor.extract[List[Suoritusjako]](body).right.get
     }
   }

--- a/src/test/scala/fi/oph/koski/raportointikanta/RaportointikantaSpec.scala
+++ b/src/test/scala/fi/oph/koski/raportointikanta/RaportointikantaSpec.scala
@@ -7,10 +7,11 @@ import fi.oph.koski.henkilo.KoskiSpecificMockOppijat
 import fi.oph.koski.henkilo.KoskiSpecificMockOppijat.{master, masterEiKoskessa}
 import fi.oph.koski.json.{JsonFiles, JsonSerializer}
 import fi.oph.koski.organisaatio.MockOrganisaatiot
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import fi.oph.koski.schema._
 import fi.oph.koski.util.Wait
 import fi.oph.koski.{DirtiesFixtures, KoskiHttpSpec}
-import fi.oph.scalaschema.SchemaValidatingExtractor
+import fi.oph.scalaschema.{ExtractionContext, SchemaValidatingExtractor}
 import org.json4s.JsonAST.{JBool, JObject}
 import org.json4s.jackson.JsonMethods
 import org.scalatest.{FreeSpec, Matchers}
@@ -122,7 +123,8 @@ class RaportointikantaSpec
   }
 
   "Opiskeluoikeuksien lataus" - {
-    import fi.oph.koski.schema.KoskiSchema.deserializationContext
+    implicit val context: ExtractionContext = strictDeserialization
+
     val ammatillinenJson = JsonFiles.readFile("src/test/resources/backwardcompatibility/ammatillinen-perustutkinto_2020-04-24.json")
     val oid = "1.2.246.562.15.123456"
     val ammatillinenOpiskeluoikeus = SchemaValidatingExtractor.extract[Oppija](ammatillinenJson).right.get.opiskeluoikeudet.head.asInstanceOf[AmmatillinenOpiskeluoikeus].copy(oid = Some(oid))

--- a/src/test/scala/fi/oph/koski/schema/ArviointiSpec.scala
+++ b/src/test/scala/fi/oph/koski/schema/ArviointiSpec.scala
@@ -3,6 +3,7 @@ package fi.oph.koski.schema
 import fi.oph.koski.KoskiApplicationForTests
 import fi.oph.koski.documentation.AmmatillinenExampleData.{hylätty, hyväksytty}
 import fi.oph.koski.json.JsonSerializer
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import org.json4s.jackson.JsonMethods.parse
 import org.scalatest.{FreeSpec, Matchers}
 
@@ -115,7 +116,8 @@ class ArviointiSpec extends FreeSpec with Matchers {
 
   private lazy val app = KoskiApplicationForTests
 
-  private def read[T](s: String)(implicit mf : Manifest[T]) = app.validatingAndResolvingExtractor.extract[T](parse(s)).toOption.get
+  private def read[T](s: String)(implicit mf : Manifest[T]) = app.validatingAndResolvingExtractor
+    .extract[T](strictDeserialization)(parse(s)).toOption.get
 
   def numeerinenArviointi(arvosana: Int, päivä: LocalDate = LocalDate.of(2016, 6, 4)): LukionArviointi = {
     NumeerinenLukionArviointi(arvosana = Koodistokoodiviite(koodiarvo = arvosana.toString, koodistoUri = "arviointiasteikkoyleissivistava"), päivä)

--- a/src/test/scala/fi/oph/koski/schema/KoskiOppijaExamplesValidationSpec.scala
+++ b/src/test/scala/fi/oph/koski/schema/KoskiOppijaExamplesValidationSpec.scala
@@ -1,15 +1,14 @@
 package fi.oph.koski.schema
 
 import java.time.LocalDate
-
 import com.fasterxml.jackson.databind.JsonNode
 import com.github.fge.jackson.JsonLoader
 import com.github.fge.jsonschema.main.{JsonSchemaFactory, JsonValidator}
 import fi.oph.koski.documentation.AmmatillinenExampleData._
 import fi.oph.koski.documentation.Examples
 import fi.oph.koski.json.JsonSerializer
-import fi.oph.koski.schema.KoskiSchema.deserializationContext
-import fi.oph.scalaschema.SchemaValidatingExtractor
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
+import fi.oph.scalaschema.{ExtractionContext, SchemaValidatingExtractor}
 import fi.oph.scalaschema.extraction.{EmptyString, RegExMismatch, ValidationError}
 import org.json4s.JsonAST.JString
 import org.scalatest.{FreeSpec, Matchers}
@@ -79,6 +78,7 @@ class KoskiOppijaExamplesValidationSpec extends FreeSpec with Matchers {
   }
 
   def deserialize[T : TypeTag](obj: T): Either[List[ValidationError], T] = {
+    implicit val context: ExtractionContext = strictDeserialization
     SchemaValidatingExtractor.extract(JsonSerializer.serializeWithRoot(obj))
   }
 }

--- a/src/test/scala/fi/oph/koski/schema/SerializationSpec.scala
+++ b/src/test/scala/fi/oph/koski/schema/SerializationSpec.scala
@@ -5,12 +5,13 @@ import fi.oph.koski.henkilo.{KoskiSpecificMockOppijat, OppijaHenkilöWithMasterI
 import fi.oph.koski.json.JsonSerializer
 import fi.oph.koski.log.Logging
 import fi.oph.koski.perustiedot.{OpiskeluoikeudenHenkilötiedot, OpiskeluoikeudenOsittaisetTiedot, OpiskeluoikeudenPerustiedot}
-import fi.oph.scalaschema.SchemaValidatingExtractor
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
+import fi.oph.scalaschema.{ExtractionContext, SchemaValidatingExtractor}
 import org.scalatest.{FreeSpec, Matchers}
 
 class SerializationSpec extends FreeSpec with Matchers with Logging {
+  private implicit val context: ExtractionContext = strictDeserialization
   "Serialization / deserialization" - {
-    import fi.oph.koski.schema.KoskiSchema.deserializationContext
     "Tunnustaminen" in {
       val json = JsonSerializer.serializeWithRoot(AmmatillinenExampleData.tunnustettu)
       val tunnustettu = SchemaValidatingExtractor.extract[OsaamisenTunnustaminen](json).right.get

--- a/src/test/scala/fi/oph/koski/schema/SerializationSpec.scala
+++ b/src/test/scala/fi/oph/koski/schema/SerializationSpec.scala
@@ -81,7 +81,7 @@ class SerializationSpec extends FreeSpec with Matchers with Logging {
 
           kaikkiSuoritukset.foreach { s =>
             val jsonString = JsonSerializer.serializeWithRoot(s)
-            val suoritus = SchemaValidatingExtractor.extract[Suoritus](jsonString) match {
+            SchemaValidatingExtractor.extract[Suoritus](jsonString) match {
               case Right(suoritus) => suoritus should (equal(s))
               case Left(error) => fail(s"deserialization of $s failed: $error")
             }

--- a/src/test/scala/fi/oph/koski/sure/SureSpec.scala
+++ b/src/test/scala/fi/oph/koski/sure/SureSpec.scala
@@ -240,7 +240,7 @@ class SureSpec extends FreeSpec with KoskiHttpSpec with OpiskeluoikeusTestMethod
   }
 
   private def muuttuneetKursorillaIteroi(firstCursor: String): Seq[MuuttuneetOppijatResponse] = {
-    var responses = collection.mutable.ArrayBuffer[MuuttuneetOppijatResponse]()
+    val responses = collection.mutable.ArrayBuffer[MuuttuneetOppijatResponse]()
     var cursor = firstCursor
     while (true) {
       val res = muuttuneetKursorilla(cursor)

--- a/src/test/scala/fi/oph/koski/sure/SureSpec.scala
+++ b/src/test/scala/fi/oph/koski/sure/SureSpec.scala
@@ -9,18 +9,18 @@ import fi.oph.koski.json.JsonSerializer
 import fi.oph.koski.koskiuser.MockUsers.{stadinAmmattiopistoKatselija, stadinVastuukäyttäjä}
 import fi.oph.koski.koskiuser.{MockUsers, UserWithPassword}
 import fi.oph.koski.log.AuditLogTester
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import fi.oph.koski.schema._
 import fi.oph.koski.{DatabaseTestMethods, KoskiHttpSpec}
-import fi.oph.scalaschema.SchemaValidatingExtractor
+import fi.oph.scalaschema.{ExtractionContext, SchemaValidatingExtractor}
 import org.json4s.JsonAST.{JArray, JBool}
 import org.json4s.jackson.JsonMethods
 import org.json4s.{DefaultFormats, JString, JValue}
 import org.scalatest.{FreeSpec, Matchers}
 
 class SureSpec extends FreeSpec with KoskiHttpSpec with OpiskeluoikeusTestMethodsAmmatillinen with DatabaseTestMethods with Matchers {
-
-  import fi.oph.koski.schema.KoskiSchema.deserializationContext
-  implicit val formats = DefaultFormats
+  private implicit val context: ExtractionContext = strictDeserialization
+  private implicit val formats = DefaultFormats
 
   "Sure-rajapinnat" - {
     "/api/sure/oids" - {

--- a/src/test/scala/fi/oph/koski/tools/AddIgnoreKoskiValidatorFlag.scala
+++ b/src/test/scala/fi/oph/koski/tools/AddIgnoreKoskiValidatorFlag.scala
@@ -2,21 +2,20 @@ package fi.oph.koski.tools
 
 
 import java.io.File
-
 import fi.oph.koski.KoskiApplicationForTests
 import fi.oph.koski.json.JsonFiles
 import fi.oph.koski.koskiuser.{AccessType, KoskiSpecificSession}
-import fi.oph.koski.schema.KoskiSchema.deserializationContext
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import fi.oph.koski.schema.Oppija
-import fi.oph.scalaschema.SchemaValidatingExtractor
+import fi.oph.scalaschema.{ExtractionContext, SchemaValidatingExtractor}
 import org.json4s.JsonAST.{JBool, JField, JObject, JValue}
 
 object AddIgnoreKoskiValidatorFlag extends App {
-
-  val dirName = "src/test/resources/backwardcompatibility"
-  lazy val koskiValidator = KoskiApplicationForTests.validator
-  implicit val user = KoskiSpecificSession.systemUser
-  implicit val accessType = AccessType.read
+  private val dirName = "src/test/resources/backwardcompatibility"
+  private lazy val koskiValidator = KoskiApplicationForTests.validator
+  private implicit val user = KoskiSpecificSession.systemUser
+  private implicit val accessType = AccessType.read
+  private implicit val context: ExtractionContext = strictDeserialization
 
   def modifyJsons = {
     val existingFiles = new File(dirName).list().filter(_.endsWith(".json")).map(fullName)

--- a/src/test/scala/fi/oph/koski/valpas/SureHakukoosteServiceSpec.scala
+++ b/src/test/scala/fi/oph/koski/valpas/SureHakukoosteServiceSpec.scala
@@ -129,7 +129,8 @@ object SureHakukoosteServiceSpec {
       |      },
       |      "lyhytNimi": {
       |        "fi": "YH",
-      |        "sv": "GA"
+      |        "sv": "GA",
+      |        "en": ""
       |      },
       |      "koodistoUri": "hakutapa",
       |      "koodistoVersio": 1
@@ -185,7 +186,8 @@ object SureHakukoosteServiceSpec {
       |        },
       |        "hakukohdeOrganisaatio": "1.2.246.562.10.38864316104",
       |        "organisaatioNimi": {},
-      |        "koulutusOid": "1.2.246.562.17.83264128444"
+      |        "koulutusOid": "1.2.246.562.17.83264128444",
+      |        "valintakoe": []
       |      },
       |      {
       |        "hakukohdeNimi": {},

--- a/src/test/scala/fi/oph/koski/versioning/BackwardCompatibilitySpec.scala
+++ b/src/test/scala/fi/oph/koski/versioning/BackwardCompatibilitySpec.scala
@@ -2,17 +2,16 @@ package fi.oph.koski.versioning
 
 import java.io.File
 import java.time.LocalDate
-
 import fi.oph.koski.KoskiApplicationForTests
 import fi.oph.koski.documentation.Example
 import fi.oph.koski.documentation.Examples.examples
 import fi.oph.koski.json.{JsonFiles, JsonSerializer}
 import fi.oph.koski.koskiuser.{AccessType, KoskiSpecificSession}
 import fi.oph.koski.log.Logging
-import fi.oph.koski.schema.KoskiSchema.deserializationContext
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import fi.oph.koski.schema.{KoskeenTallennettavaOpiskeluoikeus, Oppija}
 import fi.oph.koski.util.EnvVariables
-import fi.oph.scalaschema.SchemaValidatingExtractor
+import fi.oph.scalaschema.{ExtractionContext, SchemaValidatingExtractor}
 import org.json4s.JValue
 import org.json4s.JsonAST.{JArray, JBool, JObject}
 import org.json4s.jackson.JsonMethods
@@ -103,6 +102,7 @@ class BackwardCompatibilitySpec extends FreeSpec with Matchers with Logging with
     filename in {
       val (json, skipRoundtripCheck, skipKoskiValidator) = readFile(filename)
 
+      implicit val context: ExtractionContext = strictDeserialization
       SchemaValidatingExtractor.extract[Oppija](json) match {
         case Left(errors) => fail("Backwards compatibility problem: " + errors)
         case Right(oppija) =>

--- a/src/test/scala/fi/oph/koski/ytr/YtrKoesuoritusApiSpec.scala
+++ b/src/test/scala/fi/oph/koski/ytr/YtrKoesuoritusApiSpec.scala
@@ -3,12 +3,14 @@ package fi.oph.koski.ytr
 import fi.oph.koski.KoskiHttpSpec
 import fi.oph.koski.api.OpiskeluoikeusTestMethods
 import fi.oph.koski.henkilo.KoskiSpecificMockOppijat
-import fi.oph.koski.json.JsonSerializer
-import fi.oph.scalaschema.SchemaValidatingExtractor
+import fi.oph.koski.schema.KoskiSchema.strictDeserialization
+import fi.oph.scalaschema.{ExtractionContext, SchemaValidatingExtractor}
 import org.json4s.jackson.JsonMethods
 import org.scalatest.FreeSpec
 
 class YtrKoesuoritusApiSpec extends FreeSpec with KoskiHttpSpec with OpiskeluoikeusTestMethods {
+  private implicit val context: ExtractionContext = strictDeserialization
+
   "Kansalainen" - {
     "voi hakea koesuorituslistauksen" in {
       post("api/ytrkoesuoritukset/" + KoskiSpecificMockOppijat.ylioppilasLukiolainen.oid, headers = kansalainenLoginHeaders(KoskiSpecificMockOppijat.ylioppilasLukiolainen.hetu.get) ++ jsonContent) {
@@ -42,7 +44,6 @@ class YtrKoesuoritusApiSpec extends FreeSpec with KoskiHttpSpec with Opiskeluoik
   lazy val huoltaja = JsonSerializer.writeWithRoot(Map("huollettava" -> false))
   lazy val huollettava = JsonSerializer.writeWithRoot(Map("huollettava" -> true))
 
-  import fi.oph.koski.schema.KoskiSchema.deserializationContext
   private def readExams: List[ExamResponse] =
     SchemaValidatingExtractor.extract[List[ExamResponse]](JsonMethods.parse(body)).right.get
 

--- a/src/test/scala/fi/oph/koski/ytr/YtrKoesuoritusApiSpec.scala
+++ b/src/test/scala/fi/oph/koski/ytr/YtrKoesuoritusApiSpec.scala
@@ -11,6 +11,17 @@ import org.scalatest.FreeSpec
 class YtrKoesuoritusApiSpec extends FreeSpec with KoskiHttpSpec with OpiskeluoikeusTestMethods {
   private implicit val context: ExtractionContext = strictDeserialization
 
+  private def readExams: List[ExamResponse] =
+    SchemaValidatingExtractor.extract[List[ExamResponse]](JsonMethods.parse(body)).right.get
+
+  private val expected = List(
+    ExamResponse(period = "2012K", examId = "A", copyOfExamPaper = Some("2345K_XX_12345.pdf")),
+    ExamResponse(period = "2012K", examId = "BB", copyOfExamPaper = Some("not-found-from-s3.pdf")),
+    ExamResponse(period = "2012K", examId = "EA", copyOfExamPaper = Some("1.pdf")),
+    ExamResponse(period = "2012K", examId = "GE", copyOfExamPaper = Some("2.pdf")),
+    ExamResponse(period = "2012K", examId = "N", copyOfExamPaper = Some("1234S_YY_420.html"))
+  )
+
   "Kansalainen" - {
     "voi hakea koesuorituslistauksen" in {
       post("api/ytrkoesuoritukset/" + KoskiSpecificMockOppijat.ylioppilasLukiolainen.oid, headers = kansalainenLoginHeaders(KoskiSpecificMockOppijat.ylioppilasLukiolainen.hetu.get) ++ jsonContent) {
@@ -40,18 +51,4 @@ class YtrKoesuoritusApiSpec extends FreeSpec with KoskiHttpSpec with Opiskeluoik
       }
     }
   }
-
-  lazy val huoltaja = JsonSerializer.writeWithRoot(Map("huollettava" -> false))
-  lazy val huollettava = JsonSerializer.writeWithRoot(Map("huollettava" -> true))
-
-  private def readExams: List[ExamResponse] =
-    SchemaValidatingExtractor.extract[List[ExamResponse]](JsonMethods.parse(body)).right.get
-
-  private val expected = List(
-    ExamResponse(period = "2012K", examId = "A", copyOfExamPaper = Some("2345K_XX_12345.pdf")),
-    ExamResponse(period = "2012K", examId = "BB", copyOfExamPaper = Some("not-found-from-s3.pdf")),
-    ExamResponse(period = "2012K", examId = "EA", copyOfExamPaper = Some("1.pdf")),
-    ExamResponse(period = "2012K", examId = "GE", copyOfExamPaper = Some("2.pdf")),
-    ExamResponse(period = "2012K", examId = "N", copyOfExamPaper = Some("1234S_YY_420.html"))
-  )
 }


### PR DESCRIPTION
Muutokset Sure-API:n vastauksen validointiin aiheuttivat sen, ettei APIn palauttamia tyhjiä merkkijonoja ja "ylimääräisiä" (Valppaan tietomalliin kuulumattomia) kenttiä enää hyväksytty parsinnassa.

Varsinainen korjaus ongelmaan on viimeisimmässä commitissa ja regressiotesti sitä edellisessä. Korjauksen siisti toteutus vaati lisäksi isompaa refaktorointia parsintaan.