### PR TITLE
TOR-797 - Käytetään päätason suorituksen suoritustyyppiä identifioimaan opiskeluoikeus

### DIFF
--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/OpiskeluoikeusIdentifier.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/OpiskeluoikeusIdentifier.scala
@@ -10,6 +10,7 @@ object OpiskeluoikeusIdentifier {
         opiskeluoikeus.koulutustoimija.map(_.oid),
         opiskeluoikeus.tyyppi.koodiarvo,
         opiskeluoikeus.suoritukset.headOption.map(_.koulutusmoduuli.tunniste.koodiarvo),
+        opiskeluoikeus.suoritukset.headOption.map(_.tyyppi.koodiarvo),
         None)
   }
 }
@@ -22,5 +23,6 @@ case class OppijaOidOrganisaatioJaTyyppi(oppijaOid: String,
                                          koulutustoimija: Option[String],
                                          opiskeluoikeudenTyyppi: String,
                                          päätasonSuorituksenKoulutusmoduulinTyyppi: Option[String],
+                                         päätasonSuorituksenSuoritustyyppi: Option[String],
                                          lähdejärjestelmäId: Option[LähdejärjestelmäId]) extends OpiskeluoikeusIdentifier
 case class OpiskeluoikeusByOid(oid: String) extends OpiskeluoikeusIdentifier

--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/PostgresOpiskeluoikeusRepository.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/PostgresOpiskeluoikeusRepository.scala
@@ -181,6 +181,7 @@ class PostgresOpiskeluoikeusRepository(
             opiskeluoikeus.koulutustoimija.map(_.oid),
             opiskeluoikeus.tyyppi.koodiarvo,
             opiskeluoikeus.suoritukset.headOption.map(_.koulutusmoduuli.tunniste.koodiarvo),
+            opiskeluoikeus.suoritukset.headOption.map(_.tyyppi.koodiarvo),
             opiskeluoikeus.lähdejärjestelmänId) == identifier
         }).map(_.toList).map(Right(_))
     }

--- a/web/test/spec/useampiSamanOppilaitoksenVoimassaOlevaOpintoOikeusSpec.js
+++ b/web/test/spec/useampiSamanOppilaitoksenVoimassaOlevaOpintoOikeusSpec.js
@@ -51,6 +51,22 @@ describe('Useampi voimassa oleva opinto oikeus samassa oppilaitoksessa', functio
     it('ei ole sallittu', function() {
       expect(page.getErrorMessage()).to.equal('Opiskeluoikeutta ei voida lisätä, koska oppijalla on jo vastaava opiskeluoikeus.')
     })
+    describe('kun suoritustyyppi eroaa', function() {
+      before(
+        opinnot.opiskeluoikeudet.lisääOpiskeluoikeus,
+        addOppija.selectOppilaitos('Stadin ammatti- ja aikuisopisto'),
+        addOppija.selectOpiskeluoikeudenTyyppi('Ammatillinen koulutus'),
+        addOppija.selectOppimäärä('Ammatillisen tutkinnon osa/osia'),
+        addOppija.selectTutkinto('Autoalan perustutkinto'),
+        addOppija.selectSuoritustapa('Ammatillinen perustutkinto'),
+        addOppija.selectAloituspäivä('1.1.2018'),
+        addOppija.selectOpintojenRahoitus('Valtionosuusrahoitteinen koulutus'),
+        addOppija.submitModal
+      )
+      it('on sallittu', function() {
+        expect(opinnot.opiskeluoikeudet.opiskeluoikeuksienMäärä()).to.equal(3)
+      })
+    })
   })
   describe('muussa ammatillisessa koulutuksessa', function() {
     before(
@@ -72,7 +88,7 @@ describe('Useampi voimassa oleva opinto oikeus samassa oppilaitoksessa', functio
       addOppija.submitModal
     )
     it('on sallittu', function() {
-      expect(opinnot.opiskeluoikeudet.opiskeluoikeuksienMäärä()).to.equal(4)
+      expect(opinnot.opiskeluoikeudet.opiskeluoikeuksienMäärä()).to.equal(5)
     })
   })
 })


### PR DESCRIPTION
Tiketti: https://jira.eduuni.fi/browse/TOR-797

Aikasemmin korjattu siten, että lisätty koulutusmoduulin tunniste identifioimaan opiskeluoikeus. Tämä ei kuitenkaan riitä, jos samaa tutkintoa on opiskeltu sekä osatutkinotavoitteisena että tutkintotavoitteisena.

Lisätty päätason suorituksen tyyppi opiskeluoikeuden erottavaksi tekijäksi.