### PR TITLE
1.8 Voimaan tulevan lain mukaan opiskeluoikeuden maksuttomuus-tieto t…

### DIFF
--- a/src/main/scala/fi/oph/koski/validation/MaksuttomuusValidation.scala
+++ b/src/main/scala/fi/oph/koski/validation/MaksuttomuusValidation.scala
@@ -17,7 +17,7 @@ object MaksuttomuusValidation {
                                        (implicit user: KoskiSpecificSession): HttpStatus = {
     val suoritusVaatiiMaksuttomuusTiedon = oppivelvollisuudenSuorittamiseenKelpaavaMuuKuinPeruskoulunOpiskeluoikeus(opiskeluoikeus)
     val oppijanIkäOikeuttaaMaksuttomuuden = oppijanSyntymäpäivä.exists(bd => !LocalDate.of(2004, 1, 1).isAfter(bd))
-    val alkamispäiväOikeuttaaMaksuttomuuden = opiskeluoikeus.alkamispäivä.exists(d => !d.isBefore(LocalDate.of(2021, 8, 1)))
+    val alkamispäiväOikeuttaaMaksuttomuuden = opiskeluoikeus.alkamispäivä.exists(d => !d.isBefore(LocalDate.of(2021, 1, 1)))
     val maksuttomuusTietoOnSiirretty = opiskeluoikeus.lisätiedot.collect { case l: MaksuttomuusTieto => l.maksuttomuus.toList.flatten.length > 0 }.getOrElse(false)
     val maksuttomuuttaPidennettyOnSiirretty = opiskeluoikeus.lisätiedot.collect { case l : MaksuttomuusTieto => l.oikeuttaMaksuttomuuteenPidennetty.toList.flatten.length > 0 }.getOrElse(false)
 
@@ -30,8 +30,8 @@ object MaksuttomuusValidation {
       HttpStatus.validate(!eiPiirissäMuttaMaksuttomuusTietojaSiirretty) { KoskiErrorCategory.badRequest.validation("Tieto koulutuksen maksuttomuudesta ei ole relevantti tässä opiskeluoikeudessa, sillä opiskelija on suorittanut perusopetuksen, aikuisten perusopetuksen oppimäärän tai International Schoolin 9. vuosiluokan ennen 1.1.2021.")}
     } else {
       HttpStatus.fold(
-        HttpStatus.validate(!maksuttomuusTietoOnSiirretty) { KoskiErrorCategory.badRequest.validation("Tieto koulutuksen maksuttomuudesta ei ole relevantti tässä opiskeluoikeudessa, sillä opiskeluoikeus on alkanut ennen 1.8.2021 ja/tai oppija ei annetun syntymäajan perusteella ole ikänsä puolesta laajennetun oppivelvollisuuden piirissä.")},
-        HttpStatus.validate(!maksuttomuuttaPidennettyOnSiirretty) { KoskiErrorCategory.badRequest.validation("Tieto koulutuksen maksuttomuudesta ei ole relevantti tässä opiskeluoikeudessa, sillä opiskeluoikeus on alkanut ennen 1.8.2021 ja/tai oppija ei annetun syntymäajan perusteella ole ikänsä puolesta laajennetun oppivelvollisuuden piirissä.")}
+        HttpStatus.validate(!maksuttomuusTietoOnSiirretty) { KoskiErrorCategory.badRequest.validation("Tieto koulutuksen maksuttomuudesta ei ole relevantti tässä opiskeluoikeudessa, sillä opiskeluoikeus on alkanut ennen 1.1.2021 ja/tai oppija ei annetun syntymäajan perusteella ole ikänsä puolesta laajennetun oppivelvollisuuden piirissä.")},
+        HttpStatus.validate(!maksuttomuuttaPidennettyOnSiirretty) { KoskiErrorCategory.badRequest.validation("Tieto koulutuksen maksuttomuudesta ei ole relevantti tässä opiskeluoikeudessa, sillä opiskeluoikeus on alkanut ennen 1.1.2021 ja/tai oppija ei annetun syntymäajan perusteella ole ikänsä puolesta laajennetun oppivelvollisuuden piirissä.")}
       )
     }
   }

--- a/src/test/scala/fi/oph/koski/api/MaksuttomuusSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/MaksuttomuusSpec.scala
@@ -16,24 +16,24 @@ import java.time.LocalDate.{of => date}
 class MaksuttomuusSpec extends FreeSpec with OpiskeluoikeusTestMethodsAmmatillinen with KoskiHttpSpec {
 
   "Tiedon siirtäminen" - {
-    lazy val opiskeluoikeus = alkamispäivällä(defaultOpiskeluoikeus, date(2021, 8, 1))
+    lazy val opiskeluoikeus = alkamispäivällä(defaultOpiskeluoikeus, date(2021, 1, 1))
     "Testattavan opiskeluoikeuden suoritus on merkitty vaativan maksuttomuustiedon lisätiedoilta" in {
       opiskeluoikeus.suoritukset.collectFirst { case s: SuoritusVaatiiMahdollisestiMaksuttomuusTiedonOpiskeluoikeudelta => s }.isDefined shouldBe(true)
     }
-    "Vaaditaan vuonna 2004 tai sen jälkeen syntyneiltä, joiden opiskeluoikeus on alkanut 1.8.2021 ja sisältää suorituksen joka vaatii maksuttomuus tiedon" in {
+    "Vaaditaan vuonna 2004 tai sen jälkeen syntyneiltä, joiden opiskeluoikeus on alkanut 1.1.2021 ja sisältää suorituksen joka vaatii maksuttomuus tiedon" in {
       putOpiskeluoikeus(opiskeluoikeus, KoskiSpecificMockOppijat.oikeusOpiskelunMaksuttomuuteen) {
         verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation("Tieto koulutuksen maksuttomuudesta puuttuu."))
       }
     }
-    "Ei saa siirtää jos opiskeluoikeus on alkanut ennen 1.8.2021" in {
+    "Ei saa siirtää jos opiskeluoikeus on alkanut ennen 1.1.2021" in {
       putMaksuttomuus(
         List(
-          Maksuttomuus(date(2021, 8, 1), None, true)
+          Maksuttomuus(date(2020, 12, 31), None, true)
         ),
         KoskiSpecificMockOppijat.oikeusOpiskelunMaksuttomuuteen,
-        alkamispäivällä(defaultOpiskeluoikeus, date(2021, 7, 31))
+        alkamispäivällä(defaultOpiskeluoikeus, date(2020, 12, 31))
       ) {
-        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation("Tieto koulutuksen maksuttomuudesta ei ole relevantti tässä opiskeluoikeudessa, sillä opiskeluoikeus on alkanut ennen 1.8.2021 ja/tai oppija ei annetun syntymäajan perusteella ole ikänsä puolesta laajennetun oppivelvollisuuden piirissä."))
+        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation("Tieto koulutuksen maksuttomuudesta ei ole relevantti tässä opiskeluoikeudessa, sillä opiskeluoikeus on alkanut ennen 1.1.2021 ja/tai oppija ei annetun syntymäajan perusteella ole ikänsä puolesta laajennetun oppivelvollisuuden piirissä."))
       }
     }
     "Ei saa siirtää jos henkilö on syntynyt ennen vuotta 2004" in {
@@ -44,7 +44,7 @@ class MaksuttomuusSpec extends FreeSpec with OpiskeluoikeusTestMethodsAmmatillin
         KoskiSpecificMockOppijat.eiOikeuttaMaksuttomuuteen,
         alkamispäivällä(defaultOpiskeluoikeus, date(2021, 8, 1))
       ) {
-        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation("Tieto koulutuksen maksuttomuudesta ei ole relevantti tässä opiskeluoikeudessa, sillä opiskeluoikeus on alkanut ennen 1.8.2021 ja/tai oppija ei annetun syntymäajan perusteella ole ikänsä puolesta laajennetun oppivelvollisuuden piirissä."))
+        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation("Tieto koulutuksen maksuttomuudesta ei ole relevantti tässä opiskeluoikeudessa, sillä opiskeluoikeus on alkanut ennen 1.1.2021 ja/tai oppija ei annetun syntymäajan perusteella ole ikänsä puolesta laajennetun oppivelvollisuuden piirissä."))
       }
     }
     "Ei saa siirtää jos opiskeluoikeus ei sisällä suoritusta joka vaatii maksuttomuus tiedon" in {
@@ -58,7 +58,7 @@ class MaksuttomuusSpec extends FreeSpec with OpiskeluoikeusTestMethodsAmmatillin
         ),
         KoskiSpecificMockOppijat.oikeusOpiskelunMaksuttomuuteen, oo
       ) {
-        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation("Tieto koulutuksen maksuttomuudesta ei ole relevantti tässä opiskeluoikeudessa, sillä opiskeluoikeus on alkanut ennen 1.8.2021 ja/tai oppija ei annetun syntymäajan perusteella ole ikänsä puolesta laajennetun oppivelvollisuuden piirissä."))
+        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation("Tieto koulutuksen maksuttomuudesta ei ole relevantti tässä opiskeluoikeudessa, sillä opiskeluoikeus on alkanut ennen 1.1.2021 ja/tai oppija ei annetun syntymäajan perusteella ole ikänsä puolesta laajennetun oppivelvollisuuden piirissä."))
       }
     }
     "Siirto kun opiskelijalla perusopetuksen päättötodistus tai siihen verrattavissa oleva suoritus" - {
@@ -166,7 +166,7 @@ class MaksuttomuusSpec extends FreeSpec with OpiskeluoikeusTestMethodsAmmatillin
             vahvistus = vahvistusPaikkakunnalla(päivä = date(2021, 1, 1))
           )),
           alkamispäivä = date(2010, 8, 1),
-          päättymispäivä = Some(date(2021, 8, 1)),
+          päättymispäivä = Some(date(2021, 8, 1))
         )
 
         putOpiskeluoikeus(opiskeluoikeus, KoskiSpecificMockOppijat.oikeusOpiskelunMaksuttomuuteen) {
@@ -203,7 +203,7 @@ class MaksuttomuusSpec extends FreeSpec with OpiskeluoikeusTestMethodsAmmatillin
     }
     "Maksuttomuus-tietoa ei voi siirtää jos on pelkästään muun vuosiluokan MYP-suorituksia" in {
       putOpiskeluoikeus(opiskeluoikeus.withSuoritukset(List(ysiLuokka)), KoskiSpecificMockOppijat.oikeusOpiskelunMaksuttomuuteen) {
-        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation("Tieto koulutuksen maksuttomuudesta ei ole relevantti tässä opiskeluoikeudessa, sillä opiskeluoikeus on alkanut ennen 1.8.2021 ja/tai oppija ei annetun syntymäajan perusteella ole ikänsä puolesta laajennetun oppivelvollisuuden piirissä."))
+        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation("Tieto koulutuksen maksuttomuudesta ei ole relevantti tässä opiskeluoikeudessa, sillä opiskeluoikeus on alkanut ennen 1.1.2021 ja/tai oppija ei annetun syntymäajan perusteella ole ikänsä puolesta laajennetun oppivelvollisuuden piirissä."))
       }
     }
   }

--- a/web/app/opiskeluoikeus/Maksuttomuus.js
+++ b/web/app/opiskeluoikeus/Maksuttomuus.js
@@ -5,7 +5,7 @@ import {t} from '../i18n/i18n'
 
 export const checkAlkamispäivä = d => {
   const validDate = formatISODate(d)
-  return validDate && parseISODate(validDate) >= new Date(2021, 7, 1) // 7=Elokuu, month indexing starts from 0
+  return validDate && parseISODate(validDate) >= new Date(2021, 0, 1) // 0=Tammikuu, month indexing starts from 0
 }
 
 export const checkSuoritus = (s) => s

--- a/web/test/spec/maksuttomuusSpec.js
+++ b/web/test/spec/maksuttomuusSpec.js
@@ -9,7 +9,7 @@ describe('Maksuttomuus', function() {
       before(
         prepareForNewOppija('pää', '010104A6094'),
         addOppija.enterValidDataAmmatillinen(),
-        addOppija.selectAloituspäivä('1.8.2021'),
+        addOppija.selectAloituspäivä('1.1.2021'),
         addOppija.selectMaksuttomuus(1),
         addOppija.submit,
         opinnot.expandAll
@@ -18,7 +18,7 @@ describe('Maksuttomuus', function() {
       it('Lisätiedoissa on maksuttomuus-tieto', function() {
         expect(extractAsText(S('.lisätiedot'))).to.equal(
           'Lisätiedot\n' +
-          'Koulutuksen maksuttomuus 1.8.2021 — Maksuton'
+          'Koulutuksen maksuttomuus 1.1.2021 — Maksuton'
         )
       })
 
@@ -90,11 +90,11 @@ describe('Maksuttomuus', function() {
   })
 
   describe('Maksuttomuus tieto ei näytetä valittavaksi', function () {
-    describe('Jos opiskeluoikeus alkaa ennen 1.8.2021', function () {
+    describe('Jos opiskeluoikeus alkaa ennen 1.1.2021', function () {
       before(
         prepareForNewOppija('pää', '311203A1454'),
         addOppija.enterValidDataAmmatillinen(),
-        addOppija.selectAloituspäivä('31.7.2021'),
+        addOppija.selectAloituspäivä('31.12.2020')
       )
       it('On piilotettu', function () {
         expect(S('.opiskeluoikeuden-tiedot').length).to.equal(0)
@@ -104,7 +104,7 @@ describe('Maksuttomuus', function() {
       before(
         prepareForNewOppija('pää', '311203A1454'),
         addOppija.enterValidDataMuuAmmatillinen(),
-        addOppija.selectAloituspäivä('1.8.2021'),
+        addOppija.selectAloituspäivä('1.1.2021')
       )
       it('On piilotettu', function () {
         expect(S('.opiskeluoikeuden-tiedot').length).to.equal(0)


### PR DESCRIPTION
…ulee siirtää opiskeluoikeuksiin, jotka alkavat 1.1.2021;

Ennen lain voimaantuloa tiedon siirto vaadittiin 1.8 alkavilta opiskeluoikeuksilta