### PR TITLE
Korjaa DIA-oppiaine VT koodiarvolla;

### DIFF
--- a/src/main/scala/fi/oph/koski/schema/DIA.scala
+++ b/src/main/scala/fi/oph/koski/schema/DIA.scala
@@ -309,7 +309,6 @@ case class DIAOppiaineMuu(
   @KoodistoKoodiarvo("US")
   @KoodistoKoodiarvo("FI")
   @KoodistoKoodiarvo("ET")
-  @KoodistoKoodiarvo("VT")
   tunniste: Koodistokoodiviite,
   laajuus: Option[LaajuusVuosiviikkotunneissa],
   @Description("Oppiaineen osa-alue (1-3)")


### PR DESCRIPTION
Koodiarvo oli sallittu kahteen eri oppiaineeseen jolloin schema ei osaa päätellä kummasta oppiaineesta on oikeasti kyse.
Koodiarvolla ei oltu siirretty yhtään suoritusta, joten voidaan poistaa koodiarvo väärästä paikasta.