### PR TITLE
TOR-1402: Estä tilanne, jossa taulukon vaakavierityspalkki hukkuu liian pitkän taulukon takia

### DIFF
--- a/valpas-web/src/components/containers/BottomDrawer.tsx
+++ b/valpas-web/src/components/containers/BottomDrawer.tsx
@@ -1,7 +1,7 @@
 import bem from "bem-ts"
-import { plainComponent } from "../../utils/plaincomponent"
+import { forwardRefComponent } from "../../utils/plaincomponent"
 import "./BottomDrawer.less"
 
 const b = bem("bottomdrawer")
 
-export const BottomDrawer = plainComponent("aside", b("container"))
+export const BottomDrawer = forwardRefComponent("aside", b("container"))

--- a/valpas-web/src/components/containers/cards.less
+++ b/valpas-web/src/components/containers/cards.less
@@ -23,6 +23,10 @@
 .card__body {
   position: relative;
   padding: @card-padding;
+
+  &.card__body--constrained {
+    overflow: scroll;
+  }
 }
 
 .columns__column .card,

--- a/valpas-web/src/components/containers/cards.tsx
+++ b/valpas-web/src/components/containers/cards.tsx
@@ -1,5 +1,6 @@
 import bem from "bem-ts"
-import React from "react"
+import React, { useEffect, useRef, useState } from "react"
+import { joinClassNames } from "../../utils/classnames"
 import { plainComponent } from "../../utils/plaincomponent"
 import "./cards.less"
 
@@ -21,3 +22,65 @@ export const BorderlessCard = plainComponent("section", b(["borderless"]))
 export const CardHeader = plainComponent("header", b("header"))
 
 export const CardBody = plainComponent("div", b("body"))
+
+export type ConstrainedCardBodyProps = React.HTMLAttributes<HTMLDivElement> & {
+  extraMargin?: number
+}
+
+/**
+ * Versio CardBodysta, joka pyrkii pysymään korkeudeltaan kohtuullisen kokoisena
+ */
+export const ConstrainedCardBody = ({
+  style,
+  className,
+  extraMargin,
+  ...rest
+}: ConstrainedCardBodyProps) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [maxHeight, setMaxHeight] = useState<number | undefined>(undefined)
+
+  useEffect(() => {
+    const updateMaxHeight = () =>
+      setMaxHeight(calculateConstrainedBodyMaxHeight(containerRef, extraMargin))
+
+    updateMaxHeight()
+
+    window.addEventListener("resize", updateMaxHeight)
+    return () => window.removeEventListener("resize", updateMaxHeight)
+  }, [extraMargin])
+
+  return (
+    <div
+      ref={containerRef}
+      className={joinClassNames(b("body", { constrained: true }), className)}
+      style={{ ...style, maxHeight }}
+      {...rest}
+    />
+  )
+}
+
+const calculateConstrainedBodyMaxHeight = (
+  containerRef: React.RefObject<HTMLDivElement>,
+  extraMargin: number = 0
+) => {
+  const defaultBaseMargin = 50
+  const cardMargin = 30
+  const minHeight = 500
+  const viewHeight = document.documentElement.clientHeight
+
+  // Vaihtoehto 1) venytä body lähes ruudun alareunaan asti
+  let stretchToBottomHeight = 0
+  if (containerRef.current) {
+    const containerTop = containerRef.current.getBoundingClientRect().top
+    stretchToBottomHeight = viewHeight - containerTop - extraMargin - cardMargin
+  }
+
+  // Vaihtoehto 2) venytä bodya niin että se ja kortin otsikko täyttävät ikkunan lähes kokonaan pystysuunnassa
+  const fillVerticallyHeight =
+    viewHeight - defaultBaseMargin - cardMargin * 2 - extraMargin
+
+  return Math.max(
+    minHeight,
+    Math.min(stretchToBottomHeight, fillVerticallyHeight)
+  )
+}

--- a/valpas-web/src/components/tables/Table.less
+++ b/valpas-web/src/components/tables/Table.less
@@ -117,3 +117,9 @@
     }
   }
 }
+
+.card__body--constrained {
+  .table__container {
+    display: contents;
+  }
+}

--- a/valpas-web/src/components/tables/Table.less
+++ b/valpas-web/src/components/tables/Table.less
@@ -6,12 +6,10 @@
 @table-v-padding: 0.5rem;
 
 .table__container {
-  @media screen and (max-width: 1600px) {
-    overflow: scroll;
-    table {
-      width: auto;
-      min-width: 100%;
-    }
+  overflow: scroll;
+  table {
+    width: auto;
+    min-width: 100%;
   }
 }
 

--- a/valpas-web/src/state/useBoundingClientRect.tsx
+++ b/valpas-web/src/state/useBoundingClientRect.tsx
@@ -1,0 +1,22 @@
+import { useEffect, useMemo, useRef, useState } from "react"
+
+export type UseBoundClientRectValue = {
+  ref: React.RefObject<HTMLElement>
+  rect: DOMRect | null
+}
+
+export const useBoundingClientRect = (): UseBoundClientRectValue => {
+  const ref = useRef<HTMLElement>(null)
+  const [rect, setRect] = useState<DOMRect | null>(null)
+
+  useEffect(() => {
+    const update = () => setRect(ref.current?.getBoundingClientRect() || null)
+    update()
+    window.addEventListener("resize", update)
+    return () => window.removeEventListener("resize", update)
+  }, [])
+
+  const result = useMemo(() => ({ ref, rect }), [rect])
+
+  return result
+}

--- a/valpas-web/src/utils/plaincomponent.tsx
+++ b/valpas-web/src/utils/plaincomponent.tsx
@@ -10,3 +10,20 @@ export const plainComponent = (tag: string, baseClassName: string) => {
     <Plain className={joinClassNames(baseClassName, className)} {...rest} />
   )
 }
+
+export const forwardRefComponent = (tag: string, baseClassName: string) => {
+  const Plain = tag
+  return React.forwardRef(
+    (
+      { className, ...rest }: PlainComponentProps,
+      ref: React.ForwardedRef<HTMLElement>
+    ) => (
+      <Plain
+        className={joinClassNames(baseClassName, className)}
+        {...rest}
+        // @ts-ignore
+        ref={ref}
+      />
+    )
+  )
+}

--- a/valpas-web/src/views/hakutilanne/HakutilanneDrawer.tsx
+++ b/valpas-web/src/views/hakutilanne/HakutilanneDrawer.tsx
@@ -21,62 +21,64 @@ export type HakutilanneDrawerProps = {
   tekijäorganisaatio: Organisaatio
 }
 
-export const HakutilanneDrawer = (props: HakutilanneDrawerProps) => {
-  const oppijat = props.selectedOppijat
+export const HakutilanneDrawer = React.forwardRef(
+  (props: HakutilanneDrawerProps, ref: React.ForwardedRef<HTMLElement>) => {
+    const oppijat = props.selectedOppijat
 
-  const [modalVisible, setModalVisible] = useState(false)
-  const oppijaOids = useMemo(() => oppijat.map((o) => o.oppija.henkilö.oid), [
-    oppijat,
-  ])
-  const pohjatiedot = useApiWithParams(
-    fetchKuntailmoituksenPohjatiedot,
-    modalVisible ? [oppijaOids, props.tekijäorganisaatio.oid] : undefined
-  )
+    const [modalVisible, setModalVisible] = useState(false)
+    const oppijaOids = useMemo(() => oppijat.map((o) => o.oppija.henkilö.oid), [
+      oppijat,
+    ])
+    const pohjatiedot = useApiWithParams(
+      fetchKuntailmoituksenPohjatiedot,
+      modalVisible ? [oppijaOids, props.tekijäorganisaatio.oid] : undefined
+    )
 
-  return (
-    <>
-      <BottomDrawer>
-        <div className={b("ilmoittaminen")}>
-          <h4 className={b("ilmoittaminentitle")}>
-            <T id="ilmoittaminen_drawer__title" />
-          </h4>
-          <div className={b("ilmoittamisenalarivi")}>
-            <span className={b("valittujaoppilaita")}>
-              <T
-                id="ilmoittaminen_drawer__valittuja_oppilaita"
-                params={{ määrä: oppijat.length }}
-              />
-            </span>
-            <RaisedButton
-              disabled={A.isEmpty(oppijat) || isLoading(pohjatiedot)}
-              onClick={() => setModalVisible(true)}
-            >
-              <T id="ilmoittaminen_drawer__siirry_ilmoittamiseen" />
-            </RaisedButton>
-            {mapLoading(pohjatiedot, () => (
-              <Spinner />
-            ))}
-            {mapError(pohjatiedot, () => (
-              <Error>
-                <T id="ilmoittaminen_drawer__pohjatietojen_haku_epäonnistui" />
-              </Error>
-            ))}
+    return (
+      <>
+        <BottomDrawer ref={ref}>
+          <div className={b("ilmoittaminen")}>
+            <h4 className={b("ilmoittaminentitle")}>
+              <T id="ilmoittaminen_drawer__title" />
+            </h4>
+            <div className={b("ilmoittamisenalarivi")}>
+              <span className={b("valittujaoppilaita")}>
+                <T
+                  id="ilmoittaminen_drawer__valittuja_oppilaita"
+                  params={{ määrä: oppijat.length }}
+                />
+              </span>
+              <RaisedButton
+                disabled={A.isEmpty(oppijat) || isLoading(pohjatiedot)}
+                onClick={() => setModalVisible(true)}
+              >
+                <T id="ilmoittaminen_drawer__siirry_ilmoittamiseen" />
+              </RaisedButton>
+              {mapLoading(pohjatiedot, () => (
+                <Spinner />
+              ))}
+              {mapError(pohjatiedot, () => (
+                <Error>
+                  <T id="ilmoittaminen_drawer__pohjatietojen_haku_epäonnistui" />
+                </Error>
+              ))}
+            </div>
           </div>
-        </div>
-      </BottomDrawer>
+        </BottomDrawer>
 
-      {modalVisible && isSuccess(pohjatiedot) ? (
-        <Ilmoituslomake
-          oppijat={oppijat.map((o) => ({
-            henkilö: o.oppija.henkilö,
-            opiskeluoikeudet: o.oppija.opiskeluoikeudet,
-            lisätiedot: o.lisätiedot,
-          }))}
-          pohjatiedot={pohjatiedot.data}
-          tekijäorganisaatio={props.tekijäorganisaatio}
-          onClose={() => setModalVisible(false)}
-        />
-      ) : null}
-    </>
-  )
-}
+        {modalVisible && isSuccess(pohjatiedot) ? (
+          <Ilmoituslomake
+            oppijat={oppijat.map((o) => ({
+              henkilö: o.oppija.henkilö,
+              opiskeluoikeudet: o.oppija.opiskeluoikeudet,
+              lisätiedot: o.lisätiedot,
+            }))}
+            pohjatiedot={pohjatiedot.data}
+            tekijäorganisaatio={props.tekijäorganisaatio}
+            onClose={() => setModalVisible(false)}
+          />
+        ) : null}
+      </>
+    )
+  }
+)

--- a/valpas-web/src/views/hakutilanne/HakutilanneView.tsx
+++ b/valpas-web/src/views/hakutilanne/HakutilanneView.tsx
@@ -7,7 +7,11 @@ import * as Ord from "fp-ts/Ord"
 import * as string from "fp-ts/string"
 import React, { useMemo, useState } from "react"
 import { Redirect, useHistory } from "react-router"
-import { Card, CardBody, CardHeader } from "../../components/containers/cards"
+import {
+  Card,
+  CardHeader,
+  ConstrainedCardBody,
+} from "../../components/containers/cards"
 import { Page } from "../../components/containers/Page"
 import { Dropdown } from "../../components/forms/Dropdown"
 import { Spinner } from "../../components/icons/Spinner"
@@ -28,6 +32,7 @@ import {
   createHakutilannePathWithOrg,
   HakutilanneViewRouteProps,
 } from "../../state/paths"
+import { useBoundingClientRect } from "../../state/useBoundingClientRect"
 import { nonNull } from "../../utils/arrays"
 import { ErrorView } from "../ErrorView"
 import { HakutilanneDrawer } from "./HakutilanneDrawer"
@@ -81,6 +86,8 @@ export const HakutilanneView = withRequiresHakeutumisenValvonta(
     const orgOptions = getOrgOptions(organisaatiot)
     const organisaatio = organisaatiot.find((o) => o.oid === organisaatioOid)
 
+    const drawerRect = useBoundingClientRect()
+
     const changeOrganisaatio = (oid?: Oid) => {
       if (oid) {
         history.push(oid)
@@ -119,7 +126,7 @@ export const HakutilanneView = withRequiresHakeutumisenValvonta(
               </Counter>
             )}
           </CardHeader>
-          <CardBody>
+          <ConstrainedCardBody extraMargin={drawerRect.rect?.height}>
             {isLoading && <Spinner />}
             {data && (
               <HakutilanneTable
@@ -130,10 +137,11 @@ export const HakutilanneView = withRequiresHakeutumisenValvonta(
                 onSetMuuHaku={setMuuHaku}
               />
             )}
-          </CardBody>
+          </ConstrainedCardBody>
         </Card>
         {organisaatio && (
           <HakutilanneDrawer
+            ref={drawerRect.ref}
             selectedOppijat={selectedOppijat}
             tekijäorganisaatio={organisaatio}
           />

--- a/valpas-web/src/views/suorittaminen/oppivelvolliset/SuorittaminenOppivelvollisetView.tsx
+++ b/valpas-web/src/views/suorittaminen/oppivelvolliset/SuorittaminenOppivelvollisetView.tsx
@@ -14,8 +14,8 @@ import { useApiWithParams } from "../../../api/apiHooks"
 import { isLoading, isSuccess } from "../../../api/apiUtils"
 import {
   Card,
-  CardBody,
   CardHeader,
+  ConstrainedCardBody,
 } from "../../../components/containers/cards"
 import { Page } from "../../../components/containers/Page"
 import { Dropdown } from "../../../components/forms/Dropdown"
@@ -141,7 +141,7 @@ export const SuorittaminenOppivelvollisetView = withRequiresSuorittamisenValvont
                   </Counter>
                 )}
               </CardHeader>
-              <CardBody>
+              <ConstrainedCardBody>
                 {isLoading(fetch) && <Spinner />}
                 {isSuccess(fetch) && fetch.data.length == 0 && (
                   <NoDataMessage>
@@ -155,7 +155,7 @@ export const SuorittaminenOppivelvollisetView = withRequiresSuorittamisenValvont
                     onCountChange={setCounters}
                   />
                 )}
-              </CardBody>
+              </ConstrainedCardBody>
             </Card>
           </Page>
         ) : (


### PR DESCRIPTION
Tämä korjaus estää taulukon kasvamisen pystysuunnassa mahdottomasti. Eli vaakavieritys palkki pysyy saatavilla nyt käyttäjille, jotka sitä tarvitsevat (esim. ei käytössä tai osata käyttää trackpad-vieritystä). Algoritmi yrittää löytää sopivan korkeuden taulukolle haarukoimalla muutamasta erilaisesta vaihtoehdosta.

Testattu Windows 10 Chromella ja Edgellä ja tuntuisi pelittävän.

![image(1)](https://user-images.githubusercontent.com/6116633/129856447-10ecbbb5-4186-434d-aa8a-e7b62db06f45.png)
