### PR TITLE
Valpas virheenkäsittely

### DIFF
--- a/src/main/resources/valpas/localization/valpas-default-texts.json
+++ b/src/main/resources/valpas/localization/valpas-default-texts.json
@@ -193,6 +193,7 @@
   "apivirhe__palvelinongelma": "Virhe: Pyyntöä ei voitu suorittaa palvelimen ongelman takia ({{virhe}})",
   "apivirhe__aikakatkaisu": "Virhe: Pyyntö aikakatkaistiin. Syynä voi olla esimerkiksi liian monta yhtäaikaista käyttäjää. Yritä myöhemmin uudestaan.",
   "apivirhe__virheellinen_vastaus": "Virhe: Palvelimelta saatu vastaus on virheellisesti muodostettu",
+  "apivirhe__tuntematon": "Virhe: Pyyntö epäonnistui tuntemattomasta syystä",
   "organisaatiovalitsin__lakkautettu_prefix": "LAKKAUTETTU",
   "suorittaminen_nav__oppivelvolliset": "Oppivelvolliset",
   "suorittaminen_nav__hae_hetulla": "Hae hetulla",

--- a/src/main/scala/fi/oph/koski/valpas/ValpasErrorCategory.scala
+++ b/src/main/scala/fi/oph/koski/valpas/ValpasErrorCategory.scala
@@ -19,17 +19,17 @@ object ValpasErrorCategory {
     val toiminto = subcategory("toiminto", "Käyttäjällä ei ole oikeuksia toimintoon")
   }
 
-  object internalError extends ErrorCategory("internalError", 500, "Internal server error")
+  object internalError extends ErrorCategory("internalError", 500, "Palvelinvirhe")
 
-  object notImplemented extends ErrorCategory("notImplemented", 501, "Not implemented") {
+  object notImplemented extends ErrorCategory("notImplemented", 501, "Ei toteutettu") {
     val kuntailmoituksenMuokkaus = subcategory("kuntailmoituksenMuokkaus", "Kuntailmoitusta ei voi muokata")
   }
 
-  object badGateway extends ErrorCategory("badGateway", 502, "Bad gateway") {
+  object badGateway extends ErrorCategory("badGateway", 502, "Virhe yhdyskäytävässä tai ulkoisessa palvelussa") {
     val sure = subcategory("sure", "Suoritusrekisterin palauttama hakukoostetieto oli viallinen.")
   }
 
-  object unavailable extends ErrorCategory("unavailable", 503, "Service unavailable") {
+  object unavailable extends ErrorCategory("unavailable", 503, "Palvelu ei ole juuri nyt käytettävissä") {
     val sure = subcategory("sure", "Hakukoosteita ei juuri nyt saada haettua suoritusrekisteristä. Yritä myöhemmin uudelleen.")
   }
 }

--- a/valpas-web/src/components/typography/error.tsx
+++ b/valpas-web/src/components/typography/error.tsx
@@ -1,5 +1,7 @@
 import bem from "bem-ts"
 import React from "react"
+import { ApiError } from "../../api/apiFetch"
+import { T } from "../../i18n/i18n"
 import "./Error.less"
 
 const b = bem("error")
@@ -10,4 +12,22 @@ export type ErrorProps = {
 
 export const Error = (props: ErrorProps) => (
   <div className={b()}>{props.children}</div>
+)
+
+export type ApiErrorsProps = {
+  errors: ApiError[]
+}
+
+export const ApiErrors = (props: ApiErrorsProps) => (
+  <Error>
+    {props.errors.length > 0 ? (
+      <ul>
+        {props.errors.map((error, index) => (
+          <li key={index}>{error.message}</li>
+        ))}
+      </ul>
+    ) : (
+      <T id="apivirhe__tuntematon" />
+    )}
+  </Error>
 )

--- a/valpas-web/src/views/hakutilanne/HakutilanneView.tsx
+++ b/valpas-web/src/views/hakutilanne/HakutilanneView.tsx
@@ -17,6 +17,7 @@ import { Dropdown } from "../../components/forms/Dropdown"
 import { Spinner } from "../../components/icons/Spinner"
 import { DataTableCountChangeEvent } from "../../components/tables/DataTable"
 import { Counter } from "../../components/typography/Counter"
+import { ApiErrors } from "../../components/typography/error"
 import { getLocalized, t, T } from "../../i18n/i18n"
 import {
   useOrganisaatiotJaKäyttöoikeusroolit,
@@ -75,7 +76,9 @@ export const HakutilanneView = withRequiresHakeutumisenValvonta(
     const organisaatioOid =
       props.match.params.organisaatioOid || organisaatiot[0]?.oid
 
-    const { data, isLoading, setMuuHaku } = useOppijatData(organisaatioOid)
+    const { data, isLoading, errors, setMuuHaku } = useOppijatData(
+      organisaatioOid
+    )
 
     const [counters, setCounters] = useState<DataTableCountChangeEvent>({
       filteredRowCount: 0,
@@ -137,6 +140,7 @@ export const HakutilanneView = withRequiresHakeutumisenValvonta(
                 onSetMuuHaku={setMuuHaku}
               />
             )}
+            {errors !== undefined && <ApiErrors errors={errors} />}
           </ConstrainedCardBody>
         </Card>
         {organisaatio && (

--- a/valpas-web/src/views/hakutilanne/useOppijatData.ts
+++ b/valpas-web/src/views/hakutilanne/useOppijatData.ts
@@ -6,7 +6,7 @@ import {
   useApiWithParams,
   useLocalDataCopy,
 } from "../../api/apiHooks"
-import { isLoading } from "../../api/apiUtils"
+import { isError, isLoading } from "../../api/apiUtils"
 import { OpiskeluoikeusSuppeatTiedot } from "../../state/apitypes/opiskeluoikeus"
 import {
   lisätietoMatches,
@@ -75,6 +75,7 @@ export const useOppijatData = (organisaatioOid?: Oid) => {
     data: localData,
     setMuuHaku: storeMuuHakuState,
     isLoading: isLoading(oppijatFetch),
+    errors: isError(oppijatFetch) ? oppijatFetch.errors : undefined,
   }
 }
 

--- a/valpas-web/src/views/oppija/OppivelvollisuudenKeskeytysModal.tsx
+++ b/valpas-web/src/views/oppija/OppivelvollisuudenKeskeytysModal.tsx
@@ -2,6 +2,7 @@ import bem from "bem-ts"
 import { isNonEmpty } from "fp-ts/lib/Array"
 import React, { useCallback, useState } from "react"
 import { createOppivelvollisuudenKeskeytys } from "../../api/api"
+import { ApiError } from "../../api/apiFetch"
 import { useApiMethod, useOnApiSuccess } from "../../api/apiHooks"
 import { isError } from "../../api/apiUtils"
 import { RaisedButton } from "../../components/buttons/RaisedButton"
@@ -17,7 +18,7 @@ import {
   organisaatiotToOptions,
 } from "../../components/forms/Dropdown"
 import { RadioButton } from "../../components/forms/RadioButton"
-import { Error } from "../../components/typography/error"
+import { ApiErrors } from "../../components/typography/error"
 import { SecondaryHeading } from "../../components/typography/headings"
 import { T, t } from "../../i18n/i18n"
 import {
@@ -64,7 +65,7 @@ export const OppivelvollisuudenKeskeytysModal = (
       <OppivelvollisuudenKeskeytysForm
         organisaatiot={organisaatiot}
         onSubmit={submit}
-        errors={isError(create) ? create.errors.map((e) => e.message) : []}
+        errors={isError(create) ? create.errors : []}
       />
     </Modal>
   )
@@ -75,7 +76,7 @@ export const OppivelvollisuudenKeskeytysModal = (
 type OppivelvollisuudenKeskeytysFormProps = {
   organisaatiot: Organisaatio[]
   onSubmit: (aikaväli: OppivelvollisuudenKeskeytysFormValues) => void
-  errors: string[]
+  errors: ApiError[]
 }
 
 type OppivelvollisuudenKeskeytysFormValues = {
@@ -178,15 +179,7 @@ const OppivelvollisuudenKeskeytysForm = (
         />
       </OppivelvollisuudenKeskeytysOption>
 
-      {isNonEmpty(props.errors) && (
-        <Error>
-          <ul>
-            {props.errors.map((error, index) => (
-              <li key={index}>{error}</li>
-            ))}
-          </ul>
-        </Error>
-      )}
+      {isNonEmpty(props.errors) && <ApiErrors errors={props.errors} />}
 
       <RaisedButton
         id="ovkeskeytys-submit"

--- a/valpas-web/src/views/suorittaminen/oppivelvolliset/SuorittaminenOppivelvollisetView.tsx
+++ b/valpas-web/src/views/suorittaminen/oppivelvolliset/SuorittaminenOppivelvollisetView.tsx
@@ -11,7 +11,7 @@ import {
   fetchOppijatSuorittaminenCache,
 } from "../../../api/api"
 import { useApiWithParams } from "../../../api/apiHooks"
-import { isLoading, isSuccess } from "../../../api/apiUtils"
+import { isError, isLoading, isSuccess } from "../../../api/apiUtils"
 import {
   Card,
   CardHeader,
@@ -22,6 +22,7 @@ import { Dropdown } from "../../../components/forms/Dropdown"
 import { Spinner } from "../../../components/icons/Spinner"
 import { DataTableCountChangeEvent } from "../../../components/tables/DataTable"
 import { Counter } from "../../../components/typography/Counter"
+import { ApiErrors } from "../../../components/typography/error"
 import { NoDataMessage } from "../../../components/typography/NoDataMessage"
 import { getLocalized, t, T } from "../../../i18n/i18n"
 import {
@@ -155,6 +156,7 @@ export const SuorittaminenOppivelvollisetView = withRequiresSuorittamisenValvont
                     onCountChange={setCounters}
                   />
                 )}
+                {isError(fetch) && <ApiErrors errors={fetch.errors} />}
               </ConstrainedCardBody>
             </Card>
           </Page>


### PR DESCRIPTION
Käännetty loputkin APIn palauttamat virheet suomeksi, jotta niitä voidaan käyttää suoraan käyttöliittymässä kuten muitakin virheilmoituksia. Kaikista virheistä toki puuttuu yhä lokalisaatiot ruotsiksi ja englanniksi...