### PR TITLE
TOR-1495 - Luva - uusia laajuuden arvoja

### DIFF
--- a/src/main/resources/mockdata/koodisto/koodit/koskikoulutustendiaarinumerot.json
+++ b/src/main/resources/mockdata/koodisto/koodit/koskikoulutustendiaarinumerot.json
@@ -918,4 +918,24 @@
     "codeElementVersion" : 2,
     "passive" : false
   } ]
+}, {
+  "koodiUri" : "koskikoulutustendiaarinumerot_oph49582020",
+  "koodiArvo" : "OPH-4958-2020",
+  "metadata" : [ {
+    "nimi" : "Lukiokoulutukseen valmistavan koulutuksen opetussuunnitelman perusteet 2021",
+    "lyhytNimi" : "",
+    "kuvaus" : "",
+    "kieli" : "FI"
+  }, {
+    "nimi" : "Lukiokoulutukseen valmistavan koulutuksen opetussuunnitelman perusteet 2021",
+    "lyhytNimi" : "",
+    "kuvaus" : "",
+    "kieli" : "SV"
+  } ],
+  "versio" : 1,
+  "withinCodeElements" : [ {
+    "codeElementUri" : "koulutustyyppi_23",
+    "codeElementVersion" : 2,
+    "passive" : false
+  } ]
 } ]

--- a/src/main/scala/fi/oph/koski/documentation/ExamplesLukio.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesLukio.scala
@@ -458,7 +458,7 @@ object LukioExampleData {
   def matematiikka(matematiikka: String, perusteenDiaarinumero: Option[String]) =
     LukionMatematiikka2015(oppimäärä = Koodistokoodiviite(koodiarvo = matematiikka, koodistoUri = "oppiainematematiikka"), perusteenDiaarinumero = perusteenDiaarinumero)
 
-  def laajuus(laajuus: Float, yksikkö: String = "4"): LaajuusKursseissa = LaajuusKursseissa(laajuus, Koodistokoodiviite(koodistoUri = "opintojenlaajuusyksikko", koodiarvo = yksikkö))
+  def laajuus(laajuus: Double, yksikkö: String = laajuusKursseissa.koodiarvo): LaajuusKursseissa = LaajuusKursseissa(laajuus, Koodistokoodiviite(koodistoUri = "opintojenlaajuusyksikko", koodiarvo = yksikkö))
 
   def lukionOppiaine(aine: String, laajuus: LaajuusKursseissa, diaarinumero: Option[String]) =
     LukionMuuValtakunnallinenOppiaine2015(tunniste = Koodistokoodiviite(koodistoUri = "koskioppiaineetyleissivistava", koodiarvo = aine), perusteenDiaarinumero = diaarinumero, laajuus = Some(laajuus))

--- a/src/main/scala/fi/oph/koski/http/KoskiErrorCategory.scala
+++ b/src/main/scala/fi/oph/koski/http/KoskiErrorCategory.scala
@@ -152,6 +152,7 @@ object KoskiErrorCategory {
         val osasuoritustenLaajuuksienSumma = subcategory("osasuoritustenLaajuuksienSumma", "Osasuoritusten laajuuksien summa ei täsmää")
         val oppiaineenLaajuusPuuttuu = subcategory("oppiaineenLaajuusPuuttuu", "Oppiaineen laajuus puuttuu")
         val lukiodiplominLaajuusEiOle2Opintopistettä = subcategory("lukiodiplominLaajuusVäärä", "Lukiodiplomin laajuuden on oltava aina 2 opintopistettä")
+        val lukioonValmistavallaKoulutuksellaVääräLaajuudenArvo = subcategory("lukioonValmistavallaKoulutuksellaVääräLaajuudenArvo", "Lukioon valmistavan koulutuksen suorituksella voi olla laajuuden koodiyksikkönä vain '2', jos suorituksen diaarinumero on 'OPH-4958-2020'")
       }
       val laajuudet = new Laajuudet
 

--- a/src/main/scala/fi/oph/koski/schema/LukioonValmistavaKoulutus.scala
+++ b/src/main/scala/fi/oph/koski/schema/LukioonValmistavaKoulutus.scala
@@ -1,7 +1,8 @@
 package fi.oph.koski.schema
 
-import java.time.{LocalDate, LocalDateTime}
+import fi.oph.koski.documentation.ExampleData.laajuusOpintopisteissä
 
+import java.time.{LocalDate, LocalDateTime}
 import fi.oph.koski.koskiuser.Rooli
 import fi.oph.koski.schema.annotation._
 import fi.oph.scalaschema.annotation.{DefaultValue, Description, MaxItems, Title}
@@ -59,7 +60,7 @@ case class LukioonValmistavaKoulutus(
   @KoodistoKoodiarvo("999906")
   tunniste: Koodistokoodiviite = Koodistokoodiviite("999906", koodistoUri = "koulutus"),
   perusteenDiaarinumero: Option[String],
-  laajuus: Option[LaajuusKursseissa] = None,
+  laajuus: Option[LaajuusOpintopisteissäTaiKursseissa] = None,
   koulutustyyppi: Option[Koodistokoodiviite] = None
 ) extends DiaarinumerollinenKoulutus with KoulutusmoduuliValinnainenLaajuus
 
@@ -183,7 +184,7 @@ case class LukioonValmistavanKurssinSuoritus(
 ) extends KurssinSuoritus with MahdollisestiSuorituskielellinen
 
 sealed trait LukioonValmistavanKoulutuksenKurssi extends KoulutusmoduuliValinnainenLaajuus {
-  def laajuus: Option[LaajuusKursseissa]
+  def laajuus: Option[LaajuusOpintopisteissäTaiKursseissa]
 }
 
 @Title("Valtakunnallinen lukioon valmistavan koulutuksen kurssi tai moduuli")
@@ -195,7 +196,7 @@ case class ValtakunnallinenLukioonValmistavanKoulutuksenKurssi(
   @OksaUri("tmpOKSAID873", "kurssi")
   @Title("Nimi")
   tunniste: Koodistokoodiviite,
-  override val laajuus: Option[LaajuusKursseissa]
+  override val laajuus: Option[LaajuusOpintopisteissäTaiKursseissa]
 ) extends LukioonValmistavanKoulutuksenKurssi with KoodistostaLöytyväKoulutusmoduuli
 
 @Title("Paikallinen lukioon valmistavan koulutuksen kurssi tai moduuli")
@@ -203,7 +204,7 @@ case class ValtakunnallinenLukioonValmistavanKoulutuksenKurssi(
 case class PaikallinenLukioonValmistavanKoulutuksenKurssi(
   @FlattenInUI
   tunniste: PaikallinenKoodi,
-  override val laajuus: Option[LaajuusKursseissa],
+  override val laajuus: Option[LaajuusOpintopisteissäTaiKursseissa],
   kuvaus: LocalizedString
 ) extends LukioonValmistavanKoulutuksenKurssi with PaikallinenKoulutusmoduuli with StorablePreference
 


### PR DESCRIPTION
Laajuudet arvoina tietyissä tapauksissa '2' ja '4' hyväksytty. Yksi uusi validaatio; uusimmassa opsissa vain '2' sallitaan.

https://jira.eduuni.fi/browse/TOR-1495