### PR TITLE
LaajuusOpintopisteissäTaiKursseissa nimensä mukaiseksi; ei viikkoja mukaan

### DIFF
--- a/src/main/scala/fi/oph/koski/schema/Laajuus.scala
+++ b/src/main/scala/fi/oph/koski/schema/Laajuus.scala
@@ -24,7 +24,7 @@ case class LaajuusOpintoviikoissa(
   arvo: Double,
   @KoodistoKoodiarvo("1")
   yksikkö: Koodistokoodiviite = laajuusOpintoviikoissa
-) extends LaajuusOpintopisteissäTaiKursseissa
+) extends Laajuus
 
 case class LaajuusOpintopisteissä(
   arvo: Double,


### PR DESCRIPTION
Epähuomiossa oli Virta-datan parsinnan yhteydessä lisätty `LaajuusOpintoviikkoissa` laitettu perimään `LaajuusOpintopisteissäTaiKursseissa` kun pitäisi periä vain suoraan `Laajuus`.

Pyritty tarkistamaan tuotannon raportointitietokannasta mahdollisimman hyvin, että  siellä ei ole suorituksia, joissa on käytössä `LaajuusOpintopisteissäTaiKursseissa´ ja joille olisi nyt laajuus laitettu viikkoina.