### PR TITLE
Valppaan käännösvälimuistien automaattinen tyhjentäminen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ scripts/deploy.retry
 valpas-web/dist
 valpas-web/node/
 valpas-web/.parcel-cache/
+valpas-web/.last-build

--- a/valpas-web/autoclear.js
+++ b/valpas-web/autoclear.js
@@ -1,0 +1,48 @@
+const { exec } = require("child_process")
+const { join } = require("path")
+const { readFile, writeFile } = require("fs/promises")
+
+const run = (command) =>
+  new Promise((resolve, reject) => {
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        reject({ error, stderr: stderr.toString() })
+      } else {
+        resolve(stdout.toString().trim())
+      }
+    })
+  })
+
+const readFileNeverFail = (filepath) => readFile(filepath).catch(() => null)
+
+const getCurrentBranch = () => run("git rev-parse --abbrev-ref HEAD")
+const getGitRootDir = () => run("git rev-parse --show-toplevel")
+const clearCache = () => run("npm run clean")
+
+const getVersionPath = async () =>
+  join(await getGitRootDir(), "valpas-web", ".last-build")
+
+const getLastBuildVersion = async () =>
+  (await readFileNeverFail(await getVersionPath())).toString()
+
+const setLastBuildVersion = async (version) =>
+  writeFile(await getVersionPath(), version)
+
+const autoclearCache = async (variant) => {
+  const previous = await getLastBuildVersion()
+  const next = `${await getCurrentBranch()}:${variant}`
+  if (previous != next) {
+    console.log(
+      `Branch or build target change detected (${previous} -> ${next}): clearing caches...`
+    )
+    await clearCache()
+    setLastBuildVersion(next)
+  }
+}
+
+const getVariant = () => {
+  const flag = process.argv.filter((a) => a.match(/^--.+$/))[0]
+  return flag ? flag.slice(2) : "dev"
+}
+
+autoclearCache(getVariant()).catch(console.error)

--- a/valpas-web/package.json
+++ b/valpas-web/package.json
@@ -8,16 +8,17 @@
     "npm": "7"
   },
   "scripts": {
-    "start": "parcel serve src/index.html",
+    "start": "node autoclear.js && parcel serve src/index.html",
     "start:watch": "concurrently npm:start npm:lint:types:watch",
-    "start:raamit": "npm run clean && VIRKAILIJA_RAAMIT_HOST=\"https://virkailija.untuvaopintopolku.fi/\" parcel serve src/index.html",
+    "start:raamit": "node autoclear.js --dev-raamit && VIRKAILIJA_RAAMIT_HOST=\"https://virkailija.untuvaopintopolku.fi/\" parcel serve src/index.html",
+    "start:integration": "node autoclear.js --integration && parcel serve src/index.html --no-hmr --no-cache",
     "test": "npm run test:unit && npm run test:integration",
-    "test:unit": "jest --runInBand src",
+    "test:unit": "node autoclear.js --unittest && jest --runInBand src",
     "test:integration": "jest --config jest.integrationtests.config.js --runInBand test/integrationtests",
     "test:integration:debug": "SHOW_BROWSER=true jest --config jest.integrationtests.config.js --runInBand test/integrationtests",
     "test:integration:browserstack": "jest --config jest.integrationtests.browserstack.config.js --runInBand test/integrationtests",
-    "build:local": "NODE_ENV=development parcel build src/index.html --no-scope-hoist",
-    "build:prod": "parcel build src/index.html --public-url /valpas --no-scope-hoist",
+    "build:local": "node autoclear.js && NODE_ENV=development parcel build src/index.html --no-scope-hoist",
+    "build:prod": "node autoclear.js --prod && parcel build src/index.html --public-url /valpas --no-scope-hoist",
     "lint": "npm run lint:types && npm run lint:format && npm run lint:problems",
     "lint:types": "tsc --noEmit",
     "lint:types:watch": "tsc --noEmit --watch --preserveWatchOutput",
@@ -31,7 +32,6 @@
     "type": "git",
     "url": "git+https://github.com/Opetushallitus/koski.git"
   },
-  "license": "EUPL-1.1",
   "homepage": "https://github.com/Opetushallitus/koski#readme",
   "browserslist": [
     "defaults"

--- a/valpas-web/test/integrationtests-env/setup.js
+++ b/valpas-web/test/integrationtests-env/setup.js
@@ -22,7 +22,7 @@ module.exports = async () => {
  */
 const serve = () =>
   new Promise((resolve, _reject) => {
-    const parcel = spawn("npm", ["start", "--", "--no-hmr", "--no-cache"])
+    const parcel = spawn("npm", ["run", "start:integration"])
     parcel.stdout.on("data", (stdout) => {
       log(stdout)
       if (stdout.includes("✨ Built in")) {


### PR DESCRIPTION
Parantaa devausergonomiaa tyhjentämällä automaattisesti käännösvälimuistin aina kun branch tai käännöskohde (dev, prod, integration test jne.) vaihtuu.

Pitäisi korjata ongelma, jossa devaaja saa selaimen konsolin täyteen virheilmoituksia puuttuvista moduuleista.
