### PR TITLE
TOR-1241: Polkumäärittelyiden refaktorointi

### DIFF
--- a/valpas-web/src/utils/tableDataFormatters/commonFormatters.tsx
+++ b/valpas-web/src/utils/tableDataFormatters/commonFormatters.tsx
@@ -7,7 +7,7 @@ import {
   suorituksenTyyppiToKoulutustyyppi,
 } from "../../state/apitypes/suorituksentyyppi"
 import { ISODate, Oid } from "../../state/common"
-import { createOppijaPath } from "../../state/paths"
+import { oppijaPath } from "../../state/paths"
 import { OppijaViewBackNavProps } from "../../views/oppija/OppijaView"
 import { FilterableValue } from "../conversions"
 import { formatNullableDate } from "../date"
@@ -34,7 +34,7 @@ export const oppijanNimiValue = (urlBackRef: keyof OppijaViewBackNavProps) => (
   basePath: string
 ): Value => {
   const value = `${henkilö.sukunimi} ${henkilö.etunimet}`
-  const linkTo = createOppijaPath(basePath, {
+  const linkTo = oppijaPath.href(basePath, {
     oppijaOid: henkilö.oid,
     [urlBackRef]: organisaatioOid,
   })

--- a/valpas-web/src/utils/tableDataFormatters/hakemuksentila.tsx
+++ b/valpas-web/src/utils/tableDataFormatters/hakemuksentila.tsx
@@ -9,7 +9,7 @@ import { getLocalizedMaybe, t, Translation } from "../../i18n/i18n"
 import { HakuSuppeatTiedot } from "../../state/apitypes/haku"
 import { OppijaHakutilanteillaSuppeatTiedot } from "../../state/apitypes/oppija"
 import { Oid } from "../../state/common"
-import { createOppijaPath } from "../../state/paths"
+import { oppijaPath } from "../../state/paths"
 import { formatNullableDate } from "../date"
 
 export const hakemuksenTilaValue = (
@@ -59,7 +59,7 @@ const hakemuksenTilaDisplay = (
           {hakemuksenTilaValue}
         </ExternalLink>
       ) : (
-        <Link to={createOppijaPath(basePath, { oppijaOid })}>
+        <Link to={oppijaPath.href(basePath, { oppijaOid })}>
           {hakemuksenTilaValue}
         </Link>
       )

--- a/valpas-web/src/views/HomeView.tsx
+++ b/valpas-web/src/views/HomeView.tsx
@@ -9,10 +9,10 @@ import {
 } from "../state/accessRights"
 import { useBasePath } from "../state/basePath"
 import {
-  createHakutilannePathWithoutOrg,
-  createKuntailmoitusPath,
-  createMaksuttomuusPath,
-  createSuorittaminenPath,
+  hakutilannePathWithoutOrg,
+  kuntailmoitusPath,
+  maksuttomuusPath,
+  suorittaminenPath,
 } from "../state/paths"
 import { AccessRightsView } from "./AccessRightsView"
 
@@ -26,19 +26,19 @@ const useRedirectPath = (): string | null => {
   const roles = useKäyttöoikeusroolit()
 
   if (kuntavalvontaAllowed(roles)) {
-    return createKuntailmoitusPath(basePath)
+    return kuntailmoitusPath.href(basePath)
   }
 
   if (hakeutumisenValvontaAllowed(roles)) {
-    return createHakutilannePathWithoutOrg(basePath)
+    return hakutilannePathWithoutOrg.href(basePath)
   }
 
   if (maksuttomuudenValvontaAllowed(roles)) {
-    return createMaksuttomuusPath(basePath)
+    return maksuttomuusPath.href(basePath)
   }
 
   if (suorittamisenValvontaAllowed(roles)) {
-    return createSuorittaminenPath(basePath)
+    return suorittaminenPath.route(basePath)
   }
 
   return null

--- a/valpas-web/src/views/VirkailijaApp.tsx
+++ b/valpas-web/src/views/VirkailijaApp.tsx
@@ -18,7 +18,6 @@ import {
 import { BasePathProvider, useBasePath } from "../state/basePath"
 import { FeatureFlagEnabler } from "../state/featureFlags"
 import {
-  createHakutilannePathWithoutOrg,
   hakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg,
   hakeutumisvalvonnanKunnalleIlmoitetutPathWithoutOrg,
   hakutilannePathWithOrg,
@@ -86,159 +85,171 @@ const VirkailijaRoutes = () => {
     <KäyttöoikeusroolitProvider value={organisaatiotJaKayttooikeusroolit.data}>
       <Switch>
         <Route exact path={`${basePath}/pilotti2021`}>
-          <Redirect to={createHakutilannePathWithoutOrg(basePath)} />
+          <Redirect to={hakutilannePathWithoutOrg.href(basePath)} />
         </Route>
         <Route exact path={`${basePath}/rouhinta`}>
           <FeatureFlagEnabler
             features={["rouhinta"]}
-            redirectTo={createHakutilannePathWithoutOrg(basePath)}
+            redirectTo={hakutilannePathWithoutOrg.href(basePath)}
           />
         </Route>
         <Route
           exact
-          path={hakutilannePathWithoutOrg(basePath)}
+          path={hakutilannePathWithoutOrg.route(basePath)}
           render={(routeProps) => (
             <HakutilanneViewWithoutOrgOid
-              redirectUserWithoutAccessTo={rootPath(basePath)}
+              redirectUserWithoutAccessTo={rootPath.href(basePath)}
               {...routeProps}
             />
           )}
         />
         <Route
           exact
-          path={nivelvaiheenHakutilannePathWithoutOrg(basePath)}
+          path={nivelvaiheenHakutilannePathWithoutOrg.route(basePath)}
           render={(routeProps) => (
             <NivelvaiheenHakutilanneViewWithoutOrgOid
-              redirectUserWithoutAccessTo={rootPath(basePath)}
+              redirectUserWithoutAccessTo={rootPath.route(basePath)}
               {...routeProps}
             />
           )}
         />
         <Route
           exact
-          path={hakeutumisvalvonnanKunnalleIlmoitetutPathWithoutOrg(basePath)}
+          path={hakeutumisvalvonnanKunnalleIlmoitetutPathWithoutOrg.route(
+            basePath
+          )}
           render={(routeProps) => (
             <HakeutumisenKunnalleIlmoitetutViewWithoutOrgOid
-              redirectUserWithoutAccessTo={rootPath(basePath)}
+              redirectUserWithoutAccessTo={rootPath.href(basePath)}
               {...routeProps}
             />
           )}
         />
         <Route
           exact
-          path={hakutilannePathWithOrg(basePath)}
+          path={hakutilannePathWithOrg.route(basePath)}
           render={(routeProps) => (
             <HakutilanneView
-              redirectUserWithoutAccessTo={rootPath(basePath)}
+              redirectUserWithoutAccessTo={rootPath.href(basePath)}
               {...routeProps}
             />
           )}
         />
         <Route
           exact
-          path={nivelvaiheenHakutilannePathWithOrg(basePath)}
+          path={nivelvaiheenHakutilannePathWithOrg.route(basePath)}
           render={(routeProps) => (
             <NivelvaiheenHakutilanneView
-              redirectUserWithoutAccessTo={rootPath(basePath)}
+              redirectUserWithoutAccessTo={rootPath.href(basePath)}
               {...routeProps}
             />
           )}
         />
         <Route
           exact
-          path={hakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg(basePath)}
+          path={hakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg.route(
+            basePath
+          )}
           render={(routeProps) => (
             <HakeutumisenKunnalleIlmoitetutView
-              redirectUserWithoutAccessTo={rootPath(basePath)}
+              redirectUserWithoutAccessTo={rootPath.href(basePath)}
               {...routeProps}
             />
           )}
         />
         <Route
           exact
-          path={oppijaPath(basePath)}
+          path={oppijaPath.route(basePath)}
           render={(routeProps) => (
             <OppijaView
-              redirectUserWithoutAccessTo={rootPath(basePath)}
+              redirectUserWithoutAccessTo={rootPath.href(basePath)}
               {...routeProps}
             />
           )}
         />
         <Route
           exact
-          path={suorittamisvalvonnanKunnalleIlmoitetutPathWithoutOrg(basePath)}
+          path={suorittamisvalvonnanKunnalleIlmoitetutPathWithoutOrg.route(
+            basePath
+          )}
           render={(routeProps) => (
             <SuorittamisenKunnalleIlmoitetutViewWithoutOrgOid
-              redirectUserWithoutAccessTo={rootPath(basePath)}
+              redirectUserWithoutAccessTo={rootPath.href(basePath)}
               {...routeProps}
             />
           )}
         />
         <Route
           exact
-          path={suorittaminenPath(basePath)}
+          path={suorittaminenPath.route(basePath)}
           render={(routeProps) => (
             <SuorittaminenOppivelvollisetViewWithoutOrgOid
-              redirectUserWithoutAccessTo={rootPath(basePath)}
+              redirectUserWithoutAccessTo={rootPath.href(basePath)}
               {...routeProps}
             />
           )}
         />
         <Route
           exact
-          path={suorittamisvalvonnanKunnalleIlmoitetutPathWithOrg(basePath)}
+          path={suorittamisvalvonnanKunnalleIlmoitetutPathWithOrg.route(
+            basePath
+          )}
           render={(routeProps) => (
             <SuorittamisenKunnalleIlmoitetutView
-              redirectUserWithoutAccessTo={rootPath(basePath)}
+              redirectUserWithoutAccessTo={rootPath.href(basePath)}
               {...routeProps}
             />
           )}
         />
         <Route
           exact
-          path={suorittaminenPathWithOrg(basePath)}
+          path={suorittaminenPathWithOrg.route(basePath)}
           render={(routeProps) => (
             <SuorittaminenOppivelvollisetView
-              redirectUserWithoutAccessTo={rootPath(basePath)}
+              redirectUserWithoutAccessTo={rootPath.href(basePath)}
               {...routeProps}
             />
           )}
         />
-        <Route exact path={suorittaminenHetuhakuPath(basePath)}>
+        <Route exact path={suorittaminenHetuhakuPath.route(basePath)}>
           <SuorittaminenHetuhaku
-            redirectUserWithoutAccessTo={rootPath(basePath)}
+            redirectUserWithoutAccessTo={rootPath.href(basePath)}
           />
         </Route>
-        <Route exact path={maksuttomuusPath(basePath)}>
-          <MaksuttomuusView redirectUserWithoutAccessTo={rootPath(basePath)} />
+        <Route exact path={maksuttomuusPath.route(basePath)}>
+          <MaksuttomuusView
+            redirectUserWithoutAccessTo={rootPath.href(basePath)}
+          />
         </Route>
         <Route
           exact
-          path={kuntailmoitusPath(basePath)}
+          path={kuntailmoitusPath.route(basePath)}
           render={(routeProps) => (
             <KuntailmoitusViewWithoutOrgOid
-              redirectUserWithoutAccessTo={rootPath(basePath)}
+              redirectUserWithoutAccessTo={rootPath.href(basePath)}
               {...routeProps}
             />
           )}
         />
         <Route
           exact
-          path={kuntailmoitusPathWithOrg(basePath)}
+          path={kuntailmoitusPathWithOrg.route(basePath)}
           render={(routeProps) => (
             <KuntailmoitusView
-              redirectUserWithoutAccessTo={rootPath(basePath)}
+              redirectUserWithoutAccessTo={rootPath.href(basePath)}
               {...routeProps}
             />
           )}
         />
-        <Route exact path={kunnanHetuhakuPath(basePath)}>
-          <KuntaHetuhaku redirectUserWithoutAccessTo={rootPath(basePath)} />
+        <Route exact path={kunnanHetuhakuPath.route(basePath)}>
+          <KuntaHetuhaku
+            redirectUserWithoutAccessTo={rootPath.href(basePath)}
+          />
         </Route>
-        <Route exact path={käyttöoikeusPath(basePath)}>
+        <Route exact path={käyttöoikeusPath.route(basePath)}>
           <AccessRightsView />
         </Route>
-        <Route exact path={rootPath(basePath)}>
+        <Route exact path={rootPath.route(basePath)}>
           <HomeView />
         </Route>
         <Route component={NotFoundView} />

--- a/valpas-web/src/views/hakutilanne/HakutilanneNavigation.tsx
+++ b/valpas-web/src/views/hakutilanne/HakutilanneNavigation.tsx
@@ -6,9 +6,9 @@ import {
 import { t } from "../../i18n/i18n"
 import { Oid } from "../../state/common"
 import {
-  createHakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg,
-  createHakutilannePathWithOrg,
-  createNivelvaiheenHakutilannePathWithOrg,
+  hakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg,
+  hakutilannePathWithOrg,
+  nivelvaiheenHakutilannePathWithOrg,
 } from "../../state/paths"
 
 export type HakutilanneNavigationProps = {
@@ -19,24 +19,21 @@ export const HakutilanneNavigation = (props: HakutilanneNavigationProps) => {
   const navOptions: TabNavigationItem[] = [
     {
       display: t("hakeutumisvelvollisetnavi__hakutilanne"),
-      linkTo: createHakutilannePathWithOrg(undefined, {
+      linkTo: hakutilannePathWithOrg.href(null, {
         organisaatioOid: props.selectedOrganisaatio,
       }),
     },
     {
       display: t("hakeutumisvelvollisetnavi__nivelvaihe"),
-      linkTo: createNivelvaiheenHakutilannePathWithOrg(undefined, {
+      linkTo: nivelvaiheenHakutilannePathWithOrg.href(null, {
         organisaatioOid: props.selectedOrganisaatio,
       }),
     },
     {
       display: t("hakeutumisvelvollisetnavi__kunnalle_tehdyt_ilmoitukset"),
-      linkTo: createHakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg(
-        undefined,
-        {
-          organisaatioOid: props.selectedOrganisaatio,
-        }
-      ),
+      linkTo: hakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg.href(null, {
+        organisaatioOid: props.selectedOrganisaatio,
+      }),
     },
   ]
 

--- a/valpas-web/src/views/hakutilanne/HakutilanneView.tsx
+++ b/valpas-web/src/views/hakutilanne/HakutilanneView.tsx
@@ -22,8 +22,8 @@ import {
 } from "../../state/accessRights"
 import { Oid } from "../../state/common"
 import {
-  createHakutilannePathWithOrg,
-  HakutilanneViewRouteProps,
+  hakutilannePathWithOrg,
+  OrganisaatioOidRouteProps,
 } from "../../state/paths"
 import { useBoundingClientRect } from "../../state/useBoundingClientRect"
 import { ErrorView } from "../ErrorView"
@@ -40,7 +40,7 @@ const b = bem("hakutilanneview")
 const organisaatioTyyppi = "OPPILAITOS"
 const organisaatioHakuRooli = "OPPILAITOS_HAKEUTUMINEN"
 
-export type HakutilanneViewProps = HakutilanneViewRouteProps
+export type HakutilanneViewProps = OrganisaatioOidRouteProps
 
 export const HakutilanneViewWithoutOrgOid = withRequiresHakeutumisenValvonta(
   () => (
@@ -48,7 +48,7 @@ export const HakutilanneViewWithoutOrgOid = withRequiresHakeutumisenValvonta(
       organisaatioHakuRooli={organisaatioHakuRooli}
       organisaatioTyyppi={organisaatioTyyppi}
       redirectTo={(basePath, organisaatioOid) =>
-        createHakutilannePathWithOrg(basePath, {
+        hakutilannePathWithOrg.href(basePath, {
           organisaatioOid,
         })
       }

--- a/valpas-web/src/views/hakutilanne/NivelvaiheenHakutilanneView.tsx
+++ b/valpas-web/src/views/hakutilanne/NivelvaiheenHakutilanneView.tsx
@@ -22,8 +22,8 @@ import {
 import { useBasePath } from "../../state/basePath"
 import { Oid } from "../../state/common"
 import {
-  createNivelvaiheenHakutilannePathWithOrg,
-  NivelvaiheenHakutilanneViewRouteProps,
+  nivelvaiheenHakutilannePathWithOrg,
+  OrganisaatioOidRouteProps,
 } from "../../state/paths"
 import { ErrorView } from "../ErrorView"
 import { OrganisaatioAutoRedirect } from "../OrganisaatioAutoRedirect"
@@ -36,7 +36,7 @@ import { useNivelvaiheenOppijatData } from "./useOppijatData"
 const organisaatioTyyppi = "OPPILAITOS"
 const organisaatioHakuRooli = "OPPILAITOS_HAKEUTUMINEN"
 
-export type NivelvaiheenHakutilanneViewProps = NivelvaiheenHakutilanneViewRouteProps
+export type NivelvaiheenHakutilanneViewProps = OrganisaatioOidRouteProps
 
 export const NivelvaiheenHakutilanneViewWithoutOrgOid = withRequiresHakeutumisenValvonta(
   () => (
@@ -44,7 +44,7 @@ export const NivelvaiheenHakutilanneViewWithoutOrgOid = withRequiresHakeutumisen
       organisaatioHakuRooli={organisaatioHakuRooli}
       organisaatioTyyppi={organisaatioTyyppi}
       redirectTo={(basePath, organisaatioOid) =>
-        createNivelvaiheenHakutilannePathWithOrg(basePath, {
+        nivelvaiheenHakutilannePathWithOrg.href(basePath, {
           organisaatioOid,
         })
       }
@@ -78,7 +78,7 @@ export const NivelvaiheenHakutilanneView = withRequiresHakeutumisenValvonta(
       (oid?: Oid) => {
         if (oid) {
           history.push(
-            createNivelvaiheenHakutilannePathWithOrg(basePath, {
+            nivelvaiheenHakutilannePathWithOrg.href(basePath, {
               organisaatioOid: oid,
             })
           )

--- a/valpas-web/src/views/hakutilanne/VirkailijaMainNavigation.tsx
+++ b/valpas-web/src/views/hakutilanne/VirkailijaMainNavigation.tsx
@@ -14,10 +14,10 @@ import {
   useKäyttöoikeusroolit,
 } from "../../state/accessRights"
 import {
-  createHakutilannePathWithoutOrg,
-  createKuntailmoitusPath,
-  createMaksuttomuusPath,
-  createSuorittaminenPath,
+  hakutilannePathWithoutOrg,
+  kuntailmoitusPath,
+  maksuttomuusPath,
+  suorittaminenPath,
 } from "../../state/paths"
 
 type NavOption = MainNavigationItem & { visibleToRoles: AccessGuard }
@@ -29,22 +29,22 @@ export const VirkailijaMainNavigation = () => {
     () => [
       {
         display: t("ylänavi__kuntailmoitukset"),
-        linkTo: createKuntailmoitusPath(),
+        linkTo: kuntailmoitusPath.href(),
         visibleToRoles: kuntavalvontaAllowed,
       },
       {
         display: t("ylänavi__hakeutumisvelvolliset"),
-        linkTo: createHakutilannePathWithoutOrg(),
+        linkTo: hakutilannePathWithoutOrg.href(),
         visibleToRoles: hakeutumisenValvontaAllowed,
       },
       {
         display: t("ylänavi__oppivelvollisuuden_suorittaminen"),
-        linkTo: createSuorittaminenPath(),
+        linkTo: suorittaminenPath.href(),
         visibleToRoles: suorittamisenValvontaAllowed,
       },
       {
         display: t("ylänavi__maksuttomuusoikeuden_arviointi"),
-        linkTo: createMaksuttomuusPath(),
+        linkTo: maksuttomuusPath.href(),
         visibleToRoles: maksuttomuudenValvontaAllowed,
       },
     ],

--- a/valpas-web/src/views/kunnalleilmoitetut/HakeutumisenKunnalleIlmoitetutView.tsx
+++ b/valpas-web/src/views/kunnalleilmoitetut/HakeutumisenKunnalleIlmoitetutView.tsx
@@ -2,8 +2,8 @@ import React from "react"
 import { t } from "../../i18n/i18n"
 import { withRequiresHakeutumisenValvonta } from "../../state/accessRights"
 import {
-  createHakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg,
-  KunnalleIlmoitetutViewRouteProps,
+  hakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg,
+  OrganisaatioOidRouteProps,
 } from "../../state/paths"
 import { ErrorView } from "../ErrorView"
 import { HakutilanneNavigation } from "../hakutilanne/HakutilanneNavigation"
@@ -20,7 +20,7 @@ export const HakeutumisenKunnalleIlmoitetutViewWithoutOrgOid = withRequiresHakeu
       organisaatioHakuRooli={organisaatioHakuRooli}
       organisaatioTyyppi={organisaatioTyyppi}
       redirectTo={(basePath, organisaatioOid) =>
-        createHakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg(basePath, {
+        hakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg.href(basePath, {
           organisaatioOid,
         })
       }
@@ -29,7 +29,7 @@ export const HakeutumisenKunnalleIlmoitetutViewWithoutOrgOid = withRequiresHakeu
   )
 )
 
-export type HakeutumisenKunnalleIlmoitetutViewProps = KunnalleIlmoitetutViewRouteProps
+export type HakeutumisenKunnalleIlmoitetutViewProps = OrganisaatioOidRouteProps
 
 export const HakeutumisenKunnalleIlmoitetutView = withRequiresHakeutumisenValvonta(
   (props: HakeutumisenKunnalleIlmoitetutViewProps) => (
@@ -45,7 +45,7 @@ export const HakeutumisenKunnalleIlmoitetutView = withRequiresHakeutumisenValvon
           selectedOrganisaatio={props.match.params.organisaatioOid!}
         />
       }
-      linkCreator={createHakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg}
+      linkCreator={hakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg.href}
     />
   )
 )

--- a/valpas-web/src/views/kunnalleilmoitetut/KunnalleIlmoitetutTable.tsx
+++ b/valpas-web/src/views/kunnalleilmoitetut/KunnalleIlmoitetutTable.tsx
@@ -13,7 +13,7 @@ import { KuntailmoitusSuppeatTiedot } from "../../state/apitypes/kuntailmoitus"
 import { OppijaHakutilanteillaSuppeatTiedot } from "../../state/apitypes/oppija"
 import { useBasePath } from "../../state/basePath"
 import { Oid } from "../../state/common"
-import { createOppijaPath } from "../../state/paths"
+import { oppijaPath } from "../../state/paths"
 import { formatNullableDate } from "../../utils/date"
 import { OppijaViewBackNavProps } from "../oppija/OppijaView"
 
@@ -100,7 +100,7 @@ const oppijanNimi = (
   backRefName: keyof OppijaViewBackNavProps
 ): Value => {
   const value = `${oppija.oppija.henkilö.sukunimi} ${oppija.oppija.henkilö.etunimet}`
-  const linkTo = createOppijaPath(basePath, {
+  const linkTo = oppijaPath.href(basePath, {
     oppijaOid: oppija.oppija.henkilö.oid,
     [backRefName]: organisaatioOid,
   })

--- a/valpas-web/src/views/kunnalleilmoitetut/SuorittamisenKunnalleilmoitetutView.tsx
+++ b/valpas-web/src/views/kunnalleilmoitetut/SuorittamisenKunnalleilmoitetutView.tsx
@@ -2,8 +2,8 @@ import React from "react"
 import { t } from "../../i18n/i18n"
 import { withRequiresSuorittamisenValvonta } from "../../state/accessRights"
 import {
-  createSuorittamisvalvonnanKunnalleIlmoitetutPathWithOrg,
-  KunnalleIlmoitetutViewRouteProps,
+  OrganisaatioOidRouteProps,
+  suorittamisvalvonnanKunnalleIlmoitetutPathWithOrg,
 } from "../../state/paths"
 import { ErrorView } from "../ErrorView"
 import { useSuorittamisvalvonnanKunnalleTehdytIlmoitukset } from "../hakutilanne/useOppijatData"
@@ -20,7 +20,7 @@ export const SuorittamisenKunnalleIlmoitetutViewWithoutOrgOid = withRequiresSuor
       organisaatioHakuRooli={organisaatioHakuRooli}
       organisaatioTyyppi={organisaatioTyyppi}
       redirectTo={(basePath, organisaatioOid) =>
-        createSuorittamisvalvonnanKunnalleIlmoitetutPathWithOrg(basePath, {
+        suorittamisvalvonnanKunnalleIlmoitetutPathWithOrg.href(basePath, {
           organisaatioOid,
         })
       }
@@ -29,7 +29,7 @@ export const SuorittamisenKunnalleIlmoitetutViewWithoutOrgOid = withRequiresSuor
   )
 )
 
-export type SuorittamisenKunnalleIlmoitetutViewProps = KunnalleIlmoitetutViewRouteProps
+export type SuorittamisenKunnalleIlmoitetutViewProps = OrganisaatioOidRouteProps
 
 export const SuorittamisenKunnalleIlmoitetutView = withRequiresSuorittamisenValvonta(
   (props: SuorittamisenKunnalleIlmoitetutViewProps) => (
@@ -45,7 +45,7 @@ export const SuorittamisenKunnalleIlmoitetutView = withRequiresSuorittamisenValv
           selectedOrganisaatio={props.match.params.organisaatioOid!}
         />
       }
-      linkCreator={createSuorittamisvalvonnanKunnalleIlmoitetutPathWithOrg}
+      linkCreator={suorittamisvalvonnanKunnalleIlmoitetutPathWithOrg.href}
     />
   )
 )

--- a/valpas-web/src/views/kunta/KuntaNavigation.tsx
+++ b/valpas-web/src/views/kunta/KuntaNavigation.tsx
@@ -8,9 +8,9 @@ import { t } from "../../i18n/i18n"
 import { kuntavalvontaAllowed } from "../../state/accessRights"
 import { Oid } from "../../state/common"
 import {
-  createKunnanHetuhakuPath,
-  createKuntailmoitusPath,
-  createKuntailmoitusPathWithOrg,
+  kunnanHetuhakuPath,
+  kuntailmoitusPath,
+  kuntailmoitusPathWithOrg,
 } from "../../state/paths"
 
 export type KuntaNavigationProps = {
@@ -22,12 +22,12 @@ export const KuntaNavigation = (props: KuntaNavigationProps) => {
     {
       display: t("kuntailmoitus_nav__ilmoitetut"),
       linkTo: props.selectedOrganisaatio
-        ? createKuntailmoitusPathWithOrg("", props.selectedOrganisaatio)
-        : createKuntailmoitusPath(),
+        ? kuntailmoitusPathWithOrg.href("", props.selectedOrganisaatio)
+        : kuntailmoitusPath.href(),
     },
     {
       display: t("kuntailmoitus_nav__hae_hetulla"),
-      linkTo: createKunnanHetuhakuPath(),
+      linkTo: kunnanHetuhakuPath.href(),
     },
   ]
 

--- a/valpas-web/src/views/kunta/hetuhaku/KuntaHetuhaku.tsx
+++ b/valpas-web/src/views/kunta/hetuhaku/KuntaHetuhaku.tsx
@@ -9,7 +9,7 @@ import { DummyOrganisaatioValitsin } from "../../../components/shared/Organisaat
 import { t } from "../../../i18n/i18n"
 import { withRequiresKuntavalvonta } from "../../../state/accessRights"
 import { isFeatureFlagEnabled } from "../../../state/featureFlags"
-import { createKunnanHetuhakuPath } from "../../../state/paths"
+import { kunnanHetuhakuPath } from "../../../state/paths"
 import { OppijaSearch } from "../../../views/oppijasearch/OppijaSearch"
 import { KuntaNavigation } from "../KuntaNavigation"
 import { KuntaHetulistahaku } from "./KuntaHetulistahaku"
@@ -27,7 +27,7 @@ export const KuntaHetuhaku = withRequiresKuntavalvonta(() => {
       <OppijaSearch
         searchState={search}
         onQuery={search.call}
-        prevPath={createKunnanHetuhakuPath()}
+        prevPath={kunnanHetuhakuPath.href()}
       />
       {isFeatureFlagEnabled("rouhinta") && <KuntaHetulistahaku />}
     </Page>

--- a/valpas-web/src/views/kunta/kuntailmoitus/KuntailmoitusTable.tsx
+++ b/valpas-web/src/views/kunta/kuntailmoitus/KuntailmoitusTable.tsx
@@ -16,7 +16,7 @@ import { organisaatioNimi } from "../../../state/apitypes/organisaatiot"
 import { useBasePath } from "../../../state/basePath"
 import { Oid } from "../../../state/common"
 import { perusopetuksenJälkeisetOpiskeluoikeustiedot } from "../../../state/opiskeluoikeustiedot"
-import { createOppijaPath } from "../../../state/paths"
+import { oppijaPath } from "../../../state/paths"
 import { formatNullableDate } from "../../../utils/date"
 
 export type KuntailmoitusTableProps = {
@@ -96,7 +96,7 @@ const ilmoitusToTableData = (basePath: string, organisaatioOid: string) => (
         value: `${henkilö.sukunimi} ${henkilö.etunimet}`,
         display: (
           <Link
-            to={createOppijaPath(basePath, {
+            to={oppijaPath.href(basePath, {
               kuntailmoitusRef: organisaatioOid,
               oppijaOid: henkilö.oid,
             })}

--- a/valpas-web/src/views/kunta/kuntailmoitus/KuntailmoitusView.tsx
+++ b/valpas-web/src/views/kunta/kuntailmoitus/KuntailmoitusView.tsx
@@ -34,7 +34,7 @@ import { getNäytettävätIlmoitukset } from "../../../state/apitypes/kuntailmoi
 import { OppijaKuntailmoituksillaSuppeatTiedot } from "../../../state/apitypes/oppija"
 import { useBasePath } from "../../../state/basePath"
 import { Oid } from "../../../state/common"
-import { createKuntailmoitusPathWithOrg } from "../../../state/paths"
+import { kuntailmoitusPathWithOrg } from "../../../state/paths"
 import { ErrorView } from "../../ErrorView"
 import { KuntaNavigation } from "../KuntaNavigation"
 import { KuntailmoitusTable } from "./KuntailmoitusTable"
@@ -64,7 +64,7 @@ export const KuntailmoitusViewWithoutOrgOid = withRequiresKuntavalvonta(() => {
   )
   return storedOrFallbackOrg ? (
     <Redirect
-      to={createKuntailmoitusPathWithOrg(basePath, storedOrFallbackOrg)}
+      to={kuntailmoitusPathWithOrg.href(basePath, storedOrFallbackOrg)}
     />
   ) : (
     <OrganisaatioMissingView />

--- a/valpas-web/src/views/maksuttomuus/MaksuttomuusOppijaSearch.tsx
+++ b/valpas-web/src/views/maksuttomuus/MaksuttomuusOppijaSearch.tsx
@@ -20,7 +20,7 @@ import {
   expectValidHetu,
   expectValidOid,
 } from "../../state/formValidators"
-import { createOppijaPath } from "../../state/paths"
+import { oppijaPath } from "../../state/paths"
 import { FormValidators, useFormState } from "../../state/useFormState"
 import "./MaksuttomuusOppijaSearch.less"
 
@@ -151,7 +151,7 @@ const MaksuttomuusOppijaSearchMatchResult = (
       {": "}
       <Link
         className={b("resultlink")}
-        to={createOppijaPath(basePath, {
+        to={oppijaPath.href(basePath, {
           oppijaOid: result.oid,
           prev: props.prevPath,
         })}

--- a/valpas-web/src/views/maksuttomuus/MaksuttomuusView.tsx
+++ b/valpas-web/src/views/maksuttomuus/MaksuttomuusView.tsx
@@ -6,7 +6,7 @@ import {
 import { useApiMethod } from "../../api/apiHooks"
 import { Page } from "../../components/containers/Page"
 import { withRequiresMaksuttomuudenValvonta } from "../../state/accessRights"
-import { createMaksuttomuusPath } from "../../state/paths"
+import { maksuttomuusPath } from "../../state/paths"
 import { MaksuttomuusOppijaSearch } from "./MaksuttomuusOppijaSearch"
 
 export const MaksuttomuusView = withRequiresMaksuttomuudenValvonta(() => {
@@ -20,7 +20,7 @@ export const MaksuttomuusView = withRequiresMaksuttomuudenValvonta(() => {
       <MaksuttomuusOppijaSearch
         searchState={search}
         onQuery={search.call}
-        prevPath={createMaksuttomuusPath()}
+        prevPath={maksuttomuusPath.href()}
       />
     </Page>
   )

--- a/valpas-web/src/views/oppija/OppijaView.tsx
+++ b/valpas-web/src/views/oppija/OppijaView.tsx
@@ -23,15 +23,16 @@ import { HenkilöLaajatTiedot } from "../../state/apitypes/henkilo"
 import { isAktiivinenKuntailmoitus } from "../../state/apitypes/kuntailmoitus"
 import { OppijaHakutilanteillaLaajatTiedot } from "../../state/apitypes/oppija"
 import {
-  createHakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg,
-  createHakutilannePathWithOrg as createHakutilannePathWithOrg,
-  createHakutilannePathWithoutOrg as createHakutilannePathWithoutOrg,
-  createKuntailmoitusPathWithOrg,
-  createNivelvaiheenHakutilannePathWithOrg,
-  createSuorittaminenPathWithOrg,
-  createSuorittamisvalvonnanKunnalleIlmoitetutPathWithOrg,
+  hakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg,
+  hakutilannePathWithOrg,
+  hakutilannePathWithoutOrg,
+  kuntailmoitusPathWithOrg,
+  nivelvaiheenHakutilannePathWithOrg,
+  OppijaPathBackRefs,
   OppijaViewRouteProps,
   parseQueryFromProps as parseSearchQueryFromProps,
+  suorittaminenPathWithOrg,
+  suorittamisvalvonnanKunnalleIlmoitetutPathWithOrg,
 } from "../../state/paths"
 import { plainComponent } from "../../utils/plaincomponent"
 import { OppijaKuntailmoitus } from "./OppijaKuntailmoitus"
@@ -61,7 +62,7 @@ export const OppijaView = withRequiresJokinOikeus((props: OppijaViewProps) => {
         suorittaminenRef={searchQuery.suorittaminenRef}
         suorittaminenIlmoitetutRef={searchQuery.suorittaminenIlmoitetutRef}
         oppija={isSuccess(oppija) ? oppija.data : undefined}
-        prevPage={searchQuery.prev}
+        prev={searchQuery.prev}
       />
       <OppijaHeadings oppija={oppija} oid={queryOid} />
 
@@ -129,45 +130,38 @@ export const OppijaView = withRequiresJokinOikeus((props: OppijaViewProps) => {
 })
 
 export type OppijaViewBackNavProps = {
-  hakutilanneRef?: string
-  hakutilanneNivelvaiheRef?: string
-  hakutilanneIlmoitetutRef?: string
-  kuntailmoitusRef?: string
-  suorittaminenRef?: string
-  suorittaminenIlmoitetutRef?: string
   oppija?: OppijaHakutilanteillaLaajatTiedot
-  prevPage?: string
-}
+} & OppijaPathBackRefs
 
 const BackNav = (props: OppijaViewBackNavProps) => {
   const targetPath = () => {
     const fallback = props.oppija?.oppija.hakeutumisvalvovatOppilaitokset[0]
-    if (props.prevPage) {
-      return props.prevPage
+    if (props.prev) {
+      return props.prev
     } else if (props.hakutilanneRef) {
-      return createHakutilannePathWithOrg("", {
+      return hakutilannePathWithOrg.href(null, {
         organisaatioOid: props.hakutilanneRef,
       })
     } else if (props.hakutilanneNivelvaiheRef) {
-      return createNivelvaiheenHakutilannePathWithOrg("", {
+      return nivelvaiheenHakutilannePathWithOrg.href(null, {
         organisaatioOid: props.hakutilanneNivelvaiheRef,
       })
     } else if (props.hakutilanneIlmoitetutRef) {
-      return createHakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg("", {
+      return hakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg.href(null, {
         organisaatioOid: props.hakutilanneIlmoitetutRef,
       })
     } else if (props.kuntailmoitusRef) {
-      return createKuntailmoitusPathWithOrg("", props.kuntailmoitusRef)
+      return kuntailmoitusPathWithOrg.href(null, props.kuntailmoitusRef)
     } else if (props.suorittaminenRef) {
-      return createSuorittaminenPathWithOrg("", props.suorittaminenRef)
+      return suorittaminenPathWithOrg.href(null, props.suorittaminenRef)
     } else if (props.suorittaminenIlmoitetutRef) {
-      return createSuorittamisvalvonnanKunnalleIlmoitetutPathWithOrg("", {
+      return suorittamisvalvonnanKunnalleIlmoitetutPathWithOrg.href(null, {
         organisaatioOid: props.suorittaminenIlmoitetutRef,
       })
     } else if (fallback) {
-      return createHakutilannePathWithOrg("", { organisaatioOid: fallback })
+      return hakutilannePathWithOrg.href(null, { organisaatioOid: fallback })
     } else {
-      return createHakutilannePathWithoutOrg("")
+      return hakutilannePathWithoutOrg.href()
     }
   }
 

--- a/valpas-web/src/views/oppijasearch/OppijaSearch.tsx
+++ b/valpas-web/src/views/oppijasearch/OppijaSearch.tsx
@@ -19,7 +19,7 @@ import {
   expectValidHetu,
   expectValidOid,
 } from "../../state/formValidators"
-import { createOppijaPath } from "../../state/paths"
+import { oppijaPath } from "../../state/paths"
 import { FormValidators, useFormState } from "../../state/useFormState"
 import "./OppijaSearch.less"
 
@@ -122,7 +122,7 @@ const OppijaSearchMatchResult = (props: OppijaSearchMatchResultProps) => {
       {": "}
       <Link
         className={b("resultlink")}
-        to={createOppijaPath(basePath, {
+        to={oppijaPath.href(basePath, {
           oppijaOid: result.oid,
           prev: props.prevPath,
         })}

--- a/valpas-web/src/views/suorittaminen/SuorittaminenNavigation.tsx
+++ b/valpas-web/src/views/suorittaminen/SuorittaminenNavigation.tsx
@@ -8,11 +8,11 @@ import { t } from "../../i18n/i18n"
 import { suorittamisenValvontaAllowed } from "../../state/accessRights"
 import { Oid } from "../../state/common"
 import {
-  createSuorittaminenHetuhakuPath,
-  createSuorittaminenPath,
-  createSuorittaminenPathWithOrg,
-  createSuorittamisvalvonnanKunnalleIlmoitetutPathWithOrg,
-  createSuorittamisvalvonnanKunnalleIlmoitetutPathWithoutOrg,
+  suorittaminenHetuhakuPath,
+  suorittaminenPath,
+  suorittaminenPathWithOrg,
+  suorittamisvalvonnanKunnalleIlmoitetutPathWithOrg,
+  suorittamisvalvonnanKunnalleIlmoitetutPathWithoutOrg,
 } from "../../state/paths"
 
 export type SuorittaminenNavigationProps = {
@@ -26,20 +26,20 @@ export const SuorittaminenNavigation = (
     {
       display: t("suorittaminen_nav__oppivelvolliset"),
       linkTo: props.selectedOrganisaatio
-        ? createSuorittaminenPathWithOrg("", props.selectedOrganisaatio)
-        : createSuorittaminenPath(),
+        ? suorittaminenPathWithOrg.href(null, props.selectedOrganisaatio)
+        : suorittaminenPath.href(),
     },
     {
       display: t("suorittaminen_nav__kunnalle_tehdyt_ilmoitukset"),
       linkTo: props.selectedOrganisaatio
-        ? createSuorittamisvalvonnanKunnalleIlmoitetutPathWithOrg("", {
+        ? suorittamisvalvonnanKunnalleIlmoitetutPathWithOrg.href(null, {
             organisaatioOid: props.selectedOrganisaatio,
           })
-        : createSuorittamisvalvonnanKunnalleIlmoitetutPathWithoutOrg(),
+        : suorittamisvalvonnanKunnalleIlmoitetutPathWithoutOrg.href(),
     },
     {
       display: t("suorittaminen_nav__hae_hetulla"),
-      linkTo: createSuorittaminenHetuhakuPath(),
+      linkTo: suorittaminenHetuhakuPath.href(),
     },
   ]
 

--- a/valpas-web/src/views/suorittaminen/hetuhaku/SuorittaminenHetuhaku.tsx
+++ b/valpas-web/src/views/suorittaminen/hetuhaku/SuorittaminenHetuhaku.tsx
@@ -8,7 +8,7 @@ import { Page } from "../../../components/containers/Page"
 import { DummyOrganisaatioValitsin } from "../../../components/shared/OrganisaatioValitsin"
 import { t, T } from "../../../i18n/i18n"
 import { withRequiresSuorittamisenValvonta } from "../../../state/accessRights"
-import { createSuorittaminenHetuhakuPath } from "../../../state/paths"
+import { suorittaminenHetuhakuPath } from "../../../state/paths"
 import { OppijaSearch } from "../../../views/oppijasearch/OppijaSearch"
 import { SuorittaminenNavigation } from "../SuorittaminenNavigation"
 
@@ -31,7 +31,7 @@ export const SuorittaminenHetuhaku = withRequiresSuorittamisenValvonta(() => {
       <OppijaSearch
         searchState={search}
         onQuery={search.call}
-        prevPath={createSuorittaminenHetuhakuPath()}
+        prevPath={suorittaminenHetuhakuPath.href()}
       />
     </Page>
   )

--- a/valpas-web/src/views/suorittaminen/oppivelvolliset/SuorittaminenOppivelvollisetTable.tsx
+++ b/valpas-web/src/views/suorittaminen/oppivelvolliset/SuorittaminenOppivelvollisetTable.tsx
@@ -35,7 +35,7 @@ import {
 import { useBasePath } from "../../../state/basePath"
 import { ISODate, Oid } from "../../../state/common"
 import { perusopetuksenJälkeistäPreferoivatOpiskeluoikeustiedot } from "../../../state/opiskeluoikeustiedot"
-import { createOppijaPath } from "../../../state/paths"
+import { oppijaPath } from "../../../state/paths"
 import { formatDate, formatNullableDate } from "../../../utils/date"
 
 export type SuorittaminenOppivelvollisetTableProps = {
@@ -146,7 +146,7 @@ const oppijaToTableData = (basePath: string, organisaatioOid: string) => (
           value: `${henkilö.sukunimi} ${henkilö.etunimet}${opiskeluoikeus.onTehtyIlmoitus}`,
           display: (
             <Link
-              to={createOppijaPath(basePath, {
+              to={oppijaPath.href(basePath, {
                 suorittaminenRef: organisaatioOid,
                 oppijaOid: henkilö.oid,
               })}

--- a/valpas-web/src/views/suorittaminen/oppivelvolliset/SuorittaminenOppivelvollisetView.tsx
+++ b/valpas-web/src/views/suorittaminen/oppivelvolliset/SuorittaminenOppivelvollisetView.tsx
@@ -29,7 +29,7 @@ import {
 } from "../../../state/accessRights"
 import { useBasePath } from "../../../state/basePath"
 import { Oid } from "../../../state/common"
-import { createSuorittaminenPathWithOrg } from "../../../state/paths"
+import { suorittaminenPathWithOrg } from "../../../state/paths"
 import { SuorittaminenOppivelvollisetTable } from "../../../views/suorittaminen/oppivelvolliset/SuorittaminenOppivelvollisetTable"
 import { SuorittaminenNavigation } from "../../../views/suorittaminen/SuorittaminenNavigation"
 import { ErrorView } from "../../ErrorView"
@@ -57,7 +57,7 @@ export const SuorittaminenOppivelvollisetViewWithoutOrgOid = withRequiresSuoritt
     )
     return storedOrFallbackOrg ? (
       <Redirect
-        to={createSuorittaminenPathWithOrg(basePath, storedOrFallbackOrg)}
+        to={suorittaminenPathWithOrg.href(basePath, storedOrFallbackOrg)}
       />
     ) : (
       <OrganisaatioMissingView />

--- a/valpas-web/test/integrationtests/hakutilanne.shared.ts
+++ b/valpas-web/test/integrationtests/hakutilanne.shared.ts
@@ -1,5 +1,5 @@
 import { Oid } from "../../src/state/common"
-import { createHakutilannePathWithoutOrg } from "../../src/state/paths"
+import { hakutilannePathWithoutOrg } from "../../src/state/paths"
 import {
   clickElement,
   expectElementEventuallyVisible,
@@ -63,7 +63,7 @@ export const internationalSchoolTableContent = `
   Oppivelvollinen-int-school-kesken-keväällä-2021 Valpas                            | 18.2.2005  | 9B  | –                   | Ei hakemusta | – | – | –                                                                                        |
 `
 
-export const hakutilannePath = createHakutilannePathWithoutOrg("/virkailija")
+export const hakutilannePath = hakutilannePathWithoutOrg.href("/virkailija")
 
 export const oppijaRowSelector = (oppijaOid: Oid) =>
   `.hakutilanne .table__row[data-row*="${oppijaOid}"] td:first-child a`

--- a/valpas-web/test/integrationtests/hakutilanne.test.ts
+++ b/valpas-web/test/integrationtests/hakutilanne.test.ts
@@ -1,7 +1,4 @@
-import {
-  createHakutilannePathWithOrg,
-  createOppijaPath,
-} from "../../src/state/paths"
+import { hakutilannePathWithOrg, oppijaPath } from "../../src/state/paths"
 import {
   clickElement,
   expectElementEventuallyVisible,
@@ -72,20 +69,20 @@ const aapajaoenKouluTableContent = `
   KahdenKoulunYsi-ilmo Valpas                             | 21.11.2004  | 9C | 29.5.2021  | Ei hakemusta         | –                           | –                         | –                                                                          |
 `
 
-const jklHakutilannePath = createHakutilannePathWithOrg("/virkailija", {
+const jklHakutilannePath = hakutilannePathWithOrg.href("/virkailija", {
   organisaatioOid: jyväskylänNormaalikouluOid,
 })
-const kulosaariHakutilannePath = createHakutilannePathWithOrg("/virkailija", {
+const kulosaariHakutilannePath = hakutilannePathWithOrg.href("/virkailija", {
   organisaatioOid: kulosaarenAlaAsteOid,
 })
-const aapajoenKouluHakutilannePath = createHakutilannePathWithOrg(
+const aapajoenKouluHakutilannePath = hakutilannePathWithOrg.href(
   "/virkailija",
   {
     organisaatioOid: aapajoenKouluOid,
   }
 )
 
-const internationalSchoolHakutilannePath = createHakutilannePathWithOrg(
+const internationalSchoolHakutilannePath = hakutilannePathWithOrg.href(
   "/virkailija",
   {
     organisaatioOid: internationalSchoolOid,
@@ -95,7 +92,7 @@ const internationalSchoolHakutilannePath = createHakutilannePathWithOrg(
 const kulosaarenOppijaOid = "1.2.246.562.24.00000000029"
 const viikinNormaalikouluOid = "1.2.246.562.10.81927839589"
 
-const viikinNormaalikouluHakutilannePath = createHakutilannePathWithOrg(
+const viikinNormaalikouluHakutilannePath = hakutilannePathWithOrg.href(
   "/virkailija",
   {
     organisaatioOid: viikinNormaalikouluOid,
@@ -199,7 +196,7 @@ describe("Hakutilannenäkymä", () => {
     await openOppijaView(kulosaarenOppijaOid)
     await urlIsEventually(
       pathToUrl(
-        createOppijaPath("/virkailija", {
+        oppijaPath.href("/virkailija", {
           oppijaOid: kulosaarenOppijaOid,
           hakutilanneRef: kulosaarenAlaAsteOid,
         })
@@ -234,7 +231,7 @@ describe("Hakutilannenäkymä", () => {
 
   it("Oppijasivulta, jolta puuttuu organisaatioreferenssi, ohjataan oikean organisaation hakutilannenäkymään", async () => {
     await loginAs(
-      createOppijaPath("/virkailija", {
+      oppijaPath.href("/virkailija", {
         oppijaOid: kulosaarenOppijaOid,
       }),
       "valpas-useampi-peruskoulu"

--- a/valpas-web/test/integrationtests/kuntailmoitus.shared.ts
+++ b/valpas-web/test/integrationtests/kuntailmoitus.shared.ts
@@ -1,7 +1,7 @@
 import { NonEmptyArray } from "fp-ts/lib/NonEmptyArray"
 import { By, WebElement } from "selenium-webdriver"
 import { Oid } from "../../src/state/common"
-import { createOppijaPath } from "../../src/state/paths"
+import { oppijaPath } from "../../src/state/paths"
 import { fromEntries, objectEntry } from "../../src/utils/objects"
 import {
   clickElement,
@@ -100,13 +100,13 @@ export const teeKuntailmoitusOppijanäkymistä = async (
   for (const oppija of oppijat) {
     // Tee ilmoitus oppijakohtaisesta näkymästä käsin, ja tarkista, että uuden ilmoituksen tiedot ilmestyvät näkyviin
     await goToLocation(
-      createOppijaPath("/virkailija", {
+      oppijaPath.href("/virkailija", {
         oppijaOid: oppija.oid,
       })
     )
     await urlIsEventually(
       pathToUrl(
-        createOppijaPath("/virkailija", {
+        oppijaPath.href("/virkailija", {
           oppijaOid: oppija.oid,
         })
       )

--- a/valpas-web/test/integrationtests/kuntailmoitus.test.ts
+++ b/valpas-web/test/integrationtests/kuntailmoitus.test.ts
@@ -1,7 +1,8 @@
 import { NonEmptyArray } from "fp-ts/lib/NonEmptyArray"
 import {
-  createHakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg,
-  createOppijaPath,
+  hakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg,
+  oppijaPath,
+  suorittaminenHetuhakuPath,
 } from "../../src/state/paths"
 import {
   clickElement,
@@ -33,7 +34,6 @@ import {
   täytäJaLähetäLomake,
 } from "./kuntailmoitus.shared"
 import { jyväskylänNormaalikouluOid } from "./oids"
-import { suorittaminenHetuhakuPath } from "./suorittaminen.shared"
 
 const opo: Tekijä = {
   nimi: "käyttäjä valpas-jkl-normaali",
@@ -239,7 +239,7 @@ describe("Kuntailmoituksen tekeminen", () => {
 
   it("happy path suorittamisen valvojana", async () => {
     await loginAs(
-      suorittaminenHetuhakuPath,
+      suorittaminenHetuhakuPath.href("/virkailija"),
       "valpas-pelkkä-suorittaminen",
       true
     )
@@ -250,7 +250,11 @@ describe("Kuntailmoituksen tekeminen", () => {
   })
 
   it("happy path hakeutumisen ja suorittamisen valvojana", async () => {
-    await loginAs(suorittaminenHetuhakuPath, "valpas-nivelvaihe", true)
+    await loginAs(
+      suorittaminenHetuhakuPath.href("/virkailija"),
+      "valpas-nivelvaihe",
+      true
+    )
     await teeKuntailmoitusOppijanäkymistä(
       nivelvaiheenValvojanOppijat,
       nivelvaiheenValvoja
@@ -306,7 +310,7 @@ const teeKuntailmoitusHakutilannenäkymästä = async (
 
   // Tarkista että oppijat ovat ilmestyneet "kunnalle tehdyt ilmoitukset" -tauluun
   for (const oppija of oppijat) {
-    const ilmotuksetPath = createHakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg(
+    const ilmotuksetPath = hakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg.href(
       "/virkailija",
       {
         organisaatioOid: tekijä.organisaatioOid,
@@ -319,12 +323,12 @@ const teeKuntailmoitusHakutilannenäkymästä = async (
 
   // Tarkista oppijakohtaisista näkymistä, että ilmoituksen tiedot ovat siellä
   for (const oppija of oppijat) {
-    const oppijaPath = createOppijaPath("/virkailija", {
+    const path = oppijaPath.href("/virkailija", {
       oppijaOid: oppija.oid,
       hakutilanneRef: jyväskylänNormaalikouluOid,
     })
-    await goToLocation(oppijaPath)
-    await urlIsEventually(pathToUrl(oppijaPath))
+    await goToLocation(path)
+    await urlIsEventually(pathToUrl(path))
     expect(await getIlmoitusData()).toEqual(oppija.expected)
   }
 }

--- a/valpas-web/test/integrationtests/kuntailmoituslista.test.ts
+++ b/valpas-web/test/integrationtests/kuntailmoituslista.test.ts
@@ -1,8 +1,8 @@
 import { Oid } from "../../src/state/common"
 import {
-  createKuntailmoitusPath,
-  createKuntailmoitusPathWithOrg,
-  createOppijaPath,
+  kuntailmoitusPath,
+  kuntailmoitusPathWithOrg,
+  oppijaPath,
 } from "../../src/state/paths"
 import {
   clickElement,
@@ -32,7 +32,7 @@ const openOppijaView = async (oppijaOid: Oid) => {
   await clickElement(selector)
 }
 
-const rootPath = createKuntailmoitusPath("/virkailija")
+const rootPath = kuntailmoitusPath.href("/virkailija")
 
 const ilmoitustitle = (
   näkyviäIlmoituksia: number,
@@ -55,7 +55,7 @@ describe("Kunnan listanäkymä", () => {
     await loginAs(rootPath, "valpas-useita-kuntia", false, "2021-12-01")
     await urlIsEventually(
       pathToUrl(
-        createKuntailmoitusPathWithOrg("/virkailija", helsinginKaupunkiOid)
+        kuntailmoitusPathWithOrg.href("/virkailija", helsinginKaupunkiOid)
       )
     )
     await textEventuallyEquals(".card__header", ilmoitustitle(1, 0))
@@ -72,14 +72,14 @@ describe("Kunnan listanäkymä", () => {
     await selectOrganisaatio(0)
     await urlIsEventually(
       pathToUrl(
-        createKuntailmoitusPathWithOrg("/virkailija", helsinginKaupunkiOid)
+        kuntailmoitusPathWithOrg.href("/virkailija", helsinginKaupunkiOid)
       )
     )
     await textEventuallyEquals(".card__header", ilmoitustitle(0, 1))
 
     await selectOrganisaatio(1)
     await urlIsEventually(
-      pathToUrl(createKuntailmoitusPathWithOrg("/virkailija", pyhtäänKuntaOid))
+      pathToUrl(kuntailmoitusPathWithOrg.href("/virkailija", pyhtäänKuntaOid))
     )
     await textEventuallyEquals(".card__header", ilmoitustitle(4, 3))
   })
@@ -91,13 +91,13 @@ describe("Kunnan listanäkymä", () => {
 
     await selectOrganisaatio(1)
     await urlIsEventually(
-      pathToUrl(createKuntailmoitusPathWithOrg("/virkailija", pyhtäänKuntaOid))
+      pathToUrl(kuntailmoitusPathWithOrg.href("/virkailija", pyhtäänKuntaOid))
     )
 
     await openOppijaView(pyhtäänOppijaOid)
     await urlIsEventually(
       pathToUrl(
-        createOppijaPath("/virkailija", {
+        oppijaPath.href("/virkailija", {
           oppijaOid: pyhtäänOppijaOid,
           kuntailmoitusRef: pyhtäänKuntaOid,
         })
@@ -106,7 +106,7 @@ describe("Kunnan listanäkymä", () => {
 
     await clickElement(".oppijaview__backbutton a")
     await urlIsEventually(
-      createKuntailmoitusPathWithOrg("/virkailija", pyhtäänKuntaOid)
+      kuntailmoitusPathWithOrg.href("/virkailija", pyhtäänKuntaOid)
     )
   })
 
@@ -128,7 +128,7 @@ describe("Kunnan listanäkymä", () => {
 
     await selectOrganisaatio(1)
     await urlIsEventually(
-      pathToUrl(createKuntailmoitusPathWithOrg("/virkailija", pyhtäänKuntaOid))
+      pathToUrl(kuntailmoitusPathWithOrg.href("/virkailija", pyhtäänKuntaOid))
     )
 
     await textEventuallyEquals(".card__header", ilmoitustitle(4, 3))

--- a/valpas-web/test/integrationtests/login.test.ts
+++ b/valpas-web/test/integrationtests/login.test.ts
@@ -1,8 +1,5 @@
 import fetch from "node-fetch"
-import {
-  createHakutilannePathWithOrg,
-  createOppijaPath,
-} from "../../src/state/paths"
+import { hakutilannePathWithOrg, oppijaPath } from "../../src/state/paths"
 import {
   clickElement,
   expectElementEventuallyVisible,
@@ -56,17 +53,17 @@ describe("Login / Logout / kirjautuminen", () => {
   })
 
   it("Käyttäjä on kirjautumisen jälkeen osoitteessa, jonne hän alunperin yritti", async () => {
-    const oppijaPath = createOppijaPath("/virkailija", {
+    const path = oppijaPath.href("/virkailija", {
       oppijaOid: "1.2.246.562.24.00000000001",
     })
-    await loginAs(oppijaPath, "valpas-jkl-normaali")
-    await urlIsEventually(pathToUrl(oppijaPath))
+    await loginAs(path, "valpas-jkl-normaali")
+    await urlIsEventually(pathToUrl(path))
   })
 
   it("Session vanheneminen vie käyttäjän kirjautumiseen", async () => {
     const organisaatioOid = "1.2.246.562.10.14613773812"
     await loginAs(
-      createHakutilannePathWithOrg("/virkailija", { organisaatioOid }),
+      hakutilannePathWithOrg.href("/virkailija", { organisaatioOid }),
       "valpas-jkl-normaali"
     )
 

--- a/valpas-web/test/integrationtests/nivelvaiheenkuntailmoitus.test.ts
+++ b/valpas-web/test/integrationtests/nivelvaiheenkuntailmoitus.test.ts
@@ -1,8 +1,8 @@
 import { NonEmptyArray } from "fp-ts/lib/NonEmptyArray"
 import {
-  createHakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg,
-  createNivelvaiheenHakutilannePathWithOrg,
-  createOppijaPath,
+  hakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg,
+  nivelvaiheenHakutilannePathWithOrg,
+  oppijaPath,
 } from "../../src/state/paths"
 import {
   clickElement,
@@ -32,7 +32,7 @@ import {
 import { ressunLukioTableContent_syyskuu2021 } from "./nivelvaihehakutilanne.shared"
 import { jyväskylänNormaalikouluOid, ressunLukioOid } from "./oids"
 
-const ressunLukioHakutilannePath = createNivelvaiheenHakutilannePathWithOrg(
+const ressunLukioHakutilannePath = nivelvaiheenHakutilannePathWithOrg.href(
   "/virkailija",
   {
     organisaatioOid: ressunLukioOid,
@@ -125,7 +125,7 @@ const teeKuntailmoitusHakutilannenäkymästä = async (
 
   // Tarkista että oppijat ovat ilmestyneet "kunnalle tehdyt ilmoitukset" -tauluun
   for (const oppija of oppijat) {
-    const ilmotuksetPath = createHakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg(
+    const ilmotuksetPath = hakeutumisvalvonnanKunnalleIlmoitetutPathWithOrg.href(
       "/virkailija",
       {
         organisaatioOid: tekijä.organisaatioOid,
@@ -138,12 +138,12 @@ const teeKuntailmoitusHakutilannenäkymästä = async (
 
   // Tarkista oppijakohtaisista näkymistä, että ilmoituksen tiedot ovat siellä
   for (const oppija of oppijat) {
-    const oppijaPath = createOppijaPath("/virkailija", {
+    const path = oppijaPath.href("/virkailija", {
       oppijaOid: oppija.oid,
       hakutilanneRef: jyväskylänNormaalikouluOid,
     })
-    await goToLocation(oppijaPath)
-    await urlIsEventually(pathToUrl(oppijaPath))
+    await goToLocation(path)
+    await urlIsEventually(pathToUrl(path))
     expect(await getIlmoitusData()).toEqual(oppija.expected)
   }
 }

--- a/valpas-web/test/integrationtests/nivelvaihehakutilanne.test.ts
+++ b/valpas-web/test/integrationtests/nivelvaihehakutilanne.test.ts
@@ -1,7 +1,7 @@
 import {
-  createNivelvaiheenHakutilannePathWithOrg,
-  createNivelvaiheenHakutilannePathWithoutOrg,
-  createOppijaPath,
+  nivelvaiheenHakutilannePathWithOrg,
+  nivelvaiheenHakutilannePathWithoutOrg,
+  oppijaPath,
 } from "../../src/state/paths"
 import {
   clickElement,
@@ -35,25 +35,25 @@ import {
 } from "./oids"
 import { selectOrganisaatioByNimi } from "./organisaatiovalitsin-helpers"
 
-const nivelvaiheenHakutilannePath = createNivelvaiheenHakutilannePathWithoutOrg(
+const nivelvaiheenHakutilannePath = nivelvaiheenHakutilannePathWithoutOrg.href(
   "/virkailija"
 )
 
-const ressunLukioHakutilannePath = createNivelvaiheenHakutilannePathWithOrg(
+const ressunLukioHakutilannePath = nivelvaiheenHakutilannePathWithOrg.href(
   "/virkailija",
   {
     organisaatioOid: ressunLukioOid,
   }
 )
 
-const aapajoenKouluHakutilannePath = createNivelvaiheenHakutilannePathWithOrg(
+const aapajoenKouluHakutilannePath = nivelvaiheenHakutilannePathWithOrg.href(
   "/virkailija",
   {
     organisaatioOid: aapajoenKouluOid,
   }
 )
 
-const internationalSchoolHakutilannePath = createNivelvaiheenHakutilannePathWithOrg(
+const internationalSchoolHakutilannePath = nivelvaiheenHakutilannePathWithOrg.href(
   "/virkailija",
   {
     organisaatioOid: internationalSchoolOid,
@@ -168,7 +168,7 @@ describe("Nivelvaiheen hakutilannenäkymä", () => {
     await openOppijaView(oppijaOid)
     await urlIsEventually(
       pathToUrl(
-        createOppijaPath("/virkailija", {
+        oppijaPath.href("/virkailija", {
           oppijaOid: oppijaOid,
           hakutilanneNivelvaiheRef: ressunLukioOid,
         })

--- a/valpas-web/test/integrationtests/oppija.test.ts
+++ b/valpas-web/test/integrationtests/oppija.test.ts
@@ -1,4 +1,4 @@
-import { createOppijaPath } from "../../src/state/paths"
+import { oppijaPath } from "../../src/state/paths"
 import { formatDate, today } from "../../src/utils/date"
 import {
   clickElement,
@@ -13,87 +13,84 @@ import {
 } from "../integrationtests-env/browser/fail-on-console"
 import { loginAs, resetMockData } from "../integrationtests-env/browser/reset"
 
-const ysiluokkaKeskenKeväälläPath = createOppijaPath("/virkailija", {
+const ysiluokkaKeskenKeväälläPath = oppijaPath.href("/virkailija", {
   oppijaOid: "1.2.246.562.24.00000000001",
 })
-const päällekkäisiäOppivelvollisuuksiaPath = createOppijaPath("/virkailija", {
+const päällekkäisiäOppivelvollisuuksiaPath = oppijaPath.href("/virkailija", {
   oppijaOid: "1.2.246.562.24.00000000003",
 })
-const ysiluokkaValmisKeväälläPath = createOppijaPath("/virkailija", {
+const ysiluokkaValmisKeväälläPath = oppijaPath.href("/virkailija", {
   oppijaOid: "1.2.246.562.24.00000000011",
 })
-const lukionAloittanutPath = createOppijaPath("/virkailija", {
+const lukionAloittanutPath = oppijaPath.href("/virkailija", {
   oppijaOid: "1.2.246.562.24.00000000015",
 })
-const lukionLokakuussaAloittanutPath = createOppijaPath("/virkailija", {
+const lukionLokakuussaAloittanutPath = oppijaPath.href("/virkailija", {
   oppijaOid: "1.2.246.562.24.00000000016",
 })
-const kahdellaOppijaOidillaPath = createOppijaPath("/virkailija", {
+const kahdellaOppijaOidillaPath = oppijaPath.href("/virkailija", {
   oppijaOid: "1.2.246.562.24.00000000017",
 })
-const turvakiellollinenOppijaPath = createOppijaPath("/virkailija", {
+const turvakiellollinenOppijaPath = oppijaPath.href("/virkailija", {
   oppijaOid: "1.2.246.562.24.00000000024",
 })
-const epäonninenOppijaPath = createOppijaPath("/virkailija", {
+const epäonninenOppijaPath = oppijaPath.href("/virkailija", {
   oppijaOid: "1.2.246.562.24.00000000028",
 })
-const montaHakuaJoistaYksiPäättynytOppijaPath = createOppijaPath(
-  "/virkailija",
-  {
-    oppijaOid: "1.2.246.562.24.00000000009",
-  }
-)
-const lukionAineopinnotAloittanutPath = createOppijaPath("/virkailija", {
+const montaHakuaJoistaYksiPäättynytOppijaPath = oppijaPath.href("/virkailija", {
+  oppijaOid: "1.2.246.562.24.00000000009",
+})
+const lukionAineopinnotAloittanutPath = oppijaPath.href("/virkailija", {
   oppijaOid: "1.2.246.562.24.00000000033",
 })
-const lukioOpiskelijaPath = createOppijaPath("/virkailija", {
+const lukioOpiskelijaPath = oppijaPath.href("/virkailija", {
   oppijaOid: "1.2.246.562.24.00000000004",
 })
-const vsopPath = createOppijaPath("/virkailija", {
+const vsopPath = oppijaPath.href("/virkailija", {
   oppijaOid: "1.2.246.562.24.00000000046",
 })
-const oppivelvollisuusKeskeytettyMääräajaksiPath = createOppijaPath(
+const oppivelvollisuusKeskeytettyMääräajaksiPath = oppijaPath.href(
   "/virkailija",
   {
     oppijaOid: "1.2.246.562.24.00000000056",
   }
 )
-const oppivelvollisuusKeskeytettyToistaiseksiPath = createOppijaPath(
+const oppivelvollisuusKeskeytettyToistaiseksiPath = oppijaPath.href(
   "/virkailija",
   {
     oppijaOid: "1.2.246.562.24.00000000057",
   }
 )
-const eiOppivelvollisuudenSuorittamiseenKelpaaviaOpiskeluoikeuksiaPath = createOppijaPath(
+const eiOppivelvollisuudenSuorittamiseenKelpaaviaOpiskeluoikeuksiaPath = oppijaPath.href(
   "/virkailija",
   {
     oppijaOid: "1.2.246.562.24.00000000058",
   }
 )
-const hetutonPath = createOppijaPath("/virkailija", {
+const hetutonPath = oppijaPath.href("/virkailija", {
   oppijaOid: "1.2.246.562.24.00000000059",
 })
 
-const opiskeluoikeusKeskeytettyMääräajaksiPath = createOppijaPath(
+const opiskeluoikeusKeskeytettyMääräajaksiPath = oppijaPath.href(
   "/virkailija",
   {
     oppijaOid: "1.2.246.562.24.00000000077",
   }
 )
 
-const opiskeluoikeusLomaPath = createOppijaPath("/virkailija", {
+const opiskeluoikeusLomaPath = oppijaPath.href("/virkailija", {
   oppijaOid: "1.2.246.562.24.00000000078",
 })
 
-const opiskeluoikeusValmaPath = createOppijaPath("/virkailija", {
+const opiskeluoikeusValmaPath = oppijaPath.href("/virkailija", {
   oppijaOid: "1.2.246.562.24.00000000062",
 })
 
-const opiskeluoikeusIntSchoolPerusopetusPath = createOppijaPath("/virkailija", {
+const opiskeluoikeusIntSchoolPerusopetusPath = oppijaPath.href("/virkailija", {
   oppijaOid: "1.2.246.562.24.00000000094",
 })
 
-const maksuttomuuttaPidennettyPath = createOppijaPath("/virkailija", {
+const maksuttomuuttaPidennettyPath = oppijaPath.href("/virkailija", {
   oppijaOid: "1.2.246.562.24.00000000127",
 })
 

--- a/valpas-web/test/integrationtests/oppijahaku.test.ts
+++ b/valpas-web/test/integrationtests/oppijahaku.test.ts
@@ -1,8 +1,8 @@
 import {
-  createKunnanHetuhakuPath,
-  createMaksuttomuusPath,
-  createOppijaPath,
-  createSuorittaminenHetuhakuPath,
+  kunnanHetuhakuPath,
+  maksuttomuusPath,
+  oppijaPath,
+  suorittaminenHetuhakuPath,
 } from "../../src/state/paths"
 import {
   clickElement,
@@ -26,9 +26,9 @@ describe("Oppijahaku", () => {
     await submit("maksuttomuusoppijasearch")
     await expectResultToBe(
       "Löytyi: Oppivelvollinen-ysiluokka-kesken-keväällä-2021 Valpas (221105A3023)",
-      createOppijaPath("/virkailija", {
+      oppijaPath.href("/virkailija", {
         oppijaOid: "1.2.246.562.24.00000000001",
-        prev: createMaksuttomuusPath(),
+        prev: maksuttomuusPath.href(),
       }),
       "maksuttomuusoppijasearch"
     )
@@ -43,9 +43,9 @@ describe("Oppijahaku", () => {
     await submit("maksuttomuusoppijasearch")
     await expectResultToBe(
       "Löytyi: Oppivelvollinen-ysiluokka-kesken-keväällä-2021 Valpas (221105A3023)",
-      createOppijaPath("/virkailija", {
+      oppijaPath.href("/virkailija", {
         oppijaOid: "1.2.246.562.24.00000000001",
-        prev: createMaksuttomuusPath(),
+        prev: maksuttomuusPath.href(),
       }),
       "maksuttomuusoppijasearch"
     )
@@ -57,9 +57,9 @@ describe("Oppijahaku", () => {
     await submit("maksuttomuusoppijasearch")
     await expectResultToBe(
       "Löytyi: Lukio-opiskelija Valpas (070504A717P)",
-      createOppijaPath("/virkailija", {
+      oppijaPath.href("/virkailija", {
         oppijaOid: "1.2.246.562.24.00000000004",
-        prev: createMaksuttomuusPath(),
+        prev: maksuttomuusPath.href(),
       }),
       "maksuttomuusoppijasearch"
     )
@@ -68,16 +68,16 @@ describe("Oppijahaku", () => {
   it("Suorittaminen: Haku löytää henkilötunnuksen perusteella oppijan, jonka tietojen näkemiseen käyttäjällä on vain suorittamisoikeus, ja linkkaa detaljisivulle", async () => {
     await hakuLogin(
       "valpas-pelkkä-suorittaminen",
-      createSuorittaminenHetuhakuPath("/virkailija"),
+      suorittaminenHetuhakuPath.href("/virkailija"),
       "article#suorittaminenhetuhaku"
     )
     await fillQueryField("070504A717P")
     await submit()
     await expectResultToBe(
       "Löytyi: Lukio-opiskelija Valpas (070504A717P)",
-      createOppijaPath("/virkailija", {
+      oppijaPath.href("/virkailija", {
         oppijaOid: "1.2.246.562.24.00000000004",
-        prev: createSuorittaminenHetuhakuPath(),
+        prev: suorittaminenHetuhakuPath.href(),
       })
     )
   })
@@ -85,16 +85,16 @@ describe("Oppijahaku", () => {
   it("Kunta: Haku löytää henkilötunnuksen perusteella oppijan, jonka tietojen näkemiseen käyttäjällä on vain kuntaoikeus, ja linkkaa detaljisivulle", async () => {
     await hakuLogin(
       "valpas-helsinki",
-      createKunnanHetuhakuPath("/virkailija"),
+      kunnanHetuhakuPath.href("/virkailija"),
       "article#kuntahetuhaku"
     )
     await fillQueryField("070504A717P")
     await submit()
     await expectResultToBe(
       "Löytyi: Lukio-opiskelija Valpas (070504A717P)",
-      createOppijaPath("/virkailija", {
+      oppijaPath.href("/virkailija", {
         oppijaOid: "1.2.246.562.24.00000000004",
-        prev: createKunnanHetuhakuPath(),
+        prev: kunnanHetuhakuPath.href(),
       })
     )
   })
@@ -108,9 +108,9 @@ describe("Oppijahaku", () => {
     await submit("maksuttomuusoppijasearch")
     await expectResultToBe(
       "Löytyi: Lukio-opiskelija Valpas (070504A717P)",
-      createOppijaPath("/virkailija", {
+      oppijaPath.href("/virkailija", {
         oppijaOid: "1.2.246.562.24.00000000004",
-        prev: createMaksuttomuusPath(),
+        prev: maksuttomuusPath.href(),
       }),
       "maksuttomuusoppijasearch"
     )
@@ -119,16 +119,16 @@ describe("Oppijahaku", () => {
   it("Suorittaminen: Haku löytää oppijanumeron perusteella oppijan, jonka tietojen näkemiseen käyttäjällä on vain suorittamisoikeus, ja linkkaa detaljisivulle", async () => {
     await hakuLogin(
       "valpas-pelkkä-suorittaminen",
-      createSuorittaminenHetuhakuPath("/virkailija"),
+      suorittaminenHetuhakuPath.href("/virkailija"),
       "article#suorittaminenhetuhaku"
     )
     await fillQueryField("1.2.246.562.24.00000000004")
     await submit()
     await expectResultToBe(
       "Löytyi: Lukio-opiskelija Valpas (070504A717P)",
-      createOppijaPath("/virkailija", {
+      oppijaPath.href("/virkailija", {
         oppijaOid: "1.2.246.562.24.00000000004",
-        prev: createSuorittaminenHetuhakuPath(),
+        prev: suorittaminenHetuhakuPath.href(),
       })
     )
   })
@@ -136,16 +136,16 @@ describe("Oppijahaku", () => {
   it("Kunta: Haku löytää oppijanumeron perusteella oppijan, jonka tietojen näkemiseen käyttäjällä on vain kuntaoikeus, ja linkkaa detaljisivulle", async () => {
     await hakuLogin(
       "valpas-helsinki",
-      createKunnanHetuhakuPath("/virkailija"),
+      kunnanHetuhakuPath.href("/virkailija"),
       "article#kuntahetuhaku"
     )
     await fillQueryField("1.2.246.562.24.00000000004")
     await submit()
     await expectResultToBe(
       "Löytyi: Lukio-opiskelija Valpas (070504A717P)",
-      createOppijaPath("/virkailija", {
+      oppijaPath.href("/virkailija", {
         oppijaOid: "1.2.246.562.24.00000000004",
-        prev: createKunnanHetuhakuPath(),
+        prev: kunnanHetuhakuPath.href(),
       })
     )
   })
@@ -186,7 +186,7 @@ describe("Oppijahaku", () => {
   it("Suorittaminen: Haku kertoo ettei oppijaa löydy, jos oppijan tietoja ei löydy rekistereistä", async () => {
     await hakuLogin(
       "valpas-pelkkä-suorittaminen",
-      createSuorittaminenHetuhakuPath("/virkailija"),
+      suorittaminenHetuhakuPath.href("/virkailija"),
       "article#suorittaminenhetuhaku"
     )
     await fillQueryField("040392-530U")
@@ -199,7 +199,7 @@ describe("Oppijahaku", () => {
   it("Kunta: Haku kertoo ettei oppijaa löydy, jos oppijan tietoja ei löydy rekistereistä", async () => {
     await hakuLogin(
       "valpas-helsinki",
-      createKunnanHetuhakuPath("/virkailija"),
+      kunnanHetuhakuPath.href("/virkailija"),
       "article#kuntahetuhaku"
     )
     await fillQueryField("040392-530U")
@@ -231,7 +231,7 @@ describe("Oppijahaku", () => {
     )
     await hakuLogin(
       "valpas-pelkkä-suorittaminen",
-      createSuorittaminenHetuhakuPath("/virkailija"),
+      suorittaminenHetuhakuPath.href("/virkailija"),
       "article#suorittaminenhetuhaku"
     )
     await fillQueryField("180304A082P")
@@ -245,7 +245,7 @@ describe("Oppijahaku", () => {
     allowNetworkError("api/henkilohaku/kunta/180304A082P", "403 (Forbidden)")
     await hakuLogin(
       "valpas-helsinki",
-      createKunnanHetuhakuPath("/virkailija"),
+      kunnanHetuhakuPath.href("/virkailija"),
       "article#kuntahetuhaku"
     )
     await fillQueryField("180304A082P")
@@ -309,9 +309,9 @@ describe("Oppijahaku", () => {
     await submit("maksuttomuusoppijasearch")
     await expectResultToBe(
       "Löytyi: Ei-oppivelvollisuuden-suorittamiseen-kelpaavia-opiskeluoikeuksia Valpas (061005A671V)",
-      createOppijaPath("/virkailija", {
+      oppijaPath.href("/virkailija", {
         oppijaOid: "1.2.246.562.24.00000000058",
-        prev: createMaksuttomuusPath(),
+        prev: maksuttomuusPath.href(),
       }),
       "maksuttomuusoppijasearch"
     )
@@ -323,9 +323,9 @@ describe("Oppijahaku", () => {
     await submit("maksuttomuusoppijasearch")
     await expectResultToBe(
       "Löytyi: Inter-valmistunut-9-2021 Valpas (200405A780K)",
-      createOppijaPath("/virkailija", {
+      oppijaPath.href("/virkailija", {
         oppijaOid: "1.2.246.562.24.00000000080",
-        prev: createMaksuttomuusPath(),
+        prev: maksuttomuusPath.href(),
       }),
       "maksuttomuusoppijasearch"
     )
@@ -338,9 +338,9 @@ describe("Oppijahaku", () => {
     await submit("maksuttomuusoppijasearch")
     await expectResultToBe(
       "Löytyi: Hetuton Valpas",
-      createOppijaPath("/virkailija", {
+      oppijaPath.href("/virkailija", {
         oppijaOid: "1.2.246.562.24.00000000059",
-        prev: createMaksuttomuusPath(),
+        prev: maksuttomuusPath.href(),
       }),
       "maksuttomuusoppijasearch"
     )
@@ -354,9 +354,9 @@ describe("Oppijahaku", () => {
     await submit("maksuttomuusoppijasearch")
     await expectResultToBe(
       "Löytyi: Oppivelvollinen-hetullinen Valpas (030105A7507)",
-      createOppijaPath("/virkailija", {
+      oppijaPath.href("/virkailija", {
         oppijaOid: oppijaMasterOid,
-        prev: createMaksuttomuusPath(),
+        prev: maksuttomuusPath.href(),
       }),
       "maksuttomuusoppijasearch"
     )
@@ -365,16 +365,16 @@ describe("Oppijahaku", () => {
   it("Kunta: Haku löytää oppijan, vaikka hänellä ei ole oppivelvollisuuden suorittamiseen kelpaavia opintoja", async () => {
     await hakuLogin(
       "valpas-helsinki",
-      createKunnanHetuhakuPath("/virkailija"),
+      kunnanHetuhakuPath.href("/virkailija"),
       "article#kuntahetuhaku"
     )
     await fillQueryField("061005A671V") // Ei-oppivelvollisuuden-suorittamiseen-kelpaavia-opiskeluoikeuksia Valpas
     await submit()
     await expectResultToBe(
       "Löytyi: Ei-oppivelvollisuuden-suorittamiseen-kelpaavia-opiskeluoikeuksia Valpas (061005A671V)",
-      createOppijaPath("/virkailija", {
+      oppijaPath.href("/virkailija", {
         oppijaOid: "1.2.246.562.24.00000000058",
-        prev: createKunnanHetuhakuPath(),
+        prev: kunnanHetuhakuPath.href(),
       })
     )
   })
@@ -393,7 +393,7 @@ describe("Oppijahaku", () => {
 
 const hakuLogin = async (
   user: string = "valpas-jkl-normaali",
-  path: string = createMaksuttomuusPath("/virkailija"),
+  path: string = maksuttomuusPath.href("/virkailija"),
   selector: string = "article#maksuttomuus"
 ) => {
   await loginAs(path, user)

--- a/valpas-web/test/integrationtests/suorittaminen.shared.ts
+++ b/valpas-web/test/integrationtests/suorittaminen.shared.ts
@@ -1,9 +1,8 @@
 import { Oid } from "../../src/state/common"
 import {
-  createSuorittaminenHetuhakuPath,
-  createSuorittaminenPath,
-  createSuorittaminenPathWithOrg,
-  createSuorittamisvalvonnanKunnalleIlmoitetutPathWithOrg,
+  suorittaminenPath,
+  suorittaminenPathWithOrg,
+  suorittamisvalvonnanKunnalleIlmoitetutPathWithOrg,
 } from "../../src/state/paths"
 import {
   clickElement,
@@ -64,22 +63,19 @@ export const internationalSchoolSuorittaminenTableContent = `
   Int-school-yli-2kk-aiemmin-9-valmistunut-10-jatkanut Valpas                       | 11.11.2005 | International school | Läsnä | International School of Helsinki | 1.8.2021   | – | – | 11.11.2023 asti
     `
 
-export const suorittaminenHetuhakuPath = createSuorittaminenHetuhakuPath(
-  "/virkailija"
-)
-export const suorittaminenListaPath = createSuorittaminenPath("/virkailija")
+export const suorittaminenListaPath = suorittaminenPath.href("/virkailija")
 
-export const suorittaminenListaJklPath = createSuorittaminenPathWithOrg(
+export const suorittaminenListaJklPath = suorittaminenPathWithOrg.href(
   "/virkailija",
   jyväskylänNormaalikouluOid
 )
 
-export const suorittaminenListaHkiPath = createSuorittaminenPathWithOrg(
+export const suorittaminenListaHkiPath = suorittaminenPathWithOrg.href(
   "/virkailija",
   helsinginMedialukioOid
 )
 
-export const suorittaminenKuntailmoitusListaJklPath = createSuorittamisvalvonnanKunnalleIlmoitetutPathWithOrg(
+export const suorittaminenKuntailmoitusListaJklPath = suorittamisvalvonnanKunnalleIlmoitetutPathWithOrg.href(
   "/virkailija",
   { organisaatioOid: jyväskylänNormaalikouluOid }
 )

--- a/valpas-web/test/integrationtests/suorittaminen.test.ts
+++ b/valpas-web/test/integrationtests/suorittaminen.test.ts
@@ -1,5 +1,5 @@
 import { Oid } from "../../src/state/common"
-import { createSuorittaminenPathWithOrg } from "../../src/state/paths"
+import { suorittaminenPathWithOrg } from "../../src/state/paths"
 import {
   clickElement,
   expectElementEventuallyNotVisible,
@@ -52,28 +52,28 @@ import {
   suorittaminenListaPath,
 } from "./suorittaminen.shared"
 
-const jklSuorittaminenPath = createSuorittaminenPathWithOrg(
+const jklSuorittaminenPath = suorittaminenPathWithOrg.href(
   "/virkailija",
   jyväskylänNormaalikouluOid
 )
 
-const aapajokiSuorittaminenPath = createSuorittaminenPathWithOrg(
+const aapajokiSuorittaminenPath = suorittaminenPathWithOrg.href(
   "/virkailija",
   aapajoenKouluOid
 )
 
-const stadinAmmattiopistoSuorittaminenPath = createSuorittaminenPathWithOrg(
+const stadinAmmattiopistoSuorittaminenPath = suorittaminenPathWithOrg.href(
   "/virkailija",
   stadinAmmattiopistoOid
 )
 
-const internationalSchoolSuorittaminenPath = createSuorittaminenPathWithOrg(
+const internationalSchoolSuorittaminenPath = suorittaminenPathWithOrg.href(
   "/virkailija",
   internationalSchoolOid
 )
 
 const viikinNormaalikouluId = "1.2.246.562.10.81927839589"
-const viikinNormaalikouluSuorittaminenPath = createSuorittaminenPathWithOrg(
+const viikinNormaalikouluSuorittaminenPath = suorittaminenPathWithOrg.href(
   "/virkailija",
   viikinNormaalikouluId
 )


### PR DESCRIPTION
paths.ts on mennyt vuoden saatossa aika sekavaan tilaan ja herkkä erilaisille copy&paste- ja muokkausvirheille.

Muutettu nyt deklaratiivisempaan suuntaan, mutta samalla hajosi sen tarjoama sisäinen rajapinta, joten joka toista tiedostoa on varmaan nyt muokattu...

Yhtenäistin joitakin tyypityksiä samalla.
