### PR TITLE
TOR-1592: CodeQL-löydösten korjaus

### DIFF
--- a/valpas-web/src/components/navigation/ExternalLink.tsx
+++ b/valpas-web/src/components/navigation/ExternalLink.tsx
@@ -11,7 +11,12 @@ export type ExternalLinkProps = {
 }
 
 export const ExternalLink = (props: ExternalLinkProps) => (
-  <a href={props.to} target="_blank" className="externallink">
+  <a
+    href={props.to}
+    target="_blank"
+    className="externallink"
+    rel="noopener noreferrer"
+  >
     {props.children} <OpenInNewIcon inline className={b("icon")} />
   </a>
 )

--- a/web/app/dokumentaatio/Dokumentaatio.jsx
+++ b/web/app/dokumentaatio/Dokumentaatio.jsx
@@ -19,7 +19,7 @@ const JsonExample = ({category, example}) => {
   return (
     <li className="example-item">
       <a className="example-link" onClick={() => expandedA.modify(v => !v)}>{example.description}</a>
-      <a className="example-as-json" href={example.link} target="_blank">{'lataa JSON'}</a>
+      <a className="example-as-json" href={example.link} target="_blank" rel="noopener noreferrer">{'lataa JSON'}</a>
       {expandedA.flatMap(v => v
         ? Http.cachedGet('/koski/api/documentation/categoryExamples/'+category+'/'+example.name+'/table.html').map(c => <JsonExampleTable contents={c}/>)
         : null
@@ -98,7 +98,7 @@ export const dokumentaatioKoodistotP = () => dokumentaatioContentP('/koski/dokum
     content: (<div>
       <div dangerouslySetInnerHTML={{__html: htmlSections.koodistot}}></div>
       <ul>
-        {koodistot.map(koodistoUri => <li><a href={'/koski/dokumentaatio/koodisto/' + koodistoUri + '/latest'} target='_blank'>{koodistoUri}</a></li>)}
+        {koodistot.map(koodistoUri => <li><a href={'/koski/dokumentaatio/koodisto/' + koodistoUri + '/latest'} target='_blank' rel="noopener noreferrer">{koodistoUri}</a></li>)}
       </ul>
     </div>),
     title: 'Dokumentaatio - Koodistot'

--- a/web/app/editor/StringEditor.jsx
+++ b/web/app/editor/StringEditor.jsx
@@ -20,7 +20,7 @@ export const StringEditor = ({model, placeholder, autoFocus}) => {
 
 let splitToRows = (data) => data.replace(/\r\n*/g, '\n').split('\n').map((line, k) => <span key={k}>{k > 0 ? <br/> : null}{line}</span>)
 
-const buildRegex = model => new RegExp(model.regularExpression.replace(/\\/g, '\\'))
+const buildRegex = model => new RegExp(model.regularExpression)
 
 StringEditor.handlesOptional = () => true
 StringEditor.isEmpty = m => !modelData(m)

--- a/web/app/i18n/LocalizedExternalLink.jsx
+++ b/web/app/i18n/LocalizedExternalLink.jsx
@@ -3,7 +3,7 @@ import {lang} from './i18n'
 import ExternalLinkIcon from '../omadata/luvanhallinta/ExternalLinkIcon'
 
 export const LocalizedExternalLink = ({options, children}) => (
-  <a target="_blank" href={options[lang] || options['fi']}>
+  <a target="_blank" href={options[lang] || options['fi']} rel="noopener noreferrer">
     {children}
     {' '}
     <ExternalLinkIcon />

--- a/web/app/omadata/luvanhallinta/LuvanHallintaDisclaimer.jsx
+++ b/web/app/omadata/luvanhallinta/LuvanHallintaDisclaimer.jsx
@@ -8,7 +8,7 @@ export const LuvanHallintaDisclaimer = () => (
     <p>
       {'*'}
       <Text name='Koskee vain opintotietoja --prefix'/>
-      <a className='kayttoluvat-external-link' href={t('tietosuojaseloste-link')} target='_blank'>
+      <a className='kayttoluvat-external-link' href={t('tietosuojaseloste-link')} target='_blank' rel="noopener noreferrer">
         <ExternalLinkIcon/>
         <Text name='Koskee vain opintotietoja --link-title'/>
       </a>

--- a/web/app/omattiedot/suoritusjako/SuoritusjakoLink.jsx
+++ b/web/app/omattiedot/suoritusjako/SuoritusjakoLink.jsx
@@ -133,7 +133,7 @@ export class SuoritusjakoLink extends React.Component {
           </div>
           <div className='suoritusjako-link__bottom-container'>
             <div className='suoritusjako-link__preview'>
-              <a className='text-button-small' target='_blank' href={url}><Text name='Katso, miltä suoritusote näyttää selaimessa'/></a>
+              <a className='text-button-small' target='_blank' href={url} rel="noopener noreferrer"><Text name='Katso, miltä suoritusote näyttää selaimessa'/></a>
             </div>
             <div className='suoritusjako-link__remove'>
               <button className={`text-button-small${(isDateUpdatePending ? '--disabled' : '')}`} onClick={this.confirmDelete.bind(this)} disabled={isDateUpdatePending}>

--- a/web/app/suoritus/OmatTiedotSuoritustaulukko.jsx
+++ b/web/app/suoritus/OmatTiedotSuoritustaulukko.jsx
@@ -83,7 +83,7 @@ const YtrArvosanaColumn = (parentSuoritus) => {
 
 const KoesuoritusLink = ({copyOfExamPaper, kokeenNimi, parentSuoritus}) =>
   copyOfExamPaper
-    ? (<a className='text-button-small' target='_blank' href={`/koski/koesuoritus/${copyOfExamPaper}${parentSuoritus.context.huollettava ? '?huollettava=' + parentSuoritus.context.oppijaOid : ''}`}>
+    ? (<a className='text-button-small' target='_blank' href={`/koski/koesuoritus/${copyOfExamPaper}${parentSuoritus.context.huollettava ? '?huollettava=' + parentSuoritus.context.oppijaOid : ''}`} rel="noopener noreferrer">
         <Text className='show-koesuoritus-text' name='Näytä koesuoritus' aria-label={t(kokeenNimi) + '. ' + t('Näytä koesuoritus')}/>
       </a>)
     : null

--- a/web/app/suoritus/PerusteEditor.jsx
+++ b/web/app/suoritus/PerusteEditor.jsx
@@ -26,6 +26,6 @@ PerusteEditor.handlesOptional= () => true
 const perusteLinkki = (peruste, perusteEditor) => {
   const map404 = { errorMapper: (e) => e.httpStatus === 404 ? Bacon.never() : Bacon.Error(e) }
   return Http.cachedGet(`/koski/api/tutkinnonperusteet/peruste/${encodeURIComponent(peruste)}/linkki?lang=${encodeURIComponent(lang)}`, map404).map('.url').map(linkki =>
-    <a target="_blank" href={linkki}>{perusteEditor}</a>
+    <a target="_blank" href={linkki} rel="noopener noreferrer">{perusteEditor}</a>
   ).startWith(perusteEditor)
 }

--- a/web/app/virkailija/VirkailijaOppijaView.jsx
+++ b/web/app/virkailija/VirkailijaOppijaView.jsx
@@ -220,8 +220,8 @@ export class Oppija extends React.Component {
               {modelData(henkilö, 'turvakielto') && <span title={t('Henkilöllä on turvakielto')} className="turvakielto"/>}
               <a href={`/koski/api/oppija/${modelData(henkilö, 'oid')}/opintotiedot-json`}>{'JSON'}</a>
               {showHenkilöUiLink.map(show => show && <HenkilöUiLink henkilö={henkilö} yksilöity={modelData(oppija, 'yksilöity')} />)}
-              {showVirtaXmlLink.map(show => show && <a href={`/koski/api/oppija/${modelData(henkilö, 'oid')}/virta-opintotiedot-xml`} target='_blank'>{'Virta XML'}</a>)}
-              {showSureLink.map(show => show && <a href={`/suoritusrekisteri/#/opiskelijat?henkilo=${modelData(henkilö, 'oid')}`} target='_blank'>{'Suoritusrekisteri'}</a>)}
+              {showVirtaXmlLink.map(show => show && <a href={`/koski/api/oppija/${modelData(henkilö, 'oid')}/virta-opintotiedot-xml`} target='_blank' rel="noopener noreferrer">{'Virta XML'}</a>)}
+              {showSureLink.map(show => show && <a href={`/suoritusrekisteri/#/opiskelijat?henkilo=${modelData(henkilö, 'oid')}`} target='_blank' rel="noopener noreferrer">{'Suoritusrekisteri'}</a>)}
             </h2>
             <div className="oppijanumero">{t('Oppijanumero')}{`: ${modelData(henkilö, 'oid')}`}</div>
             {
@@ -239,7 +239,7 @@ export class Oppija extends React.Component {
 }
 
 const HenkilöUiLink = ({henkilö, yksilöity}) => {
-  return (<a href={`/henkilo-ui/oppija/${modelData(henkilö, 'oid')}?permissionCheckService=KOSKI`} target='_blank' title={t('OppijanumerorekisteriLinkTooltip')} className='oppijanumerorekisteri-link'>
+  return (<a href={`/henkilo-ui/oppija/${modelData(henkilö, 'oid')}?permissionCheckService=KOSKI`} target='_blank' title={t('OppijanumerorekisteriLinkTooltip')} className='oppijanumerorekisteri-link' rel="noopener noreferrer">
     <Text name='Oppijanumerorekisteri'/>
     {!yksilöity && <Text className='yksilöimätön' name='Oppijaa ei ole yksilöity. Tee yksilöinti oppijanumerorekisterissä'/>}
   </a>)

--- a/web/static/json-schema-viewer/index.html
+++ b/web/static/json-schema-viewer/index.html
@@ -179,7 +179,7 @@
     })(jQuery);
 
     function schemaName() {
-      var nameInParams = window.location.search.match(new RegExp('(?:[\?\&]schema=)([^&]+)'))
+      var nameInParams = window.location.search.match(new RegExp('(?:[?&]schema=)([^&]+)'))
       var schemaName
       if (nameInParams) {
         schemaName = nameInParams[1]


### PR DESCRIPTION
Löydökset: https://github.com/artoj-nixu/koski/security/code-scanning

Osa löydöksistä testeistä ja Korhopankista, joita ei mielestäni kannata korjata (esimerkiksi ei järkeä ottaa stringien sanitointikirjastoa käyttöön selector-lauseen rakentamiseen testin sisällä). Jos joskus isketään ci-putkeen skanneri, niin tuollaiset mielestäni ignoreen.