### PR TITLE
[VAATII SPEKSAUSTA] TOR-1590: Poista/muuta aikaraja kuntailmoitusten aktiivisuusmäärittelystä

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -140,7 +140,6 @@ valpas = {
     ilmoitustenEnsimmäinenTallennuspäivä = "2021-08-01"
     keväänValmistumisjaksollaValmistuneidenViimeinenTarkastelupäivä = "0000-09-30"
     tulevaisuuteenMerkitynPerusopetuksenSuorituksenAikaikkunaPäivinä = 28
-    kuntailmoitusAktiivisuusKuukausina = 2
 
     2021 {
       keväänValmistumisjaksoLoppu = "2021-05-31"

--- a/src/main/scala/fi/oph/koski/valpas/ValpasKuntailmoitusApiServlet.scala
+++ b/src/main/scala/fi/oph/koski/valpas/ValpasKuntailmoitusApiServlet.scala
@@ -25,10 +25,10 @@ class ValpasKuntailmoitusApiServlet(implicit val application: KoskiApplication)
   private lazy val kuntailmoitusService = application.valpasKuntailmoitusService
   private lazy val oppijaService = application.valpasOppijaService
 
-  get("/oppijat/:kuntaOid/aktiiviset") {
+  get("/oppijat/:kuntaOid") {
     val kuntaOid: Organisaatio.Oid = params("kuntaOid")
     renderEither(
-      oppijaService.getKunnanOppijatSuppeatTiedot(kuntaOid, true)
+      oppijaService.getKunnanOppijatSuppeatTiedot(kuntaOid)
         .tap(_ => auditLogKuntaKatsominen(kuntaOid))
     )
   }

--- a/src/main/scala/fi/oph/koski/valpas/ValpasOppijaService.scala
+++ b/src/main/scala/fi/oph/koski/valpas/ValpasOppijaService.scala
@@ -575,25 +575,11 @@ class ValpasOppijaService(
   )(
     kuntailmoitukset: Seq[ValpasKuntailmoitusLaajatTiedot]
   ): Seq[ValpasKuntailmoitusLaajatTiedotLisätiedoilla] = {
-    kuntailmoitukset.zipWithIndex.map(kuntailmoitusWithIndex => {
-      val aktiivinen = kuntailmoitusWithIndex match {
-
-        // Alle 2 kk vanha ilmoitus on aina aktiivinen
-        case (kuntailmoitus, 0) if !rajapäivätService.tarkastelupäivä.isAfter(
-          kuntailmoitus.aikaleima.get.toLocalDate.plusMonths(rajapäivätService.kuntailmoitusAktiivisuusKuukausina)
-        ) => true
-
-        // Jos yli 2 kk, ilmoitus on aktiivinen,
-        // jos mikään ov-suorittamiseen kelpaava opiskeluoikeus ei ole voimassa
-        case (kuntailmoitus, 0) =>
-          oppija.opiskeluoikeudet.forall(oo => !oo.isOpiskelu)
-
-        // Muut kuin uusin ilmoitus ovat aina ei-aktiivisia
-        case (kuntailmoitus, _) => false
-      }
-
-      ValpasKuntailmoitusLaajatTiedotLisätiedoilla(kuntailmoitusWithIndex._1, aktiivinen)
-    })
+    kuntailmoitukset.zipWithIndex.map { case (kuntailmoitus, index) =>
+      // Viimeisin kuntailmoitus on aktiivinen jos mikään ov-suorittamiseen kelpaava opiskeluoikeus ei ole voimassa
+      val aktiivinen = (index == 0) && oppija.opiskeluoikeudet.forall(oo => !oo.isOpiskelu)
+      ValpasKuntailmoitusLaajatTiedotLisätiedoilla(kuntailmoitus, aktiivinen)
+    }
   }
 
   private def fetchOppivelvollisuudenKeskeytykset(

--- a/src/main/scala/fi/oph/koski/valpas/ValpasOppijaService.scala
+++ b/src/main/scala/fi/oph/koski/valpas/ValpasOppijaService.scala
@@ -258,7 +258,7 @@ class ValpasOppijaService(
     oppija.copy(oppivelvollisuudenKeskeytykset = oppija.oppivelvollisuudenKeskeytykset.filter(_.voimassa))
 
   def getKunnanOppijatSuppeatTiedot
-    (kuntaOid: Organisaatio.Oid, haeAktiiviset: Boolean)
+    (kuntaOid: Organisaatio.Oid)
     (implicit session: ValpasSession)
   : Either[HttpStatus, Seq[OppijaKuntailmoituksillaSuppeatTiedot]] = {
     accessResolver.assertAccessToOrg(ValpasRooli.KUNTA, kuntaOid)
@@ -294,7 +294,6 @@ class ValpasOppijaService(
         OppijaKuntailmoituksillaSuppeatTiedot(
           oppija = ValpasOppijaSuppeatTiedot(oppija),
           kuntailmoitukset = kuntailmoitukset
-            .filter(_.aktiivinen == haeAktiiviset)
             .map(ValpasKuntailmoitusSuppeatTiedot.apply)
         )
       }))

--- a/src/main/scala/fi/oph/koski/valpas/opiskeluoikeusrepository/ValpasRajapaivatService.scala
+++ b/src/main/scala/fi/oph/koski/valpas/opiskeluoikeusrepository/ValpasRajapaivatService.scala
@@ -24,8 +24,6 @@ trait ValpasRajapäivätService extends Logging {
 
   def keväänValmistumisjaksollaValmistuneidenViimeinenTarkastelupäivä: LocalDate
   def perusopetussuorituksenNäyttämisenAikaraja: LocalDate
-
-  def kuntailmoitusAktiivisuusKuukausina: Long
 }
 
 object ValpasRajapäivätService {
@@ -48,9 +46,6 @@ object ValpasRajapäivätService {
 
   val tulevaisuuteenMerkitynPerusopetuksenSuorituksenAikaikkunaPäivinäPath =
     "valpas.rajapäivät.tulevaisuuteenMerkitynPerusopetuksenSuorituksenAikaikkunaPäivinä"
-
-  val kuntailmoitusAktiivisuusKuukausina =
-    "valpas.rajapäivät.kuntailmoitusAktiivisuusKuukausina"
 
   def apply(config: Config) = {
     if (config.getBoolean(UseMockPath)) {
@@ -108,9 +103,6 @@ class MockValpasRajapäivätService(defaultService: ConfigValpasRajapäivätServ
 
   def perusopetussuorituksenNäyttämisenAikaraja: LocalDate =
     tarkastelupäivä.plusDays(defaultService.tulevaisuuteenMerkitynPerusopetuksenSuorituksenAikaikkunaPäivinä)
-
-  def kuntailmoitusAktiivisuusKuukausina: Long =
-    defaultService.kuntailmoitusAktiivisuusKuukausina
 }
 
 class ConfigValpasRajapäivätService(config: Config) extends ValpasRajapäivätService {
@@ -165,9 +157,6 @@ class ConfigValpasRajapäivätService(config: Config) extends ValpasRajapäivät
 
   val tulevaisuuteenMerkitynPerusopetuksenSuorituksenAikaikkunaPäivinä: Long =
     config.getLong(ValpasRajapäivätService.tulevaisuuteenMerkitynPerusopetuksenSuorituksenAikaikkunaPäivinäPath)
-
-  val kuntailmoitusAktiivisuusKuukausina: Long =
-    config.getLong(ValpasRajapäivätService.kuntailmoitusAktiivisuusKuukausina)
 }
 
 case class OletuksenaEdellinenVuosiKonfiguraattori(

--- a/src/test/scala/fi/oph/koski/valpas/ValpasKuntailmoitusApiServletSpec.scala
+++ b/src/test/scala/fi/oph/koski/valpas/ValpasKuntailmoitusApiServletSpec.scala
@@ -650,7 +650,7 @@ class ValpasKuntailmoitusApiServletSpec extends ValpasTestBase with BeforeAndAft
 
   "Oppijoiden hakeminen kuntailmoitus-apin kautta jättää auditlogimerkinnän" in {
     get(
-      uri = s"/valpas/api/kuntailmoitus/oppijat/${MockOrganisaatiot.helsinginKaupunki}/aktiiviset",
+      uri = s"/valpas/api/kuntailmoitus/oppijat/${MockOrganisaatiot.helsinginKaupunki}",
       headers = authHeaders(ValpasMockUsers.valpasHelsinki)
     ) {
       verifyResponseStatusOk()
@@ -666,7 +666,7 @@ class ValpasKuntailmoitusApiServletSpec extends ValpasTestBase with BeforeAndAft
 
   "Oppijoiden hakeminen kuntailmoitus-apin kautta väärästä organisaatiosta palauttaa virheen" in {
     get(
-      uri = s"/valpas/api/kuntailmoitus/oppijat/${MockOrganisaatiot.pyhtäänKunta}/aktiiviset",
+      uri = s"/valpas/api/kuntailmoitus/oppijat/${MockOrganisaatiot.pyhtäänKunta}",
       headers = authHeaders(ValpasMockUsers.valpasHelsinki)
     ) {
       verifyResponseStatus(
@@ -678,7 +678,7 @@ class ValpasKuntailmoitusApiServletSpec extends ValpasTestBase with BeforeAndAft
 
   "Oppijoiden hakeminen kuntailmoitus-apin kautta ilman kuntaoikeuksia palauttaa virheen" in {
     get(
-      uri = s"/valpas/api/kuntailmoitus/oppijat/${MockOrganisaatiot.helsinginKaupunki}/aktiiviset",
+      uri = s"/valpas/api/kuntailmoitus/oppijat/${MockOrganisaatiot.helsinginKaupunki}",
       headers = authHeaders(ValpasMockUsers.valpasHelsinkiPeruskoulu)
     ) {
       verifyResponseStatus(

--- a/src/test/scala/fi/oph/koski/valpas/ValpasOppijaServiceSpec.scala
+++ b/src/test/scala/fi/oph/koski/valpas/ValpasOppijaServiceSpec.scala
@@ -656,11 +656,11 @@ class ValpasOppijaServiceSpec extends ValpasOppijaServiceTestBase with BeforeAnd
     val expectedIlmoitukset = Seq(
       ValpasKuntailmoitusLaajatTiedotLisätiedoilla(
         täydennäAikaleimallaJaOrganisaatiotiedoilla(karsiPerustietoihin(ValpasExampleData.oppilaitoksenIlmoitusKaikillaTiedoillaAapajoenPeruskoulusta)),
-        true
+        aktiivinen = false
       ),
       ValpasKuntailmoitusLaajatTiedotLisätiedoilla(
         täydennäAikaleimallaJaOrganisaatiotiedoilla(ValpasExampleData.oppilaitoksenIlmoitusKaikillaTiedoilla),
-        false
+        aktiivinen = false
       )
     )
 
@@ -674,11 +674,11 @@ class ValpasOppijaServiceSpec extends ValpasOppijaServiceTestBase with BeforeAnd
     val expectedIlmoitukset = Seq(
       ValpasKuntailmoitusLaajatTiedotLisätiedoilla(
         täydennäAikaleimallaJaOrganisaatiotiedoilla(ValpasExampleData.oppilaitoksenIlmoitusKaikillaTiedoillaAapajoenPeruskoulusta),
-        true
+        aktiivinen = false
       ),
       ValpasKuntailmoitusLaajatTiedotLisätiedoilla(
         täydennäAikaleimallaJaOrganisaatiotiedoilla(karsiPerustietoihin(ValpasExampleData.oppilaitoksenIlmoitusKaikillaTiedoilla)),
-        false
+        aktiivinen = false
       )
     )
 
@@ -706,9 +706,9 @@ class ValpasOppijaServiceSpec extends ValpasOppijaServiceTestBase with BeforeAnd
     validateKuntailmoitukset(oppija, Seq(expectedIlmoitus))
   }
 
-  "kuntailmoitukset: aktiivinen jos on ilmoituksen tekemisen jälkeen alkanut ov-suorittamiseen kelpaava opiskeluoikeus ja on kulunut 2 kk tai alle" in {
+  "kuntailmoitukset: ei-aktiivinen jos on ilmoituksen tekemisen jälkeen alkanut ov-suorittamiseen kelpaava opiskeluoikeus" in {
     val ilmoituksenTekopäivä = date(2021,7,15)
-    val tarkastelupäivä = ilmoituksenTekopäivä.plusMonths(rajapäivätService.kuntailmoitusAktiivisuusKuukausina)
+    val tarkastelupäivä = date(2021, 8, 15)
 
     rajapäivätService.asInstanceOf[MockValpasRajapäivätService].asetaMockTarkastelupäivä(ilmoituksenTekopäivä)
     val ilmoitus = ValpasKuntailmoitusLaajatTiedotJaOppijaOid(
@@ -723,38 +723,15 @@ class ValpasOppijaServiceSpec extends ValpasOppijaServiceTestBase with BeforeAnd
 
     val expectedIlmoitus = ValpasKuntailmoitusLaajatTiedotLisätiedoilla(
       täydennäAikaleimallaJaOrganisaatiotiedoilla(ValpasExampleData.oppilaitoksenIlmoitusKaikillaTiedoilla, ilmoituksenTekopäivä.atStartOfDay),
-      true
+      aktiivinen = false
     )
 
     validateKuntailmoitukset(oppija, Seq(expectedIlmoitus))
   }
 
-  "kuntailmoitukset: ei-aktiivinen jos on ilmoituksen tekemisen jälkeen alkanut ov-suorittamiseen kelpaava opiskeluoikeus ja on kulunut yli 2 kk" in {
-    val ilmoituksenTekopäivä = date(2021,7,15)
-    val tarkastelupäivä = ilmoituksenTekopäivä.plusMonths(rajapäivätService.kuntailmoitusAktiivisuusKuukausina).plusDays(1)
-
-    rajapäivätService.asInstanceOf[MockValpasRajapäivätService].asetaMockTarkastelupäivä(ilmoituksenTekopäivä)
-    val ilmoitus = ValpasKuntailmoitusLaajatTiedotJaOppijaOid(
-      ValpasMockOppijat.lukionAloittanut.oid,
-      ValpasExampleData.oppilaitoksenIlmoitusKaikillaTiedoilla
-    )
-    kuntailmoitusRepository.create(ilmoitus, Seq.empty)
-
-    rajapäivätService.asInstanceOf[MockValpasRajapäivätService].asetaMockTarkastelupäivä(tarkastelupäivä)
-    val oppija = oppijaService.getOppijaLaajatTiedotYhteystiedoillaJaKuntailmoituksilla(ValpasMockOppijat.lukionAloittanut.oid)(defaultSession)
-      .toOption.get
-
-    val expectedIlmoitus = ValpasKuntailmoitusLaajatTiedotLisätiedoilla(
-      täydennäAikaleimallaJaOrganisaatiotiedoilla(ValpasExampleData.oppilaitoksenIlmoitusKaikillaTiedoilla, ilmoituksenTekopäivä.atStartOfDay),
-      false
-    )
-
-    validateKuntailmoitukset(oppija, Seq(expectedIlmoitus))
-  }
-
-  "kuntailmoitukset: aktiivinen, vaikka on yli 2 kk ilmoituksesta, mutta ei ole voimassaolevaa opiskeluoikeutta" in {
+  "kuntailmoitukset: aktiivinen, jos ei ole voimassaolevaa opiskeluoikeutta" in {
     val ilmoituksenTekopäivä = date(2021,6,10)
-    val tarkastelupäivä = ilmoituksenTekopäivä.plusMonths(rajapäivätService.kuntailmoitusAktiivisuusKuukausina).plusDays(10)
+    val tarkastelupäivä = ilmoituksenTekopäivä
 
     rajapäivätService.asInstanceOf[MockValpasRajapäivätService].asetaMockTarkastelupäivä(ilmoituksenTekopäivä)
     val ilmoitus = ValpasKuntailmoitusLaajatTiedotJaOppijaOid(
@@ -775,7 +752,7 @@ class ValpasOppijaServiceSpec extends ValpasOppijaServiceTestBase with BeforeAnd
 
   "kuntailmoitukset: aktiivinen, vaikka yli 2 kk ilmoituksesta, jos on ilmoituksen tekemisen jälkeen alkanut ov-suorittamiseen kelpaamaton opiskeluoikeus" in {
     val ilmoituksenTekopäivä = date(2021,6,10)
-    val tarkastelupäivä = ilmoituksenTekopäivä.plusMonths(rajapäivätService.kuntailmoitusAktiivisuusKuukausina).plusDays(10)
+    val tarkastelupäivä = ilmoituksenTekopäivä
 
     rajapäivätService.asInstanceOf[MockValpasRajapäivätService].asetaMockTarkastelupäivä(ilmoituksenTekopäivä)
     val ilmoitus = ValpasKuntailmoitusLaajatTiedotJaOppijaOid(

--- a/src/test/scala/fi/oph/koski/valpas/ValpasOppijaServiceSpec.scala
+++ b/src/test/scala/fi/oph/koski/valpas/ValpasOppijaServiceSpec.scala
@@ -1026,34 +1026,35 @@ class ValpasOppijaServiceSpec extends ValpasOppijaServiceTestBase with BeforeAnd
     ) shouldBe false
   }
 
-  "Kuntailmoitusten hakeminen kunnalle: palauttaa oikeat oppijat, case #1" in {
-    rajapäivätService.asInstanceOf[MockValpasRajapäivätService].asetaMockTarkastelupäivä(date(2021,8,30))
+  "Kuntailmoitukset" - {
+    "Kuntailmoitusten hakeminen kunnalle: palauttaa oikeat oppijat, case #1" in {
+      rajapäivätService.asInstanceOf[MockValpasRajapäivätService].asetaMockTarkastelupäivä(date(2021, 8, 30))
 
-    validateKunnanIlmoitetutOppijat(
-      organisaatioOid = MockOrganisaatiot.helsinginKaupunki,
-      aktiiviset = true,
-      user = ValpasMockUsers.valpasHelsinki
-    )(Seq(
-      ValpasMockOppijat.lukionAloittanutJaLopettanutJollaIlmoituksia
-    ))
-  }
+      validateKunnanIlmoitetutOppijat(
+        organisaatioOid = MockOrganisaatiot.helsinginKaupunki,
+        user = ValpasMockUsers.valpasHelsinki
+      )(Seq(
+        ValpasMockOppijat.lukionAloittanutJaLopettanutJollaIlmoituksia
+      ))
+    }
 
-  "Kuntailmoitusten hakeminen kunnalle: palauttaa oikeat oppijat, case #2" in {
-    rajapäivätService.asInstanceOf[MockValpasRajapäivätService].asetaMockTarkastelupäivä(date(2021,8,30))
+    "Kuntailmoitusten hakeminen kunnalle: palauttaa oikeat oppijat, case #2" in {
+      rajapäivätService.asInstanceOf[MockValpasRajapäivätService].asetaMockTarkastelupäivä(date(2021, 8, 30))
 
-    validateKunnanIlmoitetutOppijat(
-      organisaatioOid = MockOrganisaatiot.pyhtäänKunta,
-      aktiiviset = true,
-      user = ValpasMockUsers.valpasPyhtääJaAapajoenPeruskoulu
-    )(Seq(
-      ValpasMockOppijat.lukionAloittanutJaLopettanutJollaIlmoituksia,
-      ValpasMockOppijat.oppivelvollinenMonellaOppijaOidillaJollaIlmoitusMaster,
-      ValpasMockOppijat.oppivelvollinenMonellaOppijaOidillaJollaIlmoitusMaster2,
-      ValpasMockOppijat.kahdenKoulunYsiluokkalainenJollaIlmoitus,
-      ValpasMockOppijat.kasiinAstiToisessaKoulussaOllutJollaIlmoitus,
-      ValpasMockOppijat.valmistunutYsiluokkalainenJollaIlmoitus,
-      ValpasMockOppijat.ilmoituksenLisätiedotPoistettu,
-    ))
+      validateKunnanIlmoitetutOppijat(
+        organisaatioOid = MockOrganisaatiot.pyhtäänKunta,
+        user = ValpasMockUsers.valpasPyhtääJaAapajoenPeruskoulu
+      )(Seq(
+        ValpasMockOppijat.lukionAloittanutJaLopettanutJollaIlmoituksia,
+        ValpasMockOppijat.lukionAloittanutJollaVanhaIlmoitus,
+        ValpasMockOppijat.oppivelvollinenMonellaOppijaOidillaJollaIlmoitusMaster,
+        ValpasMockOppijat.oppivelvollinenMonellaOppijaOidillaJollaIlmoitusMaster2,
+        ValpasMockOppijat.kahdenKoulunYsiluokkalainenJollaIlmoitus,
+        ValpasMockOppijat.kasiinAstiToisessaKoulussaOllutJollaIlmoitus,
+        ValpasMockOppijat.valmistunutYsiluokkalainenJollaIlmoitus,
+        ValpasMockOppijat.ilmoituksenLisätiedotPoistettu,
+      ))
+    }
   }
 
   "Oppijalle, jonka kuntailmoituksista on poistettu lisätiedot, palautuu kuntailmoitukset vajailla tiedoilla" in {

--- a/src/test/scala/fi/oph/koski/valpas/ValpasOppijaServiceTestBase.scala
+++ b/src/test/scala/fi/oph/koski/valpas/ValpasOppijaServiceTestBase.scala
@@ -43,15 +43,14 @@ trait ValpasOppijaServiceTestBase extends ValpasTestBase {
 
   protected def validateKunnanIlmoitetutOppijat(
     organisaatioOid: Oid,
-    aktiiviset: Boolean,
     user: ValpasMockUser
   )(expectedOppijat: Seq[LaajatOppijaHenkilöTiedot]) = {
-    val result = getKunnanIlmoitetutOppijat(organisaatioOid, aktiiviset, user)
+    val result = getKunnanIlmoitetutOppijat(organisaatioOid, user)
     result.map(_.map(_.oppija.henkilö.oid).sorted) shouldBe Right(expectedOppijat.map(_.oid).sorted)
   }
 
-  private def getKunnanIlmoitetutOppijat(organisaatioOid: Oid, aktiiviset: Boolean, user: ValpasMockUser) = {
-    oppijaService.getKunnanOppijatSuppeatTiedot(organisaatioOid, aktiiviset)(session(user))
+  private def getKunnanIlmoitetutOppijat(organisaatioOid: Oid, user: ValpasMockUser) = {
+    oppijaService.getKunnanOppijatSuppeatTiedot(organisaatioOid)(session(user))
   }
 
   protected def canAccessOppijaYhteystiedoillaJaKuntailmoituksilla(oppija: LaajatOppijaHenkilöTiedot, user: ValpasMockUser): Boolean =

--- a/valpas-web/src/api/api.ts
+++ b/valpas-web/src/api/api.ts
@@ -272,7 +272,7 @@ export const createKuntailmoitus = (
 export const fetchKuntailmoitukset = (kuntaOid: Oid) =>
   handleExpiredSession(
     apiGet<OppijaKuntailmoituksillaSuppeatTiedot[]>(
-      `valpas/api/kuntailmoitus/oppijat/${kuntaOid}/aktiiviset`
+      `valpas/api/kuntailmoitus/oppijat/${kuntaOid}`
     )
   )
 

--- a/valpas-web/test/integrationtests/kuntailmoitus.shared.ts
+++ b/valpas-web/test/integrationtests/kuntailmoitus.shared.ts
@@ -86,10 +86,13 @@ export const pyhtääTableContent = `
 export const pyhtääTableContent_kaikkiIlmoitukset = `
   Ilmoituksen-lisätiedot–poistettu Valpas           | 5.9.2021  | 1.2.246.562.10.14613773812  | 19.5.2005   | –
   scheduleKahdella-oppija-oidilla-ilmo Valpas       | 5.9.2021  | Aapajoen koulu              | 4.6.2005    | doneJyväskylän normaalikoulu, Lukiokoulutus
+  scheduleKahdella-oppija-oidilla-ilmo Valpas       | 5.9.2021  | Jyväskylän normaalikoulu    | 4.6.2005    | doneJyväskylän normaalikoulu, Lukiokoulutus
   scheduleKahdella-oppija-oidilla-ilmo-2 Valpas     | 5.9.2021  | Jyväskylän normaalikoulu    | 3.6.2005    | doneJyväskylän normaalikoulu, Lukiokoulutus
   KahdenKoulunYsi-ilmo Valpas	                      | 5.9.2021  | Jyväskylän normaalikoulu    | 21.11.2004  | –
   KasiinAstiToisessaKoulussaOllut-ilmo Valpas	      | 5.9.2021  | Jyväskylän normaalikoulu    | 2.5.2005    | –
+  scheduleLukionAloittanut-ilmo Valpas              | 15.6.2021 | Jyväskylän normaalikoulu    | 11.4.2005   | doneJyväskylän normaalikoulu, Lukiokoulutus
   scheduleLukionAloittanutJaLopettanut-ilmo Valpas  | 20.9.2021 | Jyväskylän normaalikoulu    | 5.4.2005    | doneJyväskylän normaalikoulu, Lukiokoulutus
+  scheduleLukionAloittanutJaLopettanut-ilmo Valpas  | 15.6.2021 | Jyväskylän normaalikoulu    | 5.4.2005    | doneJyväskylän normaalikoulu, Lukiokoulutus
   Ysiluokka-valmis-keväällä-2021-ilmo Valpas        | 5.9.2021  | Jyväskylän normaalikoulu    | 26.8.2005   | –
 `
 

--- a/valpas-web/test/integrationtests/kuntailmoituslista.test.ts
+++ b/valpas-web/test/integrationtests/kuntailmoituslista.test.ts
@@ -58,7 +58,7 @@ describe("Kunnan listanäkymä", () => {
         kuntailmoitusPathWithOrg.href("/virkailija", helsinginKaupunkiOid)
       )
     )
-    await textEventuallyEquals(".card__header", ilmoitustitle(1, 0))
+    await textEventuallyEquals(".card__header", ilmoitustitle(1, 1))
     await dataTableEventuallyEquals(
       ".kuntailmoitus",
       hkiTableContent_20211201,
@@ -75,13 +75,13 @@ describe("Kunnan listanäkymä", () => {
         kuntailmoitusPathWithOrg.href("/virkailija", helsinginKaupunkiOid)
       )
     )
-    await textEventuallyEquals(".card__header", ilmoitustitle(0, 1))
+    await textEventuallyEquals(".card__header", ilmoitustitle(0, 2))
 
     await selectOrganisaatio(1)
     await urlIsEventually(
       pathToUrl(kuntailmoitusPathWithOrg.href("/virkailija", pyhtäänKuntaOid))
     )
-    await textEventuallyEquals(".card__header", ilmoitustitle(4, 3))
+    await textEventuallyEquals(".card__header", ilmoitustitle(4, 6))
   })
 
   it("Käyminen oppijakohtaisessa näkymässä ei hukkaa valittua organisaatiota", async () => {
@@ -131,7 +131,7 @@ describe("Kunnan listanäkymä", () => {
       pathToUrl(kuntailmoitusPathWithOrg.href("/virkailija", pyhtäänKuntaOid))
     )
 
-    await textEventuallyEquals(".card__header", ilmoitustitle(4, 3))
+    await textEventuallyEquals(".card__header", ilmoitustitle(4, 6))
     await dataTableEventuallyEquals(".kuntailmoitus", pyhtääTableContent, "|")
 
     await clickElement('[data-testid="arkistoidutcb"]')


### PR DESCRIPTION
Alunperin osa tikettiä TOR-1590, mutta irrotettu omaan pullariin talteen, koska tämä pitää miettiä vielä tarkemmin.
