### PR TITLE
TOR-xxxx: Lisää automaattisesti generoituva dokumentaatio Valpas-schemalle

### DIFF
--- a/src/main/scala/fi/oph/koski/documentation/DocumentationApiServlet.scala
+++ b/src/main/scala/fi/oph/koski/documentation/DocumentationApiServlet.scala
@@ -10,6 +10,7 @@ import fi.oph.koski.schema.KoskiSchema
 import fi.oph.koski.servlet.{KoskiSpecificApiServlet, NoCache}
 import fi.oph.koski.valvira.ValviraSchema
 import fi.oph.koski.valpas.kela.ValpasKelaSchema
+import fi.oph.koski.valpas.opiskeluoikeusrepository.ValpasInternalSchema
 
 import scala.reflect.runtime.{universe => ru}
 
@@ -51,6 +52,14 @@ class DocumentationApiServlet extends KoskiSpecificApiServlet with Unauthenticat
 
   get("/valpas-kela-oppija-schema.json") {
     ValpasKelaSchema.schemaJson
+  }
+
+  get("/valpas-internal-laaja-schema.json") {
+    ValpasInternalSchema.laajaSchemaJson
+  }
+
+  get("/valpas-internal-suppea-schema.json") {
+    ValpasInternalSchema.suppeaSchemaJson
   }
 
   get("/migri-oppija-schema.json") {

--- a/src/main/scala/fi/oph/koski/valpas/opiskeluoikeusrepository/ValpasOppija.scala
+++ b/src/main/scala/fi/oph/koski/valpas/opiskeluoikeusrepository/ValpasOppija.scala
@@ -2,11 +2,18 @@ package fi.oph.koski.valpas.opiskeluoikeusrepository
 
 import fi.oph.koski.koodisto.KoodistoViitePalvelu
 import fi.oph.koski.schema.annotation.KoodistoUri
-import fi.oph.koski.schema.{Koodistokoodiviite, LocalizedString, Maksuttomuus, OikeuttaMaksuttomuuteenPidennetty}
+import fi.oph.koski.schema.{Koodistokoodiviite, KoskiSchema, LocalizedString, Maksuttomuus, OikeuttaMaksuttomuuteenPidennetty}
 import fi.oph.koski.valpas.hakukooste.{Hakukooste, Hakutoive, Harkinnanvaraisuus, Valintatila, Vastaanottotieto}
 import fi.oph.scalaschema.annotation.SyntheticProperty
-
 import java.time.{LocalDate, LocalDateTime}
+
+import org.json4s.JValue
+import fi.oph.scalaschema.{AnyOfSchema, ClassSchema, SchemaToJson}
+
+object ValpasInternalSchema {
+  lazy val laajaSchemaJson: JValue = SchemaToJson.toJsonSchema(KoskiSchema.createSchema(classOf[ValpasOppijaLaajatTiedot]).asInstanceOf[ClassSchema])
+  lazy val suppeaSchemaJson: JValue = SchemaToJson.toJsonSchema(KoskiSchema.createSchema(classOf[ValpasOppijaSuppeatTiedot]).asInstanceOf[ClassSchema])
+}
 
 trait ValpasOppija {
   def henkilö: ValpasHenkilö


### PR DESCRIPTION
Ks. commit-viestit.

Tämän jälkeen schemaa pääsee tutkimaan visuaalisesti poluissa

https://virkailija.testiopintopolku.fi/koski/json-schema-viewer/?schema=valpas-internal-laaja-schema.json ja
https://virkailija.testiopintopolku.fi/koski/json-schema-viewer/?schema=valpas-internal-suppea-schema.json .