### PR TITLE
TOR-1622 - validaatio varhaiskasvatuksen toimipisteen vaihdosta

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -201,7 +201,6 @@ raportit = {
 
 # mock.casClient.usernameForAllVirkailijaTickets="tunnuksesi"
 validaatiot = {
-    oppilaitoksenMuutosValidaatioAstuuVoimaan = "2021-01-01"
     ammatillisenPerusteidenVoimassaoloTarkastusAstuuVoimaan = "2022-01-01"
 }
 

--- a/src/main/scala/fi/oph/koski/config/KoskiApplication.scala
+++ b/src/main/scala/fi/oph/koski/config/KoskiApplication.scala
@@ -85,8 +85,24 @@ class KoskiApplication(
   lazy val historyRepository = OpiskeluoikeusHistoryRepository(masterDatabase.db)
   lazy val virta = TimedProxy[AuxiliaryOpiskeluoikeusRepository](VirtaOpiskeluoikeusRepository(virtaClient, oppilaitosRepository, koodistoViitePalvelu, organisaatioRepository, virtaAccessChecker, Some(validator)))
   lazy val henkilöCache = new KoskiHenkilöCache(masterDatabase.db)
-  lazy val possu = TimedProxy[KoskiOpiskeluoikeusRepository](new PostgresOpiskeluoikeusRepository(masterDatabase.db, historyRepository, henkilöCache, oidGenerator, henkilöRepository.opintopolku, perustiedotSyncRepository, valpasRajapäivätService))
-  lazy val possuV2 = TimedProxy[KoskiOpiskeluoikeusRepository](new PostgresOpiskeluoikeusRepositoryV2(masterDatabase.db, historyRepository, henkilöCache, oidGenerator, henkilöRepository.opintopolku, perustiedotSyncRepository, valpasRajapäivätService))
+  lazy val possu = TimedProxy[KoskiOpiskeluoikeusRepository](new PostgresOpiskeluoikeusRepository(
+    masterDatabase.db,
+    historyRepository,
+    henkilöCache,
+    oidGenerator,
+    henkilöRepository.opintopolku,
+    perustiedotSyncRepository,
+    organisaatioRepository,
+    ePerusteet))
+  lazy val possuV2 = TimedProxy[KoskiOpiskeluoikeusRepository](new PostgresOpiskeluoikeusRepositoryV2(
+    masterDatabase.db,
+    historyRepository,
+    henkilöCache,
+    oidGenerator,
+    henkilöRepository.opintopolku,
+    perustiedotSyncRepository,
+    organisaatioRepository,
+    ePerusteet))
   lazy val ytr = TimedProxy[AuxiliaryOpiskeluoikeusRepository](YtrOpiskeluoikeusRepository(ytrRepository, organisaatioRepository, oppilaitosRepository, koodistoViitePalvelu, ytrAccessChecker, Some(validator), koskiLocalizationRepository))
   lazy val opiskeluoikeusRepository = new CompositeOpiskeluoikeusRepository(possu, virta, ytr)
   lazy val opiskeluoikeusRepositoryV2 = new CompositeOpiskeluoikeusRepository(possuV2, virta, ytr)

--- a/src/main/scala/fi/oph/koski/documentation/AmmatillinenExampleData.scala
+++ b/src/main/scala/fi/oph/koski/documentation/AmmatillinenExampleData.scala
@@ -152,8 +152,6 @@ object AmmatillinenExampleData {
   lazy val tutkintotoimikunta: Organisaatio = Tutkintotoimikunta("Autokorjaamoalan tutkintotoimikunta", "8406")
   lazy val lähdeWinnova = Koodistokoodiviite("winnova", Some("Winnova"), "lahdejarjestelma", Some(1))
   lazy val lähdePrimus = Koodistokoodiviite("primus", Some("Primus"), "lahdejarjestelma", Some(1))
-  lazy val winnovaLähdejärjestelmäId = LähdejärjestelmäId(Some("12345"), lähdeWinnova)
-  lazy val primusLähdejärjestelmäId = LähdejärjestelmäId(Some("12345"), lähdePrimus)
   lazy val arvosanaViisi = Koodistokoodiviite("5", Some("5"), "arviointiasteikkoammatillinen15", Some(1))
   lazy val arviointiViisi = Some(List(arviointi(arvosanaViisi)))
   lazy val hyväksytty: Koodistokoodiviite = Koodistokoodiviite("Hyväksytty", Some("Hyväksytty"), "arviointiasteikkoammatillinenhyvaksyttyhylatty", Some(1))
@@ -187,6 +185,9 @@ object AmmatillinenExampleData {
     vahvistus = vahvistusValinnaisellaTittelillä(date(2013, 5, 31), stadinAmmattiopisto),
     tutkinnonOsanRyhmä = ammatillisetTutkinnonOsat
   )
+
+  def winnovaLähdejärjestelmäId(ooId: String) = LähdejärjestelmäId(Some(ooId), lähdeWinnova)
+  def primusLähdejärjestelmäId(ooId: String) = LähdejärjestelmäId(Some(ooId), lähdePrimus)
 
   def autonLisävarustetyöt(pakollinen: Boolean, kuvaus: String = "Tuunaus") = MuuValtakunnallinenTutkinnonOsa(
     Koodistokoodiviite("100037", Some("Auton lisävarustetyöt"), "tutkinnonosat", Some(1)),

--- a/src/main/scala/fi/oph/koski/documentation/ExamplesAmmatillinen.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesAmmatillinen.scala
@@ -228,7 +228,7 @@ object AmmatillinenPerustutkintoExample {
     ))
   )
 
-  lazy val tunnustettuPaikallinenTutkinnonOsa = Oppija(exampleHenkilö, List(tunnustettuPaikallinenTutkinnonOsaOpiskeluoikeus))
+  lazy val tunnustettuPaikallinenTutkinnonOsa = Oppija(exampleHenkilö.copy(hetu = "250266-497T"), List(tunnustettuPaikallinenTutkinnonOsaOpiskeluoikeus))
 }
 
 object AmmatillinenReforminMukainenPerustutkintoExample {
@@ -335,7 +335,7 @@ object AmmatillinenReforminMukainenPerustutkintoExample {
   )
 
   lazy val example = Oppija(
-    exampleHenkilö,
+    exampleHenkilö.copy(hetu = "020882-577H"),
     List(opiskeluoikeus)
   )
 }
@@ -344,6 +344,7 @@ object AmmatillinenOldExamples {
   lazy val uusi: Oppija = oppija()
 
   lazy val oppisopimus = oppija(
+    henkilö = exampleHenkilö.copy(hetu = "160586-873P"),
     opiskeluoikeus = opiskeluoikeus(
       oppilaitos = stadinAmmattiopisto,
       tutkinto = AmmatillisenTutkinnonSuoritus(
@@ -363,9 +364,11 @@ object AmmatillinenOldExamples {
     )))
   )
 
-  lazy val paikallinen = oppija(opiskeluoikeus = opiskeluoikeus(
-    tutkinto = autoalanPerustutkinnonSuoritus().copy(suoritustapa = suoritustapaNäyttö),
-    osat = Some(List(paikallisenOsanSuoritus))
+  lazy val paikallinen = oppija(
+    henkilö = exampleHenkilö.copy(hetu = "170694-385F"),
+    opiskeluoikeus = opiskeluoikeus(
+      tutkinto = autoalanPerustutkinnonSuoritus().copy(suoritustapa = suoritustapaNäyttö),
+      osat = Some(List(paikallisenOsanSuoritus))
   ))
 
   lazy val mukautettu = oppija(opiskeluoikeus = opiskeluoikeus(
@@ -400,15 +403,17 @@ object AmmatillinenOldExamples {
     tutkinnonOsanRyhmä = yksilöllisestiLaajentavatTutkinnonOsat
   )
 
-  lazy val tutkinnonOsaToisestaTutkinnosta = oppija(opiskeluoikeus = opiskeluoikeus(
-    tutkinto = AmmatillisenTutkinnonSuoritus(
-      koulutusmoduuli = AmmatillinenTutkintoKoulutus(Koodistokoodiviite("351301", Some("Autoalan perustutkinto"), "koulutus", None), Some("39/011/2014")),
-      suoritustapa = suoritustapaNäyttö,
-      järjestämismuodot = None,
-      toimipiste = stadinToimipiste,
-      suorituskieli = suomenKieli
-    ),
-    osat = Some(List(muunAmmatillisenTutkinnonOsanSuoritus))
+  lazy val tutkinnonOsaToisestaTutkinnosta = oppija(
+    henkilö = exampleHenkilö.copy(hetu = "240550-475R"),
+    opiskeluoikeus = opiskeluoikeus(
+      tutkinto = AmmatillisenTutkinnonSuoritus(
+        koulutusmoduuli = AmmatillinenTutkintoKoulutus(Koodistokoodiviite("351301", Some("Autoalan perustutkinto"), "koulutus", None), Some("39/011/2014")),
+        suoritustapa = suoritustapaNäyttö,
+        järjestämismuodot = None,
+        toimipiste = stadinToimipiste,
+        suorituskieli = suomenKieli
+      ),
+      osat = Some(List(muunAmmatillisenTutkinnonOsanSuoritus))
   ))
 
   lazy val ops = Oppija(
@@ -472,7 +477,7 @@ object AmmatillinenOldExamples {
       )))
 
   lazy val full = Oppija(
-    Henkilö.withOid("1.2.246.562.24.00000000001"),
+    Henkilö.withOid("1.2.246.562.24.00000000010"),
     List(
       AmmatillinenOpiskeluoikeus(
         arvioituPäättymispäivä = Some(date(2015, 5, 31)),

--- a/src/main/scala/fi/oph/koski/fixture/KoskiSpecificDatabaseFixtureCreator.scala
+++ b/src/main/scala/fi/oph/koski/fixture/KoskiSpecificDatabaseFixtureCreator.scala
@@ -210,7 +210,7 @@ object AmmatillinenOpiskeluoikeusTestData {
   }
 
   lazy val lähdejärjestelmällinenOpiskeluoikeus: AmmatillinenOpiskeluoikeus =
-    opiskeluoikeus(MockOrganisaatiot.stadinAmmattiopisto).copy(lähdejärjestelmänId = Some(AmmatillinenExampleData.winnovaLähdejärjestelmäId))
+    opiskeluoikeus(MockOrganisaatiot.stadinAmmattiopisto).copy(lähdejärjestelmänId = Some(AmmatillinenExampleData.winnovaLähdejärjestelmäId("l-050504")))
 
   lazy val mitätöityOpiskeluoikeus: AmmatillinenOpiskeluoikeus = {
     val baseOo = opiskeluoikeus(MockOrganisaatiot.stadinAmmattiopisto)
@@ -224,7 +224,7 @@ object AmmatillinenOpiskeluoikeusTestData {
 object PerusopetuksenOpiskeluoikeusTestData {
   lazy val lähdejärjestelmällinenOpiskeluoikeus: PerusopetuksenOpiskeluoikeus =
     PerusopetusExampleData.päättötodistusOpiskeluoikeus(oppilaitos = Oppilaitos(MockOrganisaatiot.stadinAmmattiopisto, None, None)).copy(
-      lähdejärjestelmänId = Some(AmmatillinenExampleData.primusLähdejärjestelmäId)
+      lähdejärjestelmänId = Some(AmmatillinenExampleData.primusLähdejärjestelmäId("l-0303032"))
     )
 
   lazy val mitätöityOpiskeluoikeus: PerusopetuksenOpiskeluoikeus =

--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/KoskiOpiskeluoikeusRepository.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/KoskiOpiskeluoikeusRepository.scala
@@ -12,7 +12,6 @@ import org.json4s.JValue
 
 trait KoskiOpiskeluoikeusRepository {
   def findByOid(oid: String)(implicit user: KoskiSpecificSession): Either[HttpStatus, OpiskeluoikeusRow]
-  def findByLähdejärjestelmäId(id: LähdejärjestelmäId)(implicit user: KoskiSpecificSession): Either[HttpStatus, OpiskeluoikeusRow]
   def getOppijaOidsForOpiskeluoikeus(opiskeluoikeusOid: String)(implicit user: KoskiSpecificSession): Either[HttpStatus, List[Henkilö.Oid]]
   def createOrUpdate(
     oppijaOid: PossiblyUnverifiedHenkilöOid,

--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/KoskiOpiskeluoikeusRepository.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/KoskiOpiskeluoikeusRepository.scala
@@ -12,6 +12,7 @@ import org.json4s.JValue
 
 trait KoskiOpiskeluoikeusRepository {
   def findByOid(oid: String)(implicit user: KoskiSpecificSession): Either[HttpStatus, OpiskeluoikeusRow]
+  def findByLähdejärjestelmäId(id: LähdejärjestelmäId)(implicit user: KoskiSpecificSession): Either[HttpStatus, OpiskeluoikeusRow]
   def getOppijaOidsForOpiskeluoikeus(opiskeluoikeusOid: String)(implicit user: KoskiSpecificSession): Either[HttpStatus, List[Henkilö.Oid]]
   def createOrUpdate(
     oppijaOid: PossiblyUnverifiedHenkilöOid,

--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/OpiskeluoikeusChangeValidator.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/OpiskeluoikeusChangeValidator.scala
@@ -1,14 +1,48 @@
 package fi.oph.koski.opiskeluoikeus
 
+import fi.oph.koski.eperusteet.EPerusteetRepository
 import fi.oph.koski.http.{HttpStatus, KoskiErrorCategory}
+import fi.oph.koski.organisaatio.OrganisaatioRepository
 import fi.oph.koski.schema.KoskeenTallennettavaOpiskeluoikeus
+import fi.oph.koski.validation.AmmatillinenValidation.validateVanhanOpiskeluoikeudenTapaukset
 
-object OpiskeluoikeusChangeValidator {
+class OpiskeluoikeusChangeValidator(organisaatioRepository: OrganisaatioRepository, ePerusteet: EPerusteetRepository) {
   def validateOpiskeluoikeusChange(oldState: KoskeenTallennettavaOpiskeluoikeus, newState: KoskeenTallennettavaOpiskeluoikeus): HttpStatus = {
+    HttpStatus.fold(
+      validateOpiskeluoikeudenTyypinMuutos(oldState, newState),
+      validateLähdejärjestelmäIdnPoisto(oldState, newState),
+      validateOppilaitoksenMuutos(oldState, newState),
+      validateVanhanOpiskeluoikeudenTapaukset(oldState, newState, ePerusteet)
+    )
+  }
+
+  def validateOpiskeluoikeudenTyypinMuutos(oldState: KoskeenTallennettavaOpiskeluoikeus, newState: KoskeenTallennettavaOpiskeluoikeus): HttpStatus = {
     if (oldState.tyyppi.koodiarvo != newState.tyyppi.koodiarvo) {
       KoskiErrorCategory.forbidden.kiellettyMuutos(s"Opiskeluoikeuden tyyppiä ei voi vaihtaa. Vanha tyyppi ${oldState.tyyppi.koodiarvo}. Uusi tyyppi ${newState.tyyppi.koodiarvo}.")
-    } else if (oldState.lähdejärjestelmänId.isDefined && newState.lähdejärjestelmänId.isEmpty) {
+    } else {
+      HttpStatus.ok
+    }
+  }
+
+  def validateLähdejärjestelmäIdnPoisto(oldState: KoskeenTallennettavaOpiskeluoikeus, newState: KoskeenTallennettavaOpiskeluoikeus): HttpStatus = {
+    if (oldState.lähdejärjestelmänId.isDefined && newState.lähdejärjestelmänId.isEmpty) {
       KoskiErrorCategory.forbidden.kiellettyMuutos("Opiskeluoikeuden lähdejärjestelmäId:tä ei voi poistaa.")
+    } else {
+      HttpStatus.ok
+    }
+  }
+
+  private def validateOppilaitoksenMuutos(vanhaOpiskeluoikeus: KoskeenTallennettavaOpiskeluoikeus, uusiOpiskeluoikeus: KoskeenTallennettavaOpiskeluoikeus): HttpStatus = {
+    val uusiOppilaitos = uusiOpiskeluoikeus.oppilaitos.map(_.oid)
+    val vanhaOppilaitos = vanhaOpiskeluoikeus.oppilaitos.map(_.oid)
+    val koulutustoimijaPysynytSamana = uusiOpiskeluoikeus.koulutustoimija.map(_.oid).exists(uusiOid => vanhaOpiskeluoikeus.koulutustoimija.map(_.oid).contains(uusiOid))
+    val vanhaAktiivinen = vanhaOppilaitos.flatMap(oid => organisaatioRepository.getOrganisaatioHierarkia(oid).map(_.aktiivinen)).getOrElse(false)
+    val uusiAktiivinen = uusiOppilaitos.flatMap(oid => organisaatioRepository.getOrganisaatioHierarkia(oid).map(_.aktiivinen)).getOrElse(false)
+    val uusiOrganisaatioLöytyyOrganisaatioHistoriasta = vanhaOpiskeluoikeus.organisaatiohistoria.exists(_.exists(_.oppilaitos.exists(x => uusiOppilaitos.contains(x.oid))))
+    val oppilaitoksenVaihtoSallittu = uusiOrganisaatioLöytyyOrganisaatioHistoriasta || (!vanhaAktiivinen && uusiAktiivinen)
+
+    if (koulutustoimijaPysynytSamana && uusiOppilaitos != vanhaOppilaitos) {
+      HttpStatus.validate(oppilaitoksenVaihtoSallittu) { KoskiErrorCategory.badRequest.validation.organisaatio.oppilaitoksenVaihto()}
     } else {
       HttpStatus.ok
     }

--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/OpiskeluoikeusChangeValidator.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/OpiskeluoikeusChangeValidator.scala
@@ -4,7 +4,7 @@ import fi.oph.koski.eperusteet.EPerusteetRepository
 import fi.oph.koski.http.{HttpStatus, KoskiErrorCategory}
 import fi.oph.koski.organisaatio.OrganisaatioRepository
 import fi.oph.koski.schema.KoskeenTallennettavaOpiskeluoikeus
-import fi.oph.koski.validation.AmmatillinenValidation.validateVanhanOpiskeluoikeudenTapaukset
+import fi.oph.koski.validation.AmmatillinenValidation
 
 class OpiskeluoikeusChangeValidator(organisaatioRepository: OrganisaatioRepository, ePerusteet: EPerusteetRepository) {
   def validateOpiskeluoikeusChange(oldState: KoskeenTallennettavaOpiskeluoikeus, newState: KoskeenTallennettavaOpiskeluoikeus): HttpStatus = {
@@ -12,7 +12,7 @@ class OpiskeluoikeusChangeValidator(organisaatioRepository: OrganisaatioReposito
       validateOpiskeluoikeudenTyypinMuutos(oldState, newState),
       validateLähdejärjestelmäIdnPoisto(oldState, newState),
       validateOppilaitoksenMuutos(oldState, newState),
-      validateVanhanOpiskeluoikeudenTapaukset(oldState, newState, ePerusteet)
+      AmmatillinenValidation.validateVanhanOpiskeluoikeudenTapaukset(oldState, newState, ePerusteet)
     )
   }
 

--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/PostgresOpiskeluoikeusRepository.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/PostgresOpiskeluoikeusRepository.scala
@@ -75,10 +75,13 @@ class PostgresOpiskeluoikeusRepository(
   }
 
   override def findByLähdejärjestelmäId(id: LähdejärjestelmäId)(implicit user: KoskiSpecificSession): Either[HttpStatus, OpiskeluoikeusRow] = {
-    withExistenceCheck(runDbSync(OpiskeluOikeudetWithAccessCheck.filter(v => {
-      v.data.+>("lähdejärjestelmänId")+>>"id" === id.id.getOrElse("") &&
-      v.data.+>("lähdejärjestelmänId")+>"lähdejärjestelmä"+>>"koodiarvo" === id.lähdejärjestelmä.koodiarvo}
-    ).result))
+    id.id match {
+      case Some(ooIdLähdejärjestelmässä) => withExistenceCheck(runDbSync(OpiskeluOikeudetWithAccessCheck.filter(v => {
+          v.data.+>("lähdejärjestelmänId")+>>"id" === ooIdLähdejärjestelmässä &&
+          v.data.+>("lähdejärjestelmänId")+>"lähdejärjestelmä"+>>"koodiarvo" === id.lähdejärjestelmä.koodiarvo}
+      ).result))
+      case None => Left(KoskiErrorCategory.notFound.opiskeluoikeuttaEiLöydyTaiEiOikeuksia())
+    }
   }
 
   override def getOppijaOidsForOpiskeluoikeus(opiskeluoikeusOid: String)(implicit user: KoskiSpecificSession): Either[HttpStatus, List[Oid]] = withOidCheck(opiskeluoikeusOid) {

--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/PostgresOpiskeluoikeusRepository.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/PostgresOpiskeluoikeusRepository.scala
@@ -74,6 +74,13 @@ class PostgresOpiskeluoikeusRepository(
     withExistenceCheck(runDbSync(OpiskeluOikeudetWithAccessCheck.filter(_.oid === oid).result))
   }
 
+  override def findByLähdejärjestelmäId(id: LähdejärjestelmäId)(implicit user: KoskiSpecificSession): Either[HttpStatus, OpiskeluoikeusRow] = {
+    withExistenceCheck(runDbSync(OpiskeluOikeudetWithAccessCheck.filter(v => {
+      v.data.+>("lähdejärjestelmänId")+>>"id" === id.id.getOrElse("") &&
+      v.data.+>("lähdejärjestelmänId")+>"lähdejärjestelmä"+>>"koodiarvo" === id.lähdejärjestelmä.koodiarvo}
+    ).result))
+  }
+
   override def getOppijaOidsForOpiskeluoikeus(opiskeluoikeusOid: String)(implicit user: KoskiSpecificSession): Either[HttpStatus, List[Oid]] = withOidCheck(opiskeluoikeusOid) {
     withExistenceCheck(runDbSync(OpiskeluOikeudetWithAccessCheck
       .filter(_.oid === opiskeluoikeusOid)

--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/PostgresOpiskeluoikeusRepositoryV2.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/PostgresOpiskeluoikeusRepositoryV2.scala
@@ -2,13 +2,14 @@ package fi.oph.koski.opiskeluoikeus
 
 import fi.oph.koski.db.DB
 import fi.oph.koski.db._
+import fi.oph.koski.eperusteet.EPerusteetRepository
 import fi.oph.koski.henkilo._
 import fi.oph.koski.history.OpiskeluoikeusHistoryRepository
 import fi.oph.koski.http.HttpStatus
 import fi.oph.koski.koskiuser.KoskiSpecificSession
+import fi.oph.koski.organisaatio.OrganisaatioRepository
 import fi.oph.koski.perustiedot.PerustiedotSyncRepository
 import fi.oph.koski.schema.{AmmatillinenOpiskeluoikeus, KoskeenTallennettavaOpiskeluoikeus, MuunAmmatillisenKoulutuksenSuoritus}
-import fi.oph.koski.valpas.opiskeluoikeusrepository.ValpasRajapäivätService
 import slick.dbio
 import slick.dbio.Effect.{Read, Transactional, Write}
 import slick.dbio.NoStream
@@ -19,14 +20,16 @@ class PostgresOpiskeluoikeusRepositoryV2(override val db: DB,
                                          oidGenerator: OidGenerator,
                                          henkilöRepository: OpintopolkuHenkilöRepository,
                                          perustiedotSyncRepository: PerustiedotSyncRepository,
-                                         valpasRajapäivätService: ValpasRajapäivätService)
+                                         organisaatioRepository: OrganisaatioRepository,
+                                         ePerusteet: EPerusteetRepository)
   extends PostgresOpiskeluoikeusRepository(db,
     historyRepository,
     henkilöCache,
     oidGenerator,
     henkilöRepository,
     perustiedotSyncRepository,
-    valpasRajapäivätService) {
+    organisaatioRepository,
+    ePerusteet) {
 
   override protected def createOrUpdateActionBasedOnDbResult(oppijaOid: PossiblyUnverifiedHenkilöOid,
                                                              opiskeluoikeus: KoskeenTallennettavaOpiskeluoikeus,

--- a/src/main/scala/fi/oph/koski/schema/Opiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/schema/Opiskeluoikeus.scala
@@ -83,6 +83,9 @@ trait Opiskeluoikeus extends Lähdejärjestelmällinen with OrganisaatioonLiitty
   def withSuoritukset(suoritukset: List[PäätasonSuoritus]): Opiskeluoikeus = {
     shapeless.lens[Opiskeluoikeus].field[List[PäätasonSuoritus]]("suoritukset").set(this)(suoritukset)
   }
+  def aktiivinen = {
+    !tila.opiskeluoikeusjaksot.exists(_.opiskeluoikeusPäättynyt)
+  }
 }
 
 object OpiskeluoikeudenTyyppi {

--- a/src/main/scala/fi/oph/koski/tiedonsiirto/ExamplesTiedonsiirto.scala
+++ b/src/main/scala/fi/oph/koski/tiedonsiirto/ExamplesTiedonsiirto.scala
@@ -5,14 +5,14 @@ import fi.oph.koski.documentation.{AmmatillinenExampleData, AmmatillinenPerustut
 import fi.oph.koski.henkilo.{KoskiSpecificMockOppijat, LaajatOppijaHenkilöTiedot}
 import fi.oph.koski.henkilo.MockOppijat.asUusiOppija
 import fi.oph.koski.organisaatio.MockOrganisaatiot
-import fi.oph.koski.schema.{AmmatillinenOpiskeluoikeus, Oppija, Oppilaitos, TäydellisetHenkilötiedot}
+import fi.oph.koski.schema.{AmmatillinenOpiskeluoikeus, LähdejärjestelmäId, Oppija, Oppilaitos, TäydellisetHenkilötiedot}
 
 object ExamplesTiedonsiirto {
   val opiskeluoikeus: AmmatillinenOpiskeluoikeus = AmmatillinenExampleData.opiskeluoikeus().copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId))
   val failingOpiskeluoikeus: AmmatillinenOpiskeluoikeus = opiskeluoikeus.copy(oppilaitos = Some(Oppilaitos(MockOrganisaatiot.aaltoYliopisto)))
   val epävalidiHenkilö: LaajatOppijaHenkilöTiedot = KoskiSpecificMockOppijat.tiedonsiirto.copy(hetu = Some("epävalidiHetu"))
   val failingTutkinnonosaOpiskeluoikeus: AmmatillinenOpiskeluoikeus = AmmatillinenPerustutkintoExample.osittainenPerustutkintoOpiskeluoikeus.copy(
-    lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId)
+    lähdejärjestelmänId = Some(LähdejärjestelmäId(Some("75489301"), lähdeWinnova))
   )
 
   val examples: List[Example] = List(

--- a/src/main/scala/fi/oph/koski/tiedonsiirto/ExamplesTiedonsiirto.scala
+++ b/src/main/scala/fi/oph/koski/tiedonsiirto/ExamplesTiedonsiirto.scala
@@ -8,7 +8,7 @@ import fi.oph.koski.organisaatio.MockOrganisaatiot
 import fi.oph.koski.schema.{AmmatillinenOpiskeluoikeus, LähdejärjestelmäId, Oppija, Oppilaitos, TäydellisetHenkilötiedot}
 
 object ExamplesTiedonsiirto {
-  val opiskeluoikeus: AmmatillinenOpiskeluoikeus = AmmatillinenExampleData.opiskeluoikeus().copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId))
+  val opiskeluoikeus: AmmatillinenOpiskeluoikeus = AmmatillinenExampleData.opiskeluoikeus().copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId("l-244032")))
   val failingOpiskeluoikeus: AmmatillinenOpiskeluoikeus = opiskeluoikeus.copy(oppilaitos = Some(Oppilaitos(MockOrganisaatiot.aaltoYliopisto)))
   val epävalidiHenkilö: LaajatOppijaHenkilöTiedot = KoskiSpecificMockOppijat.tiedonsiirto.copy(hetu = Some("epävalidiHetu"))
   val failingTutkinnonosaOpiskeluoikeus: AmmatillinenOpiskeluoikeus = AmmatillinenPerustutkintoExample.osittainenPerustutkintoOpiskeluoikeus.copy(

--- a/src/main/scala/fi/oph/koski/validation/AmmatillinenValidation.scala
+++ b/src/main/scala/fi/oph/koski/validation/AmmatillinenValidation.scala
@@ -24,12 +24,7 @@ object AmmatillinenValidation {
   private def validateUseaPäätasonSuoritus(opiskeluoikeus: AmmatillinenOpiskeluoikeus): HttpStatus = {
     opiskeluoikeus.suoritukset.length match {
       case 1 => HttpStatus.ok
-      case 2 =>
-        if (näyttötutkintoJaNäyttöönValmistavaLöytyvät(opiskeluoikeus)) {
-          HttpStatus.ok
-        } else {
-          KoskiErrorCategory.badRequest.validation.ammatillinen.useampiPäätasonSuoritus()
-        }
+      case 2 if näyttötutkintoJaNäyttöönValmistavaLöytyvät(opiskeluoikeus) => HttpStatus.ok
       case _ => KoskiErrorCategory.badRequest.validation.ammatillinen.useampiPäätasonSuoritus()
     }
   }
@@ -41,12 +36,6 @@ object AmmatillinenValidation {
     } && opiskeluoikeus.suoritukset.exists {
       case _: NäyttötutkintoonValmistavanKoulutuksenSuoritus => true
       case _ => false
-    }
-  }
-
-  private def suoritustavat(oo: AmmatillinenOpiskeluoikeus): List[String] = {
-    oo.suoritukset.collect {
-      case osittainenTaiKokonainen: AmmatillisenTutkinnonOsittainenTaiKokoSuoritus => osittainenTaiKokonainen.suoritustapa.koodiarvo
     }
   }
 
@@ -118,5 +107,11 @@ object AmmatillinenValidation {
         case _ => true
       }
     ).map(_.koulutusmoduuli.tunniste.koodiarvo)
+  }
+
+  private def suoritustavat(oo: AmmatillinenOpiskeluoikeus): List[String] = {
+    oo.suoritukset.collect {
+      case osittainenTaiKokonainen: AmmatillisenTutkinnonOsittainenTaiKokoSuoritus => osittainenTaiKokonainen.suoritustapa.koodiarvo
+    }
   }
 }

--- a/src/main/scala/fi/oph/koski/validation/AmmatillinenValidation.scala
+++ b/src/main/scala/fi/oph/koski/validation/AmmatillinenValidation.scala
@@ -41,8 +41,9 @@ object AmmatillinenValidation {
 
   private def validatePerusteVoimassa(opiskeluoikeus: AmmatillinenOpiskeluoikeus, ePerusteet: EPerusteetRepository, config: Config): HttpStatus = {
     val validaatioViimeinenPäiväEnnenVoimassaoloa = LocalDate.parse(config.getString("validaatiot.ammatillisenPerusteidenVoimassaoloTarkastusAstuuVoimaan")).minusDays(1)
+    val voimassaolotarkastusAstunutVoimaan = LocalDate.now().isAfter(validaatioViimeinenPäiväEnnenVoimassaoloa)
 
-    if (!opiskeluoikeus.tila.opiskeluoikeusjaksot.exists(_.opiskeluoikeusPäättynyt) && LocalDate.now().isAfter(validaatioViimeinenPäiväEnnenVoimassaoloa)) {
+    if (opiskeluoikeus.aktiivinen && voimassaolotarkastusAstunutVoimaan) {
       opiskeluoikeus.suoritukset.head.koulutusmoduuli match {
         case diaarillinen: DiaarinumerollinenKoulutus if diaarillinen.perusteenDiaarinumero.isDefined =>
           ePerusteet.findUusinRakenne(diaarillinen.perusteenDiaarinumero.get) match {

--- a/src/main/scala/fi/oph/koski/validation/AmmatillinenValidation.scala
+++ b/src/main/scala/fi/oph/koski/validation/AmmatillinenValidation.scala
@@ -9,26 +9,14 @@ import com.typesafe.config.Config
 
 object AmmatillinenValidation {
   def validateAmmatillinenOpiskeluoikeus(opiskeluoikeus: KoskeenTallennettavaOpiskeluoikeus,
-                                         vanhaOpiskeluoikeus: Option[KoskeenTallennettavaOpiskeluoikeus],
                                          ePerusteet: EPerusteetRepository,
                                          config: Config): HttpStatus = {
     opiskeluoikeus match {
       case ammatillinen: AmmatillinenOpiskeluoikeus =>
         HttpStatus.fold(
           validatePerusteVoimassa(ammatillinen, ePerusteet, config),
-          validateUseaPäätasonSuoritus(ammatillinen),
-          validateVanhanOpiskeluoikeudenTapaukset(ammatillinen, vanhaOpiskeluoikeus, ePerusteet)
+          validateUseaPäätasonSuoritus(ammatillinen)
         )
-      case _ => HttpStatus.ok
-    }
-  }
-
-  private def validateVanhanOpiskeluoikeudenTapaukset(opiskeluoikeus: AmmatillinenOpiskeluoikeus,
-                                                      vanhaOpiskeluoikeus: Option[KoskeenTallennettavaOpiskeluoikeus],
-                                                      ePerusteet: EPerusteetRepository): HttpStatus = {
-    vanhaOpiskeluoikeus match {
-      case Some(vanha: AmmatillinenOpiskeluoikeus) =>
-        validateTutkintokoodinTaiSuoritustavanMuutos(opiskeluoikeus, vanha, ePerusteet)
       case _ => HttpStatus.ok
     }
   }
@@ -54,46 +42,10 @@ object AmmatillinenValidation {
     }
   }
 
-  private def validateTutkintokoodinTaiSuoritustavanMuutos(uusiOpiskeluoikeus: AmmatillinenOpiskeluoikeus,
-                                                           vanhaOpiskeluoikeus: AmmatillinenOpiskeluoikeus,
-                                                           ePerusteet: EPerusteetRepository): HttpStatus = {
-    val vanhanSuoritustavat = suoritustavat(vanhaOpiskeluoikeus)
-    val uudenSuoritustavat = suoritustavat(uusiOpiskeluoikeus)
-
-    val vanhanTutkintokoodit = tutkintokooditPoislukienPerusteestaLöytymättömät(vanhaOpiskeluoikeus, ePerusteet)
-    val uudenTutkintokoodit = tutkintokooditPoislukienPerusteestaLöytymättömät(uusiOpiskeluoikeus, ePerusteet)
-
-    // Pieni oikominen; jos tutkintokoodeja olisi kolmesta tai useammasta päätason suorituksesta, tämä ei välttämättä
-    // nappaisi kaikkia muutoksia. Mutta päätason suorituksia ei pitäisi voida olla kahta enempää, eikä samantyyppisiä
-    // päätason suorituksia yhtä enempää.
-    val suoritustapaLöytyy = vanhanSuoritustavat.count(tapa => uudenSuoritustavat.contains(tapa)) == vanhanSuoritustavat.length
-    val tutkintokoodiLöytyy = vanhanTutkintokoodit.count(koodi => uudenTutkintokoodit.contains(koodi)) == vanhanTutkintokoodit.length
-
-    if (suoritustapaLöytyy && tutkintokoodiLöytyy) {
-      HttpStatus.ok
-    } else {
-      KoskiErrorCategory.badRequest.validation.ammatillinen.muutettuSuoritustapaaTaiTutkintokoodia()
-    }
-  }
-
   private def suoritustavat(oo: AmmatillinenOpiskeluoikeus): List[String] = {
     oo.suoritukset.collect {
       case osittainenTaiKokonainen: AmmatillisenTutkinnonOsittainenTaiKokoSuoritus => osittainenTaiKokonainen.suoritustapa.koodiarvo
     }
-  }
-
-  private def tutkintokooditPoislukienPerusteestaLöytymättömät(oo: AmmatillinenOpiskeluoikeus, ePerusteet: EPerusteetRepository): List[String] = {
-    oo.suoritukset.filter(suoritus =>
-      suoritus.koulutusmoduuli match {
-        case diaarillinen: DiaarinumerollinenKoulutus =>
-          diaarillinen.perusteenDiaarinumero.flatMap(diaari => ePerusteet.findRakenne(diaari)) match {
-            case Some(rakenne) =>
-              rakenne.koulutukset.exists(_.koulutuskoodiArvo == diaarillinen.tunniste.koodiarvo)
-            case _ => true
-          }
-        case _ => true
-      }
-    ).map(_.koulutusmoduuli.tunniste.koodiarvo)
   }
 
   private def validatePerusteVoimassa(opiskeluoikeus: AmmatillinenOpiskeluoikeus, ePerusteet: EPerusteetRepository, config: Config): HttpStatus = {
@@ -116,5 +68,51 @@ object AmmatillinenValidation {
     } else {
       HttpStatus.ok
     }
+  }
+
+  def validateVanhanOpiskeluoikeudenTapaukset(vanhaOpiskeluoikeus: KoskeenTallennettavaOpiskeluoikeus,
+                                                      uusiOpiskeluoikeus: KoskeenTallennettavaOpiskeluoikeus,
+                                                      ePerusteet: EPerusteetRepository): HttpStatus = {
+    (vanhaOpiskeluoikeus, uusiOpiskeluoikeus) match {
+      case (vanha: AmmatillinenOpiskeluoikeus, uusi: AmmatillinenOpiskeluoikeus) =>
+        validateTutkintokoodinTaiSuoritustavanMuutos(vanha, uusi, ePerusteet)
+      case _ => HttpStatus.ok
+    }
+  }
+
+  private def validateTutkintokoodinTaiSuoritustavanMuutos(vanhaOpiskeluoikeus: AmmatillinenOpiskeluoikeus,
+                                                           uusiOpiskeluoikeus: AmmatillinenOpiskeluoikeus,
+                                                           ePerusteet: EPerusteetRepository): HttpStatus = {
+    val vanhanSuoritustavat = suoritustavat(vanhaOpiskeluoikeus)
+    val uudenSuoritustavat = suoritustavat(uusiOpiskeluoikeus)
+
+    val vanhanTutkintokoodit = tutkintokooditPoislukienPerusteestaLöytymättömät(vanhaOpiskeluoikeus, ePerusteet)
+    val uudenTutkintokoodit = tutkintokooditPoislukienPerusteestaLöytymättömät(uusiOpiskeluoikeus, ePerusteet)
+
+    // Pieni oikominen; jos tutkintokoodeja olisi kolmesta tai useammasta päätason suorituksesta, tämä ei välttämättä
+    // nappaisi kaikkia muutoksia. Mutta päätason suorituksia ei pitäisi voida olla kahta enempää, eikä samantyyppisiä
+    // päätason suorituksia yhtä enempää.
+    val suoritustapaLöytyy = vanhanSuoritustavat.count(tapa => uudenSuoritustavat.contains(tapa)) == vanhanSuoritustavat.length
+    val tutkintokoodiLöytyy = vanhanTutkintokoodit.count(koodi => uudenTutkintokoodit.contains(koodi)) == vanhanTutkintokoodit.length
+
+    if (suoritustapaLöytyy && tutkintokoodiLöytyy) {
+      HttpStatus.ok
+    } else {
+      KoskiErrorCategory.badRequest.validation.ammatillinen.muutettuSuoritustapaaTaiTutkintokoodia()
+    }
+  }
+
+  private def tutkintokooditPoislukienPerusteestaLöytymättömät(oo: AmmatillinenOpiskeluoikeus, ePerusteet: EPerusteetRepository): List[String] = {
+    oo.suoritukset.filter(suoritus =>
+      suoritus.koulutusmoduuli match {
+        case diaarillinen: DiaarinumerollinenKoulutus =>
+          diaarillinen.perusteenDiaarinumero.flatMap(diaari => ePerusteet.findRakenne(diaari)) match {
+            case Some(rakenne) =>
+              rakenne.koulutukset.exists(_.koulutuskoodiArvo == diaarillinen.tunniste.koodiarvo)
+            case _ => true
+          }
+        case _ => true
+      }
+    ).map(_.koulutusmoduuli.tunniste.koodiarvo)
   }
 }

--- a/src/test/resources/backwardcompatibility/ammatillinen-full_2022-01-17.json
+++ b/src/test/resources/backwardcompatibility/ammatillinen-full_2022-01-17.json
@@ -1,0 +1,889 @@
+{
+  "henkilö" : {
+    "oid" : "1.2.246.562.24.00000000010"
+  },
+  "opiskeluoikeudet" : [ {
+    "oppilaitos" : {
+      "oid" : "1.2.246.562.10.52251087186",
+      "oppilaitosnumero" : {
+        "koodiarvo" : "10105",
+        "koodistoUri" : "oppilaitosnumero"
+      },
+      "nimi" : {
+        "fi" : "Stadin ammattiopisto"
+      }
+    },
+    "arvioituPäättymispäivä" : "2015-05-31",
+    "ostettu" : true,
+    "tila" : {
+      "opiskeluoikeusjaksot" : [ {
+        "alku" : "2012-09-01",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        },
+        "opintojenRahoitus" : {
+          "koodiarvo" : "4",
+          "nimi" : {
+            "fi" : "Työnantajan kokonaan rahoittama"
+          },
+          "koodistoUri" : "opintojenrahoitus"
+        }
+      }, {
+        "alku" : "2016-01-09",
+        "tila" : {
+          "koodiarvo" : "valmistunut",
+          "nimi" : {
+            "fi" : "Valmistunut"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        },
+        "opintojenRahoitus" : {
+          "koodiarvo" : "4",
+          "nimi" : {
+            "fi" : "Työnantajan kokonaan rahoittama"
+          },
+          "koodistoUri" : "opintojenrahoitus"
+        }
+      } ]
+    },
+    "suoritukset" : [ {
+      "koulutusmoduuli" : {
+        "tunniste" : {
+          "koodiarvo" : "351301",
+          "nimi" : {
+            "fi" : "Autoalan perustutkinto"
+          },
+          "koodistoUri" : "koulutus"
+        },
+        "perusteenDiaarinumero" : "39/011/2014"
+      },
+      "suoritustapa" : {
+        "koodiarvo" : "naytto",
+        "nimi" : {
+          "fi" : "Näyttö"
+        },
+        "koodistoUri" : "ammatillisentutkinnonsuoritustapa",
+        "koodistoVersio" : 1
+      },
+      "tutkintonimike" : [ {
+        "koodiarvo" : "10024",
+        "nimi" : {
+          "fi" : "Autokorinkorjaaja"
+        },
+        "koodistoUri" : "tutkintonimikkeet"
+      } ],
+      "osaamisala" : [ {
+        "osaamisala" : {
+          "koodiarvo" : "1525",
+          "nimi" : {
+            "fi" : "Autokorinkorjauksen osaamisala"
+          },
+          "koodistoUri" : "osaamisala"
+        }
+      } ],
+      "toimipiste" : {
+        "oid" : "1.2.246.562.10.42456023292",
+        "nimi" : {
+          "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+        }
+      },
+      "vahvistus" : {
+        "päivä" : "2016-01-09",
+        "paikkakunta" : {
+          "koodiarvo" : "091",
+          "nimi" : {
+            "fi" : "Helsinki"
+          },
+          "koodistoUri" : "kunta"
+        },
+        "myöntäjäOrganisaatio" : {
+          "oid" : "1.2.246.562.10.52251087186",
+          "oppilaitosnumero" : {
+            "koodiarvo" : "10105",
+            "koodistoUri" : "oppilaitosnumero"
+          },
+          "nimi" : {
+            "fi" : "Stadin ammattiopisto"
+          }
+        },
+        "myöntäjäHenkilöt" : [ {
+          "nimi" : "Mauri Bauer",
+          "titteli" : {
+            "fi" : "puheenjohtaja"
+          },
+          "organisaatio" : {
+            "nimi" : {
+              "fi" : "Autokorjaamoalan tutkintotoimikunta"
+            },
+            "tutkintotoimikunnanNumero" : "8406"
+          }
+        }, {
+          "nimi" : "Reijo Reksi",
+          "titteli" : {
+            "fi" : "rehtori"
+          },
+          "organisaatio" : {
+            "oid" : "1.2.246.562.10.52251087186",
+            "oppilaitosnumero" : {
+              "koodiarvo" : "10105",
+              "koodistoUri" : "oppilaitosnumero"
+            },
+            "nimi" : {
+              "fi" : "Stadin ammattiopisto"
+            }
+          }
+        } ]
+      },
+      "suorituskieli" : {
+        "koodiarvo" : "FI",
+        "nimi" : {
+          "fi" : "suomi"
+        },
+        "koodistoUri" : "kieli"
+      },
+      "järjestämismuodot" : [ {
+        "alku" : "2012-09-01",
+        "järjestämismuoto" : {
+          "tunniste" : {
+            "koodiarvo" : "10",
+            "nimi" : {
+              "fi" : "Oppilaitosmuotoinen"
+            },
+            "koodistoUri" : "jarjestamismuoto",
+            "koodistoVersio" : 1
+          }
+        }
+      } ],
+      "osasuoritukset" : [ {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "100016",
+            "nimi" : {
+              "fi" : "Huolto- ja korjaustyöt"
+            },
+            "koodistoUri" : "tutkinnonosat",
+            "koodistoVersio" : 1
+          },
+          "pakollinen" : true
+        },
+        "tutkinnonOsanRyhmä" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "ammatillisentutkinnonosanryhma"
+        },
+        "toimipiste" : {
+          "oid" : "1.2.246.562.10.42456023292",
+          "nimi" : {
+            "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+          }
+        },
+        "arviointi" : [ {
+          "arvosana" : {
+            "koodiarvo" : "Hyväksytty",
+            "nimi" : {
+              "fi" : "Hyväksytty"
+            },
+            "koodistoUri" : "arviointiasteikkoammatillinenhyvaksyttyhylatty",
+            "koodistoVersio" : 1
+          },
+          "päivä" : "2012-10-20",
+          "arvioitsijat" : [ {
+            "nimi" : "Jaana Arstila"
+          }, {
+            "nimi" : "Pekka Saurmann"
+          }, {
+            "nimi" : "Juhani Mykkänen"
+          } ],
+          "hyväksytty" : true
+        } ],
+        "vahvistus" : {
+          "päivä" : "2013-01-31",
+          "myöntäjäOrganisaatio" : {
+            "oid" : "1.2.246.562.10.52251087186",
+            "oppilaitosnumero" : {
+              "koodiarvo" : "10105",
+              "koodistoUri" : "oppilaitosnumero"
+            },
+            "nimi" : {
+              "fi" : "Stadin ammattiopisto"
+            }
+          },
+          "myöntäjäHenkilöt" : [ {
+            "nimi" : "Reijo Reksi",
+            "titteli" : {
+              "fi" : "rehtori"
+            },
+            "organisaatio" : {
+              "oid" : "1.2.246.562.10.52251087186",
+              "oppilaitosnumero" : {
+                "koodiarvo" : "10105",
+                "koodistoUri" : "oppilaitosnumero"
+              },
+              "nimi" : {
+                "fi" : "Stadin ammattiopisto"
+              }
+            }
+          } ]
+        },
+        "näyttö" : {
+          "kuvaus" : {
+            "fi" : "Huolto- ja korjaustyöt"
+          },
+          "suorituspaikka" : {
+            "tunniste" : {
+              "koodiarvo" : "1",
+              "nimi" : {
+                "fi" : "työpaikka"
+              },
+              "koodistoUri" : "ammatillisennaytonsuorituspaikka",
+              "koodistoVersio" : 1
+            },
+            "kuvaus" : {
+              "fi" : "Autokorjaamo Oy, Riihimäki"
+            }
+          },
+          "suoritusaika" : {
+            "alku" : "2012-10-20",
+            "loppu" : "2012-10-20"
+          },
+          "työssäoppimisenYhteydessä" : false,
+          "arviointi" : {
+            "arvosana" : {
+              "koodiarvo" : "3",
+              "nimi" : {
+                "fi" : "K3"
+              },
+              "koodistoUri" : "arviointiasteikkoammatillinent1k3"
+            },
+            "päivä" : "2014-10-20",
+            "arvioitsijat" : [ {
+              "nimi" : "Jaana Arstila",
+              "ntm" : true
+            }, {
+              "nimi" : "Pekka Saurmann",
+              "ntm" : true
+            }, {
+              "nimi" : "Juhani Mykkänen",
+              "ntm" : false
+            } ],
+            "arviointikohteet" : [ {
+              "tunniste" : {
+                "koodiarvo" : "1",
+                "nimi" : {
+                  "fi" : "Työprosessin hallinta"
+                },
+                "koodistoUri" : "ammatillisennaytonarviointikohde"
+              },
+              "arvosana" : {
+                "koodiarvo" : "3",
+                "nimi" : {
+                  "fi" : "K3"
+                },
+                "koodistoUri" : "arviointiasteikkoammatillinent1k3"
+              }
+            }, {
+              "tunniste" : {
+                "koodiarvo" : "2",
+                "nimi" : {
+                  "fi" : "Työmenetelmien, -välineiden ja materiaalin hallinta"
+                },
+                "koodistoUri" : "ammatillisennaytonarviointikohde"
+              },
+              "arvosana" : {
+                "koodiarvo" : "2",
+                "nimi" : {
+                  "fi" : "H2"
+                },
+                "koodistoUri" : "arviointiasteikkoammatillinent1k3"
+              }
+            }, {
+              "tunniste" : {
+                "koodiarvo" : "3",
+                "nimi" : {
+                  "fi" : "Työn perustana olevan tiedon hallinta"
+                },
+                "koodistoUri" : "ammatillisennaytonarviointikohde"
+              },
+              "arvosana" : {
+                "koodiarvo" : "2",
+                "nimi" : {
+                  "fi" : "H2"
+                },
+                "koodistoUri" : "arviointiasteikkoammatillinent1k3"
+              }
+            }, {
+              "tunniste" : {
+                "koodiarvo" : "4",
+                "nimi" : {
+                  "fi" : "Elinikäisen oppimisen avaintaidot"
+                },
+                "koodistoUri" : "ammatillisennaytonarviointikohde"
+              },
+              "arvosana" : {
+                "koodiarvo" : "3",
+                "nimi" : {
+                  "fi" : "K3"
+                },
+                "koodistoUri" : "arviointiasteikkoammatillinent1k3"
+              }
+            } ],
+            "arvioinnistaPäättäneet" : [ {
+              "koodiarvo" : "1",
+              "nimi" : {
+                "fi" : "Opettaja"
+              },
+              "koodistoUri" : "ammatillisennaytonarvioinnistapaattaneet"
+            } ],
+            "arviointikeskusteluunOsallistuneet" : [ {
+              "koodiarvo" : "1",
+              "nimi" : {
+                "fi" : "Opettaja"
+              },
+              "koodistoUri" : "ammatillisennaytonarviointikeskusteluunosallistuneet"
+            }, {
+              "koodiarvo" : "4",
+              "nimi" : {
+                "fi" : "Opiskelija"
+              },
+              "koodistoUri" : "ammatillisennaytonarviointikeskusteluunosallistuneet"
+            } ],
+            "hyväksytty" : true
+          }
+        },
+        "tyyppi" : {
+          "koodiarvo" : "ammatillisentutkinnonosa",
+          "koodistoUri" : "suorituksentyyppi"
+        }
+      }, {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "123456789",
+            "nimi" : {
+              "fi" : "Pintavauriotyöt"
+            }
+          },
+          "kuvaus" : {
+            "fi" : "Opetellaan korjaamaan pinnallisia vaurioita"
+          },
+          "pakollinen" : false
+        },
+        "tutkinnonOsanRyhmä" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "ammatillisentutkinnonosanryhma"
+        },
+        "toimipiste" : {
+          "oid" : "1.2.246.562.10.42456023292",
+          "nimi" : {
+            "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+          }
+        },
+        "arviointi" : [ {
+          "arvosana" : {
+            "koodiarvo" : "Hyväksytty",
+            "nimi" : {
+              "fi" : "Hyväksytty"
+            },
+            "koodistoUri" : "arviointiasteikkoammatillinenhyvaksyttyhylatty",
+            "koodistoVersio" : 1
+          },
+          "päivä" : "2013-03-20",
+          "arvioitsijat" : [ {
+            "nimi" : "Jaana Arstila"
+          }, {
+            "nimi" : "Pekka Saurmann"
+          }, {
+            "nimi" : "Juhani Mykkänen"
+          } ],
+          "hyväksytty" : true
+        } ],
+        "vahvistus" : {
+          "päivä" : "2013-05-31",
+          "myöntäjäOrganisaatio" : {
+            "oid" : "1.2.246.562.10.52251087186",
+            "oppilaitosnumero" : {
+              "koodiarvo" : "10105",
+              "koodistoUri" : "oppilaitosnumero"
+            },
+            "nimi" : {
+              "fi" : "Stadin ammattiopisto"
+            }
+          },
+          "myöntäjäHenkilöt" : [ {
+            "nimi" : "Reijo Reksi",
+            "titteli" : {
+              "fi" : "rehtori"
+            },
+            "organisaatio" : {
+              "oid" : "1.2.246.562.10.52251087186",
+              "oppilaitosnumero" : {
+                "koodiarvo" : "10105",
+                "koodistoUri" : "oppilaitosnumero"
+              },
+              "nimi" : {
+                "fi" : "Stadin ammattiopisto"
+              }
+            }
+          } ]
+        },
+        "näyttö" : {
+          "kuvaus" : {
+            "fi" : "Pintavaurioiden korjausta"
+          },
+          "suorituspaikka" : {
+            "tunniste" : {
+              "koodiarvo" : "1",
+              "nimi" : {
+                "fi" : "työpaikka"
+              },
+              "koodistoUri" : "ammatillisennaytonsuorituspaikka",
+              "koodistoVersio" : 1
+            },
+            "kuvaus" : {
+              "fi" : "Autokorjaamo Oy, Riihimäki"
+            }
+          },
+          "suoritusaika" : {
+            "alku" : "2013-05-20",
+            "loppu" : "2013-05-20"
+          },
+          "työssäoppimisenYhteydessä" : false
+        },
+        "tyyppi" : {
+          "koodiarvo" : "ammatillisentutkinnonosa",
+          "koodistoUri" : "suorituksentyyppi"
+        }
+      }, {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "100019",
+            "nimi" : {
+              "fi" : "Mittaus- ja korivauriotyöt"
+            },
+            "koodistoUri" : "tutkinnonosat",
+            "koodistoVersio" : 1
+          },
+          "pakollinen" : true
+        },
+        "tutkinnonOsanRyhmä" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "ammatillisentutkinnonosanryhma"
+        },
+        "toimipiste" : {
+          "oid" : "1.2.246.562.10.42456023292",
+          "nimi" : {
+            "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+          }
+        },
+        "arviointi" : [ {
+          "arvosana" : {
+            "koodiarvo" : "Hyväksytty",
+            "nimi" : {
+              "fi" : "Hyväksytty"
+            },
+            "koodistoUri" : "arviointiasteikkoammatillinenhyvaksyttyhylatty",
+            "koodistoVersio" : 1
+          },
+          "päivä" : "2013-04-01",
+          "arvioitsijat" : [ {
+            "nimi" : "Jaana Arstila"
+          }, {
+            "nimi" : "Pekka Saurmann"
+          }, {
+            "nimi" : "Juhani Mykkänen"
+          } ],
+          "hyväksytty" : true
+        } ],
+        "vahvistus" : {
+          "päivä" : "2013-05-31",
+          "myöntäjäOrganisaatio" : {
+            "oid" : "1.2.246.562.10.52251087186",
+            "oppilaitosnumero" : {
+              "koodiarvo" : "10105",
+              "koodistoUri" : "oppilaitosnumero"
+            },
+            "nimi" : {
+              "fi" : "Stadin ammattiopisto"
+            }
+          },
+          "myöntäjäHenkilöt" : [ {
+            "nimi" : "Reijo Reksi",
+            "titteli" : {
+              "fi" : "rehtori"
+            },
+            "organisaatio" : {
+              "oid" : "1.2.246.562.10.52251087186",
+              "oppilaitosnumero" : {
+                "koodiarvo" : "10105",
+                "koodistoUri" : "oppilaitosnumero"
+              },
+              "nimi" : {
+                "fi" : "Stadin ammattiopisto"
+              }
+            }
+          } ]
+        },
+        "näyttö" : {
+          "kuvaus" : {
+            "fi" : "Mittaus- ja korivauriotöitä"
+          },
+          "suorituspaikka" : {
+            "tunniste" : {
+              "koodiarvo" : "1",
+              "nimi" : {
+                "fi" : "työpaikka"
+              },
+              "koodistoUri" : "ammatillisennaytonsuorituspaikka",
+              "koodistoVersio" : 1
+            },
+            "kuvaus" : {
+              "fi" : "Autokorjaamo Oy, Riihimäki"
+            }
+          },
+          "suoritusaika" : {
+            "alku" : "2013-04-01",
+            "loppu" : "2013-04-01"
+          },
+          "työssäoppimisenYhteydessä" : false
+        },
+        "tyyppi" : {
+          "koodiarvo" : "ammatillisentutkinnonosa",
+          "koodistoUri" : "suorituksentyyppi"
+        }
+      }, {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "100034",
+            "nimi" : {
+              "fi" : "Maalauksen esikäsittelytyöt"
+            },
+            "koodistoUri" : "tutkinnonosat",
+            "koodistoVersio" : 1
+          },
+          "pakollinen" : true
+        },
+        "tutkinnonOsanRyhmä" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "ammatillisentutkinnonosanryhma"
+        },
+        "toimipiste" : {
+          "oid" : "1.2.246.562.10.42456023292",
+          "nimi" : {
+            "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+          }
+        },
+        "arviointi" : [ {
+          "arvosana" : {
+            "koodiarvo" : "Hyväksytty",
+            "nimi" : {
+              "fi" : "Hyväksytty"
+            },
+            "koodistoUri" : "arviointiasteikkoammatillinenhyvaksyttyhylatty",
+            "koodistoVersio" : 1
+          },
+          "päivä" : "2014-10-20",
+          "arvioitsijat" : [ {
+            "nimi" : "Jaana Arstila"
+          }, {
+            "nimi" : "Pekka Saurmann"
+          }, {
+            "nimi" : "Juhani Mykkänen"
+          } ],
+          "hyväksytty" : true
+        } ],
+        "vahvistus" : {
+          "päivä" : "2014-11-08",
+          "myöntäjäOrganisaatio" : {
+            "oid" : "1.2.246.562.10.52251087186",
+            "oppilaitosnumero" : {
+              "koodiarvo" : "10105",
+              "koodistoUri" : "oppilaitosnumero"
+            },
+            "nimi" : {
+              "fi" : "Stadin ammattiopisto"
+            }
+          },
+          "myöntäjäHenkilöt" : [ {
+            "nimi" : "Reijo Reksi",
+            "titteli" : {
+              "fi" : "rehtori"
+            },
+            "organisaatio" : {
+              "oid" : "1.2.246.562.10.52251087186",
+              "oppilaitosnumero" : {
+                "koodiarvo" : "10105",
+                "koodistoUri" : "oppilaitosnumero"
+              },
+              "nimi" : {
+                "fi" : "Stadin ammattiopisto"
+              }
+            }
+          } ]
+        },
+        "näyttö" : {
+          "kuvaus" : {
+            "fi" : "Maalauksen esikäsittelytöitä"
+          },
+          "suorituspaikka" : {
+            "tunniste" : {
+              "koodiarvo" : "1",
+              "nimi" : {
+                "fi" : "työpaikka"
+              },
+              "koodistoUri" : "ammatillisennaytonsuorituspaikka",
+              "koodistoVersio" : 1
+            },
+            "kuvaus" : {
+              "fi" : "Autokorjaamo Oy, Riihimäki"
+            }
+          },
+          "suoritusaika" : {
+            "alku" : "2014-10-20",
+            "loppu" : "2014-10-20"
+          },
+          "työssäoppimisenYhteydessä" : false
+        },
+        "tyyppi" : {
+          "koodiarvo" : "ammatillisentutkinnonosa",
+          "koodistoUri" : "suorituksentyyppi"
+        }
+      }, {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "100037",
+            "nimi" : {
+              "fi" : "Auton lisävarustetyöt"
+            },
+            "koodistoUri" : "tutkinnonosat",
+            "koodistoVersio" : 1
+          },
+          "pakollinen" : true,
+          "laajuus" : {
+            "arvo" : 15.0,
+            "yksikkö" : {
+              "koodiarvo" : "6",
+              "nimi" : {
+                "fi" : "osaamispistettä",
+                "sv" : "kompetenspoäng",
+                "en" : "ECVET competence points"
+              },
+              "lyhytNimi" : {
+                "fi" : "osp",
+                "sv" : "kp",
+                "en" : "competence points"
+              },
+              "koodistoUri" : "opintojenlaajuusyksikko"
+            }
+          },
+          "kuvaus" : {
+            "fi" : "Tuunaus"
+          }
+        },
+        "tutkinnonOsanRyhmä" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "ammatillisentutkinnonosanryhma"
+        },
+        "toimipiste" : {
+          "oid" : "1.2.246.562.10.42456023292",
+          "nimi" : {
+            "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+          }
+        },
+        "arviointi" : [ {
+          "arvosana" : {
+            "koodiarvo" : "Hyväksytty",
+            "nimi" : {
+              "fi" : "Hyväksytty"
+            },
+            "koodistoUri" : "arviointiasteikkoammatillinenhyvaksyttyhylatty",
+            "koodistoVersio" : 1
+          },
+          "päivä" : "2015-04-01",
+          "arvioitsijat" : [ {
+            "nimi" : "Jaana Arstila"
+          }, {
+            "nimi" : "Pekka Saurmann"
+          }, {
+            "nimi" : "Juhani Mykkänen"
+          } ],
+          "hyväksytty" : true
+        } ],
+        "vahvistus" : {
+          "päivä" : "2015-05-01",
+          "myöntäjäOrganisaatio" : {
+            "oid" : "1.2.246.562.10.52251087186",
+            "oppilaitosnumero" : {
+              "koodiarvo" : "10105",
+              "koodistoUri" : "oppilaitosnumero"
+            },
+            "nimi" : {
+              "fi" : "Stadin ammattiopisto"
+            }
+          },
+          "myöntäjäHenkilöt" : [ {
+            "nimi" : "Reijo Reksi",
+            "titteli" : {
+              "fi" : "rehtori"
+            },
+            "organisaatio" : {
+              "oid" : "1.2.246.562.10.52251087186",
+              "oppilaitosnumero" : {
+                "koodiarvo" : "10105",
+                "koodistoUri" : "oppilaitosnumero"
+              },
+              "nimi" : {
+                "fi" : "Stadin ammattiopisto"
+              }
+            }
+          } ]
+        },
+        "näyttö" : {
+          "kuvaus" : {
+            "fi" : "Auton lisävarustetöitä"
+          },
+          "suorituspaikka" : {
+            "tunniste" : {
+              "koodiarvo" : "1",
+              "nimi" : {
+                "fi" : "työpaikka"
+              },
+              "koodistoUri" : "ammatillisennaytonsuorituspaikka",
+              "koodistoVersio" : 1
+            },
+            "kuvaus" : {
+              "fi" : "Autokorjaamo Oy, Riihimäki"
+            }
+          },
+          "suoritusaika" : {
+            "alku" : "2015-04-01",
+            "loppu" : "2015-04-01"
+          },
+          "työssäoppimisenYhteydessä" : false
+        },
+        "tyyppi" : {
+          "koodiarvo" : "ammatillisentutkinnonosa",
+          "koodistoUri" : "suorituksentyyppi"
+        }
+      }, {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "101050",
+            "nimi" : {
+              "fi" : "Yritystoiminnan suunnittelu"
+            },
+            "koodistoUri" : "tutkinnonosat",
+            "koodistoVersio" : 1
+          },
+          "pakollinen" : true
+        },
+        "tutkinnonOsanRyhmä" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "ammatillisentutkinnonosanryhma"
+        },
+        "toimipiste" : {
+          "oid" : "1.2.246.562.10.42456023292",
+          "nimi" : {
+            "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+          }
+        },
+        "arviointi" : [ {
+          "arvosana" : {
+            "koodiarvo" : "Hyväksytty",
+            "nimi" : {
+              "fi" : "Hyväksytty"
+            },
+            "koodistoUri" : "arviointiasteikkoammatillinenhyvaksyttyhylatty",
+            "koodistoVersio" : 1
+          },
+          "päivä" : "2016-01-09",
+          "arvioitsijat" : [ {
+            "nimi" : "Jaana Arstila"
+          }, {
+            "nimi" : "Pekka Saurmann"
+          }, {
+            "nimi" : "Juhani Mykkänen"
+          } ],
+          "hyväksytty" : true
+        } ],
+        "vahvistus" : {
+          "päivä" : "2016-01-09",
+          "paikkakunta" : {
+            "koodiarvo" : "091",
+            "nimi" : {
+              "fi" : "Helsinki"
+            },
+            "koodistoUri" : "kunta"
+          },
+          "myöntäjäOrganisaatio" : {
+            "oid" : "1.2.246.562.10.52251087186",
+            "oppilaitosnumero" : {
+              "koodiarvo" : "10105",
+              "koodistoUri" : "oppilaitosnumero"
+            },
+            "nimi" : {
+              "fi" : "Stadin ammattiopisto"
+            }
+          },
+          "myöntäjäHenkilöt" : [ {
+            "nimi" : "Reijo Reksi",
+            "titteli" : {
+              "fi" : "rehtori"
+            },
+            "organisaatio" : {
+              "oid" : "1.2.246.562.10.52251087186",
+              "oppilaitosnumero" : {
+                "koodiarvo" : "10105",
+                "koodistoUri" : "oppilaitosnumero"
+              },
+              "nimi" : {
+                "fi" : "Stadin ammattiopisto"
+              }
+            }
+          } ]
+        },
+        "tunnustettu" : {
+          "osaaminen" : {
+            "koulutusmoduuli" : {
+              "tunniste" : {
+                "koodiarvo" : "100238",
+                "nimi" : {
+                  "fi" : "Asennushitsaus"
+                },
+                "koodistoUri" : "tutkinnonosat",
+                "koodistoVersio" : 1
+              },
+              "pakollinen" : true
+            },
+            "tyyppi" : {
+              "koodiarvo" : "ammatillisentutkinnonosa",
+              "koodistoUri" : "suorituksentyyppi"
+            }
+          },
+          "selite" : {
+            "fi" : "Tutkinnon osa on tunnustettu Kone- ja metallialan perustutkinnosta"
+          },
+          "rahoituksenPiirissä" : false
+        },
+        "tyyppi" : {
+          "koodiarvo" : "ammatillisentutkinnonosa",
+          "koodistoUri" : "suorituksentyyppi"
+        }
+      } ],
+      "tyyppi" : {
+        "koodiarvo" : "ammatillinentutkinto",
+        "koodistoUri" : "suorituksentyyppi"
+      },
+      "ryhmä" : "AUT12SN"
+    } ],
+    "tyyppi" : {
+      "koodiarvo" : "ammatillinenkoulutus",
+      "koodistoUri" : "opiskeluoikeudentyyppi"
+    },
+    "alkamispäivä" : "2012-09-01",
+    "päättymispäivä" : "2016-01-09"
+  } ]
+}

--- a/src/test/resources/backwardcompatibility/ammatillinen-oppisopimus_2022-01-17.json
+++ b/src/test/resources/backwardcompatibility/ammatillinen-oppisopimus_2022-01-17.json
@@ -1,0 +1,106 @@
+{
+  "henkilö" : {
+    "hetu" : "160586-873P",
+    "etunimet" : "Aarne",
+    "kutsumanimi" : "Aarne",
+    "sukunimi" : "Ammattilainen"
+  },
+  "opiskeluoikeudet" : [ {
+    "oppilaitos" : {
+      "oid" : "1.2.246.562.10.52251087186",
+      "oppilaitosnumero" : {
+        "koodiarvo" : "10105",
+        "koodistoUri" : "oppilaitosnumero"
+      },
+      "nimi" : {
+        "fi" : "Stadin ammattiopisto"
+      }
+    },
+    "arvioituPäättymispäivä" : "2020-05-01",
+    "ostettu" : false,
+    "tila" : {
+      "opiskeluoikeusjaksot" : [ {
+        "alku" : "2016-09-01",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        },
+        "opintojenRahoitus" : {
+          "koodiarvo" : "4",
+          "nimi" : {
+            "fi" : "Työnantajan kokonaan rahoittama"
+          },
+          "koodistoUri" : "opintojenrahoitus"
+        }
+      } ]
+    },
+    "suoritukset" : [ {
+      "koulutusmoduuli" : {
+        "tunniste" : {
+          "koodiarvo" : "351301",
+          "nimi" : {
+            "fi" : "Autoalan perustutkinto"
+          },
+          "koodistoUri" : "koulutus"
+        },
+        "perusteenDiaarinumero" : "39/011/2014"
+      },
+      "suoritustapa" : {
+        "koodiarvo" : "naytto",
+        "nimi" : {
+          "fi" : "Näyttö"
+        },
+        "koodistoUri" : "ammatillisentutkinnonsuoritustapa",
+        "koodistoVersio" : 1
+      },
+      "toimipiste" : {
+        "oid" : "1.2.246.562.10.42456023292",
+        "nimi" : {
+          "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+        }
+      },
+      "alkamispäivä" : "2016-09-01",
+      "suorituskieli" : {
+        "koodiarvo" : "FI",
+        "nimi" : {
+          "fi" : "suomi"
+        },
+        "koodistoUri" : "kieli"
+      },
+      "järjestämismuodot" : [ {
+        "alku" : "2016-09-01",
+        "järjestämismuoto" : {
+          "tunniste" : {
+            "koodiarvo" : "20",
+            "nimi" : {
+              "fi" : "Oppisopimusmuotoinen"
+            },
+            "koodistoUri" : "jarjestamismuoto",
+            "koodistoVersio" : 1
+          },
+          "oppisopimus" : {
+            "työnantaja" : {
+              "nimi" : {
+                "fi" : "Autokorjaamo Oy"
+              },
+              "yTunnus" : "1234567-8"
+            }
+          }
+        }
+      } ],
+      "tyyppi" : {
+        "koodiarvo" : "ammatillinentutkinto",
+        "koodistoUri" : "suorituksentyyppi"
+      }
+    } ],
+    "tyyppi" : {
+      "koodiarvo" : "ammatillinenkoulutus",
+      "koodistoUri" : "opiskeluoikeudentyyppi"
+    },
+    "alkamispäivä" : "2016-09-01"
+  } ]
+}

--- a/src/test/resources/backwardcompatibility/ammatillinen-osatoisestatutkinnosta_2022-01-17.json
+++ b/src/test/resources/backwardcompatibility/ammatillinen-osatoisestatutkinnosta_2022-01-17.json
@@ -1,0 +1,144 @@
+{
+  "henkilö" : {
+    "hetu" : "240550-475R",
+    "etunimet" : "Aarne",
+    "kutsumanimi" : "Aarne",
+    "sukunimi" : "Ammattilainen"
+  },
+  "opiskeluoikeudet" : [ {
+    "oppilaitos" : {
+      "oid" : "1.2.246.562.10.52251087186"
+    },
+    "arvioituPäättymispäivä" : "2020-05-01",
+    "ostettu" : false,
+    "tila" : {
+      "opiskeluoikeusjaksot" : [ {
+        "alku" : "2016-09-01",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        },
+        "opintojenRahoitus" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "opintojenrahoitus"
+        }
+      } ]
+    },
+    "suoritukset" : [ {
+      "koulutusmoduuli" : {
+        "tunniste" : {
+          "koodiarvo" : "351301",
+          "nimi" : {
+            "fi" : "Autoalan perustutkinto"
+          },
+          "koodistoUri" : "koulutus"
+        },
+        "perusteenDiaarinumero" : "39/011/2014"
+      },
+      "suoritustapa" : {
+        "koodiarvo" : "naytto",
+        "nimi" : {
+          "fi" : "Näyttö"
+        },
+        "koodistoUri" : "ammatillisentutkinnonsuoritustapa",
+        "koodistoVersio" : 1
+      },
+      "toimipiste" : {
+        "oid" : "1.2.246.562.10.42456023292",
+        "nimi" : {
+          "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+        }
+      },
+      "suorituskieli" : {
+        "koodiarvo" : "FI",
+        "nimi" : {
+          "fi" : "suomi"
+        },
+        "koodistoUri" : "kieli"
+      },
+      "osasuoritukset" : [ {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "104052",
+            "koodistoUri" : "tutkinnonosat"
+          },
+          "pakollinen" : true
+        },
+        "tutkinto" : {
+          "tunniste" : {
+            "koodiarvo" : "357305",
+            "koodistoUri" : "koulutus"
+          },
+          "perusteenDiaarinumero" : "40/011/2001"
+        },
+        "tutkinnonOsanRyhmä" : {
+          "koodiarvo" : "4",
+          "koodistoUri" : "ammatillisentutkinnonosanryhma"
+        },
+        "toimipiste" : {
+          "oid" : "1.2.246.562.10.42456023292",
+          "nimi" : {
+            "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+          }
+        },
+        "arviointi" : [ {
+          "arvosana" : {
+            "koodiarvo" : "3",
+            "nimi" : {
+              "fi" : "K3"
+            },
+            "koodistoUri" : "arviointiasteikkoammatillinent1k3"
+          },
+          "päivä" : "2014-10-20",
+          "hyväksytty" : true
+        } ],
+        "vahvistus" : {
+          "päivä" : "2014-11-08",
+          "myöntäjäOrganisaatio" : {
+            "oid" : "1.2.246.562.10.52251087186",
+            "oppilaitosnumero" : {
+              "koodiarvo" : "10105",
+              "koodistoUri" : "oppilaitosnumero"
+            },
+            "nimi" : {
+              "fi" : "Stadin ammattiopisto"
+            }
+          },
+          "myöntäjäHenkilöt" : [ {
+            "nimi" : "Reijo Reksi",
+            "titteli" : {
+              "fi" : "rehtori"
+            },
+            "organisaatio" : {
+              "oid" : "1.2.246.562.10.52251087186",
+              "oppilaitosnumero" : {
+                "koodiarvo" : "10105",
+                "koodistoUri" : "oppilaitosnumero"
+              },
+              "nimi" : {
+                "fi" : "Stadin ammattiopisto"
+              }
+            }
+          } ]
+        },
+        "tyyppi" : {
+          "koodiarvo" : "ammatillisentutkinnonosa",
+          "koodistoUri" : "suorituksentyyppi"
+        }
+      } ],
+      "tyyppi" : {
+        "koodiarvo" : "ammatillinentutkinto",
+        "koodistoUri" : "suorituksentyyppi"
+      }
+    } ],
+    "tyyppi" : {
+      "koodiarvo" : "ammatillinenkoulutus",
+      "koodistoUri" : "opiskeluoikeudentyyppi"
+    },
+    "alkamispäivä" : "2016-09-01"
+  } ]
+}

--- a/src/test/resources/backwardcompatibility/ammatillinen-paikallinen_2022-01-17.json
+++ b/src/test/resources/backwardcompatibility/ammatillinen-paikallinen_2022-01-17.json
@@ -1,0 +1,171 @@
+{
+  "henkilö" : {
+    "hetu" : "170694-385F",
+    "etunimet" : "Aarne",
+    "kutsumanimi" : "Aarne",
+    "sukunimi" : "Ammattilainen"
+  },
+  "opiskeluoikeudet" : [ {
+    "oppilaitos" : {
+      "oid" : "1.2.246.562.10.52251087186"
+    },
+    "arvioituPäättymispäivä" : "2020-05-01",
+    "ostettu" : false,
+    "tila" : {
+      "opiskeluoikeusjaksot" : [ {
+        "alku" : "2016-09-01",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        },
+        "opintojenRahoitus" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "opintojenrahoitus"
+        }
+      } ]
+    },
+    "suoritukset" : [ {
+      "koulutusmoduuli" : {
+        "tunniste" : {
+          "koodiarvo" : "351301",
+          "koodistoUri" : "koulutus"
+        },
+        "perusteenDiaarinumero" : "39/011/2014"
+      },
+      "suoritustapa" : {
+        "koodiarvo" : "naytto",
+        "nimi" : {
+          "fi" : "Näyttö"
+        },
+        "koodistoUri" : "ammatillisentutkinnonsuoritustapa",
+        "koodistoVersio" : 1
+      },
+      "toimipiste" : {
+        "oid" : "1.2.246.562.10.42456023292",
+        "nimi" : {
+          "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+        }
+      },
+      "alkamispäivä" : "2016-09-01",
+      "suorituskieli" : {
+        "koodiarvo" : "FI",
+        "nimi" : {
+          "fi" : "suomi"
+        },
+        "koodistoUri" : "kieli"
+      },
+      "osasuoritukset" : [ {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "123456789",
+            "nimi" : {
+              "fi" : "Pintavauriotyöt"
+            }
+          },
+          "kuvaus" : {
+            "fi" : "Opetellaan korjaamaan pinnallisia vaurioita"
+          },
+          "pakollinen" : false
+        },
+        "tutkinnonOsanRyhmä" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "ammatillisentutkinnonosanryhma"
+        },
+        "toimipiste" : {
+          "oid" : "1.2.246.562.10.42456023292",
+          "nimi" : {
+            "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+          }
+        },
+        "arviointi" : [ {
+          "arvosana" : {
+            "koodiarvo" : "Hyväksytty",
+            "nimi" : {
+              "fi" : "Hyväksytty"
+            },
+            "koodistoUri" : "arviointiasteikkoammatillinenhyvaksyttyhylatty",
+            "koodistoVersio" : 1
+          },
+          "päivä" : "2013-03-20",
+          "arvioitsijat" : [ {
+            "nimi" : "Jaana Arstila"
+          }, {
+            "nimi" : "Pekka Saurmann"
+          }, {
+            "nimi" : "Juhani Mykkänen"
+          } ],
+          "hyväksytty" : true
+        } ],
+        "vahvistus" : {
+          "päivä" : "2013-05-31",
+          "myöntäjäOrganisaatio" : {
+            "oid" : "1.2.246.562.10.52251087186",
+            "oppilaitosnumero" : {
+              "koodiarvo" : "10105",
+              "koodistoUri" : "oppilaitosnumero"
+            },
+            "nimi" : {
+              "fi" : "Stadin ammattiopisto"
+            }
+          },
+          "myöntäjäHenkilöt" : [ {
+            "nimi" : "Reijo Reksi",
+            "titteli" : {
+              "fi" : "rehtori"
+            },
+            "organisaatio" : {
+              "oid" : "1.2.246.562.10.52251087186",
+              "oppilaitosnumero" : {
+                "koodiarvo" : "10105",
+                "koodistoUri" : "oppilaitosnumero"
+              },
+              "nimi" : {
+                "fi" : "Stadin ammattiopisto"
+              }
+            }
+          } ]
+        },
+        "näyttö" : {
+          "kuvaus" : {
+            "fi" : "Pintavaurioiden korjausta"
+          },
+          "suorituspaikka" : {
+            "tunniste" : {
+              "koodiarvo" : "1",
+              "nimi" : {
+                "fi" : "työpaikka"
+              },
+              "koodistoUri" : "ammatillisennaytonsuorituspaikka",
+              "koodistoVersio" : 1
+            },
+            "kuvaus" : {
+              "fi" : "Autokorjaamo Oy, Riihimäki"
+            }
+          },
+          "suoritusaika" : {
+            "alku" : "2013-05-20",
+            "loppu" : "2013-05-20"
+          },
+          "työssäoppimisenYhteydessä" : false
+        },
+        "tyyppi" : {
+          "koodiarvo" : "ammatillisentutkinnonosa",
+          "koodistoUri" : "suorituksentyyppi"
+        }
+      } ],
+      "tyyppi" : {
+        "koodiarvo" : "ammatillinentutkinto",
+        "koodistoUri" : "suorituksentyyppi"
+      }
+    } ],
+    "tyyppi" : {
+      "koodiarvo" : "ammatillinenkoulutus",
+      "koodistoUri" : "opiskeluoikeudentyyppi"
+    },
+    "alkamispäivä" : "2016-09-01"
+  } ]
+}

--- a/src/test/resources/backwardcompatibility/ammatillinen-reforminmukainenperustutkinto_2022-01-17.json
+++ b/src/test/resources/backwardcompatibility/ammatillinen-reforminmukainenperustutkinto_2022-01-17.json
@@ -1,0 +1,893 @@
+{
+  "henkilö" : {
+    "hetu" : "020882-577H",
+    "etunimet" : "Aarne",
+    "kutsumanimi" : "Aarne",
+    "sukunimi" : "Ammattilainen"
+  },
+  "opiskeluoikeudet" : [ {
+    "oppilaitos" : {
+      "oid" : "1.2.246.562.10.52251087186",
+      "oppilaitosnumero" : {
+        "koodiarvo" : "10105",
+        "koodistoUri" : "oppilaitosnumero"
+      },
+      "nimi" : {
+        "fi" : "Stadin ammattiopisto"
+      }
+    },
+    "arvioituPäättymispäivä" : "2020-05-31",
+    "ostettu" : false,
+    "tila" : {
+      "opiskeluoikeusjaksot" : [ {
+        "alku" : "2018-01-01",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        },
+        "opintojenRahoitus" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "opintojenrahoitus"
+        }
+      } ]
+    },
+    "suoritukset" : [ {
+      "koulutusmoduuli" : {
+        "tunniste" : {
+          "koodiarvo" : "351301",
+          "nimi" : {
+            "fi" : "Autoalan perustutkinto"
+          },
+          "koodistoUri" : "koulutus"
+        },
+        "perusteenDiaarinumero" : "OPH-2762-2017"
+      },
+      "suoritustapa" : {
+        "koodiarvo" : "reformi",
+        "nimi" : {
+          "fi" : "Ammatillinen perustutkinto"
+        },
+        "koodistoUri" : "ammatillisentutkinnonsuoritustapa",
+        "koodistoVersio" : 1
+      },
+      "tutkintonimike" : [ {
+        "koodiarvo" : "10024",
+        "nimi" : {
+          "fi" : "Autokorinkorjaaja"
+        },
+        "koodistoUri" : "tutkintonimikkeet"
+      } ],
+      "osaamisala" : [ {
+        "osaamisala" : {
+          "koodiarvo" : "1719",
+          "nimi" : {
+            "fi" : "Autokorinkorjauksen osaamisala"
+          },
+          "koodistoUri" : "osaamisala"
+        }
+      } ],
+      "toimipiste" : {
+        "oid" : "1.2.246.562.10.42456023292",
+        "nimi" : {
+          "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+        }
+      },
+      "suorituskieli" : {
+        "koodiarvo" : "FI",
+        "nimi" : {
+          "fi" : "suomi"
+        },
+        "koodistoUri" : "kieli"
+      },
+      "osaamisenHankkimistavat" : [ {
+        "alku" : "2018-01-01",
+        "osaamisenHankkimistapa" : {
+          "tunniste" : {
+            "koodiarvo" : "oppilaitosmuotoinenkoulutus",
+            "nimi" : {
+              "fi" : "Oppilaitosmuotoinen"
+            },
+            "koodistoUri" : "osaamisenhankkimistapa",
+            "koodistoVersio" : 1
+          }
+        }
+      } ],
+      "osasuoritukset" : [ {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "105708",
+            "nimi" : {
+              "fi" : "Huolto- ja korjaustyöt"
+            },
+            "koodistoUri" : "tutkinnonosat",
+            "koodistoVersio" : 1
+          },
+          "pakollinen" : true
+        },
+        "tutkinnonOsanRyhmä" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "ammatillisentutkinnonosanryhma"
+        },
+        "toimipiste" : {
+          "oid" : "1.2.246.562.10.42456023292",
+          "nimi" : {
+            "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+          }
+        },
+        "arviointi" : [ {
+          "arvosana" : {
+            "koodiarvo" : "5",
+            "nimi" : {
+              "fi" : "5"
+            },
+            "koodistoUri" : "arviointiasteikkoammatillinen15",
+            "koodistoVersio" : 1
+          },
+          "päivä" : "2014-10-20",
+          "hyväksytty" : true
+        } ],
+        "vahvistus" : {
+          "päivä" : "2016-05-31",
+          "myöntäjäOrganisaatio" : {
+            "oid" : "1.2.246.562.10.52251087186",
+            "oppilaitosnumero" : {
+              "koodiarvo" : "10105",
+              "koodistoUri" : "oppilaitosnumero"
+            },
+            "nimi" : {
+              "fi" : "Stadin ammattiopisto"
+            }
+          },
+          "myöntäjäHenkilöt" : [ {
+            "nimi" : "Reijo Reksi",
+            "titteli" : {
+              "fi" : "rehtori"
+            },
+            "organisaatio" : {
+              "oid" : "1.2.246.562.10.52251087186",
+              "oppilaitosnumero" : {
+                "koodiarvo" : "10105",
+                "koodistoUri" : "oppilaitosnumero"
+              },
+              "nimi" : {
+                "fi" : "Stadin ammattiopisto"
+              }
+            }
+          } ]
+        },
+        "näyttö" : {
+          "kuvaus" : {
+            "fi" : "Vuosihuoltojen suorittaminen"
+          },
+          "suorituspaikka" : {
+            "tunniste" : {
+              "koodiarvo" : "1",
+              "nimi" : {
+                "fi" : "työpaikka"
+              },
+              "koodistoUri" : "ammatillisennaytonsuorituspaikka",
+              "koodistoVersio" : 1
+            },
+            "kuvaus" : {
+              "fi" : "Volkswagen Center"
+            }
+          },
+          "suoritusaika" : {
+            "alku" : "2018-02-02",
+            "loppu" : "2018-02-02"
+          },
+          "työssäoppimisenYhteydessä" : false,
+          "arviointi" : {
+            "arvosana" : {
+              "koodiarvo" : "5",
+              "nimi" : {
+                "fi" : "5"
+              },
+              "koodistoUri" : "arviointiasteikkoammatillinen15",
+              "koodistoVersio" : 1
+            },
+            "päivä" : "2014-10-20",
+            "arvioitsijat" : [ {
+              "nimi" : "Jaana Arstila",
+              "ntm" : true
+            }, {
+              "nimi" : "Pekka Saurmann",
+              "ntm" : true
+            }, {
+              "nimi" : "Juhani Mykkänen",
+              "ntm" : false
+            } ],
+            "arviointikohteet" : [ {
+              "tunniste" : {
+                "koodiarvo" : "1",
+                "nimi" : {
+                  "fi" : "Työprosessin hallinta"
+                },
+                "koodistoUri" : "ammatillisennaytonarviointikohde"
+              },
+              "arvosana" : {
+                "koodiarvo" : "5",
+                "nimi" : {
+                  "fi" : "5"
+                },
+                "koodistoUri" : "arviointiasteikkoammatillinen15",
+                "koodistoVersio" : 1
+              }
+            }, {
+              "tunniste" : {
+                "koodiarvo" : "2",
+                "nimi" : {
+                  "fi" : "Työmenetelmien, -välineiden ja materiaalin hallinta"
+                },
+                "koodistoUri" : "ammatillisennaytonarviointikohde"
+              },
+              "arvosana" : {
+                "koodiarvo" : "5",
+                "nimi" : {
+                  "fi" : "5"
+                },
+                "koodistoUri" : "arviointiasteikkoammatillinen15",
+                "koodistoVersio" : 1
+              }
+            }, {
+              "tunniste" : {
+                "koodiarvo" : "3",
+                "nimi" : {
+                  "fi" : "Työn perustana olevan tiedon hallinta"
+                },
+                "koodistoUri" : "ammatillisennaytonarviointikohde"
+              },
+              "arvosana" : {
+                "koodiarvo" : "Hyväksytty",
+                "nimi" : {
+                  "fi" : "Hyväksytty"
+                },
+                "koodistoUri" : "arviointiasteikkoammatillinenhyvaksyttyhylatty",
+                "koodistoVersio" : 1
+              }
+            }, {
+              "tunniste" : {
+                "koodiarvo" : "4",
+                "nimi" : {
+                  "fi" : "Elinikäisen oppimisen avaintaidot"
+                },
+                "koodistoUri" : "ammatillisennaytonarviointikohde"
+              },
+              "arvosana" : {
+                "koodiarvo" : "5",
+                "nimi" : {
+                  "fi" : "5"
+                },
+                "koodistoUri" : "arviointiasteikkoammatillinen15",
+                "koodistoVersio" : 1
+              }
+            } ],
+            "arvioinnistaPäättäneet" : [ {
+              "koodiarvo" : "5",
+              "nimi" : {
+                "fi" : "Muu koulutuksen järjestäjän edustaja"
+              },
+              "koodistoUri" : "ammatillisennaytonarvioinnistapaattaneet"
+            } ],
+            "arviointikeskusteluunOsallistuneet" : [ {
+              "koodiarvo" : "1",
+              "nimi" : {
+                "fi" : "Opettaja"
+              },
+              "koodistoUri" : "ammatillisennaytonarviointikeskusteluunosallistuneet"
+            }, {
+              "koodiarvo" : "4",
+              "nimi" : {
+                "fi" : "Opiskelija"
+              },
+              "koodistoUri" : "ammatillisennaytonarviointikeskusteluunosallistuneet"
+            } ],
+            "hyväksytty" : true
+          }
+        },
+        "tyyppi" : {
+          "koodiarvo" : "ammatillisentutkinnonosa",
+          "koodistoUri" : "suorituksentyyppi"
+        }
+      }, {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "105715",
+            "nimi" : {
+              "fi" : "Maalauksen esikäsittelytyöt"
+            },
+            "koodistoUri" : "tutkinnonosat",
+            "koodistoVersio" : 1
+          },
+          "pakollinen" : false
+        },
+        "tutkinnonOsanRyhmä" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "ammatillisentutkinnonosanryhma"
+        },
+        "toimipiste" : {
+          "oid" : "1.2.246.562.10.42456023292",
+          "nimi" : {
+            "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+          }
+        },
+        "arviointi" : [ {
+          "arvosana" : {
+            "koodiarvo" : "5",
+            "nimi" : {
+              "fi" : "5"
+            },
+            "koodistoUri" : "arviointiasteikkoammatillinen15",
+            "koodistoVersio" : 1
+          },
+          "päivä" : "2014-10-20",
+          "hyväksytty" : true
+        } ],
+        "vahvistus" : {
+          "päivä" : "2016-05-31",
+          "myöntäjäOrganisaatio" : {
+            "oid" : "1.2.246.562.10.52251087186",
+            "oppilaitosnumero" : {
+              "koodiarvo" : "10105",
+              "koodistoUri" : "oppilaitosnumero"
+            },
+            "nimi" : {
+              "fi" : "Stadin ammattiopisto"
+            }
+          },
+          "myöntäjäHenkilöt" : [ {
+            "nimi" : "Reijo Reksi",
+            "titteli" : {
+              "fi" : "rehtori"
+            },
+            "organisaatio" : {
+              "oid" : "1.2.246.562.10.52251087186",
+              "oppilaitosnumero" : {
+                "koodiarvo" : "10105",
+                "koodistoUri" : "oppilaitosnumero"
+              },
+              "nimi" : {
+                "fi" : "Stadin ammattiopisto"
+              }
+            }
+          } ]
+        },
+        "näyttö" : {
+          "kuvaus" : {
+            "fi" : "Pieniä pohja- ja hiomamaalauksia"
+          },
+          "suorituspaikka" : {
+            "tunniste" : {
+              "koodiarvo" : "1",
+              "nimi" : {
+                "fi" : "työpaikka"
+              },
+              "koodistoUri" : "ammatillisennaytonsuorituspaikka",
+              "koodistoVersio" : 1
+            },
+            "kuvaus" : {
+              "fi" : "Volkswagen Center"
+            }
+          },
+          "suoritusaika" : {
+            "alku" : "2018-02-02",
+            "loppu" : "2018-02-02"
+          },
+          "työssäoppimisenYhteydessä" : false,
+          "arviointi" : {
+            "arvosana" : {
+              "koodiarvo" : "5",
+              "nimi" : {
+                "fi" : "5"
+              },
+              "koodistoUri" : "arviointiasteikkoammatillinen15",
+              "koodistoVersio" : 1
+            },
+            "päivä" : "2014-10-20",
+            "arvioitsijat" : [ {
+              "nimi" : "Jaana Arstila",
+              "ntm" : true
+            }, {
+              "nimi" : "Pekka Saurmann",
+              "ntm" : true
+            }, {
+              "nimi" : "Juhani Mykkänen",
+              "ntm" : false
+            } ],
+            "arviointikohteet" : [ {
+              "tunniste" : {
+                "koodiarvo" : "1",
+                "nimi" : {
+                  "fi" : "Työprosessin hallinta"
+                },
+                "koodistoUri" : "ammatillisennaytonarviointikohde"
+              },
+              "arvosana" : {
+                "koodiarvo" : "5",
+                "nimi" : {
+                  "fi" : "5"
+                },
+                "koodistoUri" : "arviointiasteikkoammatillinen15",
+                "koodistoVersio" : 1
+              }
+            }, {
+              "tunniste" : {
+                "koodiarvo" : "2",
+                "nimi" : {
+                  "fi" : "Työmenetelmien, -välineiden ja materiaalin hallinta"
+                },
+                "koodistoUri" : "ammatillisennaytonarviointikohde"
+              },
+              "arvosana" : {
+                "koodiarvo" : "5",
+                "nimi" : {
+                  "fi" : "5"
+                },
+                "koodistoUri" : "arviointiasteikkoammatillinen15",
+                "koodistoVersio" : 1
+              }
+            }, {
+              "tunniste" : {
+                "koodiarvo" : "3",
+                "nimi" : {
+                  "fi" : "Työn perustana olevan tiedon hallinta"
+                },
+                "koodistoUri" : "ammatillisennaytonarviointikohde"
+              },
+              "arvosana" : {
+                "koodiarvo" : "Hyväksytty",
+                "nimi" : {
+                  "fi" : "Hyväksytty"
+                },
+                "koodistoUri" : "arviointiasteikkoammatillinenhyvaksyttyhylatty",
+                "koodistoVersio" : 1
+              }
+            }, {
+              "tunniste" : {
+                "koodiarvo" : "4",
+                "nimi" : {
+                  "fi" : "Elinikäisen oppimisen avaintaidot"
+                },
+                "koodistoUri" : "ammatillisennaytonarviointikohde"
+              },
+              "arvosana" : {
+                "koodiarvo" : "5",
+                "nimi" : {
+                  "fi" : "5"
+                },
+                "koodistoUri" : "arviointiasteikkoammatillinen15",
+                "koodistoVersio" : 1
+              }
+            } ],
+            "arvioinnistaPäättäneet" : [ {
+              "koodiarvo" : "5",
+              "nimi" : {
+                "fi" : "Muu koulutuksen järjestäjän edustaja"
+              },
+              "koodistoUri" : "ammatillisennaytonarvioinnistapaattaneet"
+            } ],
+            "arviointikeskusteluunOsallistuneet" : [ {
+              "koodiarvo" : "1",
+              "nimi" : {
+                "fi" : "Opettaja"
+              },
+              "koodistoUri" : "ammatillisennaytonarviointikeskusteluunosallistuneet"
+            }, {
+              "koodiarvo" : "4",
+              "nimi" : {
+                "fi" : "Opiskelija"
+              },
+              "koodistoUri" : "ammatillisennaytonarviointikeskusteluunosallistuneet"
+            } ],
+            "hyväksytty" : true
+          }
+        },
+        "tyyppi" : {
+          "koodiarvo" : "ammatillisentutkinnonosa",
+          "koodistoUri" : "suorituksentyyppi"
+        }
+      }, {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "400012",
+            "nimi" : {
+              "fi" : "Viestintä- ja vuorovaikutusosaaminen"
+            },
+            "koodistoUri" : "tutkinnonosat",
+            "koodistoVersio" : 1
+          },
+          "pakollinen" : true,
+          "laajuus" : {
+            "arvo" : 8.0,
+            "yksikkö" : {
+              "koodiarvo" : "6",
+              "nimi" : {
+                "fi" : "osaamispistettä",
+                "sv" : "kompetenspoäng",
+                "en" : "ECVET competence points"
+              },
+              "lyhytNimi" : {
+                "fi" : "osp",
+                "sv" : "kp",
+                "en" : "competence points"
+              },
+              "koodistoUri" : "opintojenlaajuusyksikko"
+            }
+          }
+        },
+        "tutkinnonOsanRyhmä" : {
+          "koodiarvo" : "2",
+          "koodistoUri" : "ammatillisentutkinnonosanryhma"
+        },
+        "toimipiste" : {
+          "oid" : "1.2.246.562.10.42456023292",
+          "nimi" : {
+            "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+          }
+        },
+        "osasuoritukset" : [ {
+          "koulutusmoduuli" : {
+            "tunniste" : {
+              "koodiarvo" : "AI",
+              "koodistoUri" : "ammatillisenoppiaineet"
+            },
+            "kieli" : {
+              "koodiarvo" : "AI1",
+              "koodistoUri" : "oppiaineaidinkielijakirjallisuus"
+            },
+            "pakollinen" : true,
+            "laajuus" : {
+              "arvo" : 5.0,
+              "yksikkö" : {
+                "koodiarvo" : "6",
+                "nimi" : {
+                  "fi" : "osaamispistettä",
+                  "sv" : "kompetenspoäng",
+                  "en" : "ECVET competence points"
+                },
+                "lyhytNimi" : {
+                  "fi" : "osp",
+                  "sv" : "kp",
+                  "en" : "competence points"
+                },
+                "koodistoUri" : "opintojenlaajuusyksikko"
+              }
+            }
+          },
+          "arviointi" : [ {
+            "arvosana" : {
+              "koodiarvo" : "5",
+              "nimi" : {
+                "fi" : "5"
+              },
+              "koodistoUri" : "arviointiasteikkoammatillinen15",
+              "koodistoVersio" : 1
+            },
+            "päivä" : "2014-10-20",
+            "hyväksytty" : true
+          } ],
+          "näyttö" : {
+            "kuvaus" : {
+              "fi" : "Kirjaesitelmä"
+            },
+            "suorituspaikka" : {
+              "tunniste" : {
+                "koodiarvo" : "1",
+                "nimi" : {
+                  "fi" : "työpaikka"
+                },
+                "koodistoUri" : "ammatillisennaytonsuorituspaikka",
+                "koodistoVersio" : 1
+              },
+              "kuvaus" : {
+                "fi" : "Stadin ammattiopisto"
+              }
+            },
+            "suoritusaika" : {
+              "alku" : "2014-05-18",
+              "loppu" : "2014-05-18"
+            },
+            "työssäoppimisenYhteydessä" : false
+          },
+          "tyyppi" : {
+            "koodiarvo" : "ammatillisentutkinnonosanosaalue",
+            "koodistoUri" : "suorituksentyyppi"
+          }
+        }, {
+          "koulutusmoduuli" : {
+            "tunniste" : {
+              "koodiarvo" : "AI",
+              "koodistoUri" : "ammatillisenoppiaineet"
+            },
+            "kieli" : {
+              "koodiarvo" : "AI1",
+              "koodistoUri" : "oppiaineaidinkielijakirjallisuus"
+            },
+            "pakollinen" : false,
+            "laajuus" : {
+              "arvo" : 3.0,
+              "yksikkö" : {
+                "koodiarvo" : "6",
+                "nimi" : {
+                  "fi" : "osaamispistettä",
+                  "sv" : "kompetenspoäng",
+                  "en" : "ECVET competence points"
+                },
+                "lyhytNimi" : {
+                  "fi" : "osp",
+                  "sv" : "kp",
+                  "en" : "competence points"
+                },
+                "koodistoUri" : "opintojenlaajuusyksikko"
+              }
+            }
+          },
+          "arviointi" : [ {
+            "arvosana" : {
+              "koodiarvo" : "5",
+              "nimi" : {
+                "fi" : "5"
+              },
+              "koodistoUri" : "arviointiasteikkoammatillinen15",
+              "koodistoVersio" : 1
+            },
+            "päivä" : "2014-10-20",
+            "hyväksytty" : true
+          } ],
+          "tyyppi" : {
+            "koodiarvo" : "ammatillisentutkinnonosanosaalue",
+            "koodistoUri" : "suorituksentyyppi"
+          }
+        } ],
+        "tyyppi" : {
+          "koodiarvo" : "ammatillisentutkinnonosa",
+          "koodistoUri" : "suorituksentyyppi"
+        }
+      }, {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "2",
+            "koodistoUri" : "tutkinnonosatvalinnanmahdollisuus"
+          }
+        },
+        "tutkinnonOsanRyhmä" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "ammatillisentutkinnonosanryhma"
+        },
+        "osasuoritukset" : [ {
+          "koulutusmoduuli" : {
+            "tunniste" : {
+              "koodiarvo" : "de",
+              "nimi" : {
+                "fi" : "Saksa"
+              }
+            },
+            "kuvaus" : {
+              "fi" : "Saksa"
+            },
+            "laajuus" : {
+              "arvo" : 5.0,
+              "yksikkö" : {
+                "koodiarvo" : "6",
+                "nimi" : {
+                  "fi" : "osaamispistettä",
+                  "sv" : "kompetenspoäng",
+                  "en" : "ECVET competence points"
+                },
+                "lyhytNimi" : {
+                  "fi" : "osp",
+                  "sv" : "kp",
+                  "en" : "competence points"
+                },
+                "koodistoUri" : "opintojenlaajuusyksikko"
+              }
+            }
+          },
+          "arviointi" : [ {
+            "arvosana" : {
+              "koodiarvo" : "5",
+              "nimi" : {
+                "fi" : "5"
+              },
+              "koodistoUri" : "arviointiasteikkoammatillinen15",
+              "koodistoVersio" : 1
+            },
+            "päivä" : "2014-10-20",
+            "hyväksytty" : true
+          } ],
+          "tyyppi" : {
+            "koodiarvo" : "ammatillinenkorkeakouluopintoja",
+            "koodistoUri" : "suorituksentyyppi"
+          }
+        } ],
+        "tyyppi" : {
+          "koodiarvo" : "ammatillisentutkinnonosa",
+          "koodistoUri" : "suorituksentyyppi"
+        }
+      }, {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "1",
+            "koodistoUri" : "tutkinnonosatvalinnanmahdollisuus"
+          }
+        },
+        "tutkinnonOsanRyhmä" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "ammatillisentutkinnonosanryhma"
+        },
+        "osasuoritukset" : [ {
+          "koulutusmoduuli" : {
+            "tunniste" : {
+              "koodiarvo" : "MAA",
+              "nimi" : {
+                "fi" : "Maantieto"
+              }
+            },
+            "kuvaus" : {
+              "fi" : "Lukion maantiedon oppimäärä"
+            },
+            "perusteenDiaarinumero" : "33/011/2003"
+          },
+          "arviointi" : [ {
+            "arvosana" : {
+              "koodiarvo" : "5",
+              "nimi" : {
+                "fi" : "5"
+              },
+              "koodistoUri" : "arviointiasteikkoammatillinen15",
+              "koodistoVersio" : 1
+            },
+            "päivä" : "2014-10-20",
+            "hyväksytty" : true
+          } ],
+          "tyyppi" : {
+            "koodiarvo" : "ammatillinenlukionopintoja",
+            "koodistoUri" : "suorituksentyyppi"
+          }
+        }, {
+          "koulutusmoduuli" : {
+            "tunniste" : {
+              "koodiarvo" : "EN",
+              "nimi" : {
+                "fi" : "Englanti"
+              }
+            },
+            "kuvaus" : {
+              "fi" : "Englannin kurssi"
+            },
+            "laajuus" : {
+              "arvo" : 3.0,
+              "yksikkö" : {
+                "koodiarvo" : "6",
+                "nimi" : {
+                  "fi" : "osaamispistettä",
+                  "sv" : "kompetenspoäng",
+                  "en" : "ECVET competence points"
+                },
+                "lyhytNimi" : {
+                  "fi" : "osp",
+                  "sv" : "kp",
+                  "en" : "competence points"
+                },
+                "koodistoUri" : "opintojenlaajuusyksikko"
+              }
+            },
+            "perusteenDiaarinumero" : "33/011/2003"
+          },
+          "arviointi" : [ {
+            "arvosana" : {
+              "koodiarvo" : "5",
+              "nimi" : {
+                "fi" : "5"
+              },
+              "koodistoUri" : "arviointiasteikkoammatillinen15",
+              "koodistoVersio" : 1
+            },
+            "päivä" : "2014-10-20",
+            "hyväksytty" : true
+          } ],
+          "tyyppi" : {
+            "koodiarvo" : "ammatillinenlukionopintoja",
+            "koodistoUri" : "suorituksentyyppi"
+          }
+        }, {
+          "koulutusmoduuli" : {
+            "tunniste" : {
+              "koodiarvo" : "TVT",
+              "koodistoUri" : "ammatillisenoppiaineet"
+            },
+            "pakollinen" : true,
+            "laajuus" : {
+              "arvo" : 3.0,
+              "yksikkö" : {
+                "koodiarvo" : "6",
+                "nimi" : {
+                  "fi" : "osaamispistettä",
+                  "sv" : "kompetenspoäng",
+                  "en" : "ECVET competence points"
+                },
+                "lyhytNimi" : {
+                  "fi" : "osp",
+                  "sv" : "kp",
+                  "en" : "competence points"
+                },
+                "koodistoUri" : "opintojenlaajuusyksikko"
+              }
+            }
+          },
+          "arviointi" : [ {
+            "arvosana" : {
+              "koodiarvo" : "5",
+              "nimi" : {
+                "fi" : "5"
+              },
+              "koodistoUri" : "arviointiasteikkoammatillinen15",
+              "koodistoVersio" : 1
+            },
+            "päivä" : "2014-10-20",
+            "hyväksytty" : true
+          } ],
+          "tyyppi" : {
+            "koodiarvo" : "ammatillisentutkinnonosanosaalue",
+            "koodistoUri" : "suorituksentyyppi"
+          }
+        }, {
+          "koulutusmoduuli" : {
+            "tunniste" : {
+              "koodiarvo" : "htm",
+              "nimi" : {
+                "fi" : "Hoitotarpeen määrittäminen"
+              }
+            },
+            "kuvaus" : {
+              "fi" : "Hoitotarpeen määrittäminen"
+            }
+          },
+          "arviointi" : [ {
+            "arvosana" : {
+              "koodiarvo" : "5",
+              "nimi" : {
+                "fi" : "5"
+              },
+              "koodistoUri" : "arviointiasteikkoammatillinen15",
+              "koodistoVersio" : 1
+            },
+            "päivä" : "2014-10-20",
+            "hyväksytty" : true
+          } ],
+          "tyyppi" : {
+            "koodiarvo" : "ammatillinenmuitaopintovalmiuksiatukeviaopintoja",
+            "koodistoUri" : "suorituksentyyppi"
+          }
+        } ],
+        "tyyppi" : {
+          "koodiarvo" : "ammatillisentutkinnonosa",
+          "koodistoUri" : "suorituksentyyppi"
+        }
+      } ],
+      "tyyppi" : {
+        "koodiarvo" : "ammatillinentutkinto",
+        "koodistoUri" : "suorituksentyyppi"
+      }
+    } ],
+    "lisätiedot" : {
+      "erityinenTuki" : [ {
+        "alku" : "2018-01-01"
+      } ],
+      "vaativanErityisenTuenErityinenTehtävä" : [ {
+        "alku" : "2018-01-01"
+      } ],
+      "henkilöstökoulutus" : false,
+      "koulutusvienti" : false
+    },
+    "tyyppi" : {
+      "koodiarvo" : "ammatillinenkoulutus",
+      "koodistoUri" : "opiskeluoikeudentyyppi"
+    },
+    "alkamispäivä" : "2018-01-01"
+  } ]
+}

--- a/src/test/resources/backwardcompatibility/ammatillinen-tunnustettu_2022-01-17.json
+++ b/src/test/resources/backwardcompatibility/ammatillinen-tunnustettu_2022-01-17.json
@@ -1,0 +1,236 @@
+{
+  "henkilö" : {
+    "hetu" : "250266-497T",
+    "etunimet" : "Aarne",
+    "kutsumanimi" : "Aarne",
+    "sukunimi" : "Ammattilainen"
+  },
+  "opiskeluoikeudet" : [ {
+    "oppilaitos" : {
+      "oid" : "1.2.246.562.10.52251087186"
+    },
+    "arvioituPäättymispäivä" : "2020-05-01",
+    "ostettu" : false,
+    "tila" : {
+      "opiskeluoikeusjaksot" : [ {
+        "alku" : "2016-09-01",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        },
+        "opintojenRahoitus" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "opintojenrahoitus"
+        }
+      } ]
+    },
+    "suoritukset" : [ {
+      "koulutusmoduuli" : {
+        "tunniste" : {
+          "koodiarvo" : "351301",
+          "koodistoUri" : "koulutus"
+        },
+        "perusteenDiaarinumero" : "39/011/2014"
+      },
+      "suoritustapa" : {
+        "koodiarvo" : "naytto",
+        "nimi" : {
+          "fi" : "Näyttö"
+        },
+        "koodistoUri" : "ammatillisentutkinnonsuoritustapa",
+        "koodistoVersio" : 1
+      },
+      "toimipiste" : {
+        "oid" : "1.2.246.562.10.42456023292",
+        "nimi" : {
+          "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+        }
+      },
+      "alkamispäivä" : "2016-09-01",
+      "suorituskieli" : {
+        "koodiarvo" : "FI",
+        "nimi" : {
+          "fi" : "suomi"
+        },
+        "koodistoUri" : "kieli"
+      },
+      "osasuoritukset" : [ {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "100031",
+            "nimi" : {
+              "fi" : "Moottorin ja voimansiirron huolto ja korjaus"
+            },
+            "koodistoUri" : "tutkinnonosat"
+          },
+          "pakollinen" : false,
+          "laajuus" : {
+            "arvo" : 15.0,
+            "yksikkö" : {
+              "koodiarvo" : "6",
+              "nimi" : {
+                "fi" : "osaamispistettä",
+                "sv" : "kompetenspoäng",
+                "en" : "ECVET competence points"
+              },
+              "lyhytNimi" : {
+                "fi" : "osp",
+                "sv" : "kp",
+                "en" : "competence points"
+              },
+              "koodistoUri" : "opintojenlaajuusyksikko"
+            }
+          }
+        },
+        "tutkinnonOsanRyhmä" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "ammatillisentutkinnonosanryhma"
+        },
+        "toimipiste" : {
+          "oid" : "1.2.246.562.10.42456023292",
+          "nimi" : {
+            "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+          }
+        },
+        "arviointi" : [ {
+          "arvosana" : {
+            "koodiarvo" : "Hyväksytty",
+            "nimi" : {
+              "fi" : "Hyväksytty"
+            },
+            "koodistoUri" : "arviointiasteikkoammatillinenhyvaksyttyhylatty",
+            "koodistoVersio" : 1
+          },
+          "päivä" : "2013-03-20",
+          "arvioitsijat" : [ {
+            "nimi" : "Jaana Arstila"
+          }, {
+            "nimi" : "Pekka Saurmann"
+          }, {
+            "nimi" : "Juhani Mykkänen"
+          } ],
+          "hyväksytty" : true
+        } ],
+        "vahvistus" : {
+          "päivä" : "2013-05-31",
+          "myöntäjäOrganisaatio" : {
+            "oid" : "1.2.246.562.10.52251087186",
+            "oppilaitosnumero" : {
+              "koodiarvo" : "10105",
+              "koodistoUri" : "oppilaitosnumero"
+            },
+            "nimi" : {
+              "fi" : "Stadin ammattiopisto"
+            }
+          },
+          "myöntäjäHenkilöt" : [ {
+            "nimi" : "Reijo Reksi",
+            "titteli" : {
+              "fi" : "rehtori"
+            },
+            "organisaatio" : {
+              "oid" : "1.2.246.562.10.52251087186",
+              "oppilaitosnumero" : {
+                "koodiarvo" : "10105",
+                "koodistoUri" : "oppilaitosnumero"
+              },
+              "nimi" : {
+                "fi" : "Stadin ammattiopisto"
+              }
+            }
+          } ]
+        },
+        "tunnustettu" : {
+          "osaaminen" : {
+            "koulutusmoduuli" : {
+              "tunniste" : {
+                "koodiarvo" : "11-22-33",
+                "nimi" : {
+                  "fi" : "Moottorin korjaus"
+                }
+              },
+              "kuvaus" : {
+                "fi" : "Opiskelijan on\n- tunnettava jakopyörästön merkitys moottorin toiminnalle\n- osattava kytkeä moottorin testauslaite ja tulkita mittaustuloksen suhdetta\nvalmistajan antamiin ohjearvoihin\n- osattava käyttää moottorikorjauksessa tarvittavia perustyökaluja\n- osattava suorittaa jakopään hammashihnan vaihto annettujen ohjeiden\nmukaisesti\n- tunnettava venttiilikoneiston merkitys moottorin toiminnan osana\nosatakseen mm. ottaa se huomioon jakopään huoltoja tehdessään\n- noudatettava sovittuja työaikoja"
+              },
+              "pakollinen" : false
+            },
+            "vahvistus" : {
+              "päivä" : "2002-05-28",
+              "myöntäjäOrganisaatio" : {
+                "oid" : "1.2.246.562.10.52251087186",
+                "oppilaitosnumero" : {
+                  "koodiarvo" : "10105",
+                  "koodistoUri" : "oppilaitosnumero"
+                },
+                "nimi" : {
+                  "fi" : "Stadin ammattiopisto"
+                }
+              },
+              "myöntäjäHenkilöt" : [ {
+                "nimi" : "Reijo Reksi",
+                "organisaatio" : {
+                  "oid" : "1.2.246.562.10.52251087186",
+                  "oppilaitosnumero" : {
+                    "koodiarvo" : "10105",
+                    "koodistoUri" : "oppilaitosnumero"
+                  },
+                  "nimi" : {
+                    "fi" : "Stadin ammattiopisto"
+                  }
+                }
+              } ]
+            },
+            "näyttö" : {
+              "kuvaus" : {
+                "fi" : "Moottorin korjaus"
+              },
+              "suorituspaikka" : {
+                "tunniste" : {
+                  "koodiarvo" : "1",
+                  "nimi" : {
+                    "fi" : "työpaikka"
+                  },
+                  "koodistoUri" : "ammatillisennaytonsuorituspaikka",
+                  "koodistoVersio" : 1
+                },
+                "kuvaus" : {
+                  "fi" : "Autokorjaamo Oy, Riihimäki"
+                }
+              },
+              "suoritusaika" : {
+                "alku" : "2002-04-20",
+                "loppu" : "2002-04-20"
+              },
+              "työssäoppimisenYhteydessä" : false
+            },
+            "tyyppi" : {
+              "koodiarvo" : "ammatillisentutkinnonosa",
+              "koodistoUri" : "suorituksentyyppi"
+            }
+          },
+          "selite" : {
+            "fi" : "Tutkinnon osa on tunnustettu aiemmin suoritetusta autoalan perustutkinnon osasta (1.8.2000 nro 11/011/2000)"
+          },
+          "rahoituksenPiirissä" : false
+        },
+        "tyyppi" : {
+          "koodiarvo" : "ammatillisentutkinnonosa",
+          "koodistoUri" : "suorituksentyyppi"
+        }
+      } ],
+      "tyyppi" : {
+        "koodiarvo" : "ammatillinentutkinto",
+        "koodistoUri" : "suorituksentyyppi"
+      }
+    } ],
+    "tyyppi" : {
+      "koodiarvo" : "ammatillinenkoulutus",
+      "koodistoUri" : "opiskeluoikeudentyyppi"
+    },
+    "alkamispäivä" : "2016-09-01"
+  } ]
+}

--- a/src/test/resources/backwardcompatibility/tiedonsiirto-epaonnistunut2_2022-01-17.json
+++ b/src/test/resources/backwardcompatibility/tiedonsiirto-epaonnistunut2_2022-01-17.json
@@ -1,0 +1,83 @@
+{
+  "henkilö" : {
+    "hetu" : "280618-402H",
+    "etunimet" : "Aarne",
+    "kutsumanimi" : "Aarne",
+    "sukunimi" : "Ammattilainen"
+  },
+  "opiskeluoikeudet" : [ {
+    "lähdejärjestelmänId" : {
+      "id" : "l-244032",
+      "lähdejärjestelmä" : {
+        "koodiarvo" : "winnova",
+        "nimi" : {
+          "fi" : "Winnova"
+        },
+        "koodistoUri" : "lahdejarjestelma",
+        "koodistoVersio" : 1
+      }
+    },
+    "oppilaitos" : {
+      "oid" : "1.2.246.562.10.56753942459"
+    },
+    "arvioituPäättymispäivä" : "2020-05-01",
+    "ostettu" : false,
+    "tila" : {
+      "opiskeluoikeusjaksot" : [ {
+        "alku" : "2016-09-01",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        },
+        "opintojenRahoitus" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "opintojenrahoitus"
+        }
+      } ]
+    },
+    "suoritukset" : [ {
+      "koulutusmoduuli" : {
+        "tunniste" : {
+          "koodiarvo" : "351301",
+          "koodistoUri" : "koulutus"
+        },
+        "perusteenDiaarinumero" : "39/011/2014"
+      },
+      "suoritustapa" : {
+        "koodiarvo" : "ops",
+        "nimi" : {
+          "fi" : "Ammatillinen perustutkinto"
+        },
+        "koodistoUri" : "ammatillisentutkinnonsuoritustapa",
+        "koodistoVersio" : 1
+      },
+      "toimipiste" : {
+        "oid" : "1.2.246.562.10.42456023292",
+        "nimi" : {
+          "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+        }
+      },
+      "alkamispäivä" : "2016-09-01",
+      "suorituskieli" : {
+        "koodiarvo" : "FI",
+        "nimi" : {
+          "fi" : "suomi"
+        },
+        "koodistoUri" : "kieli"
+      },
+      "tyyppi" : {
+        "koodiarvo" : "ammatillinentutkinto",
+        "koodistoUri" : "suorituksentyyppi"
+      }
+    } ],
+    "tyyppi" : {
+      "koodiarvo" : "ammatillinenkoulutus",
+      "koodistoUri" : "opiskeluoikeudentyyppi"
+    },
+    "alkamispäivä" : "2016-09-01"
+  } ]
+}

--- a/src/test/resources/backwardcompatibility/tiedonsiirto-epaonnistunut3_2020-02-03.json
+++ b/src/test/resources/backwardcompatibility/tiedonsiirto-epaonnistunut3_2020-02-03.json
@@ -240,5 +240,6 @@
     },
     "alkamispäivä" : "2012-09-01",
     "päättymispäivä" : "2016-06-04"
-  } ]
+  } ],
+  "ignoreKoskiValidator" : true
 }

--- a/src/test/resources/backwardcompatibility/tiedonsiirto-epaonnistunut3_2020-07-06.json
+++ b/src/test/resources/backwardcompatibility/tiedonsiirto-epaonnistunut3_2020-07-06.json
@@ -280,5 +280,6 @@
     },
     "alkamispäivä" : "2012-09-01",
     "päättymispäivä" : "2016-06-04"
-  } ]
+  } ],
+  "ignoreKoskiValidator" : true
 }

--- a/src/test/resources/backwardcompatibility/tiedonsiirto-epaonnistunut3_2020-07-13.json
+++ b/src/test/resources/backwardcompatibility/tiedonsiirto-epaonnistunut3_2020-07-13.json
@@ -290,5 +290,6 @@
     },
     "alkamispäivä" : "2012-09-01",
     "päättymispäivä" : "2016-06-04"
-  } ]
+  } ],
+  "ignoreKoskiValidator" : true
 }

--- a/src/test/resources/backwardcompatibility/tiedonsiirto-epaonnistunut3_2022-01-14.json
+++ b/src/test/resources/backwardcompatibility/tiedonsiirto-epaonnistunut3_2022-01-14.json
@@ -110,15 +110,21 @@
           "oppilaitosnumero" : {
             "koodiarvo" : "00204",
             "nimi" : {
-              "fi" : "Jyväskylän normaalikoulu"
+              "fi" : "Jyväskylän normaalikoulu",
+              "sv" : "Jyväskylän normaalikoulu",
+              "en" : "Jyväskylän normaalikoulu"
             },
             "lyhytNimi" : {
-              "fi" : "Jyväskylän normaalikoulu"
+              "fi" : "Jyväskylän normaalikoulu",
+              "sv" : "Jyväskylän normaalikoulu",
+              "en" : "Jyväskylän normaalikoulu"
             },
             "koodistoUri" : "oppilaitosnumero"
           },
           "nimi" : {
-            "fi" : "Jyväskylän normaalikoulu"
+            "fi" : "Jyväskylän normaalikoulu",
+            "sv" : "Jyväskylän normaalikoulu",
+            "en" : "Jyväskylän normaalikoulu"
           },
           "kotipaikka" : {
             "koodiarvo" : "179",
@@ -139,15 +145,21 @@
             "oppilaitosnumero" : {
               "koodiarvo" : "00204",
               "nimi" : {
-                "fi" : "Jyväskylän normaalikoulu"
+                "fi" : "Jyväskylän normaalikoulu",
+                "sv" : "Jyväskylän normaalikoulu",
+                "en" : "Jyväskylän normaalikoulu"
               },
               "lyhytNimi" : {
-                "fi" : "Jyväskylän normaalikoulu"
+                "fi" : "Jyväskylän normaalikoulu",
+                "sv" : "Jyväskylän normaalikoulu",
+                "en" : "Jyväskylän normaalikoulu"
               },
               "koodistoUri" : "oppilaitosnumero"
             },
             "nimi" : {
-              "fi" : "Jyväskylän normaalikoulu"
+              "fi" : "Jyväskylän normaalikoulu",
+              "sv" : "Jyväskylän normaalikoulu",
+              "en" : "Jyväskylän normaalikoulu"
             },
             "kotipaikka" : {
               "koodiarvo" : "179",
@@ -195,6 +207,16 @@
             "arvo" : 35.0,
             "yksikkö" : {
               "koodiarvo" : "6",
+              "nimi" : {
+                "fi" : "osaamispistettä",
+                "sv" : "kompetenspoäng",
+                "en" : "ECVET competence points"
+              },
+              "lyhytNimi" : {
+                "fi" : "osp",
+                "sv" : "kp",
+                "en" : "competence points"
+              },
               "koodistoUri" : "opintojenlaajuusyksikko"
             }
           }
@@ -268,6 +290,5 @@
     },
     "alkamispäivä" : "2012-09-01",
     "päättymispäivä" : "2016-06-04"
-  } ],
-  "ignoreKoskiValidator" : true
+  } ]
 }

--- a/src/test/resources/backwardcompatibility/tiedonsiirto-epaonnistunut3_2022-01-17.json
+++ b/src/test/resources/backwardcompatibility/tiedonsiirto-epaonnistunut3_2022-01-17.json
@@ -7,7 +7,7 @@
   },
   "opiskeluoikeudet" : [ {
     "lähdejärjestelmänId" : {
-      "id" : "12345",
+      "id" : "75489301",
       "lähdejärjestelmä" : {
         "koodiarvo" : "winnova",
         "nimi" : {

--- a/src/test/resources/backwardcompatibility/tiedonsiirto-epaonnistunut_2022-01-17.json
+++ b/src/test/resources/backwardcompatibility/tiedonsiirto-epaonnistunut_2022-01-17.json
@@ -1,0 +1,83 @@
+{
+  "henkilö" : {
+    "hetu" : "270303-281N",
+    "etunimet" : "Tiina",
+    "kutsumanimi" : "Tiina",
+    "sukunimi" : "Tiedonsiirto"
+  },
+  "opiskeluoikeudet" : [ {
+    "lähdejärjestelmänId" : {
+      "id" : "l-244032",
+      "lähdejärjestelmä" : {
+        "koodiarvo" : "winnova",
+        "nimi" : {
+          "fi" : "Winnova"
+        },
+        "koodistoUri" : "lahdejarjestelma",
+        "koodistoVersio" : 1
+      }
+    },
+    "oppilaitos" : {
+      "oid" : "1.2.246.562.10.56753942459"
+    },
+    "arvioituPäättymispäivä" : "2020-05-01",
+    "ostettu" : false,
+    "tila" : {
+      "opiskeluoikeusjaksot" : [ {
+        "alku" : "2016-09-01",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        },
+        "opintojenRahoitus" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "opintojenrahoitus"
+        }
+      } ]
+    },
+    "suoritukset" : [ {
+      "koulutusmoduuli" : {
+        "tunniste" : {
+          "koodiarvo" : "351301",
+          "koodistoUri" : "koulutus"
+        },
+        "perusteenDiaarinumero" : "39/011/2014"
+      },
+      "suoritustapa" : {
+        "koodiarvo" : "ops",
+        "nimi" : {
+          "fi" : "Ammatillinen perustutkinto"
+        },
+        "koodistoUri" : "ammatillisentutkinnonsuoritustapa",
+        "koodistoVersio" : 1
+      },
+      "toimipiste" : {
+        "oid" : "1.2.246.562.10.42456023292",
+        "nimi" : {
+          "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+        }
+      },
+      "alkamispäivä" : "2016-09-01",
+      "suorituskieli" : {
+        "koodiarvo" : "FI",
+        "nimi" : {
+          "fi" : "suomi"
+        },
+        "koodistoUri" : "kieli"
+      },
+      "tyyppi" : {
+        "koodiarvo" : "ammatillinentutkinto",
+        "koodistoUri" : "suorituksentyyppi"
+      }
+    } ],
+    "tyyppi" : {
+      "koodiarvo" : "ammatillinenkoulutus",
+      "koodistoUri" : "opiskeluoikeudentyyppi"
+    },
+    "alkamispäivä" : "2016-09-01"
+  } ]
+}

--- a/src/test/resources/backwardcompatibility/tiedonsiirto-onnistunut_2022-01-17.json
+++ b/src/test/resources/backwardcompatibility/tiedonsiirto-onnistunut_2022-01-17.json
@@ -1,0 +1,83 @@
+{
+  "henkilö" : {
+    "hetu" : "270303-281N",
+    "etunimet" : "Tiina",
+    "kutsumanimi" : "Tiina",
+    "sukunimi" : "Tiedonsiirto"
+  },
+  "opiskeluoikeudet" : [ {
+    "lähdejärjestelmänId" : {
+      "id" : "l-244032",
+      "lähdejärjestelmä" : {
+        "koodiarvo" : "winnova",
+        "nimi" : {
+          "fi" : "Winnova"
+        },
+        "koodistoUri" : "lahdejarjestelma",
+        "koodistoVersio" : 1
+      }
+    },
+    "oppilaitos" : {
+      "oid" : "1.2.246.562.10.52251087186"
+    },
+    "arvioituPäättymispäivä" : "2020-05-01",
+    "ostettu" : false,
+    "tila" : {
+      "opiskeluoikeusjaksot" : [ {
+        "alku" : "2016-09-01",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        },
+        "opintojenRahoitus" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "opintojenrahoitus"
+        }
+      } ]
+    },
+    "suoritukset" : [ {
+      "koulutusmoduuli" : {
+        "tunniste" : {
+          "koodiarvo" : "351301",
+          "koodistoUri" : "koulutus"
+        },
+        "perusteenDiaarinumero" : "39/011/2014"
+      },
+      "suoritustapa" : {
+        "koodiarvo" : "ops",
+        "nimi" : {
+          "fi" : "Ammatillinen perustutkinto"
+        },
+        "koodistoUri" : "ammatillisentutkinnonsuoritustapa",
+        "koodistoVersio" : 1
+      },
+      "toimipiste" : {
+        "oid" : "1.2.246.562.10.42456023292",
+        "nimi" : {
+          "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+        }
+      },
+      "alkamispäivä" : "2016-09-01",
+      "suorituskieli" : {
+        "koodiarvo" : "FI",
+        "nimi" : {
+          "fi" : "suomi"
+        },
+        "koodistoUri" : "kieli"
+      },
+      "tyyppi" : {
+        "koodiarvo" : "ammatillinentutkinto",
+        "koodistoUri" : "suorituksentyyppi"
+      }
+    } ],
+    "tyyppi" : {
+      "koodiarvo" : "ammatillinenkoulutus",
+      "koodistoUri" : "opiskeluoikeudentyyppi"
+    },
+    "alkamispäivä" : "2016-09-01"
+  } ]
+}

--- a/src/test/resources/backwardcompatibility/tiedonsiirto-vainsyntymaaika_2022-01-17.json
+++ b/src/test/resources/backwardcompatibility/tiedonsiirto-vainsyntymaaika_2022-01-17.json
@@ -1,0 +1,83 @@
+{
+  "henkilö" : {
+    "oid" : "1.2.246.562.24.99999999123",
+    "etunimet" : "Heikki",
+    "kutsumanimi" : "Heikki",
+    "sukunimi" : "Hetuton"
+  },
+  "opiskeluoikeudet" : [ {
+    "lähdejärjestelmänId" : {
+      "id" : "l-244032",
+      "lähdejärjestelmä" : {
+        "koodiarvo" : "winnova",
+        "nimi" : {
+          "fi" : "Winnova"
+        },
+        "koodistoUri" : "lahdejarjestelma",
+        "koodistoVersio" : 1
+      }
+    },
+    "oppilaitos" : {
+      "oid" : "1.2.246.562.10.52251087186"
+    },
+    "arvioituPäättymispäivä" : "2020-05-01",
+    "ostettu" : false,
+    "tila" : {
+      "opiskeluoikeusjaksot" : [ {
+        "alku" : "2016-09-01",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        },
+        "opintojenRahoitus" : {
+          "koodiarvo" : "1",
+          "koodistoUri" : "opintojenrahoitus"
+        }
+      } ]
+    },
+    "suoritukset" : [ {
+      "koulutusmoduuli" : {
+        "tunniste" : {
+          "koodiarvo" : "351301",
+          "koodistoUri" : "koulutus"
+        },
+        "perusteenDiaarinumero" : "39/011/2014"
+      },
+      "suoritustapa" : {
+        "koodiarvo" : "ops",
+        "nimi" : {
+          "fi" : "Ammatillinen perustutkinto"
+        },
+        "koodistoUri" : "ammatillisentutkinnonsuoritustapa",
+        "koodistoVersio" : 1
+      },
+      "toimipiste" : {
+        "oid" : "1.2.246.562.10.42456023292",
+        "nimi" : {
+          "fi" : "Stadin ammattiopisto, Lehtikuusentien toimipaikka"
+        }
+      },
+      "alkamispäivä" : "2016-09-01",
+      "suorituskieli" : {
+        "koodiarvo" : "FI",
+        "nimi" : {
+          "fi" : "suomi"
+        },
+        "koodistoUri" : "kieli"
+      },
+      "tyyppi" : {
+        "koodiarvo" : "ammatillinentutkinto",
+        "koodistoUri" : "suorituksentyyppi"
+      }
+    } ],
+    "tyyppi" : {
+      "koodiarvo" : "ammatillinenkoulutus",
+      "koodistoUri" : "opiskeluoikeudentyyppi"
+    },
+    "alkamispäivä" : "2016-09-01"
+  } ]
+}

--- a/src/test/scala/fi/oph/koski/api/KäyttöoikeusryhmätSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/KäyttöoikeusryhmätSpec.scala
@@ -396,7 +396,7 @@ class KäyttöoikeusryhmätSpec
     suoritukset = List(autoalanPerustutkinnonSuoritus().copy(toimipiste = Oppilaitos(MockOrganisaatiot.omnia)))
   )
 
-  private val opiskeluoikeusLähdejärjestelmästäOmnia = opiskeluoikeusOmnia.copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId))
+  private val opiskeluoikeusLähdejärjestelmästäOmnia = opiskeluoikeusOmnia.copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId("omnia-309945")))
 
   private def haeOpiskeluoikeudetHetulla(hetu: String, käyttäjä: UserWithPassword) = searchForHenkilötiedot(hetu).map(_.oid).flatMap { oid =>
     getOpiskeluoikeudet(oid, käyttäjä)

--- a/src/test/scala/fi/oph/koski/api/OppijaUpdateSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaUpdateSpec.scala
@@ -268,7 +268,6 @@ class OppijaUpdateSpec extends AnyFreeSpec with KoskiHttpSpec with Opiskeluoikeu
 
       "Estää opiskeluoikeuden siirtymisen eri henkilölle" in {
         resetFixtures
-        val lähdejärjestelmänId2 = LähdejärjestelmäId(Some("123452"), AmmatillinenExampleData.lähdeWinnova)
         createOpiskeluoikeus(koululainen, original, user = helsinginKaupunkiPalvelukäyttäjä)
         val opiskeluoikeus = createOpiskeluoikeus(oppija, defaultOpiskeluoikeus)
 

--- a/src/test/scala/fi/oph/koski/api/OppijaUpdateSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaUpdateSpec.scala
@@ -195,12 +195,12 @@ class OppijaUpdateSpec extends AnyFreeSpec with KoskiHttpSpec with Opiskeluoikeu
       }
 
       "Mahdollistaa lähdejärjestelmä-id:n vaihtamisen (case: oppilaitos vaihtaa tietojärjestelmää)" in {
-        val original: AmmatillinenOpiskeluoikeus = defaultOpiskeluoikeus.copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId))
+        val original: AmmatillinenOpiskeluoikeus = defaultOpiskeluoikeus.copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId("win-23352")))
 
-        verifyChange(original = original, user = helsinginKaupunkiPalvelukäyttäjä, change = { existing: AmmatillinenOpiskeluoikeus => existing.copy(lähdejärjestelmänId = Some(primusLähdejärjestelmäId)) }) {
+        verifyChange(original = original, user = helsinginKaupunkiPalvelukäyttäjä, change = { existing: AmmatillinenOpiskeluoikeus => existing.copy(lähdejärjestelmänId = Some(primusLähdejärjestelmäId("primus-30405321"))) }) {
           verifyResponseStatusOk()
           val result: KoskeenTallennettavaOpiskeluoikeus = lastOpiskeluoikeusByHetu(oppija)
-          result.lähdejärjestelmänId.map(_.lähdejärjestelmä.koodiarvo) should equal(Some(primusLähdejärjestelmäId.lähdejärjestelmä.koodiarvo))
+          result.lähdejärjestelmänId.map(_.lähdejärjestelmä.koodiarvo) should equal(Some(primusLähdejärjestelmäId("").lähdejärjestelmä.koodiarvo))
         }
       }
 
@@ -227,7 +227,7 @@ class OppijaUpdateSpec extends AnyFreeSpec with KoskiHttpSpec with Opiskeluoikeu
     }
 
     "Käytettäessä lähdejärjestelmä-id:tä" - {
-      val original: AmmatillinenOpiskeluoikeus = defaultOpiskeluoikeus.copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId))
+      val original: AmmatillinenOpiskeluoikeus = defaultOpiskeluoikeus.copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId("win-03520f")))
 
       "Muokkaa olemassaolevaa opiskeluoikeutta, kun lähdejärjestelmä-id on sama" in {
         resetFixtures
@@ -250,7 +250,7 @@ class OppijaUpdateSpec extends AnyFreeSpec with KoskiHttpSpec with Opiskeluoikeu
       }
 
       "Estää tyypin vaihtamisen" in {
-        verifyChange(original = original, user = paakayttaja, change = {existing: AmmatillinenOpiskeluoikeus => TestMethodsLukio.lukionOpiskeluoikeus.copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId), oppilaitos = existing.oppilaitos)}) {
+        verifyChange(original = original, user = paakayttaja, change = {existing: AmmatillinenOpiskeluoikeus => TestMethodsLukio.lukionOpiskeluoikeus.copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId("win-03520f")), oppilaitos = existing.oppilaitos)}) {
           verifyResponseStatus(403, KoskiErrorCategory.forbidden.kiellettyMuutos("Opiskeluoikeuden tyyppiä ei voi vaihtaa. Vanha tyyppi ammatillinenkoulutus. Uusi tyyppi lukiokoulutus."))
         }
       }
@@ -272,7 +272,7 @@ class OppijaUpdateSpec extends AnyFreeSpec with KoskiHttpSpec with Opiskeluoikeu
         createOpiskeluoikeus(koululainen, original, user = helsinginKaupunkiPalvelukäyttäjä)
         val opiskeluoikeus = createOpiskeluoikeus(oppija, defaultOpiskeluoikeus)
 
-        createOrUpdate(koululainen, opiskeluoikeus.copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId)), {
+        createOrUpdate(koululainen, opiskeluoikeus.copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId("win-kf040431n"))), {
           verifyResponseStatus(403, ErrorMatcher.regex(KoskiErrorCategory.forbidden.oppijaOidinMuutos, "Oppijan oid.*ei löydy opiskeluoikeuden oppijan oideista.*".r))
         }, helsinginKaupunkiPalvelukäyttäjä)
       }
@@ -438,7 +438,7 @@ class OppijaUpdateSpec extends AnyFreeSpec with KoskiHttpSpec with Opiskeluoikeu
       }
     }
     "Väärän muotoinen hetu" in {
-      putOppija(Oppija(oppija.copy(hetu = "291297"), List(defaultOpiskeluoikeus.copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId)))), headers = authHeaders(MockUsers.helsinginKaupunkiPalvelukäyttäjä) ++ jsonContent) {
+      putOppija(Oppija(oppija.copy(hetu = "291297"), List(defaultOpiskeluoikeus.copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId("win-väärähetu"))))), headers = authHeaders(MockUsers.helsinginKaupunkiPalvelukäyttäjä) ++ jsonContent) {
         verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.henkilötiedot.hetu("Virheellinen muoto hetulla: 291297"))
       }
     }

--- a/src/test/scala/fi/oph/koski/api/OppijaValidationAmmatillinenSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationAmmatillinenSpec.scala
@@ -73,7 +73,7 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
 
         "Valtakunnallinen tutkinnonosa" - {
           "Tutkinnon osa ja arviointi ok" - {
-            "palautetaan HTTP 200" in (putTutkinnonOsaSuoritus(tutkinnonOsaSuoritus, tutkinnonSuoritustapaNäyttönä) (verifyResponseStatusOk()))
+            "palautetaan HTTP 200" in (putTutkinnonOsaSuoritus(tutkinnonOsaSuoritus, tutkinnonSuoritustapaOps) (verifyResponseStatusOk()))
           }
 
           "Tutkinnon osa ei kuulu tutkintorakenteeseen" - {
@@ -82,9 +82,9 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
                 verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.rakenne.tuntematonTutkinnonOsa("Tutkinnon osa tutkinnonosat/104052 ei löydy tutkintorakenteesta perusteelle 39/011/2014 - suoritustapa naytto"))))
             }
             "Vapaavalintaiset tutkinnon osat" - {
-              "palautetaan HTTP 400" in (putTutkinnonOsaSuoritus(tutkinnonOsaSuoritus.copy(
+              "palautetaan HTTP 200" in (putTutkinnonOsaSuoritus(tutkinnonOsaSuoritus.copy(
                   koulutusmoduuli = johtaminenJaHenkilöstönKehittäminen, tutkinnonOsanRyhmä = vapaavalintaisetTutkinnonOsat
-                ), tutkinnonSuoritustapaNäyttönä)(
+                ), tutkinnonSuoritustapaOps)(
                 verifyResponseStatusOk()))
             }
           }
@@ -122,7 +122,7 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
               "Palautetaan HTTP 200" in (
                 putTutkinnonOsaSuoritus(tutkinnonOsaSuoritus.copy(osasuoritukset = Some(List(
                   osanOsa, osanOsa
-                ))), tutkinnonSuoritustapaNäyttönä) (verifyResponseStatusOk())
+                ))), tutkinnonSuoritustapaOps) (verifyResponseStatusOk())
               )
             }
           }
@@ -239,7 +239,7 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
         "Paikallinen tutkinnonosa" - {
           "Tutkinnon osa ja arviointi ok" - {
             val suoritus = paikallinenTutkinnonOsaSuoritus.copy(tutkinnonOsanRyhmä = ammatillisetTutkinnonOsat)
-            "palautetaan HTTP 200" in (putTutkinnonOsaSuoritus(suoritus, tutkinnonSuoritustapaNäyttönä) (verifyResponseStatusOk()))
+            "palautetaan HTTP 200" in (putTutkinnonOsaSuoritus(suoritus, tutkinnonSuoritustapaOps) (verifyResponseStatusOk()))
           }
 
           "Laajuus negatiivinen" - {
@@ -267,7 +267,7 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
               tutkinto = Some(autoalanPerustutkintoUusiPeruste),
               koulutusmoduuli = tutkinnonOsaUudestaPerusteesta
             )
-            "palautetaan HTTP 200" in (putTutkinnonOsaSuoritus(suoritus, tutkinnonSuoritustapaNäyttönä)(
+            "palautetaan HTTP 200" in (putTutkinnonOsaSuoritus(suoritus, tutkinnonSuoritustapaOps)(
               verifyResponseStatusOk()))
           }
         }
@@ -282,7 +282,7 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
 
           "Kun tutkinto löytyy ja osa kuuluu sen rakenteeseen" - {
             val suoritus = osanSuoritusToisestaTutkinnosta(autoalanTyönjohdonErikoisammattitutkinto, johtaminenJaHenkilöstönKehittäminen)
-            "palautetaan HTTP 200" in (putTutkinnonOsaSuoritus(suoritus, tutkinnonSuoritustapaNäyttönä)(
+            "palautetaan HTTP 200" in (putTutkinnonOsaSuoritus(suoritus, tutkinnonSuoritustapaOps)(
               verifyResponseStatusOk()))
           }
 
@@ -294,7 +294,7 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
 
           "Kun osa ei kuulu annetun tutkinnon rakenteeseen" - {
             val suoritus = osanSuoritusToisestaTutkinnosta(parturikampaaja, johtaminenJaHenkilöstönKehittäminen)
-            "palautetaan HTTP 200 (ei validoida rakennetta tässä)" in (putTutkinnonOsaSuoritus(suoritus, tutkinnonSuoritustapaNäyttönä)(
+            "palautetaan HTTP 200 (ei validoida rakennetta tässä)" in (putTutkinnonOsaSuoritus(suoritus, tutkinnonSuoritustapaOps)(
               verifyResponseStatusOk()))
           }
 
@@ -336,7 +336,7 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
 
           "Löydetyssä rakenteessa ei ole yhtään koulutusta"  - {
             val suoritus =  autoalanPerustutkinnonSuoritus().copy(koulutusmoduuli = autoalanPerustutkinto.copy(perusteenDiaarinumero = Some("mock-empty-koulutukset")))
-            "palautetaan HTTP 200" in (putOpiskeluoikeus(defaultOpiskeluoikeus.copy(suoritukset = List(suoritus))))(
+            "palautetaan HTTP 200" in (putOpiskeluoikeus(defaultOpiskeluoikeus.copy(suoritukset = List(suoritus)), defaultHenkilö.copy(hetu = "120950-0351")))(
               verifyResponseStatusOk()
             )
           }
@@ -348,7 +348,9 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
             tutkinnonOsaSuoritus.copy(arviointi = a, vahvistus = v, alkamispäivä = alkamispäivä)
           }
 
-          def put(suoritus: AmmatillisenTutkinnonOsanSuoritus)(f: => Unit) = putTutkinnonOsaSuoritus(suoritus, tutkinnonSuoritustapaNäyttönä)(f)
+          def tilanHenkilö = defaultHenkilö.copy(hetu = "240252-7302")
+
+          def put(suoritus: AmmatillisenTutkinnonOsanSuoritus)(f: => Unit) = putTutkinnonOsaSuoritus(suoritus, tutkinnonSuoritustapaNäyttönä, tilanHenkilö)(f)
           def putOsasuoritukset(suoritukset: List[AmmatillisenTutkinnonOsanSuoritus])(f: => Unit) = putTutkinnonOsaSuoritukset(suoritukset, tutkinnonSuoritustapaNäyttönä)(f)
 
           "Arviointi ja vahvistus puuttuu" - {
@@ -478,7 +480,7 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
               "Opiskeluoikeus valmis ennen vuotta 2019" - {
                 val valmisTila = AmmatillinenOpiskeluoikeusjakso(date(2018, 12, 31), ExampleData.opiskeluoikeusValmistunut, Some(valtionosuusRahoitteinen))
                 val valmisOpiskeluoikeus = tyhjilläOsasuorituksilla.copy(tila = AmmatillinenOpiskeluoikeudenTila(tyhjilläOsasuorituksilla.tila.opiskeluoikeusjaksot :+ valmisTila), ostettu = true)
-                "palautetaan HTTP 200" in (putOpiskeluoikeus(valmisOpiskeluoikeus)(
+                "palautetaan HTTP 200" in (putOpiskeluoikeus(valmisOpiskeluoikeus, defaultHenkilö.copy(hetu = "150435-0429"))(
                   verifyResponseStatusOk()))
               }
 
@@ -514,7 +516,7 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
             suoritukset = List(autoalanPerustutkinnonSuoritus(), autoalanErikoisammattitutkinnonSuoritus())
           )
 
-          putOpiskeluoikeus(opiskeluoikeus) {
+          putOpiskeluoikeus(opiskeluoikeus, defaultHenkilö.copy(hetu = "160337-625E")) {
             verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.ammatillinen.useampiPäätasonSuoritus())
           }
         }
@@ -530,6 +532,8 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
 
       "Tutkintokoodin ja suoritustavan vaihtaminen" - {
         "Tutkintokoodia ei voi vaihtaa opiskeluoikeuden luonnin jälkeen" in {
+          val opiskelija = defaultHenkilö.copy(hetu = "270550-879P")
+
           val opiskeluoikeus = defaultOpiskeluoikeus.copy(
             suoritukset = List(autoalanPerustutkinnonSuoritus().copy(
               koulutusmoduuli = autoalanPerustutkinto.copy(
@@ -537,7 +541,7 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
               )
             ))
           )
-          val tallennettuna = putAndGetOpiskeluoikeus(opiskeluoikeus).withSuoritukset(
+          val tallennettuna = putAndGetOpiskeluoikeus(opiskeluoikeus, opiskelija).withSuoritukset(
             List(autoalanPerustutkinnonSuoritus().copy(
               koulutusmoduuli = autoalanPerustutkinto.copy(
                 tunniste = Koodistokoodiviite("357305", "koulutus")
@@ -545,29 +549,33 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
             ))
           )
 
-          putOpiskeluoikeus(tallennettuna) {
+          putOpiskeluoikeus(tallennettuna, opiskelija) {
             verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.ammatillinen.muutettuSuoritustapaaTaiTutkintokoodia())
           }
         }
 
         "Suoritustapaa ei voi vaihtaa opiskeluoikeuden luonnin jälkeen" in {
+          val opiskelija = defaultHenkilö.copy(hetu = "170794-450C")
+
           val opiskeluoikeus = defaultOpiskeluoikeus.copy(
             suoritukset = List(autoalanPerustutkinnonSuoritus().copy(
               suoritustapa = suoritustapaNäyttö
             ))
           )
-          val tallennettuna = putAndGetOpiskeluoikeus(opiskeluoikeus).withSuoritukset(
+          val tallennettuna = putAndGetOpiskeluoikeus(opiskeluoikeus, henkilö = opiskelija).withSuoritukset(
             List(autoalanPerustutkinnonSuoritus().copy(
               suoritustapa = suoritustapaOps
             ))
           )
 
-          putOpiskeluoikeus(tallennettuna) {
+          putOpiskeluoikeus(tallennettuna, henkilö = opiskelija) {
             verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.ammatillinen.muutettuSuoritustapaaTaiTutkintokoodia())
           }
         }
 
-        "'nayttotutkintoonvalmistavakoulutus'-tyypin koulutukselle voidaan lissätä kaveriksi 'ammatillinentutkinto' ja tätä ei lasketa suoritustavan/tutkintokoodin muuttamiseksi" in {
+        "'nayttotutkintoonvalmistavakoulutus'-tyypin koulutukselle voidaan lisätä kaveriksi 'ammatillinentutkinto' ja tätä ei lasketa suoritustavan/tutkintokoodin muuttamiseksi" in {
+          val opiskelija = defaultHenkilö.copy(hetu = "010914-406L")
+
           val näyttötutkinnonSuoritus = AmmatillisenTutkinnonSuoritus(
             koulutusmoduuli = sosiaaliJaTerveysalanPerustutkinto,
             suoritustapa = suoritustapaNäyttö,
@@ -580,11 +588,11 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
           val opiskeluoikeus = defaultOpiskeluoikeus.copy(
             suoritukset = List(näyttötutkintoonValmistavaSuoritus)
           )
-          val tallennettuna = putAndGetOpiskeluoikeus(opiskeluoikeus).withSuoritukset(
+          val tallennettuna = putAndGetOpiskeluoikeus(opiskeluoikeus, henkilö = opiskelija).withSuoritukset(
             List(näyttötutkinnonSuoritus, näyttötutkintoonValmistavaSuoritus)
           )
 
-          putOpiskeluoikeus(tallennettuna) {
+          putOpiskeluoikeus(tallennettuna, henkilö = opiskelija) {
             verifyResponseStatusOk()
           }
         }
@@ -722,49 +730,53 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
     }
 
     "Ammatillinen perustutkinto näyttönä" - {
+      val opiskelija = defaultHenkilö.copy(hetu = "030301-403L")
+
       "Tutkinnonosan ryhmä on määritetty" - {
         val suoritus = autoalanPerustutkinnonSuoritus().copy(suoritustapa = tutkinnonSuoritustapaNäyttönä, osasuoritukset = Some(List(tutkinnonOsaSuoritus)))
-        "palautetaan HTTP 200" in (putTutkintoSuoritus(suoritus)(verifyResponseStatusOk()))
+        "palautetaan HTTP 200" in (putTutkintoSuoritus(suoritus, opiskelija)(verifyResponseStatusOk()))
       }
 
       "Tutkinnonosan ryhmää ei ole määritetty" - {
         val suoritus = autoalanPerustutkinnonSuoritus().copy(suoritustapa = tutkinnonSuoritustapaNäyttönä, osasuoritukset = Some(List(tutkinnonOsaSuoritus.copy(tutkinnonOsanRyhmä = None))))
-        "palautetaan HTTP 200" in (putTutkintoSuoritus(suoritus)(verifyResponseStatusOk()))
+        "palautetaan HTTP 200" in (putTutkintoSuoritus(suoritus, opiskelija)(verifyResponseStatusOk()))
       }
 
       "Syötetään osaamisen hankkimistapa" - {
         val suoritus = autoalanPerustutkinnonSuoritus().copy(suoritustapa = tutkinnonSuoritustapaNäyttönä, osaamisenHankkimistavat = Some(List(OsaamisenHankkimistapajakso(date(2018,1,1), None, osaamisenHankkimistapaOppilaitos))))
-        "palautetaan HTTP 200" in (putTutkintoSuoritus(suoritus)(verifyResponseStatusOk()))
+        "palautetaan HTTP 200" in (putTutkintoSuoritus(suoritus, opiskelija)(verifyResponseStatusOk()))
       }
 
       "Syötetään koulutussopimus" - {
         val suoritus = autoalanPerustutkinnonSuoritus().copy(suoritustapa = tutkinnonSuoritustapaNäyttönä, koulutussopimukset = Some(List(koulutussopimusjakso)))
-        "palautetaan HTTP 200" in (putTutkintoSuoritus(suoritus)(verifyResponseStatusOk()))
+        "palautetaan HTTP 200" in (putTutkintoSuoritus(suoritus, opiskelija)(verifyResponseStatusOk()))
       }
 
       "Yritetty antaa keskiarvo" - {
         val suoritus = autoalanPerustutkinnonSuoritus().copy(suoritustapa = tutkinnonSuoritustapaNäyttönä, osasuoritukset = Some(List(tutkinnonOsaSuoritus)), keskiarvo = Option(2.1f))
-        "palautetaan HTTP 400" in (putTutkintoSuoritus(suoritus)(verifyResponseStatus(400, ErrorMatcher.regex(KoskiErrorCategory.badRequest.validation.jsonSchema, ".*onlyWhenMismatch.*".r))))
+        "palautetaan HTTP 400" in (putTutkintoSuoritus(suoritus, opiskelija)(verifyResponseStatus(400, ErrorMatcher.regex(KoskiErrorCategory.badRequest.validation.jsonSchema, ".*onlyWhenMismatch.*".r))))
       }
 
       "suoritus.vahvistus.päivä > päättymispäivä" - {
         val suoritus = autoalanPerustutkinnonSuoritus().copy(vahvistus = vahvistus(date(2017, 5, 31)), suoritustapa = suoritustapaNäyttö, osasuoritukset = Some(List(muunAmmatillisenTutkinnonOsanSuoritus)))
-        "palautetaan HTTP 200" in putOpiskeluoikeus(päättymispäivällä(defaultOpiskeluoikeus, date(2016, 5, 31)).copy(suoritukset = List(suoritus)))(
+        "palautetaan HTTP 200" in putOpiskeluoikeus(päättymispäivällä(defaultOpiskeluoikeus, date(2016, 5, 31)).copy(suoritukset = List(suoritus)), opiskelija)(
           verifyResponseStatusOk()
         )
       }
     }
 
     "Reformin mukainen tutkinto" - {
+      val opiskelija = defaultHenkilö.copy(hetu = "090373-474B")
+
       def reformiSuoritus = autoalanPerustutkinnonSuoritus().copy(suoritustapa = tutkinnonSuoritustapaReformi)
       "Syötetään osaamisen hankkimistapa" - {
         val suoritus = reformiSuoritus.copy(osaamisenHankkimistavat = Some(List(OsaamisenHankkimistapajakso(date(2018,1,1), None, osaamisenHankkimistapaOppilaitos))))
-        "palautetaan HTTP 200" in putTutkintoSuoritus(suoritus)(verifyResponseStatusOk())
+        "palautetaan HTTP 200" in putTutkintoSuoritus(suoritus, opiskelija)(verifyResponseStatusOk())
       }
 
       "Syötetään koulutussopimus" - {
         val suoritus = reformiSuoritus.copy(koulutussopimukset = Some(List(koulutussopimusjakso)))
-        "palautetaan HTTP 200" in putTutkintoSuoritus(suoritus)(verifyResponseStatusOk())
+        "palautetaan HTTP 200" in putTutkintoSuoritus(suoritus, opiskelija)(verifyResponseStatusOk())
       }
 
       "Osasuoritukset vanhojen perusteiden mukaan (siirtymäaika 2018)" - {
@@ -774,7 +786,7 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
         )
         def oppija(alkamispäivä: LocalDate, suoritus: AmmatillisenTutkinnonSuoritus) = {
           val opiskeluoikeus = makeOpiskeluoikeus(alkamispäivä).copy(suoritukset = List(suoritus))
-          makeOppija(defaultHenkilö, List(JsonSerializer.serializeWithRoot(opiskeluoikeus)))
+          makeOppija(opiskelija, List(JsonSerializer.serializeWithRoot(opiskeluoikeus)))
         }
 
         "Alkamispäivä 2018, rakenne validi" - {
@@ -796,7 +808,7 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
           val suoritusIlmanArviointeja = korkeakouluopintoSuoritus.copy(osasuoritukset = korkeakouluopintoSuoritus.osasuoritukset.map(_.map(_.copy(arviointi = None))))
           putTutkintoSuoritus(reformiSuoritus.copy(
             osasuoritukset = Some(List(suoritusIlmanArviointeja))
-          ))(verifyResponseStatusOk())
+          ), opiskelija)(verifyResponseStatusOk())
         }
       }
 
@@ -805,7 +817,7 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
           val suoritusIlmanArviointeja = jatkoOpintovalmiuksiaTukevienOpintojenSuoritus.copy(osasuoritukset = jatkoOpintovalmiuksiaTukevienOpintojenSuoritus.osasuoritukset.map(_.collect  { case l: LukioOpintojenSuoritus => l.copy(arviointi = None) }))
           putTutkintoSuoritus(reformiSuoritus.copy(
             osasuoritukset = Some(List(suoritusIlmanArviointeja))
-          ))(verifyResponseStatusOk())
+          ), opiskelija)(verifyResponseStatusOk())
         }
       }
     }
@@ -968,8 +980,8 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
     arviointi = Some(List(arviointiHyväksytty))
   )
 
-  def putTutkinnonOsaSuoritus[A](tutkinnonOsaSuoritus: AmmatillisenTutkinnonOsanSuoritus, tutkinnonSuoritustapa: Koodistokoodiviite)(f: => A) = {
-    putTutkintoSuoritus(withTutkinnonOsaSuoritus(tutkinnonOsaSuoritus, tutkinnonSuoritustapa))(f)
+  def putTutkinnonOsaSuoritus[A](tutkinnonOsaSuoritus: AmmatillisenTutkinnonOsanSuoritus, tutkinnonSuoritustapa: Koodistokoodiviite, henkilö: Henkilö = defaultHenkilö)(f: => A) = {
+    putTutkintoSuoritus(withTutkinnonOsaSuoritus(tutkinnonOsaSuoritus, tutkinnonSuoritustapa), henkilö)(f)
   }
 
   def putTutkinnonOsaSuoritukset[A](tutkinnonOsaSuoritukset: List[AmmatillisenTutkinnonOsanSuoritus], tutkinnonSuoritustapa: Koodistokoodiviite)(f: => A) = {
@@ -1000,7 +1012,7 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
     putOppija(makeOppija(henkilö, List(JsonSerializer.serializeWithRoot(opiskeluoikeus))), headers)(f)
   }
 
-  private def putAndGetOpiskeluoikeus(oo: AmmatillinenOpiskeluoikeus): Opiskeluoikeus = putOpiskeluoikeus(oo) {
+  private def putAndGetOpiskeluoikeus(oo: AmmatillinenOpiskeluoikeus, henkilö: Henkilö = defaultHenkilö): Opiskeluoikeus = putOpiskeluoikeus(oo, henkilö) {
     verifyResponseStatusOk()
     getOpiskeluoikeus(readPutOppijaResponse.opiskeluoikeudet.head.oid)
   }

--- a/src/test/scala/fi/oph/koski/api/OppijaValidationVapaaSivistystyöVapaatavoitteinenSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationVapaaSivistystyöVapaatavoitteinenSpec.scala
@@ -65,7 +65,7 @@ class OppijaValidationVapaaSivistystyöVapaatavoitteinenSpec extends AnyFreeSpec
     "Suoritukset" - {
       "Kun mukana lähdejärjestelmäId, validoidaan" - {
         val lähdejärjestelmällinen = VapaatavoitteinenOpiskeluoikeus.copy(
-          lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId)
+          lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId("win-423082"))
         )
 
         "Jos päätason suoritus vahvistettu, tilan tulee olla 'Hyväksytysti suoritettu'" in {

--- a/src/test/scala/fi/oph/koski/api/SuoritusjakoSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/SuoritusjakoSpec.scala
@@ -68,7 +68,7 @@ class SuoritusjakoSpec extends AnyFreeSpec with SuoritusjakoTestMethods with Mat
       "lähdejärjestelmällisellä suorituksella" in {
         val json =
           """[{
-           "lähdejärjestelmänId": "12345",
+          "lähdejärjestelmänId": "l-050504",
           "oppilaitosOid": "1.2.246.562.10.52251087186",
           "suorituksenTyyppi": "ammatillinentutkinto",
           "koulutusmoduulinTunniste": "351301"
@@ -288,7 +288,7 @@ class SuoritusjakoSpec extends AnyFreeSpec with SuoritusjakoTestMethods with Mat
       "lähdejärjestelmällisellä suorituksella" in {
         val oppija = getSuoritusjakoOppija(secrets("lähdejärjestelmällinen"))
         verifySuoritusIds(oppija, List(SuoritusIdentifier(
-          lähdejärjestelmänId = Some("12345"),
+          lähdejärjestelmänId = Some("l-050504"),
           oppilaitosOid = Some("1.2.246.562.10.52251087186"),
           suorituksenTyyppi = "ammatillinentutkinto",
           koulutusmoduulinTunniste = "351301"

--- a/src/test/scala/fi/oph/koski/api/SuostumuksenPeruutusSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/SuostumuksenPeruutusSpec.scala
@@ -78,7 +78,7 @@ class SuostumuksenPeruutusSpec extends AnyFreeSpec with Matchers with Opiskeluoi
       post(s"/api/opiskeluoikeus/suostumuksenperuutus/$vapaatavoitteinenOpiskeluoikeusOid", headers = kansalainenLoginHeaders(vapaatavoitteinenHetu)) {}
 
       val oo = defaultOpiskeluoikeus.copy(
-        lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId),
+        lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId("win-32041")),
         oid = None,
         versionumero = None
       )

--- a/src/test/scala/fi/oph/koski/api/TiedonsiirtoSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/TiedonsiirtoSpec.scala
@@ -1,6 +1,6 @@
 package fi.oph.koski.api
 
-import fi.oph.koski.documentation.AmmatillinenExampleData.winnovaLähdejärjestelmäId
+import fi.oph.koski.documentation.AmmatillinenExampleData.{lähdeWinnova, winnovaLähdejärjestelmäId}
 import fi.oph.koski.documentation.ExamplesEsiopetus
 import fi.oph.koski.henkilo.KoskiSpecificMockOppijat
 import fi.oph.koski.henkilo.KoskiSpecificMockOppijat.eerola
@@ -76,8 +76,8 @@ class TiedonsiirtoSpec extends AnyFreeSpec with KoskiHttpSpec with Opiskeluoikeu
   }
 
   "Esiopetus" in {
-    val stadinOpiskeluoikeus = defaultOpiskeluoikeus.copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId))
-    val esiopetusOpiskeluoikeus = ExamplesEsiopetus.opiskeluoikeusHelsingissä.copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId))
+    val stadinOpiskeluoikeus = defaultOpiskeluoikeus.copy(lähdejärjestelmänId = Some(LähdejärjestelmäId(Some("848223"), lähdeWinnova)))
+    val esiopetusOpiskeluoikeus = ExamplesEsiopetus.opiskeluoikeusHelsingissä.copy(lähdejärjestelmänId = Some(LähdejärjestelmäId(Some("43349052"), lähdeWinnova)))
     val markkanen = asUusiOppija(KoskiSpecificMockOppijat.markkanen)
 
     resetFixtures

--- a/src/test/scala/fi/oph/koski/api/TiedonsiirtoSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/TiedonsiirtoSpec.scala
@@ -105,7 +105,7 @@ class TiedonsiirtoSpec extends AnyFreeSpec with KoskiHttpSpec with Opiskeluoikeu
   }
 
   "Tiedonsiirtolokin katsominen" - {
-    val stadinOpiskeluoikeus = defaultOpiskeluoikeus.copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId))
+    val stadinOpiskeluoikeus = defaultOpiskeluoikeus.copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId("win-304ir3")))
     "hierarkiassa ylempänä oleva käyttäjä voi katsoa hierarkiasssa alempana olevan käyttäjän luomia rivejä" in {
       resetFixtures
       putOpiskeluoikeus(stadinOpiskeluoikeus, henkilö = defaultHenkilö, headers = authHeaders(helsinginKaupunkiPalvelukäyttäjä) ++ jsonContent) {
@@ -197,7 +197,7 @@ class TiedonsiirtoSpec extends AnyFreeSpec with KoskiHttpSpec with Opiskeluoikeu
   }
 
   "Virheellisten tiedonsiirtojen poistaminen" - {
-    val stadinOpiskeluoikeus = defaultOpiskeluoikeus.copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId))
+    val stadinOpiskeluoikeus = defaultOpiskeluoikeus.copy(lähdejärjestelmänId = Some(winnovaLähdejärjestelmäId("win-9534")))
 
     "onnistuu omille virheellisille tiedonsiirtoriveille" in {
       resetFixtures

--- a/src/test/scala/fi/oph/koski/perftest/TiedonsiirtoFixtureDataInserter.scala
+++ b/src/test/scala/fi/oph/koski/perftest/TiedonsiirtoFixtureDataInserter.scala
@@ -14,7 +14,7 @@ object TiedonsiirtoFixtureDataInserter extends App {
 
 object TiedonsiirtoFixtureDataInserterScenario extends FixtureDataInserterScenario {
   lazy val omnia = Oppilaitos(MockOrganisaatiot.omnia)
-  lazy val omniaOpiskeluoikeus: AmmatillinenOpiskeluoikeus = AmmatillinenExampleData.opiskeluoikeus(omnia, AmmatillinenExampleData.autoalanPerustutkinnonSuoritus(omnia)).copy(lähdejärjestelmänId = Some(AmmatillinenExampleData.winnovaLähdejärjestelmäId))
+  lazy val omniaOpiskeluoikeus: AmmatillinenOpiskeluoikeus = AmmatillinenExampleData.opiskeluoikeus(omnia, AmmatillinenExampleData.autoalanPerustutkinnonSuoritus(omnia)).copy(lähdejärjestelmänId = Some(AmmatillinenExampleData.winnovaLähdejärjestelmäId("win-69102")))
   lazy val opiskeluoikeudet = List.fill(3)(List(omniaOpiskeluoikeus, ExamplesTiedonsiirto.failingOpiskeluoikeus)).flatten
   def opiskeluoikeudet(x: Int) = Random.shuffle(opiskeluoikeudet)
   override def defaultUser = MockUsers.omniaPalvelukäyttäjä

--- a/web/test/spec/ammatillinenArviointiasteikkoSpec.js
+++ b/web/test/spec/ammatillinenArviointiasteikkoSpec.js
@@ -12,14 +12,12 @@ describe('Ammatillisten koulutusten arviointiasteikko', function () {
       before(
         insertExample('ammatillinen - reformin mukainen perustutkinto.json'),
         page.openPage,
-        page.oppijaHaku.searchAndSelect('280618-402H')
+        page.oppijaHaku.searchAndSelect('020882-577H')
       )
       it('Näytetään käyttöliittymässä', function () {
         verifyArviointiasteikko(
           'Tutkinnon osien arviointiasteikko :\n' +
-          '1-5, Hylätty tai Hyväksytty\n\n' +
-          'Tutkinnon osien arviointiasteikko :\n' +
-          '1-3, Hylätty tai Hyväksytty'
+          '1-5, Hylätty tai Hyväksytty'
         )
       })
     })

--- a/web/test/spec/ammatillinenSpec.js
+++ b/web/test/spec/ammatillinenSpec.js
@@ -441,7 +441,7 @@ describe('Ammatillinen koulutus', function() {
         before(
           insertExample('ammatillinen - reformin mukainen perustutkinto.json'),
           page.openPage,
-          page.oppijaHaku.searchAndSelect('280618-402H'),
+          page.oppijaHaku.searchAndSelect('020882-577H'),
           click(findFirst('.expand-all'))
         )
 


### PR DESCRIPTION
Kävi ilmi, että aikaisemmat validaatiot oppilaitoksen vaihtamisesta ja ammatillisen tutkinnon suorituksen tietojen vaihtamisesta ovat toimineet vain siinä tapauksessa, että on annettu opiskeluoikeuden oid opiskeluoikeuden mukana.

Tosiasiallisesti Koskella on kuitenkin kolme tapaa yhdistää uusi opiskeluoikeus tallennettuun opiskeluoikeuteen: Opiskeluoikeuden oid, oppijan oid + lähdejärjestelmän id ja vielä kolmantena oppijan oid + oppilaitos + opiskeluoikeuden tyyppi + päätason suorituksen tyyppi.

Nyt on refaktoroitu vanhaa opiskeluoikeutta tarvitsevat validaatiot samaan paikkaan, eli `OpiskeluoikeusChangeValidator`iin. Tämä rikkoi ison määrän ammatillisen testejä, koska testit käyttivät samaa oppijaa.

Sen lisäksi Kosken esimerkki- ja testidatassa on paljolti käytetty samaa default-arvoa ("12345") lähdejärjestelmän opiskeluoikeuden ID:lle. Tämä on sikäli vähän huono, että ei vastaa oikean maailman tapausta; lähdejärjestelmän opiskeluoikeuden ID + lähdejärjestelmän koodiarvo on uniikki yhdistelmä. Jotenka muutettu nuo lähdejärjestelmä-rakenteet vaatimaan aina jokin ID.