### PR TITLE
tor-1602 - suositaan siirtymäajan päättymispäivää validaatiossa; käytetään voimassaolon päättymispäivää jos siirtymäaikaa ei ole määritelty

### DIFF
--- a/src/main/resources/mockdata/eperusteet/rakenne-liiketalouden-perustutkinto-paattymistesti.json
+++ b/src/main/resources/mockdata/eperusteet/rakenne-liiketalouden-perustutkinto-paattymistesti.json
@@ -1,17 +1,17 @@
 {
-  "id" : 1718932,
+  "id" : 1718939,
   "globalVersion" : {
     "aikaleima" : 1513688323153
   },
   "nimi" : {
-    "fi" : "Liiketalouden perustutkinto",
+    "fi" : "Liiketalouden perustutkinto - päättymisajan testi",
     "sv" : "Grundexamen inom företagsekonomi",
     "_id" : "289703"
   },
   "koulutustyyppi" : "koulutustyyppi_1",
   "koulutukset" : [ {
     "nimi" : {
-      "fi" : "Liiketalouden perustutkinto",
+      "fi" : "Liiketalouden perustutkinto - päättymisajan testi",
       "sv" : "Grundexamen inom företagsekonomi",
       "en" : "Business, Administration, VQ",
       "_id" : "287185"
@@ -42,9 +42,8 @@
       "_id" : "2335469"
     }
   } ],
-  "diaarinumero" : "59/011/2014",
+  "diaarinumero" : "1000/011/2014",
   "voimassaoloAlkaa" : 1469998800000,
-  "siirtymaPaattyy" : 1532984400000,
   "voimassaoloLoppuu" : 1532984400000,
   "paatospvm" : 1414447200000,
   "luotu" : 1466002817813,

--- a/src/main/scala/fi/oph/koski/eperusteet/EPerusteRakenne.scala
+++ b/src/main/scala/fi/oph/koski/eperusteet/EPerusteRakenne.scala
@@ -11,6 +11,7 @@ case class EPerusteRakenne(
   diaarinumero: String,
   koulutustyyppi: String,
   voimassaoloLoppuu: Option[String],
+  siirtymaPaattyy: Option[String],
   koulutukset: List[EPerusteKoulutus],
   suoritustavat: Option[List[ESuoritustapa]],
   tutkinnonOsat: Option[List[ETutkinnonOsa]],
@@ -24,6 +25,19 @@ case class EPerusteRakenne(
   }
   def voimassaoloLoppuuLocalDate = voimassaoloLoppuu.map(ms =>
     ZonedDateTime.ofInstant(Instant.ofEpochMilli(ms.toLong), ZoneId.systemDefault()).toLocalDate())
+
+  def siirtymäPäättynyt(vertailupäivämäärä: LocalDate = LocalDate.now()) = siirtymäPäättyyLocalDate match {
+    case Some(päättymispäivämäärä) => vertailupäivämäärä.isAfter(päättymispäivämäärä)
+    case None => false
+  }
+  def siirtymäPäättyyLocalDate = siirtymaPaattyy.map(ms =>
+    ZonedDateTime.ofInstant(Instant.ofEpochMilli(ms.toLong), ZoneId.systemDefault()).toLocalDate())
+
+  def siirtymäTaiVoimassaoloPäättynyt(vertailupäivämäärä: LocalDate = LocalDate.now()) = if (siirtymaPaattyy.isDefined) {
+    siirtymäPäättynyt(vertailupäivämäärä)
+  } else {
+    voimassaoloLoppunut(vertailupäivämäärä)
+  }
 }
 
 

--- a/src/main/scala/fi/oph/koski/eperusteet/MockEPerusteetRepository.scala
+++ b/src/main/scala/fi/oph/koski/eperusteet/MockEPerusteetRepository.scala
@@ -18,6 +18,7 @@ object MockEPerusteetRepository extends EPerusteetRepository {
     "rakenne-puutarhatalouden-perustutkinto",
     "rakenne-automekaanikon-erikoisammattitutkinto",
     "rakenne-liiketalouden-perustutkinto",
+    "rakenne-liiketalouden-perustutkinto-paattymistesti",
     "rakenne-puuteollisuuden-perustutkinto",
     "rakenne-virheellinen-puuteollisuuden-perustutkinto",
     "rakenne-valma",

--- a/src/main/scala/fi/oph/koski/http/KoskiErrorCategory.scala
+++ b/src/main/scala/fi/oph/koski/http/KoskiErrorCategory.scala
@@ -124,7 +124,7 @@ object KoskiErrorCategory {
         val liianVanhaOpetussuunnitelma = subcategory("liianVanhaOpetussuunnitelma", "Uusi lukion opiskelija ei voi aloittaa vanhojen opetussuunnitelman perusteiden mukaisia opintoja 1.8.2021 tai myöhemmin. Käytä lukion opetussuunnitelman perusteen diaarinumeroa OPH-2263-2019. Jos tosiasiassa oppija on aloittanut vanhojen perusteiden mukaiset lukio-opinnot ennen 1.8.2021, häneltä puuttuu KOSKI-tietovarannosta tämä opiskeluoikeus")
         val oppimääräSuoritettuIlmanVahvistettuaOppiaineenOppimäärää = subcategory("oppimääräSuoritettuIlmanVahvistettuaOppiaineenOppimäärää", "Opiskeluoikeuden tiedoissa on oppimäärä merkitty suoritetuksi, mutta opiskeluoikeudella ei ole vahvistettuja oppiaineen oppimäärän suorituksia")
         val deprekoituLukionAineopintojenPäätasonSuorituksenKenttä = subcategory("deprekoituLukionAineopintojenPäätasonSuorituksenKenttä", "Lukion oppiaineen oppimäärän suorituksen mukana siirretty kenttä 'lukionOppimääräSuoritettu' on deprekoitu, eikä sitä tule enää käyttää. Korvaavana kenttänä toimii lukion opiskeluoikeuden kenttä 'oppimääräSuoritettu'")
-        val perusteenVoimassaoloPäättynyt = subcategory("perusteenVoimassaoloPäättynyt", "Tutkinnon perusteen voimassaolo on päättynyt. Aktiivisen opiskeluoikeuden tutkinnon rakenteen tulee olla voimassa.")
+        val perusteenVoimassaoloPäättynyt = subcategory("perusteenVoimassaoloPäättynyt", "Tutkinnon perusteen siirtymäaika on päättynyt tai, jos perusteelle ei ole määritelty siirtyymäaikaa, perusteen voimassaoloaika on päättynyt. Aktiivisen opiskeluoikeuden tutkinnon rakenteen tulee olla voimassa.")
       }
       val rakenne = new Rakenne
 

--- a/src/main/scala/fi/oph/koski/validation/AmmatillinenValidation.scala
+++ b/src/main/scala/fi/oph/koski/validation/AmmatillinenValidation.scala
@@ -104,7 +104,7 @@ object AmmatillinenValidation {
         case diaarillinen: DiaarinumerollinenKoulutus if diaarillinen.perusteenDiaarinumero.isDefined =>
           ePerusteet.findRakenne(diaarillinen.perusteenDiaarinumero.get) match {
             case Some(peruste) =>
-              if (peruste.voimassaoloLoppunut()) {
+              if (peruste.siirtymäTaiVoimassaoloPäättynyt()) {
                 KoskiErrorCategory.badRequest.validation.rakenne.perusteenVoimassaoloPäättynyt()
               } else {
                 HttpStatus.ok

--- a/src/test/scala/fi/oph/koski/api/OppijaValidationAmmatillinenSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationAmmatillinenSpec.scala
@@ -591,8 +591,17 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
       }
 
       "Vanhentunut tutkinnon rakenne" - {
-        "Ei sallita siirtoa, jos eperusteissa rakenteen voimassaolo on päättynyt kun validaatio on voimassa" in {
+        "Ei sallita siirtoa, jos eperusteissa rakenteen siirtymäaika on päättynyt kun validaatio on voimassa" in {
           val opiskeluoikeus = AmmatillinenOpiskeluoikeusTestData.opiskeluoikeus(MockOrganisaatiot.stadinAmmattiopisto, koulutusKoodi = 331101, diaariNumero = "59/011/2014")
+          implicit val session: KoskiSpecificSession = KoskiSpecificSession.systemUser
+          implicit val accessType = AccessType.write
+          val oppija = Oppija(defaultHenkilö, List(opiskeluoikeus))
+          val config = KoskiApplicationForTests.config.withValue("validaatiot.ammatillisenPerusteidenVoimassaoloTarkastusAstuuVoimaan", fromAnyRef(LocalDate.now().toString))
+          mockKoskiValidator(config).validateAsJson(oppija).left.get should equal (KoskiErrorCategory.badRequest.validation.rakenne.perusteenVoimassaoloPäättynyt())
+        }
+
+        "Ei sallita siirtoa, jos eperusteissa rakenteen voimassaolo on päättynyt ja siirtymäaikaa ei ole määritelty kun validaatio on voimassa" in {
+          val opiskeluoikeus = AmmatillinenOpiskeluoikeusTestData.opiskeluoikeus(MockOrganisaatiot.stadinAmmattiopisto, koulutusKoodi = 331101, diaariNumero = "1000/011/2014")
           implicit val session: KoskiSpecificSession = KoskiSpecificSession.systemUser
           implicit val accessType = AccessType.write
           val oppija = Oppija(defaultHenkilö, List(opiskeluoikeus))


### PR DESCRIPTION
Tiketin kommentista:

"Tutkitaan että perusteen päättymisaikavalidaatio toimii oikein.

Päättymiaika päätellään ensisijaisesti siirtymäajan päättymispäivä-kentästä. 

Jos ko. kenttä tyhjä niin vasta sitten päättymispäivä-kenttää katsotaan."