### PR TITLE
AWS-kirjastojen yhdistetty päivitys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-dynamodb</artifactId>
-      <version>1.12.140</version>
+      <version>1.12.147</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <scalatra.version>2.8.2</scalatra.version>
     <http4s.version>0.23.4</http4s.version>
     <json4s.version>4.0.4</json4s.version>
-    <awssdk.version>2.17.118</awssdk.version>
+    <awssdk.version>2.17.119</awssdk.version>
     <jetty.version>9.4.44.v20210927</jetty.version>
     <prometheus.client.version>0.14.1</prometheus.client.version>
     <scoverage.plugin.version>1.1.1</scoverage.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <scalatra.version>2.8.2</scalatra.version>
     <http4s.version>0.23.4</http4s.version>
     <json4s.version>4.0.4</json4s.version>
-    <awssdk.version>2.17.119</awssdk.version>
+    <awssdk.version>2.17.120</awssdk.version>
     <jetty.version>9.4.44.v20210927</jetty.version>
     <prometheus.client.version>0.14.1</prometheus.client.version>
     <scoverage.plugin.version>1.1.1</scoverage.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <scalatra.version>2.8.2</scalatra.version>
     <http4s.version>0.23.4</http4s.version>
     <json4s.version>4.0.4</json4s.version>
-    <awssdk.version>2.17.111</awssdk.version>
+    <awssdk.version>2.17.118</awssdk.version>
     <jetty.version>9.4.44.v20210927</jetty.version>
     <prometheus.client.version>0.14.1</prometheus.client.version>
     <scoverage.plugin.version>1.1.1</scoverage.plugin.version>


### PR DESCRIPTION
Nopeampi testata koko paketti kerralla devillä, kun ovat kaikki samalla kertaa:

- fix: upgrade com.amazonaws:aws-java-sdk-dynamodb from 1.12.140 to 1.12.147
- fix: upgrade software.amazon.awssdk:appconfig from 2.17.111 to 2.17.118
- fix: upgrade software.amazon.awssdk:cloudwatch from 2.17.111 to 2.17.119
- fix: upgrade software.amazon.awssdk:sts from 2.17.111 to 2.17.120
