### PR TITLE
TOR-1334 - rajapinta migrille valintatietojen hakuun

### DIFF
--- a/src/main/scala/fi/oph/koski/http/VirkailijaHttpClient.scala
+++ b/src/main/scala/fi/oph/koski/http/VirkailijaHttpClient.scala
@@ -42,6 +42,7 @@ object VirkailijaCredentials {
 
 object VirkailijaHttpClient {
   private val DefaultSessionCookieName = "JSESSIONID"
+  private val DefaultServiceUrlSuffix = "j_spring_cas_security_check"
 
   private def defaultClient(serviceUrl: String): Client[IO] = Http.retryingClient(serviceUrl)
 
@@ -51,18 +52,22 @@ object VirkailijaHttpClient {
   def apply(serviceConfig: ServiceConfig, serviceUrl: String, sessionCookieName: String): Http =
     apply(serviceConfig, serviceUrl, defaultClient(serviceUrl), sessionCookieName)
 
+  def apply(serviceConfig: ServiceConfig, serviceUrl: String, sessionCookieName: String, serviceUrlSuffix: String): Http =
+    apply(serviceConfig, serviceUrl, defaultClient(serviceUrl), sessionCookieName, serviceUrlSuffix)
+
   def apply(
     serviceConfig: ServiceConfig,
     serviceUrl: String,
     client: Client[IO],
-    sessionCookieName: String = DefaultSessionCookieName
+    sessionCookieName: String = DefaultSessionCookieName,
+    serviceUrlSuffix: String = DefaultServiceUrlSuffix
   ): Http = {
     val VirkailijaCredentials(username, password) = VirkailijaCredentials(serviceConfig)
     val casAuthenticatingClient = if (serviceConfig.useCas) {
       val casClient = new CasClient(serviceConfig.virkailijaUrl + "/cas", client, OpintopolkuCallerId.koski)
       CasAuthenticatingClient(
         casClient,
-        CasParams(serviceUrl, username, password),
+        CasParams(serviceUrl, serviceUrlSuffix, username, password),
         client,
         OpintopolkuCallerId.koski,
         sessionCookieName

--- a/src/main/scala/fi/oph/koski/migri/MigriService.scala
+++ b/src/main/scala/fi/oph/koski/migri/MigriService.scala
@@ -1,0 +1,36 @@
+package fi.oph.koski.migri
+
+import fi.oph.koski.config.KoskiApplication
+import fi.oph.koski.http.Http.{UriInterpolator, runIO}
+import fi.oph.koski.http.{HttpStatus, KoskiErrorCategory, ServiceConfig, VirkailijaHttpClient}
+import fi.oph.koski.json.Json4sHttp4s.json4sEncoderOf
+import fi.oph.koski.log.Logging
+import org.scalatra.auth.strategy.BasicAuthStrategy.BasicAuthRequest
+
+trait MigriService {
+  def get(oid: String, basicAuthRequest: BasicAuthRequest): Either[HttpStatus, String]
+}
+
+class RemoteMigriService (implicit val application: KoskiApplication) extends Logging with MigriService {
+  def get(oid: String, basicAuthRequest: BasicAuthRequest) = {
+    val config = ServiceConfig(application.config.getString("opintopolku.virkailija.url"), basicAuthRequest.username, basicAuthRequest.password, true)
+    val client = VirkailijaHttpClient(config,
+      "/valinta-tulos-service",
+      sessionCookieName = "session",
+      serviceUrlSuffix = "auth/login")
+
+    runIO(client.post(uri"/valinta-tulos-service/cas/migri/hakemukset/", List(oid))(json4sEncoderOf[List[String]]) {
+      case (200, text, _) => Right(text)
+      case (status, text, _) =>
+        logger.error(s"valinta-tulos-service returned status $status: $text")
+        Left(KoskiErrorCategory.internalError("Virhe kutsuttaessa valinta-tulos-servicea"))
+    })
+  }
+}
+
+class MockMigriService (implicit val application: KoskiApplication) extends Logging with MigriService {
+  def get(oid: String, basicAuthRequest: BasicAuthRequest): Either[HttpStatus, String] = {
+    // Hyvin tynkä toteutus, lähinnä tarkistetaan, että BasicAuthRequest tulee testistä perille oikeanlaisena
+    Right(oid + basicAuthRequest.username + basicAuthRequest.password)
+  }
+}

--- a/src/test/scala/fi/oph/koski/migri/MigriServiceSpec.scala
+++ b/src/test/scala/fi/oph/koski/migri/MigriServiceSpec.scala
@@ -1,0 +1,37 @@
+package fi.oph.koski.migri
+
+import fi.oph.koski.config.KoskiApplication
+import fi.oph.koski.config.KoskiApplication.defaultConfig
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatra.auth.strategy.BasicAuthStrategy.BasicAuthRequest
+import org.mockito.Mockito
+import com.typesafe.config.ConfigValueFactory.fromAnyRef
+
+import javax.servlet.http.HttpServletRequest
+
+// Tämä ei pyöritä tällä hetkellä yhtäkään oikeata testiä.
+// Tätä voi kuitenkin käyttää dokumentaationa ja nopeampaan
+// manuaaliseen testaamiseen. Voit käyttää esimerkiksi
+// testiopintopolussa olevaa migri-käyttäjää asettamalla
+// tämän käyttäjätunnuksen ja salasanan username- ja
+// password -parametreihin.
+class MigriServiceSpec extends AnyFreeSpec {
+  val application = KoskiApplication(defaultConfig.withValue(
+    "opintopolku.virkailija.url", fromAnyRef("https://virkailija.testiopintopolku.fi")
+  ))
+  val migriService = new RemoteMigriService()(application)
+
+  def basicAuthRequest: BasicAuthRequest = {
+    val request = new MockAuthRequest(Mockito.mock(classOf[HttpServletRequest]))
+    request
+  }
+
+  /*"MigriService" in {
+    migriService.get("1.2.246.562.24.51986460849", basicAuthRequest).right.get
+  }*/
+
+  class MockAuthRequest(r: HttpServletRequest) extends BasicAuthRequest(r) {
+    override def username: String = "Lasse"
+    override def password: String = "Lasse"
+  }
+}

--- a/src/test/scala/fi/oph/koski/migri/MigriSpec.scala
+++ b/src/test/scala/fi/oph/koski/migri/MigriSpec.scala
@@ -200,6 +200,17 @@ class MigriSpec extends AnyFreeSpec with KoskiHttpSpec with OpiskeluoikeusTestMe
     }
   }
 
+  "valinta-tulosten haku ohjautuu oikealle servicelle oikeilla parametreilla" in {
+    post(
+      "api/luovutuspalvelu/migri/valinta/oid",
+      JsonSerializer.writeWithRoot(MigriOidRequest("1.2.246.562.24.00000000000")),
+      headers = authHeaders(user) ++ jsonContent
+    ) {
+      val response = JsonSerializer.parse[String](body)
+      response should equal ("1.2.246.562.24.00000000000LasseLasse")
+    }
+  }
+
   private def postOid[A](oid: String, user: MockUser)(f: => A): A = {
     post(
       "api/luovutuspalvelu/migri/oid",


### PR DESCRIPTION
Koski toimii tässä lähinnä proxyna valinta-tulos-servicelle.

Jätetty tyhjä testifilu, jota käytetty manuaaliseen testaamiseen. Mielestäni se voi jatkossa olla hyvää dokumentaatiota ja kätevä testaamiseen.

Testataan routetuksen läpi pääseminen Mock-serviceä vasten.