### PR TITLE
TOR-1670 älä validoi mitätöityjä opiskeluoikeuksia

### DIFF
--- a/src/main/scala/fi/oph/koski/documentation/ExamplesVapaaSivistystyö.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesVapaaSivistystyö.scala
@@ -22,6 +22,7 @@ object ExamplesVapaaSivistystyö {
 object VapaaSivistystyöExample {
   val opiskeluoikeusHyväksytystiSuoritettu = Koodistokoodiviite("hyvaksytystisuoritettu", Some("Hyväksytysti suoritettu"), "koskiopiskeluoikeudentila", Some(1))
   val opiskeluoikeusKeskeytynyt = Koodistokoodiviite("keskeytynyt", Some("Keskeytynyt"), "koskiopiskeluoikeudentila", Some(1))
+  val opiskeluoikeusMitätöity = Koodistokoodiviite("mitatoity", Some("Mitätöity"), "koskiopiskeluoikeudentila", Some(1))
 
   lazy val opiskeluoikeusKOPS = VapaanSivistystyönOpiskeluoikeus(
     arvioituPäättymispäivä = Some(date(2022, 5, 31)),

--- a/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
+++ b/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
@@ -87,6 +87,7 @@ class KoskiValidator(
 
   private def validateOpiskeluoikeus(opiskeluoikeus: Opiskeluoikeus, henkilö: Option[Henkilö])(implicit user: KoskiSpecificSession, accessType: AccessType.Value): Either[HttpStatus, Opiskeluoikeus] = {
     opiskeluoikeus match {
+      case opiskeluoikeus if opiskeluoikeus.mitätöity => Right(opiskeluoikeus)
       case opiskeluoikeus: KoskeenTallennettavaOpiskeluoikeus =>
         updateFields(opiskeluoikeus).right.flatMap { opiskeluoikeus =>
           (validateAccess(opiskeluoikeus)

--- a/src/test/scala/fi/oph/koski/api/OppijaValidationDIASpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationDIASpec.scala
@@ -174,8 +174,7 @@ class OppijaValidationDIASpec extends AnyFreeSpec with KoskiHttpSpec with Opiske
         opiskeluoikeusEronnut,
         opiskeluoikeusKatsotaanEronneeksi,
         opiskeluoikeusValiaikaisestiKeskeytynyt,
-        opiskeluoikeusPeruutettu,
-        opiskeluoikeusMitätöity
+        opiskeluoikeusPeruutettu
       ).foreach(verifyRahoitusmuotoKielletty)
     }
   }

--- a/src/test/scala/fi/oph/koski/api/OppijaValidationVapaaSivistystyöVapaatavoitteinenSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationVapaaSivistystyöVapaatavoitteinenSpec.scala
@@ -137,7 +137,36 @@ class OppijaValidationVapaaSivistystyöVapaatavoitteinenSpec extends AnyFreeSpec
           }
         }
       }
+      "Kun opiskeluoikeus on mitätöity" - {
+        "Ei validointivirhettä, jos päätason suoritus vahvistettu, eikä tila ole 'Hyväksytysti suoritettu'" in {
+          putOpiskeluoikeus(mitätöityOpiskeluoikeus(vahvistettuPäätasonSuoritusKeskeytynytOpiskeluoikeus(VapaatavoitteinenOpiskeluoikeus))) {
+            verifyResponseStatusOk()
+          }
+        }
+        "Ei validointivirhettä, jos päätason suoritus vahvistamaton, eikä tila ole 'Keskeytynyt'" in {
+          putOpiskeluoikeus(mitätöityOpiskeluoikeus(vahvistamatonPäätasaonSuoritusHyväksyttyOpiskeluoikeus(VapaatavoitteinenOpiskeluoikeus))) {
+            verifyResponseStatusOk()
+          }
+        }
+        "Ei validointivirhettä, jos päätason suorituksella ei ole vähintään yhtä arvioitua osasuoritusta" in {
+          putOpiskeluoikeus(mitätöityOpiskeluoikeus(päätasoArvioimattomallaOsasuorituksella(VapaatavoitteinenOpiskeluoikeus))) {
+            verifyResponseStatusOk()
+          }
+        }
+      }
     }
+  }
+
+  private def mitätöityOpiskeluoikeus(oo: VapaanSivistystyönOpiskeluoikeus) = {
+    oo.copy(
+      tila = VapaanSivistystyönOpiskeluoikeudenTila(
+        oo.tila.opiskeluoikeusjaksot ++
+          List(
+            VapaanSivistystyönOpiskeluoikeusjakso(date(2022, 5, 31), opiskeluoikeusMitätöity)
+          )
+      ),
+      versionumero = oo.versionumero.map(_ + 1).orElse(Some(1))
+    )
   }
 
   private def vahvistettuPäätasonSuoritusKeskeytynytOpiskeluoikeus(oo: VapaanSivistystyönOpiskeluoikeus) = {

--- a/validaation_muutoshistoria.md
+++ b/validaation_muutoshistoria.md
@@ -1,5 +1,8 @@
 # Koskeen tallennettavien tietojen validaatiosäännöt
 
+## 1.4.2022
+- Mitätöity opiskeluoikeus jättää väliin opiskeluoikeuden validoinnin.
+
 # 22.3.2022
 - Muuta 16.3.2022 tehty validaatio estämään perusopetuksen oppimäärän vahvistaminen opiskeluoikeuden valmistuneeksi
   merkitsemisen sijasta


### PR DESCRIPTION
Mitätöinti halutaan sallia joka tapauksessa, vaikka
opiskeluoikeus ei läpäisisi validointisääntöjä.