### PR TITLE
TOR-1703 korjaa TUVA json-skeeman kuvaavia tekstejä

### DIFF
--- a/src/main/resources/localization/koski-default-texts.json
+++ b/src/main/resources/localization/koski-default-texts.json
@@ -2275,6 +2275,7 @@
   "description:Tutkintokoulutukseen valmentavan opiskeluoikeuden lukiokoulutuksen järjestämisluvan..." : "Tutkintokoulutukseen valmentavan opiskeluoikeuden lukiokoulutuksen järjestämisluvan lisätiedot",
   "description:Tutkintokoulutukseen valmentavan opiskeluoikeuden ammatillisen koulutuksen..." : "Tutkintokoulutukseen valmentavan opiskeluoikeuden ammatillisen koulutuksen järjestämisluvan lisätiedot",
   "description:Tutkintokoulutukseen valmentavan opiskeluoikeuden perusopetuksen järjestämisluvan..." : "Tutkintokoulutukseen valmentavan opiskeluoikeuden perusopetuksen järjestämisluvan lisätiedot",
+  "description:Tutkintokoulutukseen valmentavan koulutuksen suoritustiedot." : "Tutkintokoulutukseen valmentavan koulutuksen suoritustiedot.",
   "Virta virheet" : "Virta virheet",
   "description:Sisältö on aina tyhjä lista...." : "Sisältö on aina tyhjä lista. Kenttä näkyy tietomallissa vain teknisistä syistä.",
   "description:Sisältö on aina tyhjä lista..." : "Sisältö on aina tyhjä lista opiskeluoikeusjaksoja. Kenttä näkyy tietomallissa vain teknisistä syistä.",

--- a/src/main/scala/fi/oph/koski/schema/TutkintokoulutukseenValmentavaKoulutus.scala
+++ b/src/main/scala/fi/oph/koski/schema/TutkintokoulutukseenValmentavaKoulutus.scala
@@ -19,11 +19,11 @@ case class TutkintokoulutukseenValmentavanOpiskeluoikeus(
   tila: TutkintokoulutukseenValmentavanOpiskeluoikeudenTila,
   lisätiedot: Option[TutkintokoulutukseenValmentavanOpiskeluoikeudenLisätiedot] = None,
   @MaxItems(1)
-  suoritukset: List[TutkintokoulutukseenValmentavanKoulutuksenSuoritus],
+  suoritukset: List[TutkintokoulutukseenValmentavanKoulutuksenPäätasonSuoritus],
   tyyppi: Koodistokoodiviite = OpiskeluoikeudenTyyppi.tuva,
   organisaatiohistoria: Option[List[OpiskeluoikeudenOrganisaatiohistoria]] = None,
   @KoodistoUri("tuvajarjestamislupa")
-  @ReadOnly("Järjestämislupaa ei tyypillisesti vaihdeta suorituksen luonnin jälkeen")
+  @ReadOnly("")
   järjestämislupa: Koodistokoodiviite
 ) extends KoskeenTallennettavaOpiskeluoikeus {
   override def withKoulutustoimija(koulutustoimija: Koulutustoimija): KoskeenTallennettavaOpiskeluoikeus = this.copy(koulutustoimija = Some(koulutustoimija))
@@ -53,6 +53,10 @@ case class TutkintokoulutukseenValmentavanOpiskeluoikeusjakso(
   override val opintojenRahoitus: Option[Koodistokoodiviite] = None
 ) extends KoskiOpiskeluoikeusjakso
 
+trait TutkintokoulutukseenValmentavanKoulutuksenPäätasonSuoritus extends KoskeenTallennettavaPäätasonSuoritus
+
+@Title("Tutkintokoulutukseen valmentavan koulutuksen suoritustiedot")
+@Description("Tutkintokoulutukseen valmentavan koulutuksen suoritustiedot.")
 case class TutkintokoulutukseenValmentavanKoulutuksenSuoritus(
   toimipiste: OrganisaatioWithOid,
   @KoodistoUri("suorituksentyyppi")
@@ -67,8 +71,8 @@ case class TutkintokoulutukseenValmentavanKoulutuksenSuoritus(
   override val osasuoritukset: Option[List[TutkintokoulutukseenValmentavanKoulutuksenOsanSuoritus]],
   @Description("Todistuksella näytettävä lisätieto, vapaamuotoinen tekstikenttä")
   todistuksellaNäkyvätLisätiedot: Option[LocalizedString] = None
-) extends KoskeenTallennettavaPäätasonSuoritus with Toimipisteellinen with Suorituskielellinen with Todistus
-  with Arvioinniton with SuoritusVaatiiMahdollisestiMaksuttomuusTiedonOpiskeluoikeudelta with Suoritus
+) extends TutkintokoulutukseenValmentavanKoulutuksenPäätasonSuoritus with Toimipisteellinen with Suorituskielellinen
+  with Todistus with Arvioinniton with SuoritusVaatiiMahdollisestiMaksuttomuusTiedonOpiskeluoikeudelta with Suoritus
 
 @Description("Tutkintokoulutukseen valmentavan koulutuksen tunnistetiedot")
 case class TutkintokoulutukseenValmentavanKoulutus(


### PR DESCRIPTION
Korjaa schema viewerissä näkyviä tekstimuotoja.