### PR TITLE
VirkailijaHTTPClientin siistimistä;

### DIFF
--- a/src/main/scala/fi/oph/koski/healthcheck/HealthChecker.scala
+++ b/src/main/scala/fi/oph/koski/healthcheck/HealthChecker.scala
@@ -89,7 +89,7 @@ trait HealthCheck extends Logging {
   }
 
   def casCheck: HttpStatus = {
-    val VirkailijaCredentials(username, password) = VirkailijaCredentials(application.config, false)
+    val VirkailijaCredentials(username, password) = VirkailijaCredentials(application.config, true)
 
     def authenticate = try {
       Some(application.casService.authenticateVirkailija(username, Password(password)))

--- a/src/main/scala/fi/oph/koski/henkilo/OppijanumeroRekisteriClient.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/OppijanumeroRekisteriClient.scala
@@ -28,7 +28,7 @@ case class OppijanumeroRekisteriClient(config: Config) {
   private val baseUrl = "/oppijanumerorekisteri-service"
   private val totalTimeout = 1.minutes
 
-  private val oidServiceHttp = VirkailijaHttpClient(makeServiceConfig(config), baseUrl, false)
+  private val oidServiceHttp = VirkailijaHttpClient(makeServiceConfig(config), baseUrl, true)
 
   private val postRetryingOidServiceHttp = {
     // Osa POST-metodilla ONR:ään tehtävistä kyselyistä on oikeasti idempotentteja,
@@ -45,7 +45,7 @@ case class OppijanumeroRekisteriClient(config: Config) {
       makeServiceConfig(config),
       baseUrl,
       client,
-      false
+      true
     )
   }
 

--- a/src/main/scala/fi/oph/koski/huoltaja/HuollettavatRepository.scala
+++ b/src/main/scala/fi/oph/koski/huoltaja/HuollettavatRepository.scala
@@ -18,7 +18,7 @@ object HuollettavatRepository {
       case "mock" =>
         new MockHuollettavatRepository
       case url =>
-        val http = VirkailijaHttpClient(ServiceConfig.apply(config, "opintopolku.virkailija"), "/vtj-service", false)
+        val http = VirkailijaHttpClient(ServiceConfig.apply(config, "opintopolku.virkailija"), "/vtj-service", true)
         new RemoteHuollettavatRepository(http)
     }
   }

--- a/src/main/scala/fi/oph/koski/koodisto/KoodistoMuokkausPalvelu.scala
+++ b/src/main/scala/fi/oph/koski/koodisto/KoodistoMuokkausPalvelu.scala
@@ -16,7 +16,7 @@ object KoodistoMuokkausPalvelu {
 class KoodistoMuokkausPalvelu(serviceConfig: ServiceConfig) extends Logging {
   import fi.oph.koski.json.Json4sHttp4s._
 
-  val secureHttp = VirkailijaHttpClient(serviceConfig, "/koodisto-service", sessionCookieName = "SESSION", false)
+  val secureHttp = VirkailijaHttpClient(serviceConfig, "/koodisto-service", sessionCookieName = "SESSION", true)
 
   def updateKoodisto(koodisto: Koodisto): Unit = {
     runIO(secureHttp.put(uri"/koodisto-service/rest/codes/save", koodisto)(json4sEncoderOf[Koodisto])(Http.unitDecoder))

--- a/src/main/scala/fi/oph/koski/localization/LocalizationRepository.scala
+++ b/src/main/scala/fi/oph/koski/localization/LocalizationRepository.scala
@@ -126,7 +126,7 @@ class ReadOnlyRemoteLocalizationRepository(virkalijaRoot: String, val localizati
 }
 
 class RemoteLocalizationRepository(config: Config, val localizationConfig: LocalizationConfig)(implicit cacheInvalidator: CacheManager) extends CachedLocalizationService(localizationConfig) {
-  private val http = VirkailijaHttpClient(ServiceConfig.apply(config, "localization", "opintopolku.virkailija"), "/lokalisointi", false)
+  private val http = VirkailijaHttpClient(ServiceConfig.apply(config, "localization", "opintopolku.virkailija"), "/lokalisointi", true)
 
   override def fetchLocalizations(): JValue = runIO(http.get(uri"/lokalisointi/cxf/rest/v1/localisation?category=${localizationConfig.localizationCategory}")(Http.parseJson[JValue]))
 

--- a/src/main/scala/fi/oph/koski/migri/MigriService.scala
+++ b/src/main/scala/fi/oph/koski/migri/MigriService.scala
@@ -18,7 +18,7 @@ class RemoteMigriService (implicit val application: KoskiApplication) extends Lo
       "/valinta-tulos-service",
       sessionCookieName = "session",
       serviceUrlSuffix = "auth/login",
-      true)
+      false)
 
     runIO(client.post(uri"/valinta-tulos-service/cas/migri/hakemukset/", List(oid))(json4sEncoderOf[List[String]]) {
       case (200, text, _) => Right(text)

--- a/src/main/scala/fi/oph/koski/organisaatio/OrganisaatioRepository.scala
+++ b/src/main/scala/fi/oph/koski/organisaatio/OrganisaatioRepository.scala
@@ -110,7 +110,7 @@ object OrganisaatioRepository {
       case "mock" =>
         MockOrganisaatioRepository
       case url =>
-        val http = VirkailijaHttpClient(ServiceConfig.apply(config, "opintopolku.virkailija"), "/organisaatio-service", sessionCookieName = "SESSION", false)
+        val http = VirkailijaHttpClient(ServiceConfig.apply(config, "opintopolku.virkailija"), "/organisaatio-service", sessionCookieName = "SESSION", true)
         new RemoteOrganisaatioRepository(http, koodisto)
     }
   }

--- a/src/main/scala/fi/oph/koski/userdirectory/KayttooikeusServiceClient.scala
+++ b/src/main/scala/fi/oph/koski/userdirectory/KayttooikeusServiceClient.scala
@@ -9,7 +9,7 @@ import fi.oph.koski.json.Json4sHttp4s
 import cats.syntax.parallel._
 
 case class KäyttöoikeusServiceClient(config: Config) {
-  private val http = VirkailijaHttpClient(makeServiceConfig(config), "/kayttooikeus-service", false)
+  private val http = VirkailijaHttpClient(makeServiceConfig(config), "/kayttooikeus-service", true)
 
   private def makeServiceConfig(config: Config) = ServiceConfig.apply(
     config,

--- a/src/main/scala/fi/oph/koski/valpas/hakukooste/SureHakukoosteService.scala
+++ b/src/main/scala/fi/oph/koski/valpas/hakukooste/SureHakukoosteService.scala
@@ -47,7 +47,7 @@ class SureHakukoosteService(
       ServiceConfig.apply(config, "opintopolku.virkailija"),
       baseUrl,
       client,
-      false
+      true
     )
   }
 


### PR DESCRIPTION
aina ei haluta hakea virkailija-credentsejä SecretsManagerista, joten tarvitaan tapa ohittaa se haku. Toisaalta, on myös vaikea muuttaa koodia rakenteellisesti merkittävästi, koska testaaminen on hankalaa ympäristöeroavaisuuksien takia