### PR TITLE
Tuotantodataan testaamisen helpottamista

### DIFF
--- a/.github/workflows/run_koski_tests_on_branches.yml
+++ b/.github/workflows/run_koski_tests_on_branches.yml
@@ -70,8 +70,8 @@ jobs:
         run: |
           make checkdoc_schema
 
-  run_backend_tests:
-    name: Run Koski backend tests
+  run_backend_tests_api:
+    name: Run Koski backend tests (api)
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -113,8 +113,114 @@ jobs:
       - name: Start Postgres and ES containers
         run: docker-compose up -d
 
-      - name: Run backend tests
-        run: mvn test
+      - name: Run backend tests (api)
+        run: mvn test -DmembersOnlySuites="fi.oph.koski.api,\
+          fi.oph.koski.browserstack,fi.oph.koski.cache"
+
+  run_backend_tests_nonmock:
+    name: Run Koski backend tests (non-mock)
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Java 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: "8"
+          architecture: x64
+
+      - name: Setup Node 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Cache Node modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Configure sysctl limits for Elasticsearch
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+
+      - name: Start Postgres and ES containers
+        run: docker-compose up -d
+
+      - name: Run backend tests (non-mock)
+        run: mvn test -DmembersOnlySuites="fi.oph.koski.nonmockloginsecurity"
+
+  run_backend_tests_other:
+    name: Run Koski backend tests (other)
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Java 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: "8"
+          architecture: x64
+
+      - name: Setup Node 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Cache Node modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Configure sysctl limits for Elasticsearch
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+
+      - name: Start Postgres and ES containers
+        run: docker-compose up -d
+
+      - name: Run backend tests (other)
+        run: mvn test -DmembersOnlySuites="fi.oph.koski.browserstack,\
+          fi.oph.koski.cache,fi.oph.koski.editor,fi.oph.koski.environment,\
+          fi.oph.koski.etk,fi.oph.koski.henkilo,fi.oph.koski.http,\
+          fi.oph.koski.integrationtest,fi.oph.koski.json,fi.oph.koski.kela,fi.oph.koski.koodisto,\
+          fi.oph.koski.koskiuser,fi.oph.koski.localization,fi.oph.koski.log,\
+          fi.oph.koski.luovutuspalvelu,fi.oph.koski.migration,fi.oph.koski.migri,\
+          fi.oph.koski.mocha,fi.oph.koski.mydata,fi.oph.koski.omaopintopolkuloki,\
+          fi.oph.koski.opiskeluoikeus,fi.oph.koski.oppilaitos,fi.oph.koski.oppivelvollisuustieto,\
+          fi.oph.koski.organisaatio,fi.oph.koski.perftest,fi.oph.koski.raportit,\
+          fi.oph.koski.raportointikanta,fi.oph.koski.schedule,fi.oph.koski.schema,\
+          fi.oph.koski.sso,fi.oph.koski.sure,fi.oph.koski.tools,\
+          fi.oph.koski.userdirectory,fi.oph.koski.util,fi.oph.koski.valpas,\
+          fi.oph.koski.valvira,fi.oph.koski.versioning,fi.oph.koski.virta,\
+          fi.oph.koski.ytl,fi.oph.koski.ytr, fi.oph.koski.ytl,fi.oph.koski.meta"
 
   run_frontend_tests_0:
     name: Run Koski frontend tests runner 0

--- a/.github/workflows/run_koski_tests_on_branches.yml
+++ b/.github/workflows/run_koski_tests_on_branches.yml
@@ -220,7 +220,8 @@ jobs:
           fi.oph.koski.sso,fi.oph.koski.sure,fi.oph.koski.tools,\
           fi.oph.koski.userdirectory,fi.oph.koski.util,fi.oph.koski.valpas,\
           fi.oph.koski.valvira,fi.oph.koski.versioning,fi.oph.koski.virta,\
-          fi.oph.koski.ytl,fi.oph.koski.ytr, fi.oph.koski.ytl,fi.oph.koski.meta"
+          fi.oph.koski.ytl,fi.oph.koski.ytr, fi.oph.koski.ytl,fi.oph.koski.meta,\
+          fi.oph.koski.frontendvalvonta"
 
   run_frontend_tests_0:
     name: Run Koski frontend tests runner 0

--- a/.github/workflows/test_build_deploy_master.yml
+++ b/.github/workflows/test_build_deploy_master.yml
@@ -199,7 +199,8 @@ jobs:
           fi.oph.koski.sso,fi.oph.koski.sure,fi.oph.koski.tools,\
           fi.oph.koski.userdirectory,fi.oph.koski.util,fi.oph.koski.valpas,\
           fi.oph.koski.valvira,fi.oph.koski.versioning,fi.oph.koski.virta,\
-          fi.oph.koski.ytl,fi.oph.koski.ytr, fi.oph.koski.ytl,fi.oph.koski.meta"
+          fi.oph.koski.ytl,fi.oph.koski.ytr, fi.oph.koski.ytl,fi.oph.koski.meta,\
+          fi.oph.koski.frontendvalvonta"
 
   run_frontend_tests_0:
     name: Run Koski frontend tests runner 0

--- a/.github/workflows/test_build_deploy_master.yml
+++ b/.github/workflows/test_build_deploy_master.yml
@@ -49,8 +49,8 @@ jobs:
           cd ..
           make lint
 
-  run_backend_tests:
-    name: Run Koski backend tests
+  run_backend_tests_api:
+    name: Run Koski backend tests (api)
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -92,8 +92,114 @@ jobs:
       - name: Start Postgres and ES containers
         run: docker-compose up -d
 
-      - name: Run backend tests
-        run: mvn test
+      - name: Run backend tests (api)
+        run: mvn test -DmembersOnlySuites="fi.oph.koski.api,\
+          fi.oph.koski.browserstack,fi.oph.koski.cache"
+
+  run_backend_tests_nonmock:
+    name: Run Koski backend tests (non-mock)
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Java 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: "8"
+          architecture: x64
+
+      - name: Setup Node 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Cache Node modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Configure sysctl limits for Elasticsearch
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+
+      - name: Start Postgres and ES containers
+        run: docker-compose up -d
+
+      - name: Run backend tests (non-mock)
+        run: mvn test -DmembersOnlySuites="fi.oph.koski.nonmockloginsecurity"
+
+  run_backend_tests_other:
+    name: Run Koski backend tests (other)
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Java 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: "8"
+          architecture: x64
+
+      - name: Setup Node 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Cache Node modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Configure sysctl limits for Elasticsearch
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+
+      - name: Start Postgres and ES containers
+        run: docker-compose up -d
+
+      - name: Run backend tests (other)
+        run: mvn test -DmembersOnlySuites="fi.oph.koski.browserstack,\
+          fi.oph.koski.cache,fi.oph.koski.editor,fi.oph.koski.environment,\
+          fi.oph.koski.etk,fi.oph.koski.henkilo,fi.oph.koski.http,\
+          fi.oph.koski.integrationtest,fi.oph.koski.json,fi.oph.koski.kela,fi.oph.koski.koodisto,\
+          fi.oph.koski.koskiuser,fi.oph.koski.localization,fi.oph.koski.log,\
+          fi.oph.koski.luovutuspalvelu,fi.oph.koski.migration,fi.oph.koski.migri,\
+          fi.oph.koski.mocha,fi.oph.koski.mydata,fi.oph.koski.omaopintopolkuloki,\
+          fi.oph.koski.opiskeluoikeus,fi.oph.koski.oppilaitos,fi.oph.koski.oppivelvollisuustieto,\
+          fi.oph.koski.organisaatio,fi.oph.koski.perftest,fi.oph.koski.raportit,\
+          fi.oph.koski.raportointikanta,fi.oph.koski.schedule,fi.oph.koski.schema,\
+          fi.oph.koski.sso,fi.oph.koski.sure,fi.oph.koski.tools,\
+          fi.oph.koski.userdirectory,fi.oph.koski.util,fi.oph.koski.valpas,\
+          fi.oph.koski.valvira,fi.oph.koski.versioning,fi.oph.koski.virta,\
+          fi.oph.koski.ytl,fi.oph.koski.ytr, fi.oph.koski.ytl,fi.oph.koski.meta"
 
   run_frontend_tests_0:
     name: Run Koski frontend tests runner 0
@@ -462,7 +568,9 @@ jobs:
     needs:
       [
         lint_koski,
-        run_backend_tests,
+        run_backend_tests_api,
+        run_backend_tests_nonmock,
+        run_backend_tests_other,
         run_frontend_tests_0,
         run_frontend_tests_1,
         run_frontend_tests_2,

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,25 @@ js-unit-test-watch:
 
 .PHONY: backtest
 backtest:
-	mvn $(mvn_opts) -DargLine="$(mvn_argline)" test
+	mvn $(mvn_opts) -DargLine="$(mvn_argline)" test -DmembersOnlySuites="fi.oph.koski.browserstack,\
+	fi.oph.koski.cache,fi.oph.koski.editor,fi.oph.koski.environment,\
+	fi.oph.koski.etk,fi.oph.koski.henkilo,fi.oph.koski.http,\
+	fi.oph.koski.integrationtest,fi.oph.koski.json,fi.oph.koski.kela,fi.oph.koski.koodisto,\
+	fi.oph.koski.koskiuser,fi.oph.koski.localization,fi.oph.koski.log,\
+	fi.oph.koski.luovutuspalvelu,fi.oph.koski.migration,fi.oph.koski.migri,\
+	fi.oph.koski.mocha,fi.oph.koski.mydata,fi.oph.koski.omaopintopolkuloki,\
+	fi.oph.koski.opiskeluoikeus,fi.oph.koski.oppilaitos,fi.oph.koski.oppivelvollisuustieto,\
+	fi.oph.koski.organisaatio,fi.oph.koski.perftest,fi.oph.koski.raportit,\
+	fi.oph.koski.raportointikanta,fi.oph.koski.schedule,fi.oph.koski.schema,\
+	fi.oph.koski.sso,fi.oph.koski.sure,fi.oph.koski.tools,\
+	fi.oph.koski.userdirectory,fi.oph.koski.util,fi.oph.koski.valpas,\
+	fi.oph.koski.valvira,fi.oph.koski.versioning,fi.oph.koski.virta,\
+	fi.oph.koski.ytl,fi.oph.koski.ytr,fi.oph.koski.ytl,fi.oph.koski.meta,\
+	fi.oph.koski.ytl,fi.oph.koski.api,fi.oph.koski.frontendvalvonta"
+
+.PHONY: backtestnonmock
+backtestnonmock:
+	mvn $(mvn_opts) -DargLine="$(mvn_argline)" test -DmembersOnlySuites="fi.oph.koski.nonmockloginsecurity"
 
 .PHONY: fronttest
 fronttest:
@@ -93,7 +111,7 @@ screenshot:
 	ls -t web/target/screenshots|head -1|xargs -I{} open web/target/screenshots/{}
 
 .PHONY: test
-test: backtest fronttest
+test: backtest fronttest backtestnonmock
 
 ### Running application and database
 

--- a/src/main/scala/fi/oph/koski/oppija/OppijaServlet.scala
+++ b/src/main/scala/fi/oph/koski/oppija/OppijaServlet.scala
@@ -1,6 +1,6 @@
 package fi.oph.koski.oppija
 
-import fi.oph.koski.config.{Environment, KoskiApplication}
+import fi.oph.koski.config.{KoskiApplication}
 import fi.oph.koski.henkilo.HenkilöOid
 import fi.oph.koski.http.{HttpStatus, KoskiErrorCategory}
 import fi.oph.koski.json.JsonSerializer.extract
@@ -139,7 +139,7 @@ class OppijaServlet(implicit val application: KoskiApplication)
       case _ => JBool(false)
     })
 
-    envIsLocalOrUnittest && ignoreFlagInJson
+    loginEnvIsMock && ignoreFlagInJson
   }
 
   private def cleanForTesting(oppijaJson: JValue) = {
@@ -148,7 +148,7 @@ class OppijaServlet(implicit val application: KoskiApplication)
       case _ => JBool(false)
     })
 
-    val shouldClean = envIsLocalOrUnittest && cleanForTesting
+    val shouldClean = loginEnvIsMock && cleanForTesting
 
     if (shouldClean) {
       implicit val formats = DefaultFormats
@@ -165,9 +165,9 @@ class OppijaServlet(implicit val application: KoskiApplication)
     }
   }
 
-  private def envIsLocalOrUnittest = {
-    val env = Environment.currentEnvironment(application.config)
-    env == Environment.Local || env == Environment.UnitTest
+  private def loginEnvIsMock = {
+    val sec = application.config.getString("login.security")
+    sec == "mock"
   }
 }
 

--- a/src/main/scala/fi/oph/koski/schema/KoskiSchema.scala
+++ b/src/main/scala/fi/oph/koski/schema/KoskiSchema.scala
@@ -13,6 +13,7 @@ object KoskiSchema {
   lazy val lenientDeserialization = ExtractionContext(schemaFactory, ignoreUnexpectedProperties = true)
   lazy val lenientDeserializationWithIgnoringNonValidatingListItems =
     ExtractionContext(schemaFactory, ignoreUnexpectedProperties = true, ignoreNonValidatingListItems = true)
+  lazy val lenientDeserializationWithoutValidation = ExtractionContext(schemaFactory, ignoreUnexpectedProperties = true, validate = false)
 
   def createSchema(clazz: Class[_]) = schemaFactory.createSchema(clazz) match {
     case s: AnyOfSchema => s

--- a/src/main/scala/fi/oph/koski/validation/ValidatingAndResolvingExtractor.scala
+++ b/src/main/scala/fi/oph/koski/validation/ValidatingAndResolvingExtractor.scala
@@ -21,13 +21,13 @@ class ValidatingAndResolvingExtractor(
    */
   def extract[T](deserializationContext: ExtractionContext)(json: JValue)(implicit tag: TypeTag[T])
   : Either[HttpStatus, T] = {
-    val customDeserializers = if (deserializationContext.ignoreUnexpectedProperties) {
-      List()
-    } else {
+    val customDeserializers = if (deserializationContext.validate) {
       List(
         OrganisaatioResolvingCustomDeserializer(organisaatioRepository),
         KoodistoResolvingCustomDeserializer(koodistoPalvelu)
       )
+    } else {
+      List()
     }
     extract(json, deserializationContext.copy(
       customDeserializers = JaksoCustomDeserializer(customDeserializers) :: customDeserializers

--- a/src/main/scala/fi/oph/koski/validation/ValidatingAndResolvingExtractor.scala
+++ b/src/main/scala/fi/oph/koski/validation/ValidatingAndResolvingExtractor.scala
@@ -21,10 +21,14 @@ class ValidatingAndResolvingExtractor(
    */
   def extract[T](deserializationContext: ExtractionContext)(json: JValue)(implicit tag: TypeTag[T])
   : Either[HttpStatus, T] = {
-    val customDeserializers = List(
-      OrganisaatioResolvingCustomDeserializer(organisaatioRepository),
-      KoodistoResolvingCustomDeserializer(koodistoPalvelu)
-    )
+    val customDeserializers = if (deserializationContext.ignoreUnexpectedProperties) {
+      List()
+    } else {
+      List(
+        OrganisaatioResolvingCustomDeserializer(organisaatioRepository),
+        KoodistoResolvingCustomDeserializer(koodistoPalvelu)
+      )
+    }
     extract(json, deserializationContext.copy(
       customDeserializers = JaksoCustomDeserializer(customDeserializers) :: customDeserializers
     ))

--- a/src/test/resources/rikkinäinen_opiskeluoikeus.json
+++ b/src/test/resources/rikkinäinen_opiskeluoikeus.json
@@ -1,0 +1,461 @@
+{
+  "cleanForTesting": true,
+  "ignoreKoskiValidator": true,
+  "henkilö" : {
+    "oid" : "1.2.246.562.24.56711111111",
+    "hetu" : "091087-789S",
+    "syntymäaika" : "1990-1-1",
+    "etunimet" : "Olen Rikki",
+    "kutsumanimi" : "Rikki",
+    "sukunimi" : "Testidata",
+    "äidinkieli" : {
+      "koodiarvo" : "FI",
+      "nimi" : {
+        "fi" : "suomi",
+        "sv" : "finska",
+        "en" : "Finnish"
+      },
+      "lyhytNimi" : {
+        "fi" : "suomi",
+        "sv" : "finska",
+        "en" : "Finnish"
+      },
+      "koodistoUri" : "kieli",
+      "koodistoVersio" : 1
+    },
+    "kansalaisuus" : [ {
+      "koodiarvo" : "246",
+      "nimi" : {
+        "fi" : "Suomi",
+        "sv" : "Finland",
+        "en" : "Finland"
+      },
+      "lyhytNimi" : {
+        "fi" : "FI",
+        "sv" : "FI",
+        "en" : "FI"
+      },
+      "koodistoUri" : "maatjavaltiot2",
+      "koodistoVersio" : 2
+    } ],
+    "turvakielto" : false
+  },
+  "opiskeluoikeudet" : [ {
+    "versionumero" : 1,
+    "aikaleima" : "2021-08-20T13:23:36.391031",
+    "lähdejärjestelmänId" : {
+      "id" : "92362",
+      "lähdejärjestelmä" : {
+        "koodiarvo" : "primus",
+        "nimi" : {
+          "fi" : "primus"
+        },
+        "koodistoUri" : "lahdejarjestelma",
+        "koodistoVersio" : 1
+      }
+    },
+    "oppilaitos" : {
+      "oid" : "1.2.246.562.10.51720121923",
+      "oppilaitosnumero" : {
+        "koodiarvo" : "10054",
+        "nimi" : {
+          "fi" : "Omnia",
+          "sv" : "Omnia",
+          "en" : "Omnia"
+        },
+        "lyhytNimi" : {
+          "fi" : "Omnia",
+          "sv" : "Omnia",
+          "en" : "Omnia"
+        },
+        "koodistoUri" : "oppilaitosnumero",
+        "koodistoVersio" : 1
+      },
+      "nimi" : {
+        "fi" : "Omnia",
+        "sv" : "Omnia",
+        "en" : "Omnia"
+      },
+      "kotipaikka" : {
+        "koodiarvo" : "049",
+        "nimi" : {
+          "fi" : "Espoo",
+          "sv" : "Esbo"
+        },
+        "koodistoUri" : "kunta",
+        "koodistoVersio" : 2
+      }
+    },
+    "koulutustoimija" : {
+      "oid" : "1.2.246.562.10.53642770753",
+      "nimi" : {
+        "fi" : "Espoon seudun koulutuskuntayhtymä Omnia"
+      },
+      "yTunnus" : "0502454-6",
+      "kotipaikka" : {
+        "koodiarvo" : "049",
+        "nimi" : {
+          "fi" : "Espoo",
+          "sv" : "Esbo"
+        },
+        "koodistoUri" : "kunta",
+        "koodistoVersio" : 2
+      }
+    },
+    "arvioituPäättymispäivä" : "2022-09-30",
+    "ostettu" : false,
+    "tila" : {
+      "opiskeluoikeusjaksot" : [ {
+        "alku" : "2021-08-17",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä",
+            "sv" : "Närvarande",
+            "en" : "Present"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        },
+        "opintojenRahoitus" : {
+          "koodiarvo" : "1",
+          "nimi" : {
+            "fi" : "Valtionosuusrahoitteinen koulutus",
+            "sv" : "Statsandelsfinansierad utbildning"
+          },
+          "koodistoUri" : "opintojenrahoitus",
+          "koodistoVersio" : 1
+        }
+      } ]
+    },
+    "suoritukset" : [ {
+      "koulutusmoduuli" : {
+        "tunniste" : {
+          "koodiarvo" : "309902",
+          "nimi" : {
+            "fi" : "Lukion oppimäärä",
+            "sv" : "Gymnasiets lärokurs"
+          },
+          "koodistoUri" : "koulutus",
+          "koodistoVersio" : 12
+        },
+        "perusteenDiaarinumero" : "OPH-2263-2019"
+      },
+      "oppimäärä" : {
+        "koodiarvo" : "nuortenops",
+        "nimi" : {
+          "fi" : "Lukio suoritetaan nuorten opetussuunnitelman mukaan",
+          "sv" : "Gymnasiet genomförs enligt läroplanen för unga"
+        },
+        "koodistoUri" : "lukionoppimaara",
+        "koodistoVersio" : 1
+      },
+      "toimipiste" : {
+        "oid" : "1.2.246.562.10.14613773812",
+        "oppilaitosnumero" : {
+          "koodiarvo" : "00204",
+          "nimi" : {
+            "fi" : "Jyväskylän normaalikoulu",
+            "sv" : "Jyväskylän normaalikoulu",
+            "en" : "Jyväskylän normaalikoulu"
+          },
+          "lyhytNimi" : {
+            "fi" : "Jyväskylän normaalikoulu",
+            "sv" : "Jyväskylän normaalikoulu",
+            "en" : "Jyväskylän normaalikoulu"
+          },
+          "koodistoUri" : "oppilaitosnumero"
+        },
+        "nimi" : {
+          "fi" : "Jyväskylän normaalikoulu",
+          "sv" : "Jyväskylän normaalikoulu",
+          "en" : "Jyväskylän normaalikoulu"
+        },
+        "kotipaikka" : {
+          "koodiarvo" : "179",
+          "nimi" : {
+            "fi" : "Jyväskylä",
+            "sv" : "Jyväskylä"
+          },
+          "koodistoUri" : "kunta"
+        }
+      },
+      "vahvistus" : {
+        "päivä" : "2020-05-15",
+        "paikkakunta" : {
+          "koodiarvo" : "179",
+          "nimi" : {
+            "fi" : "Jyväskylä",
+            "sv" : "Jyväskylä"
+          },
+          "koodistoUri" : "kunta",
+          "koodistoVersio" : 2
+        },
+        "myöntäjäOrganisaatio" : {
+          "oid" : "1.2.246.562.10.14613773812",
+          "oppilaitosnumero" : {
+            "koodiarvo" : "00204",
+            "nimi" : {
+              "fi" : "Jyväskylän normaalikoulu",
+              "sv" : "Jyväskylän normaalikoulu",
+              "en" : "Jyväskylän normaalikoulu"
+            },
+            "lyhytNimi" : {
+              "fi" : "Jyväskylän normaalikoulu",
+              "sv" : "Jyväskylän normaalikoulu",
+              "en" : "Jyväskylän normaalikoulu"
+            },
+            "koodistoUri" : "oppilaitosnumero"
+          },
+          "nimi" : {
+            "fi" : "Jyväskylän normaalikoulu",
+            "sv" : "Jyväskylän normaalikoulu",
+            "en" : "Jyväskylän normaalikoulu"
+          },
+          "kotipaikka" : {
+            "koodiarvo" : "179",
+            "nimi" : {
+              "fi" : "Jyväskylä",
+              "sv" : "Jyväskylä"
+            },
+            "koodistoUri" : "kunta"
+          }
+        },
+        "myöntäjäHenkilöt" : [ {
+          "nimi" : "Reijo Reksi",
+          "titteli" : {
+            "fi" : "rehtori"
+          },
+          "organisaatio" : {
+            "oid" : "1.2.246.562.10.14613773812",
+            "oppilaitosnumero" : {
+              "koodiarvo" : "00204",
+              "nimi" : {
+                "fi" : "Jyväskylän normaalikoulu",
+                "sv" : "Jyväskylän normaalikoulu",
+                "en" : "Jyväskylän normaalikoulu"
+              },
+              "lyhytNimi" : {
+                "fi" : "Jyväskylän normaalikoulu",
+                "sv" : "Jyväskylän normaalikoulu",
+                "en" : "Jyväskylän normaalikoulu"
+              },
+              "koodistoUri" : "oppilaitosnumero"
+            },
+            "nimi" : {
+              "fi" : "Jyväskylän normaalikoulu",
+              "sv" : "Jyväskylän normaalikoulu",
+              "en" : "Jyväskylän normaalikoulu"
+            },
+            "kotipaikka" : {
+              "koodiarvo" : "179",
+              "nimi" : {
+                "fi" : "Jyväskylä",
+                "sv" : "Jyväskylä"
+              },
+              "koodistoUri" : "kunta"
+            }
+          }
+        } ]
+      },
+      "suoritettuErityisenäTutkintona" : false,
+      "suorituskieli" : {
+        "koodiarvo" : "FI",
+        "nimi" : {
+          "fi" : "suomi",
+          "sv" : "finska",
+          "en" : "Finnish"
+        },
+        "lyhytNimi" : {
+          "fi" : "suomi",
+          "sv" : "finska",
+          "en" : "Finnish"
+        },
+        "koodistoUri" : "kieli",
+        "koodistoVersio" : 1
+      },
+      "omanÄidinkielenOpinnot" : {
+        "arvosana" : {
+          "koodiarvo" : "8",
+          "nimi" : {
+            "fi" : "hyvä",
+            "sv" : "god"
+          },
+          "lyhytNimi" : {
+            "fi" : "8"
+          },
+          "koodistoUri" : "arviointiasteikkoyleissivistava",
+          "koodistoVersio" : 1
+        },
+        "kieli" : {
+          "koodiarvo" : "SE",
+          "nimi" : {
+            "fi" : "saame, lappi",
+            "sv" : "samiska",
+            "en" : "Northern Sami"
+          },
+          "lyhytNimi" : {
+            "fi" : "saame, lappi",
+            "sv" : "samiska",
+            "en" : "Northern Sami"
+          },
+          "koodistoUri" : "kielivalikoima",
+          "koodistoVersio" : 1
+        },
+        "laajuus" : {
+          "arvo" : 3.0,
+          "yksikkö" : {
+            "koodiarvo" : "2",
+            "nimi" : {
+              "fi" : "opintopistettä",
+              "sv" : "studiepoäng",
+              "en" : "ECTS credits"
+            },
+            "lyhytNimi" : {
+              "fi" : "op",
+              "sv" : "sp",
+              "en" : "ECTS cr"
+            },
+            "koodistoUri" : "opintojenlaajuusyksikko",
+            "koodistoVersio" : 1
+          }
+        },
+        "hyväksytty" : true
+      },
+      "puhviKoe" : {
+        "arvosana" : {
+          "koodiarvo" : "7",
+          "nimi" : {
+            "fi" : "tyydyttävä",
+            "sv" : "nöjaktig"
+          },
+          "lyhytNimi" : {
+            "fi" : "7"
+          },
+          "koodistoUri" : "arviointiasteikkoyleissivistava",
+          "koodistoVersio" : 1
+        },
+        "päivä" : "2019-08-30",
+        "hyväksytty" : true
+      },
+      "suullisenKielitaidonKokeet" : [ {
+        "kieli" : {
+          "koodiarvo" : "EN",
+          "nimi" : {
+            "fi" : "englanti",
+            "sv" : "engelska",
+            "en" : "English"
+          },
+          "lyhytNimi" : {
+            "fi" : "englanti",
+            "sv" : "engelska",
+            "en" : "English"
+          },
+          "koodistoUri" : "kielivalikoima",
+          "koodistoVersio" : 1
+        },
+        "arvosana" : {
+          "koodiarvo" : "6",
+          "nimi" : {
+            "fi" : "kohtalainen",
+            "sv" : "hjälplig"
+          },
+          "lyhytNimi" : {
+            "fi" : "6"
+          },
+          "koodistoUri" : "arviointiasteikkoyleissivistava",
+          "koodistoVersio" : 1
+        },
+        "taitotaso" : {
+          "koodiarvo" : "B1.1",
+          "nimi" : {
+            "fi" : "B1.1"
+          },
+          "koodistoUri" : "arviointiasteikkokehittyvankielitaidontasot",
+          "koodistoVersio" : 1
+        },
+        "päivä" : "2019-09-03",
+        "hyväksytty" : true
+      }, {
+        "kieli" : {
+          "koodiarvo" : "ES",
+          "nimi" : {
+            "fi" : "espanja",
+            "sv" : "spanska",
+            "en" : "Spanish"
+          },
+          "lyhytNimi" : {
+            "fi" : "espanja",
+            "sv" : "spanska",
+            "en" : "Spanish"
+          },
+          "koodistoUri" : "kielivalikoima",
+          "koodistoVersio" : 1
+        },
+        "arvosana" : {
+          "koodiarvo" : "S",
+          "nimi" : {
+            "fi" : "hyväksytty",
+            "sv" : "godkänd"
+          },
+          "lyhytNimi" : {
+            "fi" : "S"
+          },
+          "koodistoUri" : "arviointiasteikkoyleissivistava",
+          "koodistoVersio" : 1
+        },
+        "taitotaso" : {
+          "koodiarvo" : "yli_C1.1",
+          "nimi" : {
+            "fi" : "Yli C1.1"
+          },
+          "koodistoUri" : "arviointiasteikkokehittyvankielitaidontasot",
+          "koodistoVersio" : 1
+        },
+        "kuvaus" : {
+          "fi" : "Puhetaito äidinkielen tasolla"
+        },
+        "päivä" : "2019-09-03",
+        "hyväksytty" : true
+      } ],
+      "todistuksellaNäkyvätLisätiedot" : {
+        "fi" : "Osallistunut kansalliseen etäopetuskokeiluun"
+      },
+      "tyyppi" : {
+        "koodiarvo" : "lukionoppimaara",
+        "nimi" : {
+          "fi" : "Lukion oppimäärä",
+          "sv" : "Gymnasiets lärokurs",
+          "en" : "General upper secondary education  syllabus"
+        },
+        "koodistoUri" : "suorituksentyyppi",
+        "koodistoVersio" : 1
+      },
+      "ryhmä" : "AH",
+      "koulusivistyskieli" : [ {
+        "koodiarvo" : "FI",
+        "nimi" : {
+          "fi" : "suomi"
+        },
+        "koodistoUri" : "kieli"
+      } ]
+    } ],
+    "lisätiedot" : {
+      "henkilöstökoulutus" : false,
+      "koulutusvienti" : false
+    },
+    "tyyppi" : {
+      "koodiarvo" : "lukiokoulutus",
+      "nimi" : {
+        "fi" : "Lukiokoulutus",
+        "sv" : "Gymnasieutbildning"
+      },
+      "lyhytNimi" : {
+        "fi" : "Lukiokoulutus"
+      },
+      "koodistoUri" : "opiskeluoikeudentyyppi",
+      "koodistoVersio" : 1
+    },
+    "alkamispäivä" : "2021-08-17"
+  }]
+}

--- a/src/test/scala/fi/oph/koski/LocalJettyHttpSpec.scala
+++ b/src/test/scala/fi/oph/koski/LocalJettyHttpSpec.scala
@@ -1,22 +1,26 @@
 package fi.oph.koski
 
+import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.http.HttpSpecification
 import fi.oph.koski.jettylauncher.JettyLauncher
-import fi.oph.koski.log.{AccessLogTester, AuditLogTester, Logging, RootLogTester}
+import fi.oph.koski.log.Logging
 
 trait LocalJettyHttpSpec extends HttpSpecification {
-  LocalJettyHttpSpec.setup()
+  LocalJettyHttpSpec.setup(defaultKoskiApplication)
 
   override def baseUrl: String = LocalJettyHttpSpec.baseUrl
+  protected def defaultKoskiApplication: KoskiApplication = KoskiApplicationForTests
 }
 
 object LocalJettyHttpSpec extends Logging {
   private def externalJettyPort = Option(System.getProperty("test.externalJettyPort")).map(_.toInt)
+  private var defaultKoskiApplication: KoskiApplication = KoskiApplicationForTests
 
   private lazy val jetty: JettyLauncher = externalJettyPort match {
     case None =>
-      SharedJetty.start()
-      SharedJetty
+      val sharedJetty = new SharedJetty(defaultKoskiApplication)
+      sharedJetty.start()
+      sharedJetty
     case Some(port) =>
       logger.info(s"Using external jetty on port $port")
       new JettyLauncher(port, KoskiApplicationForTests)
@@ -24,9 +28,10 @@ object LocalJettyHttpSpec extends Logging {
 
   var running = false
 
-  def setup(): Unit = synchronized {
+  def setup(koskiApplication: KoskiApplication): Unit = synchronized {
     if (!running) {
       running = true
+      defaultKoskiApplication = koskiApplication
       jetty // Evaluate to start jetty
     }
   }

--- a/src/test/scala/fi/oph/koski/LocalJettyHttpSpec.scala
+++ b/src/test/scala/fi/oph/koski/LocalJettyHttpSpec.scala
@@ -23,7 +23,7 @@ object LocalJettyHttpSpec extends Logging {
       sharedJetty
     case Some(port) =>
       logger.info(s"Using external jetty on port $port")
-      new JettyLauncher(port, KoskiApplicationForTests)
+      new JettyLauncher(port, defaultKoskiApplication)
   }
 
   var running = false

--- a/src/test/scala/fi/oph/koski/SharedJetty.scala
+++ b/src/test/scala/fi/oph/koski/SharedJetty.scala
@@ -1,9 +1,11 @@
 package fi.oph.koski
 
+import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.jettylauncher.JettyLauncher
 import fi.oph.koski.log.Logging
 import fi.oph.koski.util.PortChecker
 
-object SharedJetty extends JettyLauncher(PortChecker.findFreeLocalPort, KoskiApplicationForTests) with Logging {
+class SharedJetty(koskiApplication: KoskiApplication)
+  extends JettyLauncher(PortChecker.findFreeLocalPort, koskiApplication) with Logging {
   logger.info("Start shared jetty for tests")
 }

--- a/src/test/scala/fi/oph/koski/api/OppijaGetByOidSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaGetByOidSpec.scala
@@ -44,7 +44,7 @@ class OppijaGetByOidSpec
         }
       }
       "with mitätöity oid" in {
-        val oo = createOpiskeluoikeus(KoskiSpecificMockOppijat.eero, defaultOpiskeluoikeus)
+        val oo = createOpiskeluoikeus(KoskiSpecificMockOppijat.eero, defaultOpiskeluoikeus, resetFixtures = true)
         val mitätöity = oo.copy(tila = defaultOpiskeluoikeus.tila.copy(opiskeluoikeusjaksot =
           defaultOpiskeluoikeus.tila.opiskeluoikeusjaksot :+ AmmatillinenOpiskeluoikeusjakso(alku = LocalDate.now, opiskeluoikeusMitätöity)
         ))

--- a/src/test/scala/fi/oph/koski/api/OppijaValidationNonMockEnvSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationNonMockEnvSpec.scala
@@ -1,0 +1,26 @@
+package fi.oph.koski.api
+
+import com.typesafe.config.ConfigValueFactory.fromAnyRef
+import fi.oph.koski.KoskiHttpSpec
+import fi.oph.koski.config.Environment
+import fi.oph.koski.config.KoskiApplication.defaultConfig
+import org.json4s.DefaultFormats
+import org.json4s.jackson.JsonMethods
+import org.scalatest.freespec.AnyFreeSpec
+
+import scala.io.Source
+
+class OppijaValidationNonMockEnvSpec extends AnyFreeSpec with KoskiHttpSpec with OpiskeluoikeusTestMethodsAmmatillinen {
+  defaultConfig.withValue("env", fromAnyRef(Environment.UnitTest)).withValue(
+    "opintopolku.virkailija.url", fromAnyRef("https://virkailija.testiopintopolku.fi")
+  )
+
+  "Kentät cleanForTesting ja ignoreKoskiValidator" - {
+    "Vaikka kentät määritelty, muu kuin mock-ympäristö ei ota vastaan dataa validoimatta" in {
+      val json = JsonMethods.parse(Source.fromFile("src/test/resources/rikkinäinen_opiskeluoikeus.json").mkString)
+      putOppija(json, headers = authHeaders() ++ jsonContent) {
+        verifyResponseStatusOk()
+      }
+    }
+  }
+}

--- a/src/test/scala/fi/oph/koski/api/OppijaValidationNonMockEnvSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationNonMockEnvSpec.scala
@@ -2,24 +2,24 @@ package fi.oph.koski.api
 
 import com.typesafe.config.ConfigValueFactory.fromAnyRef
 import fi.oph.koski.KoskiHttpSpec
-import fi.oph.koski.config.Environment
+import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.config.KoskiApplication.defaultConfig
-import org.json4s.DefaultFormats
+import fi.oph.koski.http.{ErrorMatcher, KoskiErrorCategory}
 import org.json4s.jackson.JsonMethods
 import org.scalatest.freespec.AnyFreeSpec
 
 import scala.io.Source
 
 class OppijaValidationNonMockEnvSpec extends AnyFreeSpec with KoskiHttpSpec with OpiskeluoikeusTestMethodsAmmatillinen {
-  defaultConfig.withValue("env", fromAnyRef(Environment.UnitTest)).withValue(
-    "opintopolku.virkailija.url", fromAnyRef("https://virkailija.testiopintopolku.fi")
-  )
+  override def defaultKoskiApplication = KoskiApplication(defaultConfig.withValue(
+    "env", fromAnyRef("not-local")
+  ))
 
   "Kentät cleanForTesting ja ignoreKoskiValidator" - {
-    "Vaikka kentät määritelty, muu kuin mock-ympäristö ei ota vastaan dataa validoimatta" in {
+    "Vaikka kentät määritelty, muu kuin local-ympäristö ei ota vastaan dataa validoimatta" in {
       val json = JsonMethods.parse(Source.fromFile("src/test/resources/rikkinäinen_opiskeluoikeus.json").mkString)
       putOppija(json, headers = authHeaders() ++ jsonContent) {
-        verifyResponseStatusOk()
+        verifyResponseStatus(400,  ErrorMatcher.regex(KoskiErrorCategory.badRequest.validation.jsonSchema, ".*unexpectedProperty.*".r))
       }
     }
   }

--- a/src/test/scala/fi/oph/koski/api/OppijaValidationSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationSpec.scala
@@ -1,9 +1,6 @@
 package fi.oph.koski.api
 
-import com.typesafe.config.ConfigValueFactory.fromAnyRef
 import fi.oph.koski.KoskiHttpSpec
-import fi.oph.koski.config.Environment
-import fi.oph.koski.config.KoskiApplication.defaultConfig
 import fi.oph.koski.documentation.AmmatillinenExampleData.{stadinAmmattiopisto, _}
 import fi.oph.koski.documentation.ExampleData.{helsinki, vahvistus}
 import fi.oph.koski.documentation.ExamplesAikuistenPerusopetus.aikuistenPerusopetuksenOpiskeluoikeusAlkuvaiheineen

--- a/src/test/scala/fi/oph/koski/meta/GithubActionsSpec.scala
+++ b/src/test/scala/fi/oph/koski/meta/GithubActionsSpec.scala
@@ -13,19 +13,25 @@ class GithubActionsSpec extends AnyFreeSpec with Matchers {
 
   "Github Actions" - {
     "Tarkistetaan, että tiedostossa run_koski_tests_on_branches.yml on mainittu kaikki testipaketit" in {
-      val branchYaml = Source.fromFile(".github/workflows/run_koski_tests_on_branches.yml").mkString
-      val missing = testPackages.filter(
-        !branchYaml.contains(_)
-      ).toList
-      withClue(s"Missing packages from tests: $missing") { missing.length should be (0) }
+      checkTestIntegrity(".github/workflows/run_koski_tests_on_branches.yml")
     }
 
     "Tarkistetaan, että tiedostossa test_build_deploy_master.yml on mainittu kaikki testipaketit" in {
-      val branchYaml = Source.fromFile(".github/workflows/test_build_deploy_master.yml").mkString
-      val missing = testPackages.filter(
-        !branchYaml.contains(_)
-      ).toList
-      withClue(s"Missing packages from tests: $missing") { missing.length should be (0) }
+      checkTestIntegrity(".github/workflows/test_build_deploy_master.yml")
     }
+  }
+
+  "Local" - {
+    "Tarkistetaan, että tiedostossa Makefile on mainittu kaikki testipaketit" in {
+      checkTestIntegrity("Makefile")
+    }
+  }
+
+  private def checkTestIntegrity(path: String) = {
+    val sourceFile = Source.fromFile(path)
+    val source = sourceFile.mkString
+    sourceFile.close()
+    val missing = testPackages.filter(!source.contains(_)).toList
+    withClue(s"Missing packages from tests: $missing") { missing.length should be (0) }
   }
 }

--- a/src/test/scala/fi/oph/koski/meta/GithubActionsSpec.scala
+++ b/src/test/scala/fi/oph/koski/meta/GithubActionsSpec.scala
@@ -1,0 +1,31 @@
+package fi.oph.koski.migration
+
+import org.json4s.jackson.JsonMethods
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.File
+import scala.io.Source
+
+class GithubActionsSpec extends AnyFreeSpec with Matchers {
+  lazy val testPackages =
+    new File("./src/test/scala/fi/oph/koski/").listFiles.filter(_.isDirectory).map("fi.oph.koski." + _.getName)
+
+  "Github Actions" - {
+    "Tarkistetaan, että tiedostossa run_koski_tests_on_branches.yml on mainittu kaikki testipaketit" in {
+      val branchYaml = Source.fromFile(".github/workflows/run_koski_tests_on_branches.yml").mkString
+      val missing = testPackages.filter(
+        !branchYaml.contains(_)
+      ).toList
+      withClue(s"Missing packages from tests: $missing") { missing.length should be (0) }
+    }
+
+    "Tarkistetaan, että tiedostossa test_build_deploy_master.yml on mainittu kaikki testipaketit" in {
+      val branchYaml = Source.fromFile(".github/workflows/test_build_deploy_master.yml").mkString
+      val missing = testPackages.filter(
+        !branchYaml.contains(_)
+      ).toList
+      withClue(s"Missing packages from tests: $missing") { missing.length should be (0) }
+    }
+  }
+}

--- a/src/test/scala/fi/oph/koski/mocha/KoskiMochaSpec.scala
+++ b/src/test/scala/fi/oph/koski/mocha/KoskiMochaSpec.scala
@@ -1,13 +1,14 @@
 package fi.oph.koski.mocha
 
-import fi.oph.koski.SharedJetty
+import fi.oph.koski.{KoskiApplicationForTests, SharedJetty}
 import org.scalatest.Tag
 import org.scalatest.freespec.AnyFreeSpec
 
 class KoskiMochaSpec extends AnyFreeSpec with KoskiCommandLineSpec {
   "Mocha tests" taggedAs(MochaTag) in {
-    SharedJetty.start()
-    runTestCommand("mocha-chrome", Seq("scripts/mocha-chrome-test.sh", SharedJetty.baseUrl + "/test/runner.html"))
+    val sharedJetty = new SharedJetty(KoskiApplicationForTests)
+    sharedJetty.start()
+    runTestCommand("mocha-chrome", Seq("scripts/mocha-chrome-test.sh", sharedJetty.baseUrl + "/test/runner.html"))
   }
 }
 

--- a/src/test/scala/fi/oph/koski/mocha/KoskiParallelMochaSpec.scala
+++ b/src/test/scala/fi/oph/koski/mocha/KoskiParallelMochaSpec.scala
@@ -1,6 +1,6 @@
 package fi.oph.koski.mocha
 
-import fi.oph.koski.SharedJetty
+import fi.oph.koski.{KoskiApplicationForTests, SharedJetty}
 import fi.oph.koski.util.Files
 import org.scalatest.Tag
 import org.scalatest.freespec.AnyFreeSpec
@@ -9,9 +9,10 @@ trait KoskiParallelMochaSpec extends AnyFreeSpec with KoskiCommandLineSpec {
   def runnerNumber: Int
   "Mocha tests" taggedAs(Tag("parallelmocha")) in {
     val specs = SplitMochaSpecs.takeSpecsForRunner(runnerNumber)
-    SharedJetty.start()
+    val sharedJetty = new SharedJetty(KoskiApplicationForTests)
+    sharedJetty.start()
     //specFiles parameter makes runner.html to only load given spec.js files
-    runTestCommand("mocha-chrome", Seq("scripts/mocha-chrome-test.sh", SharedJetty.baseUrl + s"/test/runner.html?specFiles=$specs"))
+    runTestCommand("mocha-chrome", Seq("scripts/mocha-chrome-test.sh", sharedJetty.baseUrl + s"/test/runner.html?specFiles=$specs"))
   }
 }
 

--- a/src/test/scala/fi/oph/koski/nonmockloginsecurity/OppijaValidationSpec.scala
+++ b/src/test/scala/fi/oph/koski/nonmockloginsecurity/OppijaValidationSpec.scala
@@ -1,7 +1,8 @@
-package fi.oph.koski.api
+package fi.oph.koski.nonmockloginsecurity
 
 import com.typesafe.config.ConfigValueFactory.fromAnyRef
 import fi.oph.koski.KoskiHttpSpec
+import fi.oph.koski.api.OpiskeluoikeusTestMethodsAmmatillinen
 import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.config.KoskiApplication.defaultConfig
 import fi.oph.koski.http.{ErrorMatcher, KoskiErrorCategory}
@@ -10,9 +11,9 @@ import org.scalatest.freespec.AnyFreeSpec
 
 import scala.io.Source
 
-class OppijaValidationNonMockEnvSpec extends AnyFreeSpec with KoskiHttpSpec with OpiskeluoikeusTestMethodsAmmatillinen {
+class OppijaValidationSpec extends AnyFreeSpec with KoskiHttpSpec with OpiskeluoikeusTestMethodsAmmatillinen {
   override def defaultKoskiApplication = KoskiApplication(defaultConfig.withValue(
-    "env", fromAnyRef("not-local")
+    "login.security", fromAnyRef("not-mock")
   ))
 
   "Kentät cleanForTesting ja ignoreKoskiValidator" - {

--- a/src/test/scala/fi/oph/koski/valpas/jest/ValpasFrontSpec.scala
+++ b/src/test/scala/fi/oph/koski/valpas/jest/ValpasFrontSpec.scala
@@ -1,6 +1,6 @@
 package fi.oph.koski.valpas.jest
 
-import fi.oph.koski.SharedJetty
+import fi.oph.koski.{KoskiApplicationForTests, SharedJetty}
 import fi.oph.koski.mocha.KoskiCommandLineSpec
 import org.scalatest.Tag
 import org.scalatest.freespec.AnyFreeSpec
@@ -10,10 +10,11 @@ abstract class ValpasFrontSpecBase extends AnyFreeSpec with KoskiCommandLineSpec
   def numberOfChunks: Int
 
   "Valpas front specs" taggedAs(ValpasFrontTag) in {
-    SharedJetty.start()
+    val sharedJetty = new SharedJetty(KoskiApplicationForTests)
+    sharedJetty.start()
     runTestCommand("valpas-front", Seq(
       "scripts/valpas-front-test.sh",
-      SharedJetty.hostUrl,
+      sharedJetty.hostUrl,
       chunkNumber.toString,
       numberOfChunks.toString,
     ))


### PR DESCRIPTION
Kommitit suunnilleen loogisessa järjestyksessä. Pientä aikasemman koodin refaktorointia viimeisesssä kommitissa muun asian lisäksi.

Eli kaksi laajempaa asiaa nyt tehty:

Ensinnäkin mahdollistetaan validaatioden skippaaminen ja poistetaan muutama deserialisoimaton kenttä datasta, kun ignoreKoskiValidator ja cleanForTesting -flagit asetettu jsonissa. Esimerkiksi rikkinäinen_opiskeluoikeus.json -tiedostossa käytetään nyt näitä. Tämä on mahdollista vain mock-ympäristössä.

Toisena asiana splitattu backend-testit kolmeen erikseen ajettavaan osaan. Tämä on sikäli tarpeen, että testit käyttävät jaettua Koskea ja jotta voidaan testata ylempää asiaa myös ei-mock-ympäristössä, tarvii käynnistää sille testille oma Koski. Sen lisäksi samalla haettiin pientä nopeutusta testien ajamiseen Githubissa. Noin 10 minuutin säästö saatiin aikaiseksi.