### PR TITLE
TOR-1196 lisää poikkeus pidennetyn oppivelvollisuuden validointiin

### DIFF
--- a/src/test/scala/fi/oph/koski/api/OppijaValidationEsiopetusSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationEsiopetusSpec.scala
@@ -307,6 +307,25 @@ class OppijaValidationEsiopetusSpec extends TutkinnonPerusteetTest[EsiopetuksenO
         verifyResponseStatusOk()
       }
     }
+
+    "Validointi onnistuu, vaikka pidennetyn oppivelvollisuuden jakso alkaa ennen opiskeluoikeuden ja vammaisuusjakson yhteistä alkupäivää" in {
+      val oo = defaultOpiskeluoikeus.copy(
+        tila = NuortenPerusopetuksenOpiskeluoikeudenTila(
+          opiskeluoikeusjaksot = List(
+            NuortenPerusopetuksenOpiskeluoikeusjakso(alku, opiskeluoikeusLäsnä)
+        )),
+        lisätiedot = Some(
+          ExamplesEsiopetus.lisätiedot.copy(
+            pidennettyOppivelvollisuus = Some(Aikajakso(alku.minusDays(1), None)),
+            vammainen = Some(List(Aikajakso(alku, None))),
+            vaikeastiVammainen = None
+          )
+        )
+      )
+      putOpiskeluoikeus(oo) {
+        verifyResponseStatusOk()
+      }
+    }
   }
 
   private def putAndGetOpiskeluoikeus(oo: KoskeenTallennettavaOpiskeluoikeus): EsiopetuksenOpiskeluoikeus = putOpiskeluoikeus(oo) {

--- a/validaation_muutoshistoria.md
+++ b/validaation_muutoshistoria.md
@@ -3,6 +3,8 @@
 ## 12.4.2022
 - Opiskeluoikeuden pidennetyn oppivelvollisuuden aikajakson täytyy sisältyä vammaisuusjaksojen aikajaksoihin.
   - Vammaisuuden ja vaikeasti vammaisuuden toisiinsa lomittuvat aikajaksot käsitellään yhtenäisenä aikajaksona validointia varten.
+  - Jos opiskeluoikeuden pidennetyn oppivelvollisuuden aikajakso alkaa ennen opiskeluoikeuden alkamispäivää,
+    käytetään opiskeluoikeuden alkamispäivää pidennetyn oppivelvollisuusjakson alkamispäivänä vammaisuusjaksojen validointia varten.
 
 ## 7.4.2022
 - Nuorten perusopetuksen oppimäärän suorituksessa luokka-astetta voi käyttää vain erityisen tutkinnon kanssa.


### PR DESCRIPTION
Jos pidennetty oppivelvollisuus alkaa ennen opiskeluoikeuden alkamista,
käytetään pidennetyn oppivelvollisuuden aikajakson validoinnissa
opiskeluoikeuden alkamispäivää.