### PR TITLE
TOR-1633: Poista deprekoitu GENERATE_RAPORTOINTIKANTA-arvo

### DIFF
--- a/src/main/scala/fi/oph/koski/config/RunMode.scala
+++ b/src/main/scala/fi/oph/koski/config/RunMode.scala
@@ -7,7 +7,6 @@ object RunMode extends Enumeration {
   def get: RunMode = sys.env.get("GENERATE_RAPORTOINTIKANTA") match {
     case Some("full") => GENERATE_RAPORTOINTIKANTA
     case Some("update") => GENERATE_RAPORTOINTIKANTA
-    case Some("true") => GENERATE_RAPORTOINTIKANTA // TODO: Deprekoitu arvo, poista tämä kunhan uudet lambdat on päivitetty ympäristöihin
     case Some(s) => throw new RuntimeException(s"Odottaman arvo muuttujalla GENERATE_RAPORTOINTIKANTA: ${s} (sallitut arvot: full, update)")
     case None => NORMAL
   }


### PR DESCRIPTION
Ennen tarkastettiin vain kyseisen ympäristömuuttujan olemassaolo, eikä sisältö sinänsä vaikuttanut mitään. Käytännössä sen arvo oli aina 'true' tai se puuttui.
Nyt sallitut arvot ovat ainoastaan 'update' ja 'full', jotka yksiselitteisesti kertovat, halutaanko raportointikanta generoida kokonaan uusiksi, vai tehdäänkö inkrementaalinen päivitys.
