### PR TITLE
TOR-1340 - erotetaan aikuisaineopiskelijat omalle välilehdelle myös lukion vanhoilla opseilla. 

### DIFF
--- a/src/main/scala/fi/oph/koski/documentation/ExamplesLukio.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesLukio.scala
@@ -16,6 +16,10 @@ object ExamplesLukio {
   def oppija(opiskeluoikeus: LukionOpiskeluoikeus) = Oppija(exampleHenkilö, List(opiskeluoikeus))
 
   val aikuistenOpsinPerusteet2015 = "70/011/2015"
+  val aikuistenOpsinPerusteet2004 = "4/011/2004"
+
+  val nuortenOpsinPerusteet2015 = "60/011/2015"
+  val nuortenOpsinPerusteet2003 = "33/011/2003"
 
   lazy val erityisenKoulutustehtävänJakso = ErityisenKoulutustehtävänJakso(date(2012, 9, 1), Some(date(2013, 9, 1)), Koodistokoodiviite("103", Some("Kieliin painottuva koulutus"), "erityinenkoulutustehtava"))
   lazy val ulkomaanjakso = Ulkomaanjakso(date(2012, 9, 1), Some(date(2013, 9, 1)), ruotsi, "Harjoittelua ulkomailla")

--- a/src/test/scala/fi/oph/koski/raportit/LukioKurssikertymaRaporttiSpec.scala
+++ b/src/test/scala/fi/oph/koski/raportit/LukioKurssikertymaRaporttiSpec.scala
@@ -1,22 +1,59 @@
 package fi.oph.koski.raportit
 
 import fi.oph.koski.KoskiApplicationForTests
+import fi.oph.koski.api.{PutOpiskeluoikeusTestMethods, TestMethodsLukio}
+import fi.oph.koski.documentation.ExamplesLukio.{aikuistenOpsinPerusteet2015, aineopiskelija}
+import fi.oph.koski.documentation.{AmmatillinenExampleData, ExampleData, YleissivistavakoulutusExampleData}
+import fi.oph.koski.documentation.ExampleData.suomenKieli
+import fi.oph.koski.documentation.LukioExampleData.{kurssisuoritus, lukionOppiaine, numeerinenArviointi, opiskeluoikeusAktiivinen, opiskeluoikeusPäättynyt, valtakunnallinenKurssi, valtakunnallinenVanhanOpsinKurssi}
 import fi.oph.koski.fixture.LukioKurssikertymaRaporttiFixtures
+import fi.oph.koski.henkilo.KoskiSpecificMockOppijat
 import fi.oph.koski.koskiuser.MockUsers
 import fi.oph.koski.localization.LocalizationReader
 import fi.oph.koski.log.AuditLogTester
 import fi.oph.koski.organisaatio.MockOrganisaatiot
-import fi.oph.koski.raportit.lukio.{LukioKurssikertymaAineopiskelijaRow, LukioKurssikertymaOppimaaraRow, LukioKurssinRahoitusmuotoRow, LukioMuutaKauttaRahoitetut, LukioOppiaineEriVuonnaKorotetutKurssit, LukioOppiaineEriVuonnaKorotetutKurssitRow, LukioOppiaineOpiskeluoikeudenUlkopuoliset, LukioOppiaineOpiskeluoikeudenUlkopuolisetRow, LukioOppiaineenOppimaaranKurssikertymat, LukioOppimaaranKussikertymat, LukioRahoitusmuotoEiTiedossa}
+import fi.oph.koski.raportit.lukio.{LukioKurssikertymaAineopiskelijaRow, LukioKurssikertymaOppimaaraRow, LukioKurssinRahoitusmuotoRow, LukioOppiaineEriVuonnaKorotetutKurssitRow, LukioOppiaineOpiskeluoikeudenUlkopuolisetRow}
 import fi.oph.koski.raportointikanta.RaportointikantaTestMethods
+import fi.oph.koski.schema.{LukionOpiskeluoikeudenTila, LukionOpiskeluoikeus, LukionOpiskeluoikeusjakso, LukionOppiaineenOppimääränSuoritus2015, LukionPäätasonSuoritus, Oppija}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.freespec.AnyFreeSpec
 
-class LukioKurssikertymaRaporttiSpec extends AnyFreeSpec with RaportointikantaTestMethods with BeforeAndAfterAll {
+class LukioKurssikertymaRaporttiSpec extends AnyFreeSpec with RaportointikantaTestMethods with BeforeAndAfterAll with PutOpiskeluoikeusTestMethods[LukionOpiskeluoikeus] {
+  def tag = implicitly[reflect.runtime.universe.TypeTag[LukionOpiskeluoikeus]]
+
+  override def defaultOpiskeluoikeus = TestMethodsLukio.lukionOpiskeluoikeus
 
   private lazy val t: LocalizationReader = new LocalizationReader(KoskiApplicationForTests.koskiLocalizationRepository, "fi")
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
+
+    val aikuisOpiskelija = KoskiSpecificMockOppijat.aikuisOpiskelija
+    val opiskeluOikeusAikuistenOpsilla = aineopiskelija.copy(
+      lähdejärjestelmänId = Some(AmmatillinenExampleData.primusLähdejärjestelmäId("l-0303032")),
+      oppilaitos = Some(YleissivistavakoulutusExampleData.ressunLukio),
+      tila = LukionOpiskeluoikeudenTila(
+        List(
+          LukionOpiskeluoikeusjakso(alku = LukioKurssikertymaRaporttiFixtures.raportinAikajaksoAlku, tila = opiskeluoikeusAktiivinen, opintojenRahoitus = Some(ExampleData.valtionosuusRahoitteinen)),
+        )
+      ),
+      suoritukset = List(
+        LukionOppiaineenOppimääränSuoritus2015(
+          koulutusmoduuli = lukionOppiaine("HI", diaarinumero = Some(aikuistenOpsinPerusteet2015)),
+          suorituskieli = suomenKieli,
+          toimipiste = YleissivistavakoulutusExampleData.ressunLukio,
+          osasuoritukset = Some(List(
+            kurssisuoritus(valtakunnallinenVanhanOpsinKurssi("HI1")).copy(arviointi = numeerinenArviointi(7, päivä = LukioKurssikertymaRaporttiFixtures.raportinAikajaksoAlku)),
+            kurssisuoritus(valtakunnallinenVanhanOpsinKurssi("HI2")).copy(arviointi = numeerinenArviointi(7, päivä = LukioKurssikertymaRaporttiFixtures.raportinAikajaksoAlku))
+          ))
+        )
+      )
+    )
+
+    putOppija(Oppija(aikuisOpiskelija, List(opiskeluOikeusAikuistenOpsilla))) {
+      verifyResponseStatusOk()
+    }
+
     reloadRaportointikanta
   }
 
@@ -125,6 +162,17 @@ class LukioKurssikertymaRaporttiSpec extends AnyFreeSpec with RaportointikantaTe
         ressunAineopiskelijat.eriVuonnaKorotettujaKursseja shouldBe 1
       }
     }
+    "Aikuisaineopiskelijan välilehti" - {
+      "Oppilaitoksen Oid" in {
+        ressunAikuisAineopiskelijat.oppilaitosOid shouldBe(MockOrganisaatiot.ressunLukio)
+      }
+      "Yhteensä" in {
+        ressunAikuisAineopiskelijat.kurssejaYhteensa shouldBe(2)
+      }
+      "Suoritettuja" in {
+        ressunAikuisAineopiskelijat.suoritettujaKursseja shouldBe(2)
+      }
+    }
     "Muuta kautta rahoitetuttujen välilehti" - {
       "Listan pituus sama kuin aineopiskelijoiden välilehdellä oleva laskuri" in {
         ressunMuutaKauttaRahoitetut.length shouldBe ressunAineopiskelijat.suoritetutTaiRahoitetut_muutaKauttaRahoitetut
@@ -157,6 +205,12 @@ class LukioKurssikertymaRaporttiSpec extends AnyFreeSpec with RaportointikantaTe
 
   lazy val ressunAineopiskelijat = raportti.collectFirst {
     case d: DataSheet if d.title == t.get("raportti-excel-aineopiskelijat-sheet-name") => d.rows.collect {
+      case r: LukioKurssikertymaAineopiskelijaRow => r
+    }
+  }.get.find(_.oppilaitos == "Ressun lukio").get
+
+  lazy val ressunAikuisAineopiskelijat = raportti.collectFirst {
+    case d: DataSheet if d.title == t.get("raportti-excel-aineopiskelijat-aikuisten-ops-sheet-name") => d.rows.collect {
       case r: LukioKurssikertymaAineopiskelijaRow => r
     }
   }.get.find(_.oppilaitos == "Ressun lukio").get


### PR DESCRIPTION
huom: vanhan opsin aineopiskelijoille ei erikseen ladata tietoa siitä, onko kyseessä nuorten vai aikuisten oppimäärä. yritetään päätellä tämä perusteen diaarinumerosta, mutta jos se epäonnistuu, käsitellään oletuksena suoritus nuorten opsina.

kaikille tiedyn ajan jälkeen päivitetyille vanhan lukion opsin suorituksille pitäisi olla peruste, mutta joillekin hyvin vanhoille se voi mielestäni puuttua.