### PR TITLE
TOR-1723: Korjaus liian pitkien audit-logien aiheuttamiin 500-virheisiin rouhinnassa

### DIFF
--- a/src/main/scala/fi/oph/koski/valpas/log/ValpasAuditLog.scala
+++ b/src/main/scala/fi/oph/koski/valpas/log/ValpasAuditLog.scala
@@ -1,6 +1,6 @@
 package fi.oph.koski.valpas.log
 
-import fi.oph.koski.log.{AuditLog, AuditLogMessage, AuditLogOperation}
+import fi.oph.koski.log.{AuditLog, AuditLogMessage, AuditLogOperation, LogConfiguration}
 import fi.oph.koski.schema.Organisaatio
 import fi.oph.koski.valpas.kansalainen.{KansalainenOppijatiedot, KansalaisnäkymänTiedot}
 import fi.oph.koski.valpas.{ValpasHenkilöhakuResult, ValpasLöytyiHenkilöhakuResult}
@@ -126,8 +126,12 @@ object ValpasAuditLog {
 
   // Logeilla on 16kB maksimikoko tällä hetkellä, joten logientry on jaettava. Käytännössä jokaiseen entryyn tulee
   // datan lisäksi myös 0.5-1kB muuta dataa.
-  private val hetujaEnintäänAuditlogEntryssä = 1000
-  private val oidejaEnintäänAuditlogEntryssä = 500
+  private val oidLengthInKoski = 26
+  private val hetuLength = 11
+  private val listSeparatorMaxLength = 2
+  private val maxAuditLogMessageLength = LogConfiguration.logMessageMaxLength - 1024
+  private val hetujaEnintäänAuditlogEntryssä = (maxAuditLogMessageLength / (hetuLength + listSeparatorMaxLength)).floor.toInt
+  private val oidejaEnintäänAuditlogEntryssä = (maxAuditLogMessageLength / (oidLengthInKoski + listSeparatorMaxLength)).floor.toInt
 
   def auditLogRouhintahakuHetulistalla
     (hetut: Seq[String], palautetutOppijaOidit: Seq[String])

--- a/src/test/scala/fi/oph/koski/valpas/ValpasHeturouhintaSpec.scala
+++ b/src/test/scala/fi/oph/koski/valpas/ValpasHeturouhintaSpec.scala
@@ -1,7 +1,9 @@
 package fi.oph.koski.valpas
 
 import fi.oph.koski.KoskiApplicationForTests
+import fi.oph.koski.organisaatio.MockOrganisaatiot.helsinginKaupunki
 import fi.oph.koski.raportit.{DataSheet, Sheet}
+import fi.oph.koski.valpas.log.ValpasAuditLog
 import fi.oph.koski.valpas.opiskeluoikeusfixture.{FixtureUtil, ValpasMockOppijat}
 import fi.oph.koski.valpas.rouhinta.{ValpasRouhintaPelkkäHetuSheetRow, ValpasRouhintaService}
 import fi.oph.koski.valpas.valpasuser.ValpasMockUsers
@@ -137,6 +139,11 @@ class ValpasHeturouhintaSpec extends ValpasRouhintaTestBase {
       "Virheelliset hetut sisältää oikeat hetut" in {
         virheelliset.map(_.hetu) should contain theSameElementsAs virheellisetHetut
       }
+    }
+
+    "Audit-log toimii myös isolla oppijamäärällä" in {
+      val hetut = Range.inclusive(0, 9999).map(n => s"123456-${"%04d".format(n)}")
+      ValpasAuditLog.auditLogRouhintahakuHetulistalla(hetut, hetut)(session(defaultUser))
     }
   }
 

--- a/src/test/scala/fi/oph/koski/valpas/ValpasKuntarouhintaSpec.scala
+++ b/src/test/scala/fi/oph/koski/valpas/ValpasKuntarouhintaSpec.scala
@@ -3,11 +3,14 @@ package fi.oph.koski.valpas
 import java.time.LocalDate
 import java.time.LocalDate.{of => date}
 import fi.oph.koski.KoskiApplicationForTests
+import fi.oph.koski.koskiuser.AuthenticationUser
 import fi.oph.koski.localization.LocalizationReader
 import fi.oph.koski.organisaatio.MockOrganisaatiot
+import fi.oph.koski.organisaatio.MockOrganisaatiot.helsinginKaupunki
+import fi.oph.koski.valpas.log.ValpasAuditLog
 import fi.oph.koski.valpas.opiskeluoikeusfixture.{FixtureUtil, ValpasMockOppijat}
 import fi.oph.koski.valpas.rouhinta.ValpasRouhintaService
-import fi.oph.koski.valpas.valpasuser.ValpasMockUsers
+import fi.oph.koski.valpas.valpasuser.{ValpasMockUsers, ValpasSession}
 
 object ValpasKuntarouhintaSpec {
   val tarkastelupäivä = date(2021, 5, 20)
@@ -149,6 +152,11 @@ class ValpasKuntarouhintaSpec extends ValpasRouhintaTestBase {
           )
         }
       }
+    }
+
+    "Audit-log toimii myös isolla oppijamäärällä" in {
+      val oids = Range.inclusive(1, 10000).map(n => s"1.2.246.562.10.000000${"%05d".format(n)}")
+      ValpasAuditLog.auditLogRouhintahakuKunnalla(helsinginKaupunki, oids)(session(defaultUser))
     }
   }
 


### PR DESCRIPTION
Lasketaan audit-viestiin mahtuvien oidien ja hetujen määrä
dynaamisesti, jotta vältetään jatkossa logitettavan viestin
maksimipituuden muutoksista johtuvat rikot audit-logien
pilkkomisessa pienempiin osiin.
