### PR TITLE
TOR-1340: Lukion kurssikertymäraportti/aineopiskelijat hännät

### DIFF
--- a/src/main/scala/fi/oph/koski/documentation/ExamplesLukio.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesLukio.scala
@@ -2,8 +2,8 @@ package fi.oph.koski.documentation
 
 import java.time.LocalDate
 import java.time.LocalDate.{of => date}
-
 import fi.oph.koski.documentation.ExampleData._
+import fi.oph.koski.documentation.ExamplesLukio.{aikuistenOpsinPerusteet2004, aikuistenOpsinPerusteet2015}
 import fi.oph.koski.documentation.LukioExampleData._
 import fi.oph.koski.documentation.YleissivistavakoulutusExampleData._
 import fi.oph.koski.henkilo.KoskiSpecificMockOppijat

--- a/src/main/scala/fi/oph/koski/raportointikanta/OpiskeluoikeusLoader.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/OpiskeluoikeusLoader.scala
@@ -414,6 +414,7 @@ object OpiskeluoikeusLoader extends Logging {
       },
       oppimääräKoodiarvo = ps match {
         case o: Oppimäärällinen => Some(o.oppimäärä.koodiarvo)
+        //case l: LukionPäätasonSuoritus2015 => l.oppimääränKoodiarvo
         case _ => None
       },
       alkamispäivä = ps.alkamispäivä.map(v => Date.valueOf(v)),

--- a/src/main/scala/fi/oph/koski/schema/Lukio2015.scala
+++ b/src/main/scala/fi/oph/koski/schema/Lukio2015.scala
@@ -1,9 +1,16 @@
 package fi.oph.koski.schema
 
+import fi.oph.koski.documentation.ExamplesLukio.{aikuistenOpsinPerusteet2004, aikuistenOpsinPerusteet2015}
 import fi.oph.koski.schema.annotation._
 import fi.oph.scalaschema.annotation.{DefaultValue, Description, MinItems, OnlyWhen, Title}
 
-trait LukionPäätasonSuoritus2015 extends LukionPäätasonSuoritus with Todistus with Ryhmällinen
+trait LukionPäätasonSuoritus2015 extends LukionPäätasonSuoritus with Todistus with Ryhmällinen {
+  def onAikuistenOps(diaari: String) = {
+    List(aikuistenOpsinPerusteet2015, aikuistenOpsinPerusteet2004).contains(diaari)
+  }
+
+  def oppimääränKoodiarvo: Option[String]
+}
 
 @Description("Lukion oppimäärän suoritustiedot")
 @Title("Lukion oppimäärän suoritus")
@@ -33,7 +40,9 @@ case class LukionOppimääränSuoritus2015(
   with KoulusivistyskieliKieliaineesta
   with Oppimäärällinen
   with SuoritusVaatiiMahdollisestiMaksuttomuusTiedonOpiskeluoikeudelta
-  with LukionOppimääränSuoritus
+  with LukionOppimääränSuoritus {
+  def oppimääränKoodiarvo = Some(oppimäärä.koodiarvo)
+}
 
 @Description("Lukion oppiaineen oppimäärän suoritustiedot")
 @Title("Lukion oppiaineen oppimäärän suoritus")
@@ -59,7 +68,14 @@ case class LukionOppiaineenOppimääränSuoritus2015(
   @KoodistoKoodiarvo("lukionoppiaineenoppimaara")
   tyyppi: Koodistokoodiviite = Koodistokoodiviite("lukionoppiaineenoppimaara", koodistoUri = "suorituksentyyppi"),
   ryhmä: Option[String] = None
-) extends LukionPäätasonSuoritus2015 with OppiaineenOppimääränSuoritus
+) extends LukionPäätasonSuoritus2015 with OppiaineenOppimääränSuoritus  {
+  def oppimääränKoodiarvo: Option[String] = {
+    koulutusmoduuli match {
+    case diaari: Diaarinumerollinen =>
+      diaari.perusteenDiaarinumero.map(peruste => if (onAikuistenOps(peruste)) "aikuistenops" else "nuortenops")
+    case _ => None
+  }}
+}
 
 trait LukionOppimääränOsasuoritus2015 extends LukionOppimääränPäätasonOsasuoritus
 

--- a/src/test/scala/fi/oph/koski/migration/MigrationSpec.scala
+++ b/src/test/scala/fi/oph/koski/migration/MigrationSpec.scala
@@ -27,7 +27,7 @@ class MigrationSpec extends AnyFreeSpec with Matchers {
         "LoaderUtils.scala"                                         -> "38d31b4d1cfa5e3892083bb39f7f0047",
         "MuuAmmatillinenRaporttiRowBuilder.scala"                   -> "31774fb0fbd06a775a07325e867a951f",
         "OpiskeluoikeudenUlkopuolellaArvioidutOsasuoritukset.scala" -> "4498412891d88ddd2daf422144664086",
-        "OpiskeluoikeusLoader.scala"                                -> "f0be4321ad6636aefb29aaed664dcedf",
+        "OpiskeluoikeusLoader.scala"                                -> "4dab9185f560e41bbbc4139c036afea3",
         "OrganisaatioHistoriaRowBuilder.scala"                      -> "7e586d9e273a5a4ee7beae257f22c7f4",
         "OrganisaatioLoader.scala"                                  -> "9e2e45da33ed335af4a7b0a31b139a7",
         "RaportointiDatabase.scala"                                 -> "9757acceca5de5350f245a563155c017",


### PR DESCRIPTION
This reverts commit 90252324f5cf498d8f821f5ec52bff69a5987b7f.

* kurssikertymärapsaa varten korjattu lukion oppimäärän koodiarvon tulkkaaminen, jotta saadaan aikuisten opsin mukaiset opiskelijat omalle välilehdelle raporttiin
* poistettu vanhan lukion oppiaineen päätason suorituken oppimäärän huomiointi raportointikantaa generoitaessa
