### PR TITLE
TOR-1710 salli peruskoulut esiopetuksen ostopalvelun oppilaitoksina

### DIFF
--- a/src/main/scala/fi/oph/koski/documentation/ExamplesEsiopetus.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesEsiopetus.scala
@@ -96,6 +96,9 @@ object ExamplesEsiopetus {
   def päiväkotisuoritus(toimipiste: OrganisaatioWithOid): EsiopetuksenSuoritus =
     suoritus(perusteenDiaarinumero = "102/011/2014", tunniste = päiväkodinEsiopetuksenTunniste, toimipiste = toimipiste)
 
+  def peruskoulusuoritus(toimipiste: OrganisaatioWithOid): EsiopetuksenSuoritus =
+    suoritus(perusteenDiaarinumero = "102/011/2014", tunniste = peruskoulunEsiopetuksenTunniste, toimipiste = toimipiste)
+
   lazy val osaAikainenErityisopetusLukuvuodenAikanaLV1 =
     Koodistokoodiviite("LV1", Some("Osa-aikainen erityisopetus lukuvuoden aikana"), "osaaikainenerityisopetuslukuvuodenaikana")
 

--- a/src/main/scala/fi/oph/koski/fixture/KoskiSpecificDatabaseFixtureCreator.scala
+++ b/src/main/scala/fi/oph/koski/fixture/KoskiSpecificDatabaseFixtureCreator.scala
@@ -3,14 +3,14 @@ package fi.oph.koski.fixture
 import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.documentation.AmmatillinenExampleData.{ammatillinenTutkintoSuoritus, puuteollisuudenPerustutkinnonSuoritus, puuteollisuudenPerustutkinto, stadinToimipiste, tietoJaViestintäTekniikanPerustutkinnonSuoritus}
 import fi.oph.koski.documentation.ExampleData.{opiskeluoikeusMitätöity, suomenKieli}
-import fi.oph.koski.documentation.ExamplesEsiopetus.{ostopalveluOpiskeluoikeus, päiväkotisuoritus}
+import fi.oph.koski.documentation.ExamplesEsiopetus.{ostopalveluOpiskeluoikeus, peruskoulusuoritus, päiväkotisuoritus}
 import fi.oph.koski.documentation.ExamplesPerusopetus.ysinOpiskeluoikeusKesken
 import fi.oph.koski.documentation.YleissivistavakoulutusExampleData.{helsinki, oppilaitos}
 import fi.oph.koski.documentation.{ExamplesEsiopetus, _}
 import fi.oph.koski.henkilo.{KoskiSpecificMockOppijat, OppijaHenkilö}
 import fi.oph.koski.koskiuser.{AuthenticationUser, KoskiMockUser, KoskiSpecificSession, MockUsers}
 import fi.oph.koski.organisaatio.MockOrganisaatiot
-import fi.oph.koski.organisaatio.MockOrganisaatiot.päiväkotiMajakka
+import fi.oph.koski.organisaatio.MockOrganisaatiot.{jyväskylänNormaalikoulu, päiväkotiMajakka}
 import fi.oph.koski.schema._
 
 import java.net.InetAddress
@@ -63,6 +63,12 @@ class KoskiSpecificDatabaseFixtureCreator(application: KoskiApplication) extends
         tila = NuortenPerusopetuksenOpiskeluoikeudenTila(
           ostopalveluOpiskeluoikeus.tila.opiskeluoikeusjaksot.map(j => j.copy(alku = j.alku.minusDays(1)))
         )
+      ), hkiTallentaja)),
+      (KoskiSpecificMockOppijat.eskari, updateFieldsAndValidateOpiskeluoikeus(ostopalveluOpiskeluoikeus.copy(
+        suoritukset = List(peruskoulusuoritus(oppilaitos(jyväskylänNormaalikoulu)).copy(vahvistus = None)),
+        tila = NuortenPerusopetuksenOpiskeluoikeudenTila(
+          ostopalveluOpiskeluoikeus.tila.opiskeluoikeusjaksot.map(j => j.copy(alku = date(2022, 6, 7)))
+        ),
       ), hkiTallentaja)),
       (KoskiSpecificMockOppijat.rikkinäinenOpiskeluoikeus, MaksuttomuusRaporttiFixtures.opiskeluoikeusAmmatillinenMaksuttomuuttaPidennetty.copy(
         tyyppi = OpiskeluoikeudenTyyppi.ammatillinenkoulutus.copy(

--- a/src/main/scala/fi/oph/koski/koskiuser/Kayttooikeus.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/Kayttooikeus.scala
@@ -74,10 +74,10 @@ object Käyttöoikeus {
         val filteredRoolit = globalPalveluroolit.filter(palvelurooliFilter)
         if (filteredRoolit.isEmpty) Set.empty else Set(KäyttöoikeusViranomainen(filteredRoolit))
       }
-      case KäyttöoikeusVarhaiskasvatusToimipiste(koulutustoimija, ulkopuolinenOrganisaatio, organisaatiokohtaisetPalveluroolit) =>
+      case KäyttöoikeusVarhaiskasvatusToimipiste(koulutustoimija, ulkopuolinenOrganisaatio, organisaatiokohtaisetPalveluroolit, onVarhaiskasvatuksenToimipiste) =>
       {
         val filteredRoolit = organisaatiokohtaisetPalveluroolit.filter(palvelurooliFilter)
-        if (filteredRoolit.isEmpty) Set.empty else Set(KäyttöoikeusVarhaiskasvatusToimipiste(koulutustoimija, ulkopuolinenOrganisaatio, filteredRoolit))
+        if (filteredRoolit.isEmpty) Set.empty else Set(KäyttöoikeusVarhaiskasvatusToimipiste(koulutustoimija, ulkopuolinenOrganisaatio, filteredRoolit, onVarhaiskasvatuksenToimipiste))
       }
       case _ => Set.empty
     }
@@ -158,9 +158,19 @@ trait OrgKäyttöoikeus extends Käyttöoikeus {
   def globalPalveluroolit: List[Palvelurooli] = Nil
 }
 
-case class KäyttöoikeusVarhaiskasvatusToimipiste(koulutustoimija: Koulutustoimija, ulkopuolinenOrganisaatio: OrganisaatioWithOid, organisaatiokohtaisetPalveluroolit: List[Palvelurooli]) extends OrgKäyttöoikeus
+case class KäyttöoikeusVarhaiskasvatusToimipiste(
+  koulutustoimija: Koulutustoimija,
+  ulkopuolinenOrganisaatio: OrganisaatioWithOid,
+  organisaatiokohtaisetPalveluroolit: List[Palvelurooli],
+  onVarhaiskasvatuksenToimipiste: Boolean
+) extends OrgKäyttöoikeus
 
-case class KäyttöoikeusOrg(organisaatio: OrganisaatioWithOid, organisaatiokohtaisetPalveluroolit: List[Palvelurooli], juuri: Boolean, oppilaitostyyppi: Option[String]) extends OrgKäyttöoikeus
+case class KäyttöoikeusOrg(
+  organisaatio: OrganisaatioWithOid,
+  organisaatiokohtaisetPalveluroolit: List[Palvelurooli],
+  juuri: Boolean,
+  oppilaitostyyppi: Option[String]
+) extends OrgKäyttöoikeus
 
 case class KäyttöoikeusViranomainen(globalPalveluroolit: List[Palvelurooli]) extends Käyttöoikeus {
   def globalAccessType: List[AccessType.Value] = if (globalPalveluroolit.exists(r => r.palveluName == "KOSKI" && Rooli.globaalitKoulutusmuotoRoolit.contains(r.rooli))) {

--- a/src/main/scala/fi/oph/koski/koskiuser/KayttooikeusRepository.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/KayttooikeusRepository.scala
@@ -1,6 +1,7 @@
 package fi.oph.koski.koskiuser
 
 import fi.oph.koski.cache.{CacheManager, ExpiringCache, KeyValueCache}
+import fi.oph.koski.organisaatio.OrganisaatioRepository.VarhaiskasvatusToimipisteResult
 import fi.oph.koski.organisaatio.{OrganisaatioHierarkia, OrganisaatioRepository}
 import fi.oph.koski.userdirectory.DirectoryClient
 import fi.oph.koski.util.Timing
@@ -56,13 +57,13 @@ class KäyttöoikeusRepository(organisaatioRepository: OrganisaatioRepository, d
   private def hierarkianUlkopuolisetKäyttöoikeudet(k: KäyttöoikeusOrg, organisaatioHierarkia: OrganisaatioHierarkia) =
     if (organisaatioHierarkia.varhaiskasvatuksenJärjestäjä && organisaatioHierarkia.toKoulutustoimija.isDefined) {
       organisaatioRepository.findAllVarhaiskasvatusToimipisteet.map {
-        case (toimipiste, onVarhaiskasvatuksenToimipiste) =>
-        KäyttöoikeusVarhaiskasvatusToimipiste(
-          koulutustoimija = organisaatioHierarkia.toKoulutustoimija.get,
-          ulkopuolinenOrganisaatio = toimipiste.toOidOrganisaatio,
-          organisaatiokohtaisetPalveluroolit = k.organisaatiokohtaisetPalveluroolit,
-          onVarhaiskasvatuksenToimipiste = onVarhaiskasvatuksenToimipiste
-        )
+        case v: VarhaiskasvatusToimipisteResult =>
+          KäyttöoikeusVarhaiskasvatusToimipiste(
+            koulutustoimija = organisaatioHierarkia.toKoulutustoimija.get,
+            ulkopuolinenOrganisaatio = v.organisaatio.toOidOrganisaatio,
+            organisaatiokohtaisetPalveluroolit = k.organisaatiokohtaisetPalveluroolit,
+            onVarhaiskasvatuksenToimipiste = v.varhaiskasvatuksenOrganisaatioTyyppi
+          )
       }
     } else {
       Nil

--- a/src/main/scala/fi/oph/koski/koskiuser/KayttooikeusRepository.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/KayttooikeusRepository.scala
@@ -55,11 +55,13 @@ class KäyttöoikeusRepository(organisaatioRepository: OrganisaatioRepository, d
 
   private def hierarkianUlkopuolisetKäyttöoikeudet(k: KäyttöoikeusOrg, organisaatioHierarkia: OrganisaatioHierarkia) =
     if (organisaatioHierarkia.varhaiskasvatuksenJärjestäjä && organisaatioHierarkia.toKoulutustoimija.isDefined) {
-      organisaatioRepository.findAllVarhaiskasvatusToimipisteet.map { päiväkoti =>
+      organisaatioRepository.findAllVarhaiskasvatusToimipisteet.map {
+        case (toimipiste, onVarhaiskasvatuksenToimipiste) =>
         KäyttöoikeusVarhaiskasvatusToimipiste(
           koulutustoimija = organisaatioHierarkia.toKoulutustoimija.get,
-          ulkopuolinenOrganisaatio = päiväkoti.toOidOrganisaatio,
-          organisaatiokohtaisetPalveluroolit = k.organisaatiokohtaisetPalveluroolit
+          ulkopuolinenOrganisaatio = toimipiste.toOidOrganisaatio,
+          organisaatiokohtaisetPalveluroolit = k.organisaatiokohtaisetPalveluroolit,
+          onVarhaiskasvatuksenToimipiste = onVarhaiskasvatuksenToimipiste
         )
       }
     } else {

--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/OpiskeluoikeusQueryFilter.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/OpiskeluoikeusQueryFilter.scala
@@ -30,6 +30,7 @@ object OpiskeluoikeusQueryFilter {
   case class OpiskeluoikeudenTila(tila: Koodistokoodiviite) extends OpiskeluoikeusQueryFilter
   case class Tutkintohaku(hakusana: String) extends OpiskeluoikeusQueryFilter
   case class Toimipiste(toimipiste: List[OrganisaatioWithOid]) extends OpiskeluoikeusQueryFilter
+  case class VarhaiskasvatuksenToimipiste(toimipiste: List[OrganisaatioWithOid]) extends OpiskeluoikeusQueryFilter
   case class Luokkahaku(hakusana: String) extends OpiskeluoikeusQueryFilter
   case class Nimihaku(hakusana: String) extends OpiskeluoikeusQueryFilter
   case class SuoritusJsonHaku(json: JValue) extends OpiskeluoikeusQueryFilter
@@ -80,7 +81,7 @@ private object OpiskeluoikeusQueryFilterParser extends Logging {
       case ("tutkintohaku", hakusana +: _) => Right(Tutkintohaku(hakusana))
       case ("toimipiste", oid +: _) if oid == organisaatiot.ostopalveluRootOid => organisaatiot.omatOstopalveluOrganisaatiot match {
         case Nil => Left(KoskiErrorCategory.notFound.oppilaitostaEiLöydy("Ostopalvelu/palveluseteli-toimipisteitä ei löydy"))
-        case hierarkia => Right(Toimipiste(hierarkia.map(_.toOrganisaatio)))
+        case hierarkia => Right(VarhaiskasvatuksenToimipiste(hierarkia.map(_.toOrganisaatio)))
       }
       case ("toimipiste", oid +: _) =>
         OrganisaatioOid.validateOrganisaatioOid(oid).right.flatMap { oid =>

--- a/src/main/scala/fi/oph/koski/organisaatio/OrganisaatioRepository.scala
+++ b/src/main/scala/fi/oph/koski/organisaatio/OrganisaatioRepository.scala
@@ -67,12 +67,22 @@ trait OrganisaatioRepository extends Logging {
 
   def findAllVarhaiskasvatusToimipisteet: List[OrganisaatioWithOid] = {
     OrganisaatioHierarkia.flatten(findAllHierarkiat)
-      .filter(_.organisaatiotyypit.contains(Organisaatiotyyppi.VARHAISKASVATUKSEN_TOIMIPAIKKA))
+      .filter(o =>
+        o.organisaatiotyypit.contains(Organisaatiotyyppi.VARHAISKASVATUKSEN_TOIMIPAIKKA) ||
+        o.oppilaitostyyppi.contains(Oppilaitostyyppi.peruskoulut) ||
+        o.oppilaitostyyppi.contains(Oppilaitostyyppi.peruskouluasteenErityiskoulut) ||
+        o.oppilaitostyyppi.contains(Oppilaitostyyppi.perusJaLukioasteenKoulut)
+      )
       .map(_.toOrganisaatio)
   }
 
   def findVarhaiskasvatusHierarkiat: List[OrganisaatioHierarkia] = {
-    filter(_.organisaatiotyypit.contains(Organisaatiotyyppi.VARHAISKASVATUKSEN_TOIMIPAIKKA))
+    filter(o =>
+      o.organisaatiotyypit.contains(Organisaatiotyyppi.VARHAISKASVATUKSEN_TOIMIPAIKKA) ||
+        o.oppilaitostyyppi.contains(Oppilaitostyyppi.peruskoulut) ||
+        o.oppilaitostyyppi.contains(Oppilaitostyyppi.peruskouluasteenErityiskoulut) ||
+        o.oppilaitostyyppi.contains(Oppilaitostyyppi.perusJaLukioasteenKoulut)
+    )
   }
 
   def findKunnat(): Seq[OrganisaatioHierarkia] = {

--- a/src/main/scala/fi/oph/koski/organisaatio/OrganisaatioRepository.scala
+++ b/src/main/scala/fi/oph/koski/organisaatio/OrganisaatioRepository.scala
@@ -2,12 +2,12 @@ package fi.oph.koski.organisaatio
 
 import java.lang.System.currentTimeMillis
 import java.time.LocalDate
-
 import com.typesafe.config.Config
 import fi.oph.koski.cache._
 import fi.oph.koski.http.{ServiceConfig, VirkailijaHttpClient}
 import fi.oph.koski.koodisto.KoodistoViitePalvelu
 import fi.oph.koski.log.Logging
+import fi.oph.koski.organisaatio.OrganisaatioRepository.VarhaiskasvatusToimipisteResult
 import fi.oph.koski.schema.Organisaatio.Oid
 import fi.oph.koski.schema._
 
@@ -65,15 +65,18 @@ trait OrganisaatioRepository extends Logging {
   def findAllFlattened: List[OrganisaatioHierarkia] = OrganisaatioHierarkia.flatten(findAllHierarkiat)
   def findAllHierarkiat: List[OrganisaatioHierarkia]
 
-  def findAllVarhaiskasvatusToimipisteet: List[(OrganisaatioWithOid, Boolean)] = {
+  def findAllVarhaiskasvatusToimipisteet: List[VarhaiskasvatusToimipisteResult] = {
     OrganisaatioHierarkia.flatten(findAllHierarkiat)
       .filter(o =>
         o.organisaatiotyypit.contains(Organisaatiotyyppi.VARHAISKASVATUKSEN_TOIMIPAIKKA) ||
-        o.oppilaitostyyppi.contains(Oppilaitostyyppi.peruskoulut) ||
-        o.oppilaitostyyppi.contains(Oppilaitostyyppi.peruskouluasteenErityiskoulut) ||
-        o.oppilaitostyyppi.contains(Oppilaitostyyppi.perusJaLukioasteenKoulut)
+          o.oppilaitostyyppi.contains(Oppilaitostyyppi.peruskoulut) ||
+          o.oppilaitostyyppi.contains(Oppilaitostyyppi.peruskouluasteenErityiskoulut) ||
+          o.oppilaitostyyppi.contains(Oppilaitostyyppi.perusJaLukioasteenKoulut)
       )
-      .map(o => (o.toOrganisaatio, o.organisaatiotyypit.contains(Organisaatiotyyppi.VARHAISKASVATUKSEN_TOIMIPAIKKA)))
+      .map(o => VarhaiskasvatusToimipisteResult(
+        o.toOrganisaatio,
+        o.organisaatiotyypit.contains(Organisaatiotyyppi.VARHAISKASVATUKSEN_TOIMIPAIKKA)
+      ))
   }
 
   def findVarhaiskasvatusHierarkiat: List[OrganisaatioHierarkia] = {
@@ -115,6 +118,11 @@ trait OrganisaatioRepository extends Logging {
 }
 
 object OrganisaatioRepository {
+  case class VarhaiskasvatusToimipisteResult(
+    organisaatio: OrganisaatioWithOid,
+    varhaiskasvatuksenOrganisaatioTyyppi: Boolean
+  )
+
   def apply(config: Config, koodisto: KoodistoViitePalvelu)(implicit cacheInvalidator: CacheManager) = {
     config.getString("opintopolku.virkailija.url") match {
       case "mock" =>

--- a/src/main/scala/fi/oph/koski/organisaatio/OrganisaatioRepository.scala
+++ b/src/main/scala/fi/oph/koski/organisaatio/OrganisaatioRepository.scala
@@ -65,7 +65,7 @@ trait OrganisaatioRepository extends Logging {
   def findAllFlattened: List[OrganisaatioHierarkia] = OrganisaatioHierarkia.flatten(findAllHierarkiat)
   def findAllHierarkiat: List[OrganisaatioHierarkia]
 
-  def findAllVarhaiskasvatusToimipisteet: List[OrganisaatioWithOid] = {
+  def findAllVarhaiskasvatusToimipisteet: List[(OrganisaatioWithOid, Boolean)] = {
     OrganisaatioHierarkia.flatten(findAllHierarkiat)
       .filter(o =>
         o.organisaatiotyypit.contains(Organisaatiotyyppi.VARHAISKASVATUKSEN_TOIMIPAIKKA) ||
@@ -73,7 +73,7 @@ trait OrganisaatioRepository extends Logging {
         o.oppilaitostyyppi.contains(Oppilaitostyyppi.peruskouluasteenErityiskoulut) ||
         o.oppilaitostyyppi.contains(Oppilaitostyyppi.perusJaLukioasteenKoulut)
       )
-      .map(_.toOrganisaatio)
+      .map(o => (o.toOrganisaatio, o.organisaatiotyypit.contains(Organisaatiotyyppi.VARHAISKASVATUKSEN_TOIMIPAIKKA)))
   }
 
   def findVarhaiskasvatusHierarkiat: List[OrganisaatioHierarkia] = {

--- a/src/main/scala/fi/oph/koski/perustiedot/OpiskeluoikeudenPerustiedotRepository.scala
+++ b/src/main/scala/fi/oph/koski/perustiedot/OpiskeluoikeudenPerustiedotRepository.scala
@@ -68,6 +68,14 @@ class OpiskeluoikeudenPerustiedotRepository(
           Map("term" -> Map("suoritukset.toimipiste.oid" -> toimipiste.oid))
         })
       )
+      case OpiskeluoikeusQueryFilter.VarhaiskasvatuksenToimipiste(toimipisteet) => List(
+        ElasticSearch.anyFilter(toimipisteet.map{ toimipiste =>
+          ElasticSearch.allFilter(List(
+            Map("term" -> Map("suoritukset.toimipiste.oid" -> toimipiste.oid)),
+            Map("term" -> Map("suoritukset.tyyppi.koodiarvo" -> "esiopetuksensuoritus"))
+          ))
+        })
+      )
       case _ => Nil
     }
 

--- a/src/main/scala/fi/oph/koski/raportit/RaportitService.scala
+++ b/src/main/scala/fi/oph/koski/raportit/RaportitService.scala
@@ -376,9 +376,13 @@ class RaportitService(application: KoskiApplication) {
           organisaatiotyypit = organisaatio.organisaatiotyypit,
           raportit = organisaatio.oid match {
             case organisaatioService.ostopalveluRootOid => Set(EsiopetuksenRaportti.toString, EsiopetuksenOppijaMäärienRaportti.toString)
-            case oid: String => accessResolver.mahdollisetRaporttienTyypitOrganisaatiolle(organisaatio, koulutusmuodot).map(_.toString)
+            case _: String => accessResolver.mahdollisetRaporttienTyypitOrganisaatiolle(organisaatio, koulutusmuodot).map(_.toString)
           },
-          children = buildOrganisaatioJaRaporttiTyypit(organisaatio.children, koulutusmuodot)
+          children = organisaatio.oid match {
+            case organisaatioService.ostopalveluRootOid => Nil
+            case _ => buildOrganisaatioJaRaporttiTyypit(organisaatio.children, koulutusmuodot)
+          }
+
         )
       })
       .toList

--- a/src/main/scala/fi/oph/koski/raportit/RaportitServlet.scala
+++ b/src/main/scala/fi/oph/koski/raportit/RaportitServlet.scala
@@ -305,7 +305,7 @@ class RaportitServlet(implicit val application: KoskiApplication) extends KoskiS
   private def validateOrganisaatioOid(oppilaitosOid: String) =
     OrganisaatioOid.validateOrganisaatioOid(oppilaitosOid) match {
       case Left(error) => haltWithStatus(error)
-      case Right(oid) if !session.hasReadAccess(oid) => haltWithStatus(KoskiErrorCategory.forbidden.organisaatio())
+      case Right(oid) if !session.hasRaporttiReadAccess(oid) => haltWithStatus(KoskiErrorCategory.forbidden.organisaatio())
       case Right(oid) => oid
     }
 

--- a/src/test/scala/fi/oph/koski/api/VarhaiskasvatusPerustiedotSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/VarhaiskasvatusPerustiedotSpec.scala
@@ -30,7 +30,7 @@ class VarhaiskasvatusPerustiedotSpec
         perustieto <- perustiedot
         etunimet <- perustieto.henkilö.map(_.etunimet)
         oppilaitos <- perustieto.oppilaitos.nimi.map(_.get("fi"))
-      } yield (etunimet, oppilaitos)).sorted should equal(List((eero.etunimet, "Päiväkoti Majakka"), (eskari.etunimet, "Päiväkoti Majakka"), (eskari.etunimet, "Päiväkoti Touhula")))
+      } yield (etunimet, oppilaitos)).sorted should equal(List((eero.etunimet, "Päiväkoti Majakka"), (eskari.etunimet, "Jyväskylän normaalikoulu"), (eskari.etunimet, "Päiväkoti Majakka"), (eskari.etunimet, "Päiväkoti Touhula")))
     }
 
     "Ei voi hakea muiden luomia organisaatiohierarkian ulkopuolisia perustietoja" in {

--- a/src/test/scala/fi/oph/koski/api/VarhaiskasvatusSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/VarhaiskasvatusSpec.scala
@@ -1,7 +1,7 @@
 package fi.oph.koski.api
 
 import fi.oph.koski.documentation.ExamplesEsiopetus.{ostopalvelu, päiväkodinEsiopetuksenTunniste}
-import fi.oph.koski.documentation.YleissivistavakoulutusExampleData.{oidOrganisaatio, päiväkotiTouhula, päiväkotiVironniemi}
+import fi.oph.koski.documentation.YleissivistavakoulutusExampleData.{kulosaarenAlaAste, oidOrganisaatio, päiväkotiTouhula, päiväkotiVironniemi}
 import fi.oph.koski.henkilo.MockOppijat.asUusiOppija
 import fi.oph.koski.henkilo.KoskiSpecificMockOppijat.ysiluokkalainen
 import fi.oph.koski.http.KoskiErrorCategory
@@ -63,9 +63,15 @@ class VarhaiskasvatusSpec extends AnyFreeSpec with EsiopetusSpecification {
         }
       }
 
-      "ei voi luoda perusopetuksessa järjestettävien esiopetuksen opiskeluoikeuksia organisaatiohierarkiansa ulkopuolelle" in {
+      "voi luoda perusopetuksessa järjestettävän esiopetuksen opiskeluoikeuden organisaatiohierarkian ulkopuoliselle peruskoululle" in {
+        putOpiskeluoikeus(peruskouluEsiopetus(kulosaarenAlaAste, ostopalvelu), headers = authHeaders(MockUsers.pyhtäänTallentaja) ++ jsonContent) {
+          verifyResponseStatusOk()
+        }
+      }
+
+      "ei voi luoda perusopetuksessa järjestettävien esiopetuksen opiskeluoikeuksia organisaatiohierarkiansa ulkopuolelle varhaiskasvatuksen toimipisteeseen" in {
         putOpiskeluoikeus(peruskouluEsiopetus(päiväkotiTouhula, ostopalvelu), headers = authHeaders(MockUsers.helsinkiTallentaja) ++ jsonContent) {
-          verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.koodisto.vääräKoulutuksenTunniste(s"Järjestämismuoto sallittu vain päiväkodissa järjestettävälle esiopetukselle ($päiväkodinEsiopetuksenTunniste)"))
+          verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.koodisto.vääräKoulutuksenTunniste(s"Varhaiskasvatustoimipisteeseen voi tallentaa vain päiväkodin esiopetusta (koulutus $päiväkodinEsiopetuksenTunniste)"))
         }
       }
 

--- a/src/test/scala/fi/oph/koski/organisaatio/OrganisaatioRepositorySpec.scala
+++ b/src/test/scala/fi/oph/koski/organisaatio/OrganisaatioRepositorySpec.scala
@@ -6,7 +6,9 @@ import org.scalatest.matchers.should.Matchers
 
 class OrganisaatioRepositorySpec extends AnyFreeSpec with TestEnvironment with Matchers {
   "Hakee varhaiskasvatushierarkian" in {
-    val varhaiskasvatustoimipisteet = OrganisaatioHierarkia.flatten(MockOrganisaatioRepository.findVarhaiskasvatusHierarkiat).filter(_.children.isEmpty)
-    varhaiskasvatustoimipisteet.flatMap(_.organisaatiotyypit).distinct should be(List("VARHAISKASVATUKSEN_TOIMIPAIKKA"))
+    val varhaiskasvatustoimipisteet = OrganisaatioHierarkia
+      .flatten(MockOrganisaatioRepository.findVarhaiskasvatusHierarkiat)
+      .filter(_.children.isEmpty)
+    varhaiskasvatustoimipisteet.flatMap(_.organisaatiotyypit).distinct should be(List("TOIMIPISTE", "VARHAISKASVATUKSEN_TOIMIPAIKKA", "OPPILAITOS"))
   }
 }

--- a/src/test/scala/fi/oph/koski/organisaatio/RemoteOrganisaatioRepositorySpec.scala
+++ b/src/test/scala/fi/oph/koski/organisaatio/RemoteOrganisaatioRepositorySpec.scala
@@ -40,7 +40,17 @@ class RemoteOrganisaatioRepositorySpec extends AnyFreeSpec with TestEnvironment 
     "hakee kaikki päiväkodit" in {
       val organisaatioHierarkia = organisaatioHierarkiaJson.extract[OrganisaatioHakuTulos].organisaatiot.map(MockOrganisaatioRepository.convertOrganisaatio)
       val päiväkotiCount = OrganisaatioHierarkia.flatten(organisaatioHierarkia).count(_.organisaatiotyypit.contains(VARHAISKASVATUKSEN_TOIMIPAIKKA))
-      orgRepository.findAllVarhaiskasvatusToimipisteet.length should equal(päiväkotiCount)
+      orgRepository.findAllVarhaiskasvatusToimipisteet.count(_.varhaiskasvatuksenOrganisaatioTyyppi) should equal(päiväkotiCount)
+    }
+
+    "hakee varhaiskasvatuksen toimipisteitä jotka eivät ole päiväkoteja" in {
+      val organisaatioHierarkia = organisaatioHierarkiaJson.extract[OrganisaatioHakuTulos].organisaatiot.map(MockOrganisaatioRepository.convertOrganisaatio)
+      val muuKuinPäiväkotiCount = OrganisaatioHierarkia.flatten(organisaatioHierarkia).count(o =>
+        o.oppilaitostyyppi.contains(Oppilaitostyyppi.peruskoulut) ||
+        o.oppilaitostyyppi.contains(Oppilaitostyyppi.peruskouluasteenErityiskoulut) ||
+        o.oppilaitostyyppi.contains(Oppilaitostyyppi.perusJaLukioasteenKoulut)
+      )
+      orgRepository.findAllVarhaiskasvatusToimipisteet.count(o => !o.varhaiskasvatuksenOrganisaatioTyyppi) should equal(muuKuinPäiväkotiCount)
     }
   }
 

--- a/src/test/scala/fi/oph/koski/raportit/EsiopetusRaporttiSpec.scala
+++ b/src/test/scala/fi/oph/koski/raportit/EsiopetusRaporttiSpec.scala
@@ -104,7 +104,7 @@ class EsiopetusRaporttiSpec extends AnyFreeSpec with Matchers with Raportointika
         getOppilaitokset(raportti) should equal(List("Päiväkoti Majakka", "Päiväkoti Touhula"))
         getRows(raportti).flatMap(_.ostopalveluTaiPalveluseteli) should equal(List("JM02", "JM02"))
 
-        val ostopalveluOrganisaatiot = s"$päiväkotiMajakka,$päiväkotiTouhula"
+        val ostopalveluOrganisaatiot = s"$jyväskylänNormaalikoulu,$päiväkotiMajakka,$päiväkotiTouhula"
         AuditLogTester.verifyAuditLogMessage(Map("operation" -> "OPISKELUOIKEUS_RAPORTTI", "target" -> Map("hakuEhto" -> s"raportti=esiopetus&oppilaitosOid=$ostopalveluOrganisaatiot&paiva=2006-08-13&lang=fi")))
       }
 

--- a/src/test/scala/fi/oph/koski/raportit/RaportitServletSpec.scala
+++ b/src/test/scala/fi/oph/koski/raportit/RaportitServletSpec.scala
@@ -1,6 +1,7 @@
 package fi.oph.koski.raportit
 
 
+import fi.oph.koski.KoskiApplicationForTests
 import fi.oph.koski.api.OpiskeluoikeusTestMethods
 import fi.oph.koski.http.KoskiErrorCategory
 import fi.oph.koski.koskiuser.UserWithPassword
@@ -117,6 +118,16 @@ class RaportitServletSpec extends AnyFreeSpec with RaportointikantaTestMethods w
       "ei voi ladata raporttia jos raportin opiskeluoikeuden tyyppiin ei ole oikeuksia" in {
         authGet(s"api/raportit/lukionsuoritustietojentarkistus?oppilaitosOid=${MockOrganisaatiot.jyväskylänNormaalikoulu}&alku=2016-01-01&loppu=2016-12-31&password=dummy", user = perusopetusTallentaja) {
           verifyResponseStatus(403, KoskiErrorCategory.forbidden.opiskeluoikeudenTyyppi())
+        }
+      }
+      "koulutustoimijan oikeuksilla voi ladata esiopetuksen ostopalveluiden raportin" in {
+        authGet(s"api/raportit/esiopetus?oppilaitosOid=${KoskiApplicationForTests.organisaatioService.ostopalveluRootOid}&paiva=2022-06-07&lang=fi&password=dummy", user = helsinkiTallentaja) {
+          verifyResponseStatusOk()
+        }
+      }
+      "koulutustoimijan oikeuksilla ei voi ladata perusopetuksen raporttia peruskoululle, joka on esiopetuksen ostopalvelun oppilaitos (eikä koulutustoimijan oma organisaatio)" in {
+        authGet(s"api/raportit/perusopetuksenvuosiluokka?oppilaitosOid=${MockOrganisaatiot.jyväskylänNormaalikoulu}&paiva=2022-06-07&vuosiluokka=9&lang=fi&password=dummy", user = helsinkiTallentaja) {
+          verifyResponseStatus(403, KoskiErrorCategory.forbidden.organisaatio())
         }
       }
     }

--- a/validaation_muutoshistoria.md
+++ b/validaation_muutoshistoria.md
@@ -1,5 +1,8 @@
 # Koskeen tallennettavien tietojen validaatiosäännöt
 
+## 14.6.2022
+- Sallitaan peruskoulut esiopetuksen opiskeluoikeuden oppilaitoksina, kun järjestämismuotona on ostopalvelu tai palveluseteli.
+
 ## 8.6.2022
 - Mitätöitäessä opiskeluoikeuksia ei ole n. 1.4.2022 alkaen täydennetty puuttuvia tietoja, kuten oppilaitosta,
   yhteenlaskettuja laajuuksia, perusteen nimeä jne. automaattisesti opiskeluoikeuteen ennen sen tallentamista.

--- a/web/app/virkailija/Oppijataulukko.jsx
+++ b/web/app/virkailija/Oppijataulukko.jsx
@@ -108,6 +108,7 @@ export class Oppijataulukko extends React.Component {
                 selectedOrg={{ oid: params['toimipiste'], nimi: params['toimipisteNimi']}}
                 onSelectionChanged={(org) => {this.filterBus.push(org ? { toimipiste: org.oid, toimipisteNimi: t(org.nimi) } : { toimipiste: null, toimipisteNimi: null })}}
                 noSelectionText={t('kaikki')}
+                shouldShowChildren={org => org.oid !== 'OSTOPALVELUTAIPALVELUSETELI'}
               />
             </th>
             <SortingTableHeader field='alkamispäivä' titleKey='Aloitus pvm'>

--- a/web/app/virkailija/OrganisaatioPicker.jsx
+++ b/web/app/virkailija/OrganisaatioPicker.jsx
@@ -39,7 +39,7 @@ export default class OrganisaatioPicker extends BaconComponent {
   }
   render() {
     let { organisaatiot = [], open, loading, searchString, singleResult } = this.state
-    let { onSelectionChanged, selectedOrg, canSelectOrg = () => true, shouldShowOrg = () => true, noSelectionText = '', clearText = t('kaikki') } = this.props
+    let { onSelectionChanged, selectedOrg, canSelectOrg = () => true, shouldShowOrg = () => true, shouldShowChildren = () => true, noSelectionText = '', clearText = t('kaikki') } = this.props
 
     let selectOrg = (org) => { this.setState({open: false}); onSelectionChanged(org) }
     let orgName = org => <span><Highlight search={searchString}>{t(org.nimi)}</Highlight> {org.aktiivinen ? null : <span>{' ('}<Text name="lakkautettu"/>{')'}</span>}</span>
@@ -53,9 +53,12 @@ export default class OrganisaatioPicker extends BaconComponent {
               ? <a className="nimi" onClick={ (e) => { selectOrg(org); e.preventDefault(); e.stopPropagation() }}>{orgName(org)}</a>
               : <span>{orgName(org)}</span>
           }
-          <ul className="aliorganisaatiot">
-            { renderTree(org.children) }
-          </ul>
+          {
+            shouldShowChildren(org) ?
+              <ul className="aliorganisaatiot">
+                { renderTree(org.children) }
+              </ul> : null
+          }
         </li>)
       )
     }

--- a/web/test/spec/RaportitSpec.js
+++ b/web/test/spec/RaportitSpec.js
@@ -215,6 +215,30 @@ describe('Raporttien luominen', function() {
     })
   })
 
+  describe('Organisaatiovalitsin koulutustoimijan käyttäjällä', function() {
+    const esiopetuksenOrganisaatiot = [ 'Helsingin kaupunki', 'Kulosaaren ala-aste', 'Ostopalvelu/palveluseteli' ]
+    const perusopetuksenOrganisaatiot = [ 'Helsingin kaupunki', 'Kulosaaren ala-aste', 'Stadin ammatti- ja aikuisopisto' ]
+
+    before(
+      Authentication().login('hki-tallentaja'),
+      page.openPage(),
+      page.odotaRaporttikategoriat()
+    )
+
+    it('Valittavat organisaatiot oikein esiopetukselle', function() {
+      expect(page.valittavatOrganisaatiot()).to.deep.equal(esiopetuksenOrganisaatiot)
+    })
+
+    describe('Valittavat organisaatiot oikein perusopetukselle', function() {
+      before(
+        page.valitseRaporttikategoria(1), // Perusopetus
+      )
+      it('Ostopalvelu ei valittavana', function() {
+        expect(page.valittavatOrganisaatiot()).to.deep.equal(perusopetuksenOrganisaatiot)
+      })
+    })
+  })
+
   describe('Organisaatiovalitsimen hakutoiminto', function() {
     before(
       Authentication().login('kalle'),

--- a/web/test/spec/esiopetusSpec.js
+++ b/web/test/spec/esiopetusSpec.js
@@ -10,14 +10,14 @@ describe('Esiopetus', function() {
     before(page.openPage, page.oppijaHaku.searchAndSelect('300996-870E'))
     describe('Oppijan suorituksissa', function() {
       it('näytetään', function() {
-        expect(opinnot.getOppilaitos()).to.equal('Jyväskylän normaalikoulu')
-        expect(opinnot.getTutkinto()).to.equal('Peruskoulun esiopetus')
+        expect(opinnot.getOppilaitos(1)).to.equal('Jyväskylän normaalikoulu')
+        expect(opinnot.getTutkinto(1)).to.equal('Peruskoulun esiopetus')
       })
     })
     describe('Kaikki tiedot näkyvissä', function() {
       before(opinnot.expandAll)
       it('toimii', function() {
-        expect(S('.esiopetuksensuoritus .koulutusmoduuli .tunniste').text()).to.equal('Peruskoulun esiopetus')
+        expect(S('.esiopetuksensuoritus .koulutusmoduuli .tunniste').text()).to.equal('Peruskoulun esiopetusPeruskoulun esiopetus')
       })
     })
   })
@@ -317,19 +317,27 @@ describe('Esiopetus', function() {
   })
 
   describe('Tietojen muuttaminen', function() {
+    var indexEditor = opinnot.opiskeluoikeusEditor(1)
+
     before(Authentication().login(), page.openPage, page.oppijaHaku.searchAndSelect('300996-870E'))
 
     describe('Kurssin kuvauksen ja sanallisen arvion muuttaminen', function() {
-      var kuvaus = editor.subEditor('.osasuoritukset tbody').propertyBySelector('.kuvaus')
+      var kuvaus = indexEditor.subEditor('.osasuoritukset tbody').propertyBySelector('.kuvaus')
 
-      before(editor.edit, opinnot.expandAll, kuvaus.setValue('Uusi kuvaus'), editor.saveChanges, opinnot.expandAll)
+      before(
+        click('.toggle-edit'),
+        opinnot.expandAll,
+        kuvaus.setValue('Uusi kuvaus'),
+        indexEditor.saveChanges,
+        opinnot.expandAll
+      )
       it('Toimii', function() {
         expect(kuvaus.getValue()).to.equal('Uusi kuvaus')
       })
     })
 
     describe('Päätason suorituksen poistaminen', function() {
-      before(editor.edit)
+      before(indexEditor.edit)
 
       describe('Mitätöintilinkki', function() {
         it('Ei näytetä', function() {
@@ -340,17 +348,19 @@ describe('Esiopetus', function() {
   })
 
   describe('Aloituspäivä', function() {
+    var indexEditor = opinnot.opiskeluoikeusEditor(1)
+
     before(page.openPage, page.oppijaHaku.searchAndSelect('300996-870E'))
 
     describe('Opiskeluoikeuden aloituspäivän muuttaminen', function() {
       before(
-        editor.edit,
+        indexEditor.edit,
         opinnot.expandAll,
         Page(function() {return S('#content')}).setInputValue('.tila .opiskeluoikeusjakso:last-child .date input', '1.1.2005')
       )
       it('Toimii', function() {
         expect(S('.tila .opiskeluoikeusjakso:last-child .date input').val()).to.equal('1.1.2005')
-        expect(S('.opiskeluoikeuden-voimassaoloaika .alkamispäivä .date').html()).to.equal('1.1.2005')
+        expect(S('li:nth-child(2) .opiskeluoikeuden-voimassaoloaika .alkamispäivä .date').html()).to.equal('1.1.2005')// li:nth-child(2)
       })
     })
   })

--- a/web/test/spec/esiopetusSpec.js
+++ b/web/test/spec/esiopetusSpec.js
@@ -127,15 +127,36 @@ describe('Esiopetus', function() {
 
         it('vain oman organisaation ulkopuoliset varhaiskasvatustoimipisteet näytetään', function () {
           expect(addOppija.toimipisteet()).to.deep.equal([
+            'Helsingin normaalilyseo',
+            'Helsingin yliopiston Viikin normaalikoulu',
+            'International School of Helsinki',
+            'Joensuun normaalikoulu  (lakkautettu)',
+            'Rantakylän normaalikoulu',
+            'Savonlinnan normaalikoulu  (lakkautettu)',
+            'Tulliportin normaalikoulu',
+            'Jyväskylän normaalikoulu',
+            'Helsingin Saksalainen koulu',
             'Tarina',
+            'Heinlahden ala-aste  (lakkautettu)',
+            'Hirvikosken koulu',
+            'Huutjärven koulu',
             'Ip-Huutjärvi',
             'Ip-Suur-Ahvenkoski',
+            'Purolan koulu  (lakkautettu)',
+            'Pyttis svenska skola',
             'Päiväkoti Majakka',
             'Päiväkoti Måsarna',
             'Päiväkoti Touhula',
+            'Siltakylän ala-aste  (lakkautettu)',
+            'Suur-Ahvenkosken koulu',
+            'Hämeenlinnan normaalikoulu  (lakkautettu)',
             'ARPELAN ESIOPETUS',
             'ARPELAN PÄIVÄKOTI',
+            'Aapajoen koulu  (lakkautettu)',
+            'Aapajärven koulu  (lakkautettu)',
+            'Arpelan koulu',
             'HANNULAN KOULUN ESKARI',
+            'Hannulan koulu',
             'ISOPALON PÄIVÄKOTI',
             'JUHANNUSSAAREN PÄIVÄKOTI',
             'KAAKAMON PÄIVÄKOTI',
@@ -147,11 +168,32 @@ describe('Esiopetus', function() {
             'KOKKOKANKAAN ESKRI',
             'KOKKOKANKAAN PÄIVÄKOTI',
             'KYLÄJOEN ESIOPETUS POIKKIKAIRA',
+            'Kaakamon koulu',
+            'Kantojärven koulu  (lakkautettu)',
+            'Karungin koulu',
+            'Kivirannan koulu',
+            'Kokkokankaan koulu',
+            'Kukkolan koulu  (lakkautettu)',
+            'Kyläjoen koulu',
+            'Liakan koulu  (lakkautettu)',
+            'Mustarannan koulu  (lakkautettu)',
+            'Nikunmäen koulu  (lakkautettu)',
             'NÄÄTSAAREN ESKARI',
+            'Näätsaaren koulu',
             'PIRKKIÖN ESKARI',
             'PIRKKIÖN PÄIVÄKOTI',
             'PUTAAN VUOROPÄIVÄKOTI',
-            'SEMINAARIN ESKARI'
+            'Pirkkiön koulu',
+            'Putaan koulu',
+            'Raumon koulu',
+            'SEMINAARIN ESKARI',
+            'Sattajärven koulu  (lakkautettu)',
+            'Suensaaren koulu  (lakkautettu)',
+            'Tornion Seminaarin koulu',
+            'Tornionseudun koulu  (lakkautettu)',
+            'Vojakkalan koulu  (lakkautettu)',
+            'Yliliakan koulu  (lakkautettu)',
+            'Yliraumon koulu  (lakkautettu)'
           ])
         })
 
@@ -222,6 +264,51 @@ describe('Esiopetus', function() {
                   expect(opinnot.invalidateOpiskeluoikeusIsShown()).to.equal(false)
                 })
               })
+            })
+          })
+        })
+      })
+    })
+
+    describe('Lisääminen organisaatiohierarkian ulkopuolelle peruskoulun esiopetukselle', function () {
+      before(prepareForNewOppija('hki-tallentaja', '230872-7258'))
+
+      describe('Kun kyseessä on koulutustoimija joka on myös varhaiskasvatuksen järjestäjä', function() {
+        it('Varhaiskasvatus organisaatiohierarkian ulkopuolelle valitsin näytetään', function() {
+          expect(isElementVisible(findSingle('#varhaiskasvatus-checkbox'))).to.equal(true)
+        })
+      })
+
+      describe('Kun valitaan oman organisaatiohierarkian ulkopuolelle tallentaminen', function () {
+        before(
+          addOppija.selectVarhaiskasvatusOrganisaationUlkopuolelta(true),
+          addOppija.enterOppilaitos('')
+        )
+
+
+        describe('Kun syötetään loput datat peruskoulun esiopetukselle', function() {
+          before(
+            addOppija.selectJärjestämismuoto('Ostopalvelu, kunnan tai kuntayhtymän järjestämä'),
+            addOppija.enterValidDataEsiopetus({oppilaitos: 'Hirvikosken koulu'})
+        )
+
+          it('lisää nappi enabloituu', function () {
+            expect(addOppija.isEnabled()).to.equal(true)
+          })
+
+          describe('Kun painetaan Lisää-nappia', function () {
+            before(addOppija.submitAndExpectSuccess('Tyhjä, Tero (230872-7258)', 'Peruskoulun esiopetus'))
+
+            it('lisätty oppija näytetään', function () {
+              expect(opinnot.getTutkinto()).to.equal('Peruskoulun esiopetus')
+              expect(opinnot.getOppilaitos()).to.equal('Hirvikosken koulu')
+              expect(editor.propertyBySelector('.diaarinumero').getValue()).to.equal('102/011/2014')
+              expect(extractAsText(S('.tunniste-koodiarvo'))).to.equal('001101')
+            })
+
+            it('koulutusmoduuli ja järjestämismuoto näytetään', function () {
+              expect(editor.property('koulutustoimija').getValue()).to.equal('Helsingin kaupunki')
+              expect(editor.property('järjestämismuoto').getValue()).to.equal('Ostopalvelu, kunnan tai kuntayhtymän järjestämä')
             })
           })
         })

--- a/web/test/spec/huoltajaSpec.js
+++ b/web/test/spec/huoltajaSpec.js
@@ -46,6 +46,7 @@ describe('Huollettavien tiedot', function () {
             'Päiväkoti Touhula',
             'Päiväkoti Majakka'
           ], [
+            'Peruskoulun esiopetus (2022—, läsnä)',
             'Peruskoulun esiopetus (2006—2007, valmistunut)',
             'Päiväkodin esiopetus (2006—, läsnä)',
             'Päiväkodin esiopetus (2006—, läsnä)'

--- a/web/test/spec/oppijataulukkoSpec.js
+++ b/web/test/spec/oppijataulukkoSpec.js
@@ -338,32 +338,35 @@ describe('Oppijataulukko', function() {
     before(Authentication().login('esiopetus'), page.openPage, wait.until(page.isReady))
 
     it('ei näytetä kuin oman koulun esiopetusoppijat', function() {
-      expect(page.oppijataulukko.data().map(function(row) { return row[0]})).to.deep.equal([ 'Eskari, Essi', 'Kelalle, Useita', 'Lisä-Eskari, Essiina' ])
-      expect(page.opiskeluoikeudeTotal()).to.equal('3')
+      expect(page.oppijataulukko.data().map(function(row) { return row[0]})).to.deep.equal([ 'Eskari, Essi', 'Eskari, Essi', 'Kelalle, Useita', 'Lisä-Eskari, Essiina' ])
+      expect(page.opiskeluoikeudeTotal()).to.equal('4')
     })
   })
 
   describe('Varhaiskasvatuksen järjestäjä', function() {
     before(Authentication().login('hki-tallentaja'), page.openPage, wait.until(page.isReady))
+    var organisaatiovalitsin = OrganisaatioHaku(page.oppijataulukko.tableElem)
 
-    describe('voi hakea ostopalvelutoimipisteistä joihin on tallennettu opiskeluoikeuksia', function() {
-      before(page.oppijataulukko.filterBy('tyyppi'), page.oppijataulukko.filterBy('tila'), page.oppijataulukko.filterBy('oppilaitos', 'Päiväkoti Touhula'))
+    describe('ei voi hakea yksittäisistä ostopalvelutoimipisteistä joihin on tallennettu opiskeluoikeuksia', function() {
+      before(
+        page.oppijataulukko.filterBy('tyyppi'),
+        page.oppijataulukko.filterBy('tila'),
+        organisaatiovalitsin.enter()
+      )
 
       it('toimii', function() {
-        expect(page.oppijataulukko.names()).to.deep.equal(['Eskari, Essi'])
-        expect(page.opiskeluoikeudeTotal()).to.equal('1')
+        expect(organisaatiovalitsin.oppilaitokset()).not.to.deep.include(
+          'Päiväkoti Touhula'
+        )
       })
     })
 
-    var organisaatiovalitsin = OrganisaatioHaku(page.oppijataulukko.tableElem)
     describe('voi filtteröidä hakusanalla Ostopalvelu/palveluseteli', function() {
       before(organisaatiovalitsin.enter('Ostopalvelu/palveluseteli'))
 
-      it('näyttää vain oppilaitokset joihin tallennettu dataa', function() {
+      it('näyttää vain Ostopalvelu/palveluseteli -valinnan eikä aliorganisaatioita sille', function() {
         expect(organisaatiovalitsin.oppilaitokset()).to.deep.equal([
-          'Ostopalvelu/palveluseteli Päiväkoti Majakka Päiväkoti Touhula',
-          'Päiväkoti Majakka',
-          'Päiväkoti Touhula'
+          'Ostopalvelu/palveluseteli',
         ])
       })
     })
@@ -372,9 +375,9 @@ describe('Oppijataulukko', function() {
       before(organisaatiovalitsin.select('Ostopalvelu/palveluseteli'))
 
       it('toimii', function() {
-        expect(page.oppijataulukko.names()).to.deep.equal(['Eskari, Essi', 'Eskari, Essi'])
-        expect(page.oppijataulukko.oppilaitokset().slice().sort()).to.deep.equal(['Päiväkoti Majakka', 'Päiväkoti Touhula'])
-        expect(page.opiskeluoikeudeTotal()).to.equal('2')
+        expect(page.oppijataulukko.names()).to.deep.equal(['Eskari, Essi', 'Eskari, Essi', 'Eskari, Essi'])
+        expect(page.oppijataulukko.oppilaitokset().slice().sort()).to.deep.equal(['Jyväskylän normaalikoulu', 'Päiväkoti Majakka', 'Päiväkoti Touhula'])
+        expect(page.opiskeluoikeudeTotal()).to.equal('3')
       })
     })
   })


### PR DESCRIPTION
Sallitaan peruskoulut esiopetuksen opiskeluoikeuden oppilaitoksina,
kun järjestämismuotona on ostopalvelu tai palveluseteli.

Varhaiskasvatuksen koulutustoimijoiden käyttäjät näkevät käyttöliittymällä kaikki peruskoulut,
kun lisätään esiopetuksen opiskeluoikeutta joka ostetaan oman organisaation ulkopuolelta, ja
pystyvät lisäämään oman organisaation ulkopuolisen peruskoulun opiskeluoikeuden oppilaitokseksi.