### PR TITLE
TOR-1745: Raportointikannan generoinnin kuorman tasaaminen

### DIFF
--- a/src/main/resources/db/migration/V83__create_paivitettu_opiskeluoikeus_table.sql
+++ b/src/main/resources/db/migration/V83__create_paivitettu_opiskeluoikeus_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE oph.paivitetty_opiskeluoikeus (
+    id serial,
+    opiskeluoikeus_oid text NOT NULL,
+    aikaleima timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    prosessoitu boolean NOT NULL DEFAULT false
+);
+
+CREATE UNIQUE INDEX paivitetty_opiskeluoikeus_pkey ON oph.paivitetty_opiskeluoikeus(id int4_ops);
+CREATE INDEX paivitetty_opiskeluoikeus_aikaleima_idx ON oph.paivitetty_opiskeluoikeus(aikaleima timestamptz_ops);
+CREATE INDEX paivitetty_opiskeluoikeus_prosessoitu_idx ON oph.paivitetty_opiskeluoikeus(prosessoitu bool_ops);

--- a/src/main/resources/db/migration/V84__create_paivitetty_opiskeluoikeus_trigger.sql
+++ b/src/main/resources/db/migration/V84__create_paivitetty_opiskeluoikeus_trigger.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE FUNCTION add_paivitetty_opiskeluoikeus_row()
+RETURNS TRIGGER AS $$
+    BEGIN
+        INSERT INTO paivitetty_opiskeluoikeus
+                    (opiskeluoikeus_oid, aikaleima)
+             VALUES (NEW.oid, NEW.aikaleima);
+        RETURN NEW;
+    END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER opiskeluoikeuden_paivitys
+    AFTER INSERT OR UPDATE
+    ON opiskeluoikeus
+    FOR EACH ROW
+    EXECUTE FUNCTION add_paivitetty_opiskeluoikeus_row();

--- a/src/main/scala/fi/oph/koski/config/Environment.scala
+++ b/src/main/scala/fi/oph/koski/config/Environment.scala
@@ -30,4 +30,7 @@ object Environment {
 
   def skipFixtures: Boolean =
     sys.env.getOrElse("SKIP_FIXTURES", "") == "true"
+
+  def forceLocalMigration: Option[String] =
+    sys.env.get("FORCE_LOCAL_MIGRATION")
 }

--- a/src/main/scala/fi/oph/koski/config/Environment.scala
+++ b/src/main/scala/fi/oph/koski/config/Environment.scala
@@ -27,4 +27,7 @@ object Environment {
   }
 
   def currentEnvironment(config: Config): String = config.getString("env")
+
+  def skipFixtures: Boolean =
+    sys.env.getOrElse("SKIP_FIXTURES", "") == "true"
 }

--- a/src/main/scala/fi/oph/koski/config/Environment.scala
+++ b/src/main/scala/fi/oph/koski/config/Environment.scala
@@ -11,7 +11,10 @@ object Environment {
   def isLocalDevelopmentEnvironment(config: Config): Boolean = currentEnvironment(config) == Local
 
   def isUsingLocalDevelopmentServices(app: KoskiApplication): Boolean =
-    app.masterDatabase.isLocal && app.config.getString("opintopolku.virkailija.url") == "mock"
+    app.masterDatabase.isLocal && isMockEnvironment(app.config)
+
+  def isMockEnvironment(config: Config): Boolean =
+    config.getString("opintopolku.virkailija.url") == "mock"
 
   def isServerEnvironment(config: Config): Boolean = !Set(Local, UnitTest).contains(currentEnvironment(config))
 

--- a/src/main/scala/fi/oph/koski/config/KoskiApplication.scala
+++ b/src/main/scala/fi/oph/koski/config/KoskiApplication.scala
@@ -142,6 +142,7 @@ class KoskiApplication(
   lazy val prometheusRepository = PrometheusRepository(config)
   lazy val koskiPulssi = KoskiPulssi(this)
   lazy val koskiLocalizationRepository = LocalizationRepository(config, new KoskiLocalizationConfig)
+  lazy val päivitetytOpiskeluoikeudetJono = new PäivitetytOpiskeluoikeudetJonoService(this)
   lazy val valpasLocalizationRepository = LocalizationRepository(config, new ValpasLocalizationConfig)
   lazy val valpasRajapäivätService = ValpasRajapäivätService(config)
   lazy val valpasOppijaLaajatTiedotService = new ValpasOppijaService(this)

--- a/src/main/scala/fi/oph/koski/db/Database.scala
+++ b/src/main/scala/fi/oph/koski/db/Database.scala
@@ -16,7 +16,13 @@ trait Database extends Logging {
 
   if ((config.isLocal || Environment.isLocalDevelopmentEnvironment(config.rootConfig)) && util.databaseIsLarge) {
     // Prevent running migrations against a (large) remote database when running locally
-    logger.error("Migration not allowed with a large database in local development environment")
+    val forceMigration = Environment.forceLocalMigration.contains(config.host)
+    if (forceMigration) {
+      Migration.migrateSchema(config)
+    } else {
+      val hint = s"If you really want to run this migration set environment variable FORCE_LOCAL_MIGRATION=${config.host}"
+      logger.error(s"Migration not allowed with a large database in local development environment. $hint")
+    }
   } else {
     Migration.migrateSchema(config)
   }

--- a/src/main/scala/fi/oph/koski/db/Migration.scala
+++ b/src/main/scala/fi/oph/koski/db/Migration.scala
@@ -13,13 +13,15 @@ object Migration extends Logging {
 
   private def doMigrate(config: DatabaseConfig, locations: String): Unit = {
     logger.info(s"Running migrations for ${config.dbname} from $locations")
+    createFlyway(config, locations).migrate()
+  }
 
+  private def createFlyway(config: DatabaseConfig, locations: String) = {
     val flyway = new Flyway
     flyway.setLocations(locations)
     flyway.setDataSource(config.url(useSecretsManagerProtocol = false), config.user, config.password)
     flyway.setSchemas(config.schemaName)
     flyway.setValidateOnMigrate(false)
-
-    flyway.migrate
+    flyway
   }
 }

--- a/src/main/scala/fi/oph/koski/fixture/Fixtures.scala
+++ b/src/main/scala/fi/oph/koski/fixture/Fixtures.scala
@@ -45,7 +45,7 @@ class FixtureCreator(application: KoskiApplication) extends Logging with Timing 
   def shouldUseFixtures = {
     val useFixtures: Boolean = Environment.currentEnvironment(application.config) match {
       case Environment.UnitTest => true
-      case Environment.Local => Environment.isUsingLocalDevelopmentServices(application)
+      case Environment.Local => Environment.isUsingLocalDevelopmentServices(application) && !Environment.skipFixtures
       case _ => false
     }
 

--- a/src/main/scala/fi/oph/koski/fixture/Fixtures.scala
+++ b/src/main/scala/fi/oph/koski/fixture/Fixtures.scala
@@ -31,6 +31,7 @@ class FixtureCreator(application: KoskiApplication) extends Logging with Timing 
       application.koskiLocalizationRepository.asInstanceOf[MockLocalizationRepository].reset
       application.valpasLocalizationRepository.asInstanceOf[MockLocalizationRepository].reset
       application.tiedonsiirtoService.index.deleteAll()
+      application.päivitetytOpiskeluoikeudetJono.poistaKaikki()
 
       if (reloadRaportointikanta || fixtureNameHasChanged) {
         raportointikantaService.loadRaportointikanta(force = true)

--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/PäivitetytOpiskeluoikeudetJonoService.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/PäivitetytOpiskeluoikeudetJonoService.scala
@@ -44,6 +44,9 @@ class PäivitetytOpiskeluoikeudetJonoService(application: KoskiApplication) {
 
   def poistaKaikki(): Unit =
     master.poistaKaikki()
+
+  def poistaVanhat(aikaraja: ZonedDateTime): Unit =
+    master.poistaVanhat(aikaraja)
 }
 
 trait PäivitetytOpiskeluoikeudetDbService extends QueryMethods {

--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/PäivitetytOpiskeluoikeudetJonoService.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/PäivitetytOpiskeluoikeudetJonoService.scala
@@ -1,0 +1,98 @@
+package fi.oph.koski.opiskeluoikeus
+
+import fi.oph.koski.config.{Environment, KoskiApplication}
+import fi.oph.koski.db.KoskiTables.PäivitetytOpiskeluoikeudet
+import fi.oph.koski.db.PostgresDriverWithJsonSupport.api._
+import fi.oph.koski.db.{DB, PäivitettyOpiskeluoikeusRow, QueryMethods}
+import fi.oph.koski.schema.Opiskeluoikeus
+import fi.oph.koski.util.TimeConversions._
+
+import java.time.ZonedDateTime
+
+class PäivitetytOpiskeluoikeudetJonoService(application: KoskiApplication) {
+  lazy val replica = new PäivitetytOpiskeluoikeudetReplicaDbService(application.replicaDatabase.db)
+  lazy val master = new PäivitetytOpiskeluoikeudetMasterDbService(application.masterDatabase.db, Environment.isMockEnvironment(application.config))
+
+  def päivitetytOpiskeluoikeudet(dueTime: ZonedDateTime): Seq[PäivitettyOpiskeluoikeusRow] = {
+    // Filtteröidään replicasta haettu jono masterin tietojen perusteella, jotta saadaan sellainen osajoukko, joka
+    //   1) löytyy replicasta
+    //   2) ei ole vielä käsitelty.
+    // Tämä siksi, että replica on masterista joskus jopa vartin jäljessä.
+
+    val prosessoidutRivit = master.päivitetytOpiskeluoikeudet(dueTime)
+      .filter(_.prosessoitu)
+      .map(_.id)
+
+    replica.päivitetytOpiskeluoikeudet(dueTime)
+      .filterNot(r => prosessoidutRivit.contains(r.id))
+  }
+
+  def kaikki: Seq[PäivitettyOpiskeluoikeusRow] =
+    replica.kaikki
+
+  def lisää(opiskeluoikeusOid: Opiskeluoikeus.Oid): Unit =
+    master.lisää(opiskeluoikeusOid, ZonedDateTime.now())
+
+  def alustaKaikkiKäsiteltäviksi(): Unit =
+    master.alustaKaikkiKäsiteltäviksi()
+
+  def merkitseKäsitellyiksi(käsitellytRiviIdt: Seq[Int]): Unit =
+    master.merkitseKäsitellyiksi(käsitellytRiviIdt)
+
+  def poistaKäsitellyt(): Unit =
+    master.poistaKäsitellyt()
+
+  def poistaKaikki(): Unit =
+    master.poistaKaikki()
+}
+
+trait PäivitetytOpiskeluoikeudetDbService extends QueryMethods {
+  def päivitetytOpiskeluoikeudet(dueTime: ZonedDateTime): Seq[PäivitettyOpiskeluoikeusRow] = {
+    val due = toTimestamp(dueTime)
+    runDbSync {
+      PäivitetytOpiskeluoikeudet
+        .filter(_.prosessoitu === false)
+        .filter(_.aikaleima < due)
+        .sortBy(_.aikaleima)
+        .result
+    }
+  }
+}
+
+class PäivitetytOpiskeluoikeudetReplicaDbService(val db: DB) extends PäivitetytOpiskeluoikeudetDbService {
+  def kaikki: Seq[PäivitettyOpiskeluoikeusRow] = runDbSync(PäivitetytOpiskeluoikeudet.result)
+}
+
+class PäivitetytOpiskeluoikeudetMasterDbService(val db: DB, isMockEnv: Boolean) extends PäivitetytOpiskeluoikeudetDbService {
+  def lisää(opiskeluoikeusOid: Opiskeluoikeus.Oid, aikaleima: ZonedDateTime): Unit = runDbSync {
+    PäivitetytOpiskeluoikeudet += PäivitettyOpiskeluoikeusRow(
+      opiskeluoikeusOid = opiskeluoikeusOid,
+      aikaleima = toTimestamp(aikaleima),
+    )
+  }
+
+  def alustaKaikkiKäsiteltäviksi(): Unit = {
+    val query = for { r <- PäivitetytOpiskeluoikeudet } yield r.prosessoitu
+    runDbSync(query.update(false))
+  }
+
+  def merkitseKäsitellyiksi(käsitellytRiviIdt: Seq[Int]): Unit = {
+    val query = for { r <- PäivitetytOpiskeluoikeudet if r.id inSet käsitellytRiviIdt } yield r.prosessoitu
+    runDbSync(query.update(true))
+  }
+
+  def poistaKäsitellyt(): Unit = runDbSync {
+    PäivitetytOpiskeluoikeudet
+      .filter(_.prosessoitu)
+      .delete
+  }
+
+  def poistaKaikki(): Unit =
+    if (isMockEnv) runDbSync(PäivitetytOpiskeluoikeudet.delete)
+
+  def poistaVanhat(aikaraja: ZonedDateTime): Unit = runDbSync {
+    PäivitetytOpiskeluoikeudet
+      .filter(_.aikaleima < toTimestamp(aikaraja))
+      .delete
+  }
+}

--- a/src/main/scala/fi/oph/koski/raportit/RaportitService.scala
+++ b/src/main/scala/fi/oph/koski/raportit/RaportitService.scala
@@ -8,9 +8,11 @@ import fi.oph.koski.organisaatio.OrganisaatioHierarkia
 import fi.oph.koski.raportit.aikuistenperusopetus._
 import fi.oph.koski.raportit.lukio.LukioOppiaineenOppimaaranKurssikertymat.{AikuistenOppimäärä, NuortenOppimäärä}
 import fi.oph.koski.raportit.lukio._
-import fi.oph.koski.raportit.lukio.lops2021.{Lukio2019AineopintojenOpintopistekertymat, Lukio2019MuutaKauttaRahoitetut, Lukio2019OppiaineEriVuonnaKorotetutOpintopisteet, Lukio2019OppiaineOpiskeluoikeudenUlkopuoliset, Lukio2019OppimaaranOpintopistekertymat, Lukio2019RahoitusmuotoEiTiedossa, Lukio2019RaportitRepository, Lukio2019Raportti}
+import fi.oph.koski.raportit.lukio.lops2021._
 import fi.oph.koski.schema.LocalizedString
 import fi.oph.koski.schema.Organisaatio.isValidOrganisaatioOid
+
+import java.time.LocalDateTime
 
 class RaportitService(application: KoskiApplication) {
   private val raportointiDatabase = application.raportointiDatabase
@@ -35,7 +37,15 @@ class RaportitService(application: KoskiApplication) {
   private val perusopetuksenOppijamäärätRaportti = PerusopetuksenOppijamäärätRaportti(raportointiDatabase.db, application.organisaatioService)
   private val perusopetuksenLisäopetuksenOppijamäärätRaportti = PerusopetuksenLisäopetusOppijamäärätRaportti(raportointiDatabase.db, application.organisaatioService)
 
-  def viimeisinPäivitys = raportointiDatabase.status.startedTime.get.toLocalDateTime
+  def viimeisinOpiskeluoikeuspäivitystenVastaanottoaika: LocalDateTime = {
+    val status = raportointiDatabase.status
+    status
+      .statuses
+      .find(_.name == "opiskeluoikeudet")
+      .flatMap(_.dueTime)
+      .getOrElse(status.startedTime.get)
+      .toLocalDateTime
+  }
 
   def paallekkaisetOpiskeluoikeudet(
     request: AikajaksoRaporttiRequest,

--- a/src/main/scala/fi/oph/koski/raportit/RaportitServlet.scala
+++ b/src/main/scala/fi/oph/koski/raportit/RaportitServlet.scala
@@ -39,7 +39,7 @@ class RaportitServlet(implicit val application: KoskiApplication) extends KoskiS
   }
 
   get("/paivitysaika") {
-    raportitService.viimeisinPäivitys
+    raportitService.viimeisinOpiskeluoikeuspäivitystenVastaanottoaika
   }
 
   // TODO: Tarpeeton kun uusi raporttikäli saadaan käyttöön, voi poistaa

--- a/src/main/scala/fi/oph/koski/raportointikanta/OpiskeluoikeusLoader.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/OpiskeluoikeusLoader.scala
@@ -8,6 +8,7 @@ import fi.oph.koski.opiskeluoikeus.{OpiskeluoikeusQueryService, PäivitetytOpisk
 import fi.oph.koski.raportointikanta.LoaderUtils.{convertKoodisto, convertLocalizedString}
 import fi.oph.koski.schema._
 import fi.oph.koski.suostumus.SuostumuksenPeruutusService
+import fi.oph.koski.util.TimeConversions.toTimestamp
 import fi.oph.koski.validation.MaksuttomuusValidation
 import org.json4s.JValue
 import rx.lang.scala.{Observable, Subscriber}
@@ -33,8 +34,10 @@ object OpiskeluoikeusLoader extends Logging {
     batchSize: Int = DefaultBatchSize,
     onAfterPage: (Int, Seq[OpiskeluoikeusRow]) => Unit = (_, _) => ()
   ): Observable[LoadResult] = {
-    db.setStatusLoadStarted(statusName)
-    db.setStatusLoadStarted(mitätöidytStatusName)
+    val dueTime = update.map(_.dueTime).map(toTimestamp)
+    db.setStatusLoadStarted(statusName, dueTime)
+    db.setStatusLoadStarted(mitätöidytStatusName, dueTime)
+
     update.foreach(u => {
       u.service.alustaKaikkiKäsiteltäviksi()
       db.cloneUpdateableTables(u.previousRaportointiDatabase)

--- a/src/main/scala/fi/oph/koski/raportointikanta/OpiskeluoikeusLoader.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/OpiskeluoikeusLoader.scala
@@ -1,10 +1,10 @@
 package fi.oph.koski.raportointikanta
 
-import fi.oph.koski.db.{OpiskeluoikeusRow, PoistettuOpiskeluoikeusRow}
+import fi.oph.koski.db.{DB, OpiskeluoikeusRow, PoistettuOpiskeluoikeusRow}
 import fi.oph.koski.json.JsonManipulation
 import fi.oph.koski.koskiuser.KoskiSpecificSession
 import fi.oph.koski.log.Logging
-import fi.oph.koski.opiskeluoikeus.OpiskeluoikeusQueryService
+import fi.oph.koski.opiskeluoikeus.{OpiskeluoikeusQueryService, PäivitetytOpiskeluoikeudetJonoService}
 import fi.oph.koski.raportointikanta.LoaderUtils.{convertKoodisto, convertLocalizedString}
 import fi.oph.koski.schema._
 import fi.oph.koski.suostumus.SuostumuksenPeruutusService
@@ -14,8 +14,9 @@ import rx.lang.scala.{Observable, Subscriber}
 
 import java.sql.{Date, Timestamp}
 import java.time.temporal.ChronoField
+import java.time.{LocalDateTime, ZonedDateTime}
 import java.util.concurrent.atomic.AtomicLong
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.Try
 
 object OpiskeluoikeusLoader extends Logging {
@@ -35,15 +36,21 @@ object OpiskeluoikeusLoader extends Logging {
     db.setStatusLoadStarted(statusName)
     db.setStatusLoadStarted(mitätöidytStatusName)
     update.foreach(u => {
-      db.cloneUpdateableTables(u.sourceDb)
+      u.service.alustaKaikkiKäsiteltäviksi()
+      db.cloneUpdateableTables(u.previousRaportointiDatabase)
       createIndexesForIncrementalUpdate(db)
       suoritusIds.set(db.getLatestSuoritusId)
     })
 
     var loopCount = 0
-    val result = opiskeluoikeusQueryRepository.mapOpiskeluoikeudetSivuittainWithoutAccessCheck(batchSize, update.map(_.since)) { batch =>
+
+    val result = mapOpiskeluoikeudetSivuittainWithoutAccessCheck(batchSize, update, opiskeluoikeusQueryRepository) { batch =>
       if (batch.nonEmpty) {
-        val result = if (update.isDefined) updateBatch(db, suostumuksenPeruutusService, batch) else loadBatch(db, suostumuksenPeruutusService, batch)
+        val result = if (update.isDefined) {
+          updateBatch(db, suostumuksenPeruutusService, batch)
+        } else {
+          loadBatch(db, suostumuksenPeruutusService, batch)
+        }
         onAfterPage(loopCount, batch)
         loopCount = loopCount + 1
         result
@@ -567,6 +574,22 @@ object OpiskeluoikeusLoader extends Logging {
       )
     )
   }
+
+  def mapOpiskeluoikeudetSivuittainWithoutAccessCheck[A]
+    (
+      pageSize: Int,
+      update: Option[RaportointiDatabaseUpdate],
+      opiskeluoikeusQueryRepository: OpiskeluoikeusQueryService,
+    )
+    (mapFn: Seq[OpiskeluoikeusRow] => Seq[A])
+  : Observable[A] =
+    update match {
+      case Some(update) =>
+        update.loader.load(pageSize, update)(mapFn)
+      case _ =>
+        opiskeluoikeusQueryRepository.mapOpiskeluoikeudetSivuittainWithoutAccessCheck(pageSize)(mapFn)
+    }
+
 }
 
 sealed trait LoadResult
@@ -587,6 +610,16 @@ case class OutputRows(
 )
 
 case class RaportointiDatabaseUpdate(
-  sourceDb: RaportointiDatabase,
-  since: Timestamp,
-)
+  previousRaportointiDatabase: RaportointiDatabase,
+  readReplicaDb: DB,
+  dueTime: ZonedDateTime,
+  sleepDuration: FiniteDuration,
+  service: PäivitetytOpiskeluoikeudetJonoService,
+) {
+  def dueTimeExpired: Boolean = {
+    dueTime.toLocalDateTime.isBefore(LocalDateTime.now())
+  }
+
+  val loader: PäivitettyOpiskeluoikeusLoader =
+    new PäivitettyOpiskeluoikeusLoader(readReplicaDb, service)
+}

--- a/src/main/scala/fi/oph/koski/raportointikanta/PäivitettyOpiskeluoikeusLoader.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/PäivitettyOpiskeluoikeusLoader.scala
@@ -1,0 +1,81 @@
+package fi.oph.koski.raportointikanta
+
+import fi.oph.koski.db.PostgresDriverWithJsonSupport.api._
+import fi.oph.koski.db.KoskiTables.OpiskeluOikeudet
+import fi.oph.koski.db.{DB, OpiskeluoikeusRow, PäivitettyOpiskeluoikeusRow, QueryMethods}
+import fi.oph.koski.opiskeluoikeus.PäivitetytOpiskeluoikeudetJonoService
+import rx.Observer
+import rx.functions.{Func0, Func2}
+import rx.lang.scala.Observable
+import rx.observables.SyncOnSubscribe.createStateful
+import rx.Observable.{create => createObservable}
+
+import java.time.ZonedDateTime
+
+class PäivitettyOpiskeluoikeusLoader(
+  val db: DB,
+  val opiskeluoikeusJonoService: PäivitetytOpiskeluoikeudetJonoService,
+) extends QueryMethods {
+
+  def load[A]
+    (pageSize: Int, update: RaportointiDatabaseUpdate)
+    (processRows: Seq[OpiskeluoikeusRow] => Seq[A])
+  : Observable[A] = {
+    import rx.lang.scala.JavaConverters._
+
+    case class State(
+      queue: Seq[PäivitettyOpiskeluoikeusRow],
+      updateIds: Seq[Int] = Seq.empty,
+      batchStartTime: Option[ZonedDateTime] = None,
+      resultBatch: Seq[OpiskeluoikeusRow] = Seq.empty,
+      nextPage: Int = 0,
+    ) {
+      def loadNextPage(): State = {
+        val batchStartTime = ZonedDateTime.now()
+        val index = nextPage * pageSize
+        val updates = queue.slice(index, index + pageSize)
+        val oids = updates.map(_.opiskeluoikeusOid)
+        val result = runDbSync(OpiskeluOikeudet.filter(_.oid inSet oids).result)
+        this.copy(
+          updateIds = updates.flatMap(_.id),
+          resultBatch = result,
+          batchStartTime = Some(batchStartTime),
+          nextPage = nextPage + 1,
+        )
+      }
+
+      def completed: State = this.copy(resultBatch = Nil)
+      def nothingToProcess: Boolean = resultBatch.isEmpty
+    }
+
+    object State {
+      def init(): State = {
+        val state = State(queue = opiskeluoikeusJonoService.päivitetytOpiskeluoikeudet(update.dueTime))
+        state.loadNextPage()
+      }
+    }
+
+    createObservable(createStateful[State, Seq[A]](
+      (() => State.init()): Func0[_ <: State],
+      ((state, observer) => {
+        def process(): Unit = {
+          observer.onNext(processRows(state.resultBatch))
+          opiskeluoikeusJonoService.merkitseKäsitellyiksi(state.updateIds)
+        }
+        if (state.nothingToProcess) {
+          if (state.batchStartTime.exists(_.isAfter(update.dueTime))) {
+            process()
+            observer.onCompleted()
+            state.completed
+          } else {
+            Thread.sleep(update.sleepDuration.toMillis)
+            State.init() // Restart loading
+          }
+        } else {
+          process()
+          state.loadNextPage()
+        }
+      }): Func2[_ >: State, _ >: Observer[_ >: Seq[A]], _ <: State]
+    )).asScala.flatMap(Observable.from(_))
+  }
+}

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
@@ -340,8 +340,16 @@ class RaportointiDatabase(config: RaportointiDatabaseConfigBase) extends Logging
   def setLastUpdate(name: String, time: LocalDateTime = now): Unit =
     runDbSync(sqlu"update #${schema.name}.raportointikanta_status set last_update=${toTimestamp(time)} where name = $name")
 
-  def setStatusLoadStarted(name: String): Unit =
-    runDbSync(sqlu"insert into #${schema.name}.raportointikanta_status (name, load_started, load_completed) values ($name, now(), null) on conflict (name) do update set load_started = now(), load_completed = null")
+  def setStatusLoadStarted(name: String, dueTime: Option[Timestamp] = None): Unit =
+    runDbSync(sqlu"""
+      insert into #${schema.name}.raportointikanta_status
+        (name, load_started, load_completed, due_time)
+        values ($name, now(), null, $dueTime)
+      on conflict (name) do update set
+        load_started = now(),
+        load_completed = null,
+        due_time = $dueTime
+    """)
 
   def updateStatusCount(name: String, count: Int): Unit =
     runDbSync(sqlu"update #${schema.name}.raportointikanta_status set count=count + $count, load_completed=now() where name = $name")

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabase.scala
@@ -355,17 +355,6 @@ class RaportointiDatabase(config: RaportointiDatabaseConfigBase) extends Logging
   def status: RaportointikantaStatusResponse =
     RaportointikantaStatusResponse(schema.name, queryStatus)
 
-  def latestOpiskeluoikeusTimestamp: Option[Timestamp] =
-    try {
-      runDbSync(sql"""SELECT max(aikaleima) FROM #${schema.name}.r_opiskeluoikeus""".as(_.rs.getTimestamp(1)))
-        .headOption match {
-          case Some(null) => None // Tyhjä taulu
-          case r: Any => r
-        }
-    } catch {
-      case e: PSQLException if e.getMessage.contains("does not exist") => None // Taulua ei ole vielä luotu
-    }
-
   private def queryStatus = {
     if (statusTableExists) {
       try {

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabaseSchema.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabaseSchema.scala
@@ -466,7 +466,8 @@ object RaportointiDatabaseSchema {
     val lastUpdate = column[Timestamp]("last_update", O.SqlType("timestamp default now()"))
     val loadStarted = column[Option[Timestamp]]("load_started", O.Default(None))
     val loadCompleted = column[Option[Timestamp]]("load_completed", O.Default(None))
-    def * = (name, count, lastUpdate, loadStarted, loadCompleted) <> (RaportointikantaStatusRow.tupled, RaportointikantaStatusRow.unapply)
+    val dueTime = column[Option[Timestamp]]("due_time", O.Default(None))
+    def * = (name, count, lastUpdate, loadStarted, loadCompleted, dueTime) <> (RaportointikantaStatusRow.tupled, RaportointikantaStatusRow.unapply)
   }
   class RaportointikantaStatusTableTemp(tag: Tag) extends RaportointikantaStatusTable(tag, Temp)
 }
@@ -754,7 +755,8 @@ case class RaportointikantaStatusRow(
   count: Int,
   lastUpdate: Timestamp,
   loadStarted: Option[Timestamp],
-  loadCompleted: Option[Timestamp]
+  loadCompleted: Option[Timestamp],
+  dueTime: Option[Timestamp],
 )
 
 case class MuuAmmatillinenOsasuoritusRaportointiRow(

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointikantaService.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointikantaService.scala
@@ -2,20 +2,21 @@ package fi.oph.koski.raportointikanta
 
 import fi.oph.koski.cloudwatch.CloudWatchMetricsService
 import fi.oph.koski.config.KoskiApplication
-import fi.oph.koski.db.{OpiskeluoikeusRow, RaportointiDatabaseConfig, RaportointiGenerointiDatabaseConfig}
+import fi.oph.koski.db.{OpiskeluoikeusRow, RaportointiGenerointiDatabaseConfig}
 import fi.oph.koski.koskiuser.KoskiSpecificSession
 import fi.oph.koski.log.Logging
+import fi.oph.koski.opiskeluoikeus.PäivitetytOpiskeluoikeudetJonoService
 import rx.lang.scala.schedulers.NewThreadScheduler
 import rx.lang.scala.{Observable, Scheduler}
 
-import java.sql.Timestamp
+import java.time.ZonedDateTime
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.language.postfixOps
 
 class RaportointikantaService(application: KoskiApplication) extends Logging {
   private val cloudWatchMetrics = CloudWatchMetricsService.apply(application.config)
   private val eventBridgeClient = KoskiEventBridgeClient.apply(application.config)
-  private val safeTimeLimitForNewOpintooikeusDetection: FiniteDuration = 1.hour
+  private val päivitetytOpiskeluoikeudetJonoService = application.päivitetytOpiskeluoikeudetJono
 
   def loadRaportointikanta(
     force: Boolean,
@@ -29,14 +30,14 @@ class RaportointikantaService(application: KoskiApplication) extends Logging {
       logger.info("Raportointikanta already loading, do nothing")
       false
     } else {
-      val latestOpiskeluoikeusTimestamp = raportointiDatabase.latestOpiskeluoikeusTimestamp
-      logger.info(s"Latest opiskeluoikeus update in ${raportointiDatabase.schema.name}: ${latestOpiskeluoikeusTimestamp.getOrElse("n/a")} (will be used with a safe limit of ${safeTimeLimitForNewOpintooikeusDetection.toMinutes} minutes)")
       val update = if (skipUnchangedData) {
-        latestOpiskeluoikeusTimestamp.map(since =>
-          RaportointiDatabaseUpdate(
-            sourceDb = raportointiDatabase,
-            since = new Timestamp(since.getTime - safeTimeLimitForNewOpintooikeusDetection.toMillis)
-          ))
+        Some(RaportointiDatabaseUpdate(
+          previousRaportointiDatabase = raportointiDatabase,
+          readReplicaDb = application.replicaDatabase.db,
+          dueTime = getDueTime,
+          sleepDuration = sleepDuration,
+          service = päivitetytOpiskeluoikeudetJonoService,
+        ))
       } else {
         None
       }
@@ -67,7 +68,14 @@ class RaportointikantaService(application: KoskiApplication) extends Logging {
   ): Observable[LoadResult] = {
     // Ensure that nobody uses koskiSession implicitely
     implicit val systemUser = KoskiSpecificSession.systemUser
-    OpiskeluoikeusLoader.loadOpiskeluoikeudet(application.opiskeluoikeusQueryRepository, application.suostumuksenPeruutusService, db, update, pageSize, onAfterPage)
+    OpiskeluoikeusLoader.loadOpiskeluoikeudet(
+      application.opiskeluoikeusQueryRepository,
+      application.suostumuksenPeruutusService,
+      db,
+      update,
+      pageSize,
+      onAfterPage,
+    )
   }
 
   def loadHenkilöt(db: RaportointiDatabase = raportointiDatabase): Int =
@@ -116,11 +124,16 @@ class RaportointikantaService(application: KoskiApplication) extends Logging {
     onAfterPage: (Int, Seq[OpiskeluoikeusRow]) => Unit
   ) = {
     update match {
-      case Some(u) => logger.info(s"Start updating raportointikanta in ${loadDatabase.schema.name} with new opiskeluoikeudet since ${u.since} from ${u.sourceDb.schema.name}")
+      case Some(u) => logger.info(s"Start updating raportointikanta in ${loadDatabase.schema.name} with new opiskeluoikeudet until ${u.dueTime} from ${u.previousRaportointiDatabase.schema.name}")
       case None => logger.info(s"Start loading raportointikanta into ${loadDatabase.schema.name} (full reload)")
     }
     putLoadTimeMetric(None) // To store metric more often, Cloudwatch metric does not support missing data more than 24 hours
-    loadOpiskeluoikeudet(loadDatabase, update, pageSize, onAfterPage)
+    loadOpiskeluoikeudet(
+      loadDatabase,
+      update,
+      pageSize,
+      onAfterPage,
+    )
       .subscribeOn(scheduler)
       .subscribe(
         onNext = doNothing,
@@ -132,6 +145,7 @@ class RaportointikantaService(application: KoskiApplication) extends Logging {
           //Without try-catch, in case of an exception the process just silently halts, this is a feature of java.util.concurrent.Executors
           try {
             loadRestAndSwap()
+            päivitetytOpiskeluoikeudetJonoService.poistaKäsitellyt()
             putUploadEvents()
             putLoadTimeMetric(Option(true))
             onEnd()
@@ -159,6 +173,21 @@ class RaportointikantaService(application: KoskiApplication) extends Logging {
     raportointiDatabase.vacuumAnalyze()
   }
 
+  private def getDueTime: ZonedDateTime =
+    if (isMockEnvironment) ZonedDateTime.now().plusSeconds(5) else nextMidnight
+
+  private def nextMidnight: ZonedDateTime = {
+    val now = ZonedDateTime.now()
+    ZonedDateTime.of(
+      now.getYear, now.getMonthValue, now.getDayOfMonth,
+      0, 0, 0, 0,
+      now.getZone
+    ).plusDays(1)
+  }
+
+  private val sleepDuration: FiniteDuration =
+    if (isMockEnvironment) 1.seconds else 5.minutes
+
   protected lazy val defaultScheduler: Scheduler = NewThreadScheduler()
 
   private def swapRaportointikanta(): Unit = raportointiDatabase.dropPublicAndMoveTempToPublic
@@ -167,6 +196,9 @@ class RaportointikantaService(application: KoskiApplication) extends Logging {
   private lazy val raportointiDatabase = application.raportointiGenerointiDatabase
 
   private val tietokantaUpload = "database-upload"
+
+  protected lazy val isMockEnvironment: Boolean =
+    application.config.getString("opintopolku.virkailija.url") == "mock"
 
   def shutdown = {
     Thread.sleep(60000) //Varmistetaan, että kaikki logit ehtivät varmasti siirtyä Cloudwatchiin ennen sulkemista.

--- a/src/main/scala/fi/oph/koski/util/TimeConversions.scala
+++ b/src/main/scala/fi/oph/koski/util/TimeConversions.scala
@@ -1,0 +1,20 @@
+package fi.oph.koski.util
+
+import java.sql.Timestamp
+import java.time.{LocalDateTime, ZonedDateTime}
+import scala.annotation.tailrec
+
+object TimeConversions {
+  def toLocalDateTime(time: Timestamp): LocalDateTime =
+    time.toLocalDateTime
+
+  def toZonedDateTime(time: LocalDateTime): ZonedDateTime =
+    ZonedDateTime.of(time, ZonedDateTime.now().getZone)
+
+  @tailrec
+  def toZonedDateTime(time: Timestamp): ZonedDateTime =
+    toZonedDateTime(time)
+
+  def toTimestamp(dateTime: ZonedDateTime): Timestamp =
+    new Timestamp(dateTime.toEpochSecond * 1000)
+}

--- a/src/test/scala/fi/oph/koski/migration/MigrationSpec.scala
+++ b/src/test/scala/fi/oph/koski/migration/MigrationSpec.scala
@@ -10,7 +10,7 @@ class MigrationSpec extends AnyFreeSpec with Matchers {
   "Migraatiot" - {
     "Havaittiin uusi tietokannan migraatiotiedosto. Migraatiot, varsinkin jos koskevat Kosken suurimpia tauluja, on hyvä testata tietokantareplikaa vasten.\n" +
       "Korjaa tämän testin odottama tiedostomäärä, kun olet varma että migraatiot voi viedä eteenpäin.\nDokumentaatio: documentation/tietokantamigraatiot.md" in {
-      new File("./src/main/resources/db/migration").listFiles.length should equal (82)
+      new File("./src/main/resources/db/migration").listFiles.length should equal (84)
     }
   }
 
@@ -27,13 +27,14 @@ class MigrationSpec extends AnyFreeSpec with Matchers {
         "LoaderUtils.scala"                                         -> "38d31b4d1cfa5e3892083bb39f7f0047",
         "MuuAmmatillinenRaporttiRowBuilder.scala"                   -> "31774fb0fbd06a775a07325e867a951f",
         "OpiskeluoikeudenUlkopuolellaArvioidutOsasuoritukset.scala" -> "4498412891d88ddd2daf422144664086",
-        "OpiskeluoikeusLoader.scala"                                -> "4dab9185f560e41bbbc4139c036afea3",
+        "OpiskeluoikeusLoader.scala"                                -> "e92826ae79d5f5562b9af62ba286c4cf",
         "OrganisaatioHistoriaRowBuilder.scala"                      -> "7e586d9e273a5a4ee7beae257f22c7f4",
         "OrganisaatioLoader.scala"                                  -> "9e2e45da33ed335af4a7b0a31b139a7",
-        "RaportointiDatabase.scala"                                 -> "9757acceca5de5350f245a563155c017",
+        "PäivitettyOpiskeluoikeusLoader.scala"                      -> "371a5f5801e865116bed2ee543241c92",
+        "RaportointiDatabase.scala"                                 -> "cebf82c7dc48aac0f319712b168a2677",
         "RaportointiDatabaseCustomFunctions.scala"                  -> "956f101d1219c49ac9134b72a30caf3a",
-        "RaportointiDatabaseSchema.scala"                           -> "f40e7c556d42a721d64479d011c562c5",
-        "RaportointikantaService.scala"                             -> "17d0ac119892262c99f10bd23dc66a46",
+        "RaportointiDatabaseSchema.scala"                           -> "711ac76834a54c5784acdd555a9fafe8",
+        "RaportointikantaService.scala"                             -> "f17e69b7619011ad97be89a118eb8f6f",
         "RaportointikantaServlet.scala"                             -> "2eaa7fc778aac5db6aaca76de5745e06",
         "RaportointikantaTableQueries.scala"                        -> "b97f971fa7a5896ec3c4d69882ca705d",
         "TOPKSAmmatillinenRaporttiRowBuilder.scala"                 -> "a9c26a13385ff576810f3ef831240437",

--- a/src/test/scala/fi/oph/koski/raportointikanta/OpiskeluoikeusLoaderPerfTester.scala
+++ b/src/test/scala/fi/oph/koski/raportointikanta/OpiskeluoikeusLoaderPerfTester.scala
@@ -13,7 +13,7 @@ object OpiskeluoikeusLoaderPerfTester extends App {
       .loadOpiskeluoikeudet(
         application.opiskeluoikeusQueryRepository,
         application.suostumuksenPeruutusService,
-        application.raportointiDatabase
+        application.raportointiDatabase,
       )
     loadResults.toBlocking.foreach(lr => println(s"${lr}"))
   }

--- a/src/test/scala/fi/oph/koski/raportointikanta/RaportointikantaSpec.scala
+++ b/src/test/scala/fi/oph/koski/raportointikanta/RaportointikantaSpec.scala
@@ -20,7 +20,7 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.sql.{Date, Timestamp}
-import java.time.LocalDate
+import java.time.{LocalDate, ZonedDateTime}
 
 class RaportointikantaSpec
   extends AnyFreeSpec
@@ -695,7 +695,7 @@ class RaportointikantaSpec
       päivitäRaportointikantaInkrementaalisesti()
 
       päivitäOpiskeluoikeus(opiskeluoikeus) // Palauta alkuperäiseen tilaan
-      
+
       val alkuperäinenOpiskeluoikeusCount = opiskeluoikeusCount
       val alkuperäinenMitätöityOpiskeluoikeusCount = mitätöityOpiskeluoikeusCount
 
@@ -704,7 +704,6 @@ class RaportointikantaSpec
       opiskeluoikeusCount should be(alkuperäinenOpiskeluoikeusCount + 1)
       mitätöityOpiskeluoikeusCount should be (alkuperäinenMitätöityOpiskeluoikeusCount - 1)
     }
-
   }
 
   private def opiskeluoikeusCount: Int = mainRaportointiDb.runDbSync(mainRaportointiDb.ROpiskeluoikeudet.length.result)
@@ -726,6 +725,10 @@ class RaportointikantaSpec
     loadResult should be(true)
     Wait.until(isLoading)
     Wait.until(loadComplete)
+
+    withClue("Päivitysjono on inkrementaalisen päivityksen jälkeen tyhjä") {
+      KoskiApplicationForTests.päivitetytOpiskeluoikeudetJono.kaikki.isEmpty should equal(true)
+    }
   }
 }
 


### PR DESCRIPTION
**HUOM! Ympäristöihin vieminen vaatii jokaiseen raportointitietokantaan seuraavan migraation ajamisen manuaalisesti:**

```sql
alter table raportointikanta_status add column due_time timestamp without time zone;
```

Ympäristöön viemisen jälkeen voi olla hyvä idea vetää joko full reload tai populoida työjonoon tarvittavat työt operatiiviseen kantaan pyynnöllä:

```sql
insert into paivitetty_opiskeluoikeus
	(opiskeluoikeus_oid, aikaleima)
select
	oid as opiskeluoikeus_oid,
	now() as aikaleima
from opiskeluoikeus
where aikaleima >= '2022-06-05'; -- tähän tietenkin sopiva aikaraja
```

-----------

Muutettu raportointikannan generoinnin logiikka niin: Sen sijaan että logiikka perustuu tietokannoissa oleviin opiskeluoikeuksien aikaleimoihin, lisätään opiskeluoikeuksien muutoksista rivi työjonoon, jota generointi käy läpi.

Työjono on uudessa operatiivisen tietokannan taulussa `paivitetty_opiskeluoikeus`, joka samalla ylläpitää generoinnin tilaa opiskeluoikeuksien käsittelystä. Jos generointi kaatuu ennen valmistumistaan, seuraava ajo osaa ottaa epäonnistuneen ajon työt hoidettavakseen.

Lisäksi nyt on muutettu tapaa, miten päivitettävät opiskeluoikedet valikoituvat eräajoon: ennen niitä käsiteltiin niin kauan, kun uusia opiskeluoikeuksia löytyi kannasta. Tämä johti pahimmillaan tilanteeseen, jossa eräajo kesti pidempään kuin "tyhmä" generointi tyhjältä pohjalta. Koska dataa oli käsitelty pitkälle iltapäivään, seuraava eräajo meni nopeasti läpi, jonka takia sitä seuraavalle eräajolle jäi entistä enemmän työtä, joka johti noidankehään ja ns. pumppausefektiin.

Tämä on korjattu niin, että opiskeluoikeuspäivityksiä jäädään odottelemaan puoleenyöhön asti, eikä sen jälkeen tulleita päivityksiä enää lasketa eräajoon mukaan, vaikka itse prosessointi kestäisikin pidempään.

Bonuksena korjattiin raporttisivulle näkymään oikea kellonaika, mitä edeltävät opiskeluoikeudet näkyvät raporteilla. Ennen se oli virheellisesti generoinnin aloitusaika (aikanaan tehty tietoinen päätös).