### PR TITLE
TOR-1745 parametrisoi raportointikannan generoinnin pakotus

### DIFF
--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -180,12 +180,19 @@ class ScalatraBootstrap extends LifeCycle with Logging with Timing {
   private def generateRaportointikanta(application: KoskiApplication): Unit = {
     val service = new RaportointikantaService(application)
     val generating = Future {
-      service.loadRaportointikantaAndExit(fullReload = RunMode.isFullReload)
+      service.loadRaportointikantaAndExit(fullReload = RunMode.isFullReload, forceReload = getForceMode)
     }
     generating.failed.map(error => {
       logger.error(error)("Raportointikannan generointi keskeytyi odottamattomasti")
       service.shutdown
     })
+  }
+
+  private def getForceMode: Boolean = sys.env.get("FORCE_RAPORTOINTIKANTA") match {
+    case Some("true") => true
+    case Some("false") => false
+    case Some(s) => throw new RuntimeException(s"Odottamaton arvo muuttujalla FORCE_RAPORTOINTIKANTA: ${s} (sallitut arvot: true, false)")
+    case None => false
   }
 
   override def destroy(context: ServletContext): Unit = ()

--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointikantaService.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointikantaService.scala
@@ -47,10 +47,10 @@ class RaportointikantaService(application: KoskiApplication) extends Logging {
     }
   }
 
-  def loadRaportointikantaAndExit(fullReload: Boolean): Unit = {
+  def loadRaportointikantaAndExit(fullReload: Boolean, forceReload: Boolean): Unit = {
     val skipUnchangedData = !fullReload
     loadRaportointikanta(
-      force = true,
+      force = forceReload,
       skipUnchangedData = skipUnchangedData,
       scheduler = defaultScheduler,
       onEnd = () => {

--- a/src/test/scala/fi/oph/koski/migration/MigrationSpec.scala
+++ b/src/test/scala/fi/oph/koski/migration/MigrationSpec.scala
@@ -33,7 +33,7 @@ class MigrationSpec extends AnyFreeSpec with Matchers {
         "RaportointiDatabase.scala"                                 -> "9757acceca5de5350f245a563155c017",
         "RaportointiDatabaseCustomFunctions.scala"                  -> "956f101d1219c49ac9134b72a30caf3a",
         "RaportointiDatabaseSchema.scala"                           -> "f40e7c556d42a721d64479d011c562c5",
-        "RaportointikantaService.scala"                             -> "f68c20bc0b43835b1149e8bb8a4a688f",
+        "RaportointikantaService.scala"                             -> "17d0ac119892262c99f10bd23dc66a46",
         "RaportointikantaServlet.scala"                             -> "2eaa7fc778aac5db6aaca76de5745e06",
         "RaportointikantaTableQueries.scala"                        -> "b97f971fa7a5896ec3c4d69882ca705d",
         "TOPKSAmmatillinenRaporttiRowBuilder.scala"                 -> "a9c26a13385ff576810f3ef831240437",


### PR DESCRIPTION
Lue ympäristömuuttujasta parametri, pakotetaanko raportointikannan
generointi käyntiin jos edellinen generointi on vielä kesken.