### PR TITLE
TOR-1676 Sähköposti Koski-tiimille, kun kansalainen peruu suostumuksen

### DIFF
--- a/src/main/scala/fi/oph/koski/suostumus/SuostumuksenPeruutusService.scala
+++ b/src/main/scala/fi/oph/koski/suostumus/SuostumuksenPeruutusService.scala
@@ -65,6 +65,10 @@ case class SuostumuksenPeruutusService(protected val application: KoskiApplicati
     }
   }
 
+  def teeTestimerkintäSähköpostinotifikaatiotaVarten(): Unit = {
+    teeLogimerkintäSähköpostinotifikaatiotaVarten("[TÄMÄ ON TESTIVIESTI]")
+  }
+
   private def teeLogimerkintäSähköpostinotifikaatiotaVarten(oid: String): Unit = {
     logger.warn(s"Kansalainen perui suostumuksen. Opiskeluoikeus ${oid}. Ks. tarkemmat tiedot ${application.config.getString("opintopolku.virkailija.url")}/koski/api/opiskeluoikeus/suostumuksenperuutus")
   }

--- a/src/main/scala/fi/oph/koski/suostumus/SuostumuksenPeruutusService.scala
+++ b/src/main/scala/fi/oph/koski/suostumus/SuostumuksenPeruutusService.scala
@@ -54,6 +54,7 @@ case class SuostumuksenPeruutusService(protected val application: KoskiApplicati
                 application.perustiedotSyncRepository.addDeleteToSyncQueue(opiskeluoikeudenId)
               )
             )
+            teeLogimerkintäSähköpostinotifikaatiotaVarten(oid)
             AuditLog.log(KoskiAuditLogMessage(KoskiOperation.KANSALAINEN_SUOSTUMUS_PERUMINEN, user, Map(KoskiAuditLogMessageField.opiskeluoikeusOid -> oid)))
             HttpStatus.ok
           case None =>
@@ -62,6 +63,10 @@ case class SuostumuksenPeruutusService(protected val application: KoskiApplicati
         }
       case None => KoskiErrorCategory.notFound.opiskeluoikeuttaEiLöydyTaiEiOikeuksia()
     }
+  }
+
+  private def teeLogimerkintäSähköpostinotifikaatiotaVarten(oid: String): Unit = {
+    logger.warn(s"Kansalainen perui suostumuksen. Opiskeluoikeus ${oid}. Ks. tarkemmat tiedot ${application.config.getString("opintopolku.virkailija.url")}/koski/api/opiskeluoikeus/suostumuksenperuutus")
   }
 
   def suoritusjakoTekemättäWithAccessCheck(oid: String)(implicit user: KoskiSpecificSession): HttpStatus = {

--- a/src/main/scala/fi/oph/koski/suostumus/SuostumuksenPeruutusServlet.scala
+++ b/src/main/scala/fi/oph/koski/suostumus/SuostumuksenPeruutusServlet.scala
@@ -57,4 +57,10 @@ class SuostumuksenPeruutusServlet(implicit val application: KoskiApplication)
       KoskiErrorCategory.forbidden.vainVirkailija()
     }
   }
+
+  get("/testimerkinta") {
+    requireVirkailijaOrPalvelukäyttäjä
+    application.suostumuksenPeruutusService.teeTestimerkintäSähköpostinotifikaatiotaVarten()
+    renderObject(JObject("testimerkintä" -> JBool(true)))
+  }
 }

--- a/src/test/scala/fi/oph/koski/api/SuostumuksenPeruutusSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/SuostumuksenPeruutusSpec.scala
@@ -9,7 +9,7 @@ import fi.oph.koski.documentation.ExampleData.opiskeluoikeusMitätöity
 import fi.oph.koski.documentation.VapaaSivistystyöExample.opiskeluoikeusVapaatavoitteinen
 import fi.oph.koski.koskiuser.{AuthenticationUser, KoskiSpecificSession, MockUsers}
 import fi.oph.koski.koskiuser.MockUsers.{paakayttajaMitatoidytJaPoistetutOpiskeluoikeudet, varsinaisSuomiPalvelukäyttäjä}
-import fi.oph.koski.log.{AuditLogTester, KoskiAuditLogMessageField, KoskiOperation}
+import fi.oph.koski.log.{AuditLogTester, KoskiAuditLogMessageField, KoskiOperation, RootLogTester}
 import fi.oph.koski.organisaatio.MockOrganisaatiot
 import fi.oph.koski.schema.{VapaanSivistystyönOpiskeluoikeus, VapaanSivistystyönOpiskeluoikeusjakso}
 import org.json4s.{JObject, JString}
@@ -65,6 +65,15 @@ class SuostumuksenPeruutusSpec extends AnyFreeSpec with Matchers with Opiskeluoi
           KoskiAuditLogMessageField.opiskeluoikeusOid.toString -> vapaatavoitteinenOpiskeluoikeus.oid.get
         ),
       ))
+    }
+
+    "Suostumuksen peruutuksesta tehdään määrämuotoinen log-merkintä sähköpostinotifikaation lähetystä varten" in {
+      resetFixtures()
+
+      RootLogTester.clearMessages
+      post(s"/api/opiskeluoikeus/suostumuksenperuutus/$vapaatavoitteinenOpiskeluoikeusOid", headers = kansalainenLoginHeaders(vapaatavoitteinenHetu)) {}
+
+      RootLogTester.getLogMessages.find(_.startsWith("Kansalainen")).get should equal(s"Kansalainen perui suostumuksen. Opiskeluoikeus ${vapaatavoitteinenOpiskeluoikeusOid}. Ks. tarkemmat tiedot mock/koski/api/opiskeluoikeus/suostumuksenperuutus")
     }
 
     "Opiskeluoikeudesta jää raatorivi opiskeluoikeustauluun" in {


### PR DESCRIPTION
Ks. commit-viestit.

Sähköpostinotifikaatio toteutetaan infran puolella.