### PR TITLE
TOR-1677 höllennä validointia Kela skeemaan deserialisoitaessa

### DIFF
--- a/src/main/scala/fi/oph/koski/kela/KelaAikuistenPerusopetuksenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaAikuistenPerusopetuksenSchema.scala
@@ -2,9 +2,9 @@ package fi.oph.koski.kela
 
 import fi.oph.koski.koskiuser.Rooli
 import fi.oph.koski.schema
-import fi.oph.koski.schema.{LocalizedString, OpiskeluoikeudenTyyppi}
+import fi.oph.koski.schema.OpiskeluoikeudenTyyppi
 import fi.oph.koski.schema.annotation.{KoodistoKoodiarvo, SensitiveData}
-import fi.oph.scalaschema.annotation.{Description, OnlyWhen, Title}
+import fi.oph.scalaschema.annotation.{Description, Title}
 
 import java.time.{LocalDate, LocalDateTime}
 
@@ -38,16 +38,16 @@ case class KelaAikuistenPerusopetuksenOpiskeluoikeus(
 }
 
 case class KelaAikuistenPerusopetuksenOpiskeluoikeudenLisätiedot(
-  sisäoppilaitosmainenMajoitus: Option[List[schema.Aikajakso]],
+  sisäoppilaitosmainenMajoitus: Option[List[KelaAikajakso]],
   ulkomaanjaksot: Option[List[Ulkomaanjakso]],
-  majoitusetu: Option[schema.Aikajakso],
-  ulkomailla: Option[schema.Aikajakso],
+  majoitusetu: Option[KelaAikajakso],
+  ulkomailla: Option[KelaAikajakso],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
-  tehostetunTuenPäätös: Option[schema.TehostetunTuenPäätös],
+  tehostetunTuenPäätös: Option[KelaTehostetunTuenPäätös],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
-  tehostetunTuenPäätökset: Option[List[schema.TehostetunTuenPäätös]],
-  maksuttomuus: Option[List[schema.Maksuttomuus]],
-  oikeuttaMaksuttomuuteenPidennetty: Option[List[schema.OikeuttaMaksuttomuuteenPidennetty]]
+  tehostetunTuenPäätökset: Option[List[KelaTehostetunTuenPäätös]],
+  maksuttomuus: Option[List[KelaMaksuttomuus]],
+  oikeuttaMaksuttomuuteenPidennetty: Option[List[KelaOikeuttaMaksuttomuuteenPidennetty]]
 ) extends OpiskeluoikeudenLisätiedot
 
 @Title("Aikuisten perusopetuksen suoritus")

--- a/src/main/scala/fi/oph/koski/kela/KelaAmmatillinenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaAmmatillinenSchema.scala
@@ -49,22 +49,22 @@ case class KelaAmmatillisenOpiskeluoikeusjakso(
 ) extends Opiskeluoikeusjakso
 
 case class KelaAmmatillisenOpiskeluoikeudenLisätiedot(
-  majoitus: Option[List[schema.Aikajakso]],
-  sisäoppilaitosmainenMajoitus: Option[List[schema.Aikajakso]],
+  majoitus: Option[List[KelaAikajakso]],
+  sisäoppilaitosmainenMajoitus: Option[List[KelaAikajakso]],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
-  vaativanErityisenTuenYhteydessäJärjestettäväMajoitus: Option[List[schema.Aikajakso]],
+  vaativanErityisenTuenYhteydessäJärjestettäväMajoitus: Option[List[KelaAikajakso]],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
-  erityinenTuki: Option[List[schema.Aikajakso]],
+  erityinenTuki: Option[List[KelaAikajakso]],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
-  vaativanErityisenTuenErityinenTehtävä: Option[List[schema.Aikajakso]],
+  vaativanErityisenTuenErityinenTehtävä: Option[List[KelaAikajakso]],
   ulkomaanjaksot: Option[List[Ulkomaanjakso]],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
   hojks: Option[Hojks],
-  osaAikaisuusjaksot: Option[List[schema.OsaAikaisuusJakso]],
-  opiskeluvalmiuksiaTukevatOpinnot: Option[List[schema.OpiskeluvalmiuksiaTukevienOpintojenJakso]],
-  vankilaopetuksessa: Option[List[schema.Aikajakso]],
-  maksuttomuus: Option[List[schema.Maksuttomuus]],
-  oikeuttaMaksuttomuuteenPidennetty: Option[List[schema.OikeuttaMaksuttomuuteenPidennetty]]
+  osaAikaisuusjaksot: Option[List[KelaOsaAikaisuusJakso]],
+  opiskeluvalmiuksiaTukevatOpinnot: Option[List[KelaOpiskeluvalmiuksiaTukevienOpintojenJakso]],
+  vankilaopetuksessa: Option[List[KelaAikajakso]],
+  maksuttomuus: Option[List[KelaMaksuttomuus]],
+  oikeuttaMaksuttomuuteenPidennetty: Option[List[KelaOikeuttaMaksuttomuuteenPidennetty]]
 ) extends OpiskeluoikeudenLisätiedot
 
 @Title("Ammatillisen koulutuksen suoritus")
@@ -76,7 +76,7 @@ case class KelaAmmatillinenPäätasonSuoritus(
   osasuoritukset: Option[List[KelaAmmatillinenOsasuoritus]],
   tyyppi: schema.Koodistokoodiviite,
   tila: Option[KelaKoodistokoodiviite],
-  osaamisala: Option[List[schema.Osaamisalajakso]],
+  osaamisala: Option[List[KelaOsaamisalajakso]],
   toinenOsaamisala: Option[Boolean],
   alkamispäivä: Option[LocalDate],
   järjestämismuodot: Option[List[Järjestämismuotojakso]],
@@ -103,7 +103,7 @@ case class KelaAmmatillinenOsasuoritus(
   tila: Option[KelaKoodistokoodiviite],
   tutkinto: Option[Tutkinto],
   tutkinnonOsanRyhmä: Option[KelaKoodistokoodiviite],
-  osaamisala: Option[List[schema.Osaamisalajakso]],
+  osaamisala: Option[List[KelaOsaamisalajakso]],
   alkamispäivä: Option[LocalDate],
   tunnustettu: Option[OsaamisenTunnustaminen],
   toinenOsaamisala: Option[Boolean],
@@ -157,7 +157,7 @@ case class Hojks(
 
 case class Näyttö(
   suorituspaikka: Option[NäytönSuorituspaikka],
-  suoritusaika: Option[schema.NäytönSuoritusaika],
+  suoritusaika: Option[NäytönSuoritusaika],
   työssäoppimisenYhteydessä: Boolean,
   arviointi: Option[NäytönArviointi],
 ) {
@@ -167,6 +167,11 @@ case class Näyttö(
 case class NäytönSuorituspaikka(
   tunniste: KelaKoodistokoodiviite,
   kuvaus: schema.LocalizedString
+)
+
+case class NäytönSuoritusaika(
+  alku: LocalDate,
+  loppu: LocalDate
 )
 
 case class NäytönArviointi(

--- a/src/main/scala/fi/oph/koski/kela/KelaDIASchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaDIASchema.scala
@@ -43,8 +43,8 @@ case class KelaDIAOpiskeluoikeus(
 case class KelaDIAOpiskeluoikeudenLisätiedot(
   ulkomaanjaksot: Option[List[Ulkomaanjakso]],
   ulkomainenVaihtoopiskelija: Option[Boolean],
-  maksuttomuus: Option[List[schema.Maksuttomuus]],
-  oikeuttaMaksuttomuuteenPidennetty: Option[List[schema.OikeuttaMaksuttomuuteenPidennetty]]
+  maksuttomuus: Option[List[KelaMaksuttomuus]],
+  oikeuttaMaksuttomuuteenPidennetty: Option[List[KelaOikeuttaMaksuttomuuteenPidennetty]]
 ) extends OpiskeluoikeudenLisätiedot
 
 @Title("DIA-tutkinnon suoritus")

--- a/src/main/scala/fi/oph/koski/kela/KelaInternationalSchoolSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaInternationalSchoolSchema.scala
@@ -38,8 +38,8 @@ case class KelaInternationalSchoolOpiskeluoikeus(
 
 case class KelaInternationalSchoolOpiskeluoikeudenLisätiedot(
   ulkomaanjaksot: Option[List[Ulkomaanjakso]],
-  maksuttomuus: Option[List[schema.Maksuttomuus]],
-  oikeuttaMaksuttomuuteenPidennetty: Option[List[schema.OikeuttaMaksuttomuuteenPidennetty]]
+  maksuttomuus: Option[List[KelaMaksuttomuus]],
+  oikeuttaMaksuttomuuteenPidennetty: Option[List[KelaOikeuttaMaksuttomuuteenPidennetty]]
 ) extends OpiskeluoikeudenLisätiedot
 
 @Title("International school suoritus")

--- a/src/main/scala/fi/oph/koski/kela/KelaLukionSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaLukionSchema.scala
@@ -1,7 +1,7 @@
 package fi.oph.koski.kela
 
 import fi.oph.koski.schema
-import fi.oph.koski.schema.{LocalizedString, OpiskeluoikeudenTyyppi}
+import fi.oph.koski.schema.OpiskeluoikeudenTyyppi
 import fi.oph.koski.schema.annotation.KoodistoKoodiarvo
 import fi.oph.scalaschema.annotation.{Description, Title}
 
@@ -37,11 +37,11 @@ case class KelaLukionOpiskeluoikeus(
 }
 
 case class KelaLukionOpiskeluoikeudenLisätiedot(
-  sisäoppilaitosmainenMajoitus: Option[List[schema.Aikajakso]],
+  sisäoppilaitosmainenMajoitus: Option[List[KelaAikajakso]],
   ulkomaanjaksot: Option[List[Ulkomaanjakso]],
   ulkomainenVaihtoopiskelija: Option[Boolean],
-  maksuttomuus: Option[List[schema.Maksuttomuus]],
-  oikeuttaMaksuttomuuteenPidennetty: Option[List[schema.OikeuttaMaksuttomuuteenPidennetty]]
+  maksuttomuus: Option[List[KelaMaksuttomuus]],
+  oikeuttaMaksuttomuuteenPidennetty: Option[List[KelaOikeuttaMaksuttomuuteenPidennetty]]
 ) extends OpiskeluoikeudenLisätiedot
 
 @Title("Lukion suoritus")

--- a/src/main/scala/fi/oph/koski/kela/KelaLuvaSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaLuvaSchema.scala
@@ -1,7 +1,7 @@
 package fi.oph.koski.kela
 
 import fi.oph.koski.schema
-import fi.oph.koski.schema.{LocalizedString, OpiskeluoikeudenTyyppi}
+import fi.oph.koski.schema.OpiskeluoikeudenTyyppi
 import fi.oph.koski.schema.annotation.KoodistoKoodiarvo
 import fi.oph.scalaschema.annotation.{Description, Title}
 
@@ -37,11 +37,11 @@ case class KelaLuvaOpiskeluoikeus(
 }
 
 case class KelaLuvaOpiskeluoikeudenLisätiedot(
-  sisäoppilaitosmainenMajoitus: Option[List[schema.Aikajakso]],
+  sisäoppilaitosmainenMajoitus: Option[List[KelaAikajakso]],
   ulkomaanjaksot: Option[List[Ulkomaanjakso]],
   ulkomainenVaihtoopiskelija: Option[Boolean],
-  maksuttomuus: Option[List[schema.Maksuttomuus]],
-  oikeuttaMaksuttomuuteenPidennetty: Option[List[schema.OikeuttaMaksuttomuuteenPidennetty]]
+  maksuttomuus: Option[List[KelaMaksuttomuus]],
+  oikeuttaMaksuttomuuteenPidennetty: Option[List[KelaOikeuttaMaksuttomuuteenPidennetty]]
 ) extends OpiskeluoikeudenLisätiedot
 
 @Title("Lukioon valmistavan koulutuksen suoritus")

--- a/src/main/scala/fi/oph/koski/kela/KelaOpiskeluoikeusRepository.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaOpiskeluoikeusRepository.scala
@@ -96,7 +96,7 @@ order by "masterOppijaOid", opiskeluoikeus_oid
     val json = KoskiTables.OpiskeluoikeusTable.readAsJValue(data, oid, versionumero, aikaleima)
 
     validatingAndResolvingExtractor.extract[KelaOpiskeluoikeus](
-      KoskiSchema.lenientDeserializationWithIgnoringNonValidatingListItems
+      KoskiSchema.lenientDeserializationWithIgnoringNonValidatingListItemsWithoutValidation
     )(json) match {
       case Right(oo) => oo
       case Left(errors) =>

--- a/src/main/scala/fi/oph/koski/kela/KelaOppijaConverter.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaOppijaConverter.scala
@@ -69,7 +69,7 @@ object KelaOppijaConverter extends Logging {
   }
 
   private def convertOpiskeluoikeus(opiskeluoikeus: schema.Opiskeluoikeus): KelaOpiskeluoikeus = {
-    implicit val context: ExtractionContext = KoskiSchema.lenientDeserializationWithIgnoringNonValidatingListItems
+    implicit val context: ExtractionContext = KoskiSchema.lenientDeserializationWithIgnoringNonValidatingListItemsWithoutValidation
 
     SchemaValidatingExtractor
       .extract[KelaOpiskeluoikeus](JsonSerializer.serializeWithRoot(opiskeluoikeus)).right.get match {

--- a/src/main/scala/fi/oph/koski/kela/KelaPerusopetuksenLisäopetuksenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaPerusopetuksenLisäopetuksenSchema.scala
@@ -38,20 +38,20 @@ case class KelaPerusopetuksenLisäopetuksenOpiskeluoikeus(
 }
 
 case class KelaPerusopetuksenLisäopetuksenOpiskeluoikeudenLisätiedot(
-  sisäoppilaitosmainenMajoitus: Option[List[schema.Aikajakso]],
+  sisäoppilaitosmainenMajoitus: Option[List[KelaAikajakso]],
   ulkomaanjaksot: Option[List[Ulkomaanjakso]],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
-  koulukoti: Option[List[schema.Aikajakso]],
-  majoitusetu: Option[schema.Aikajakso],
-  ulkomailla: Option[schema.Aikajakso],
+  koulukoti: Option[List[KelaAikajakso]],
+  majoitusetu: Option[KelaAikajakso],
+  ulkomailla: Option[KelaAikajakso],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
-  tehostetunTuenPäätös: Option[schema.TehostetunTuenPäätös],
+  tehostetunTuenPäätös: Option[KelaTehostetunTuenPäätös],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
-  tehostetunTuenPäätökset: Option[List[schema.TehostetunTuenPäätös]],
+  tehostetunTuenPäätökset: Option[List[KelaTehostetunTuenPäätös]],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
-  joustavaPerusopetus: Option[schema.Aikajakso],
-  maksuttomuus: Option[List[schema.Maksuttomuus]],
-  oikeuttaMaksuttomuuteenPidennetty: Option[List[schema.OikeuttaMaksuttomuuteenPidennetty]]
+  joustavaPerusopetus: Option[KelaAikajakso],
+  maksuttomuus: Option[List[KelaMaksuttomuus]],
+  oikeuttaMaksuttomuuteenPidennetty: Option[List[KelaOikeuttaMaksuttomuuteenPidennetty]]
 ) extends OpiskeluoikeudenLisätiedot
 
 @Title("Perusopetuksen lisäopetuksen suoritus")

--- a/src/main/scala/fi/oph/koski/kela/KelaPerusopetuksenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaPerusopetuksenSchema.scala
@@ -38,18 +38,18 @@ case class KelaPerusopetuksenOpiskeluoikeus(
 }
 
 case class KelaPerusopetuksenOpiskeluoikeudenLisätiedot(
-  sisäoppilaitosmainenMajoitus: Option[List[schema.Aikajakso]],
+  sisäoppilaitosmainenMajoitus: Option[List[KelaAikajakso]],
   ulkomaanjaksot: Option[List[Ulkomaanjakso]],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
-  koulukoti: Option[List[schema.Aikajakso]],
-  majoitusetu: Option[schema.Aikajakso],
-  ulkomailla: Option[schema.Aikajakso],
+  koulukoti: Option[List[KelaAikajakso]],
+  majoitusetu: Option[KelaAikajakso],
+  ulkomailla: Option[KelaAikajakso],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
-  tehostetunTuenPäätös: Option[schema.TehostetunTuenPäätös],
+  tehostetunTuenPäätös: Option[KelaTehostetunTuenPäätös],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
-  tehostetunTuenPäätökset: Option[List[schema.TehostetunTuenPäätös]],
+  tehostetunTuenPäätökset: Option[List[KelaTehostetunTuenPäätös]],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
-  joustavaPerusopetus: Option[schema.Aikajakso],
+  joustavaPerusopetus: Option[KelaAikajakso],
 ) extends OpiskeluoikeudenLisätiedot
 
 @Title("Perusopetuksen suoritus")

--- a/src/main/scala/fi/oph/koski/kela/KelaSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaSchema.scala
@@ -4,9 +4,8 @@ import com.typesafe.config.Config
 import fi.oph.koski.config.Environment
 import fi.oph.koski.henkilo.OppijaHenkilö
 import fi.oph.koski.schema
-import fi.oph.koski.schema.annotation.KoodistoUri
-import fi.oph.koski.schema.annotation.Deprecated
-import fi.oph.scalaschema.annotation.{Description, Discriminator, SyntheticProperty, Title}
+import fi.oph.koski.schema.annotation.{Deprecated, KoodistoUri, Tooltip, UnitOfMeasure}
+import fi.oph.scalaschema.annotation.{Description, Discriminator, ReadFlattened, SyntheticProperty, Title}
 import fi.oph.scalaschema.{ClassSchema, SchemaToJson}
 import org.json4s.JValue
 
@@ -197,3 +196,55 @@ case class Toimipiste(
 )
 
 case class KelaLaajuus(arvo: Double, yksikkö: KelaKoodistokoodiviite)
+
+case class KelaAikajakso (
+  alku: LocalDate,
+  loppu: Option[LocalDate]
+) {
+  override def toString: String = s"$alku – ${loppu.getOrElse("")}"
+}
+
+case class KelaOsaAikaisuusJakso(
+  alku: LocalDate,
+  loppu: Option[LocalDate],
+  @UnitOfMeasure("%")
+  osaAikaisuus: Int
+) extends KelaJakso
+
+case class KelaMaksuttomuus(
+  alku: LocalDate,
+  loppu: Option[LocalDate],
+  maksuton: Boolean
+) extends KelaJakso
+
+case class KelaTehostetunTuenPäätös(
+  alku: LocalDate,
+  loppu: Option[LocalDate],
+  tukimuodot: Option[List[KelaKoodistokoodiviite]] = None
+) extends KelaJakso
+
+trait KelaJakso {
+  def alku: LocalDate
+  def loppu: Option[LocalDate]
+  override def toString: String = s"$alku – ${loppu.getOrElse("")}"
+}
+
+case class KelaOikeuttaMaksuttomuuteenPidennetty(
+  alku: LocalDate,
+  loppu: LocalDate
+) {
+  override def toString: String = s"$alku – $loppu"
+}
+
+@ReadFlattened
+case class KelaOsaamisalajakso(
+  osaamisala: KelaKoodistokoodiviite,
+  alku: Option[LocalDate] = None,
+  loppu: Option[LocalDate] = None
+)
+
+case class KelaOpiskeluvalmiuksiaTukevienOpintojenJakso(
+  alku: LocalDate,
+  loppu: LocalDate,
+  kuvaus: schema.LocalizedString
+)

--- a/src/main/scala/fi/oph/koski/kela/KelaTutkintokoulutukseenValmentavanKoulutuksenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaTutkintokoulutukseenValmentavanKoulutuksenSchema.scala
@@ -50,21 +50,21 @@ case class KelaTuvaOpiskeluoikeusjakso(
 
 @Title("Tutkintokoulutukseen valmentavan opiskeluoikeuden järjestämisluvan lisätiedot")
 case class KelaTuvaOpiskeluoikeudenLisätiedot(
-  maksuttomuus: Option[List[schema.Maksuttomuus]],
-  oikeuttaMaksuttomuuteenPidennetty: Option[List[schema.OikeuttaMaksuttomuuteenPidennetty]],
-  majoitus: Option[List[schema.Aikajakso]],
-  sisäoppilaitosmainenMajoitus: Option[List[schema.Aikajakso]],
+  maksuttomuus: Option[List[KelaMaksuttomuus]],
+  oikeuttaMaksuttomuuteenPidennetty: Option[List[KelaOikeuttaMaksuttomuuteenPidennetty]],
+  majoitus: Option[List[KelaAikajakso]],
+  sisäoppilaitosmainenMajoitus: Option[List[KelaAikajakso]],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
-  vaativanErityisenTuenYhteydessäJärjestettäväMajoitus: Option[List[schema.Aikajakso]],
+  vaativanErityisenTuenYhteydessäJärjestettäväMajoitus: Option[List[KelaAikajakso]],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
-  erityinenTuki: Option[List[schema.Aikajakso]],
+  erityinenTuki: Option[List[KelaAikajakso]],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
-  vaativanErityisenTuenErityinenTehtävä: Option[List[schema.Aikajakso]],
+  vaativanErityisenTuenErityinenTehtävä: Option[List[KelaAikajakso]],
   ulkomaanjaksot: Option[List[Ulkomaanjakso]],
-  osaAikaisuusjaksot: Option[List[schema.OsaAikaisuusJakso]],
-  vankilaopetuksessa: Option[List[schema.Aikajakso]],
-  majoitusetu: Option[schema.Aikajakso],
-  koulukoti: Option[List[schema.Aikajakso]],
+  osaAikaisuusjaksot: Option[List[KelaOsaAikaisuusJakso]],
+  vankilaopetuksessa: Option[List[KelaAikajakso]],
+  majoitusetu: Option[KelaAikajakso],
+  koulukoti: Option[List[KelaAikajakso]],
 ) extends OpiskeluoikeudenLisätiedot
 
 @Title("Tutkintokoulutukseen valmentavan koulutuksen suoritus")

--- a/src/main/scala/fi/oph/koski/kela/KelaVapaanSivistystyönSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaVapaanSivistystyönSchema.scala
@@ -37,8 +37,8 @@ case class KelaVapaanSivistystyönOpiskeluoikeus(
 }
 
 case class KelaVapaanSivistystyönOpiskeluoikeudenLisätiedot(
-  maksuttomuus: Option[List[schema.Maksuttomuus]],
-  oikeuttaMaksuttomuuteenPidennetty: Option[List[schema.OikeuttaMaksuttomuuteenPidennetty]]
+  maksuttomuus: Option[List[KelaMaksuttomuus]],
+  oikeuttaMaksuttomuuteenPidennetty: Option[List[KelaOikeuttaMaksuttomuuteenPidennetty]]
 ) extends OpiskeluoikeudenLisätiedot
 
 @Title("Vapaan sivistystyön suoritus")

--- a/src/main/scala/fi/oph/koski/schema/KoskiSchema.scala
+++ b/src/main/scala/fi/oph/koski/schema/KoskiSchema.scala
@@ -13,6 +13,8 @@ object KoskiSchema {
   lazy val lenientDeserialization = ExtractionContext(schemaFactory, ignoreUnexpectedProperties = true)
   lazy val lenientDeserializationWithIgnoringNonValidatingListItems =
     ExtractionContext(schemaFactory, ignoreUnexpectedProperties = true, ignoreNonValidatingListItems = true)
+  lazy val lenientDeserializationWithIgnoringNonValidatingListItemsWithoutValidation =
+    ExtractionContext(schemaFactory, ignoreUnexpectedProperties = true, ignoreNonValidatingListItems = true, validate = false)
   lazy val lenientDeserializationWithoutValidation = ExtractionContext(schemaFactory, ignoreUnexpectedProperties = true, validate = false)
 
   def createSchema(clazz: Class[_]) = schemaFactory.createSchema(clazz) match {


### PR DESCRIPTION
Älä validoi aikajaksojen oikeellisuutta kun deserialisoidaan
opiskeluoikeus Kela skeemaan.

Lisätty omia luokkia aikajaksoille Kela skeemaan, jotta deserialisoinnin ignoreNonValidatingListItems-valinta ei vaikuta niihin ja jätä aikajaksoja palauttamatta.