### PR TITLE
TOR-1777 Korjaa päivämäärädialogin kaatuminen väärällä syötteellä

### DIFF
--- a/valpas-web/src/components/forms/DateRangePicker.tsx
+++ b/valpas-web/src/components/forms/DateRangePicker.tsx
@@ -1,6 +1,7 @@
 import bem from "bem-ts"
 import React, { useCallback } from "react"
 import { ISODate } from "../../state/common"
+import { isValidSortedValues } from "../../utils/date"
 import { DatePicker } from "./DatePicker"
 import "./DateRangePicker.less"
 
@@ -18,7 +19,10 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
   const values = sortDateRange(props.value)
   const setValuesSorted = useCallback(
     (range: DateRange) => {
-      props.onChange(sortDateRange(range))
+      const [value1, value2] = range
+      if (isValidSortedValues(value1, value2)) {
+        props.onChange(sortDateRange([value1, value2]))
+      }
     },
     [props]
   )

--- a/valpas-web/src/utils/date.ts
+++ b/valpas-web/src/utils/date.ts
@@ -37,3 +37,18 @@ export const dateToday = () => {
   }
   return new Date()
 }
+
+const isValidDate = (date: string) => {
+  const castDate = new Date(date)
+  if (!isNaN(castDate.getTime())) {
+    return castDate.getFullYear() <= 9999
+  }
+  return false
+}
+
+export const isValidSortedValues = (
+  value1: ISODate | null,
+  value2: ISODate | null
+) =>
+  (value1 === null || isValidDate(value1)) &&
+  (value2 === null || isValidDate(value2))

--- a/valpas-web/src/views/oppija/oppivelvollisuudenkeskeytys/OppivelvollisuudenKeskeytysForm.tsx
+++ b/valpas-web/src/views/oppija/oppivelvollisuudenkeskeytys/OppivelvollisuudenKeskeytysForm.tsx
@@ -19,7 +19,7 @@ import { ApiErrors } from "../../../components/typography/error"
 import { T, t } from "../../../i18n/i18n"
 import { Organisaatio } from "../../../state/apitypes/organisaatiot"
 import { ISODate, Oid } from "../../../state/common"
-import { today } from "../../../utils/date"
+import { isValidSortedValues, today } from "../../../utils/date"
 import "./OppivelvollisuudenKeskeytys.less"
 
 const b = bem("ovkeskeytys")
@@ -139,7 +139,11 @@ export const OppivelvollisuudenKeskeytysForm = (
       >
         <DatePicker
           value={dateRange[0]}
-          onChange={(startDate) => setDateRange([startDate, dateRange[1]])}
+          onChange={(startDate) => {
+            if (isValidSortedValues(startDate, dateRange[1])) {
+              setDateRange([startDate, dateRange[1]])
+            }
+          }}
           disabled={!toistaiseksiSelected}
         />
         <LabeledCheckbox


### PR DESCRIPTION
Tämä PR korjaa bugin, jolla Valpaksen käyttämä päivämäärädialogi kaatui väärällä syötteellä. Esimerkiksi syöte `01-01-22222` aiheuttaa poikkeuksen `react-date-picker` -kirjaston sisällä, koska syötettä ei oltu validoitu millään tavalla. Korjaus on testattu manuaalisesti.