### PR TITLE
[WIP] TOR-1721 Vähennä Valppaan perffitestien kuorma vastaamaan tuotantoa

### DIFF
--- a/src/test/scala/fi/oph/koski/perftest/PerfTestScenario.scala
+++ b/src/test/scala/fi/oph/koski/perftest/PerfTestScenario.scala
@@ -15,6 +15,7 @@ trait PerfTestScenario extends KoskidevHttpSpecification with EnvVariables with 
   def name = getClass.getSimpleName
   def readBody: Boolean = false
   def bodyValidator: Boolean = true
+  def minimumTimeBetweenOperationsMs: Int = 0
 
   override def logger = super.logger
 }

--- a/src/test/scala/fi/oph/koski/perftest/ValpasRandomPerusopetuksenOppilaitoksetGetterScenario.scala
+++ b/src/test/scala/fi/oph/koski/perftest/ValpasRandomPerusopetuksenOppilaitoksetGetterScenario.scala
@@ -30,9 +30,10 @@ object ValpasRandomPerusopetuksenOppilaitoksetGetterScenario extends PerfTestSce
     }
     !bodyContainsError
   }
+
+  override val minimumTimeBetweenOperationsMs = 2500
 }
 
 object ValpasRandomPerusopetuksenOppilaitoksetGetter extends App {
   PerfTestRunner.executeTest(ValpasRandomPerusopetuksenOppilaitoksetGetterScenario)
 }
-


### PR DESCRIPTION
Tämä ei vielä toimi: sleepillä ei ollut käytännön testissä mitään vaikutusta.
