### PR TITLE
TOR-1769 korjaa validaatio ammatillisen uudelle koodille VVAI22

### DIFF
--- a/src/main/scala/fi/oph/koski/documentation/AmmatillinenExampleData.scala
+++ b/src/main/scala/fi/oph/koski/documentation/AmmatillinenExampleData.scala
@@ -41,6 +41,7 @@ object AmmatillinenExampleData {
   )
 
   def autoalanPerustutkinnonSuoritus(toimipiste: OrganisaatioWithOid = stadinToimipiste): AmmatillisenTutkinnonSuoritus = ammatillinenTutkintoSuoritus(autoalanPerustutkinto, toimipiste)
+  def ajoneuvoalanPerustutkinnonSuoritus(toimipiste: OrganisaatioWithOid = stadinToimipiste): AmmatillisenTutkinnonSuoritus = ammatillinenTutkintoSuoritus(ajoneuvoalanPerustutkinto, toimipiste).copy(suoritustapa = suoritustapaReformi)
   def autoalanPerustutkinnonSuoritusValma(toimipiste: OrganisaatioWithOid = stadinToimipiste): ValmaKoulutuksenSuoritus = valmaSuoritus(valmaKoulutus, toimipiste)
   def autoalanErikoisammattitutkinnonSuoritus(toimipiste: OrganisaatioWithOid = stadinToimipiste): AmmatillisenTutkinnonSuoritus = ammatillinenTutkintoSuoritus(autoalanTyönjohto, toimipiste)
   def puuteollisuudenPerustutkinnonSuoritus(toimipiste: OrganisaatioWithOid = stadinToimipiste): AmmatillisenTutkinnonSuoritus = ammatillinenTutkintoSuoritus(puuteollisuudenPerustutkinto, toimipiste)

--- a/src/main/scala/fi/oph/koski/eperusteet/EPerusteRakenne.scala
+++ b/src/main/scala/fi/oph/koski/eperusteet/EPerusteRakenne.scala
@@ -13,6 +13,7 @@ case class EPerusteRakenne(
   nimi: Map[String, String],
   diaarinumero: String,
   koulutustyyppi: String,
+  voimassaoloAlkaa: Option[String],
   voimassaoloLoppuu: Option[String],
   siirtymaPaattyy: Option[String],
   koulutukset: List[EPerusteKoulutus],
@@ -30,6 +31,9 @@ case class EPerusteRakenne(
     case None => false
   }
   def voimassaoloLoppuuLocalDate = voimassaoloLoppuu.map(ms =>
+    ZonedDateTime.ofInstant(Instant.ofEpochMilli(ms.toLong), ZoneId.systemDefault()).toLocalDate())
+
+  def voimassaoloAlkaaLocalDate = voimassaoloAlkaa.map(ms =>
     ZonedDateTime.ofInstant(Instant.ofEpochMilli(ms.toLong), ZoneId.systemDefault()).toLocalDate())
 
   def siirtymäPäättynyt(vertailupäivämäärä: LocalDate = LocalDate.now()) = siirtymäPäättyyLocalDate match {

--- a/src/main/scala/fi/oph/koski/http/KoskiErrorCategory.scala
+++ b/src/main/scala/fi/oph/koski/http/KoskiErrorCategory.scala
@@ -185,7 +185,7 @@ object KoskiErrorCategory {
       class Ammatillinen extends ErrorCategory(Validation.this, "ammatillinen", "Ammatilliseen opiskeluoikeuteen liittyvä validointivirhe") {
         val muutettuSuoritustapaaTaiTutkintokoodia = subcategory("muutettuSuoritustapaaTaiTutkintokoodia", "Ammatillisessa opiskeluoikeudessa, jossa päätason suorituksena on ammatillisen tutkintokoulutuksen suoritus, ei voi vaihtaa suoritettavan tutkintokoulutuksen tutkintokoodia tai suoritustapaa. Jos on vahingossa luotu ammatillisen tutkintokoulutuksen opiskeluoikeus väärällä tutkintokoodilla tai suoritustavalla, väärän tutkintokoodin tai suoritustavan sisältävä opiskeluoikeus on ensin mitätöitävä, ja sitten on luotava uusi opiskeluoikeus oikeilla tiedoilla.")
         val useampiPäätasonSuoritus = subcategory("useampiPäätasonSuoritus", "Ammatillinen opiskeluoikeus, jossa päätason suorituksena on ammatillisen tutkintokoulutuksen suoritus, ei voi sisältää useampaa kuin yhtä päätason suoritusta, ellei kyseessä ole opiskeluoikeus, jossa suoritetaan ns. vanhamallista näyttötutkintoa ja siihen liittyvää näyttötutkintoon valmistavaa koulutusta.")
-        val yhteinenTutkinnonOsaVVAI22 = subcategory("yhteinenTutkinnonOsaVVAI22", "Ennen 1.8.2022 aloitetulle ammatillisen opiskeluoikeudelle ei voi lisätä yhteisen tutkinnon osan osa-alueen suoritusta VVAI22.")
+        val yhteinenTutkinnonOsaVVAI22 = subcategory("yhteinenTutkinnonOsaVVAI22", "Ennen 1.8.2022 voimaan tulleen perusteen kanssa ei voi lisätä yhteisen tutkinnon osan osa-alueen suoritusta VVAI22.")
       }
       val ammatillinen = new Ammatillinen
 

--- a/src/test/scala/fi/oph/koski/api/OppijaValidationAmmatillinenSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationAmmatillinenSpec.scala
@@ -9,6 +9,7 @@ import fi.oph.koski.documentation.AmmatillinenReforminMukainenPerustutkintoExamp
 import fi.oph.koski.documentation.ExampleData.{helsinki, _}
 import fi.oph.koski.documentation.{AmmatillinenExampleData, AmmattitutkintoExample, ExampleData, ExamplesValma}
 import fi.oph.koski.fixture.AmmatillinenOpiskeluoikeusTestData
+import fi.oph.koski.henkilo.KoskiSpecificMockOppijat
 import fi.oph.koski.http.{ErrorMatcher, HttpStatus, KoskiErrorCategory}
 import fi.oph.koski.json.JsonSerializer
 import fi.oph.koski.koskiuser.{AccessType, KoskiSpecificSession}
@@ -923,26 +924,21 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
     }
 
     "Yhteisen tutkinnon osan osa-alueen viestintä- ja vuorovaikutus kielivalinnalla suoritus VVAI22" - {
-      "Koodia VVAI22 ei saa tallentaa jos opiskeluoikeus on alkanut ennen 1.8.2022" in {
+      "Koodia VVAI22 ei saa tallentaa jos perusteen voimaantulon päivä on ennen 1.8.2022" in {
         val suoritus = autoalanPerustutkinnonSuoritus().copy(
-          osasuoritukset = Some(List(yhtTutkinnonOsanSuoritusVVTK22))
+          osasuoritukset = Some(List(yhtTutkinnonOsanSuoritusVVAI22()))
         )
 
         putOpiskeluoikeus(defaultOpiskeluoikeus.copy(suoritukset = List(suoritus))) {
           verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.ammatillinen.yhteinenTutkinnonOsaVVAI22())
         }
       }
-      "Koodin VVAI22 saa tallentaa jos opiskeluoikeus on alkanut 1.8.2022 tai sen jälkeen" in {
-        val alkamispäivä = date(2022, 8, 1)
-        val suoritus = autoalanPerustutkinnonSuoritus().copy(
-          alkamispäivä = Some(alkamispäivä),
-          osasuoritukset = Some(List(yhtTutkinnonOsanSuoritusVVTK22))
+      "Koodin VVAI22 saa tallentaa jos perusteen voimaantulon päivä on 1.8.2022 tai sen jälkeen" in {
+        val suoritus = ajoneuvoalanPerustutkinnonSuoritus().copy(
+          osasuoritukset = Some(List(yhtTutkinnonOsanSuoritusVVAI22("106727")))
         )
-        val tila = AmmatillinenOpiskeluoikeudenTila(List(
-          AmmatillinenOpiskeluoikeusjakso(alkamispäivä, opiskeluoikeusLäsnä, Some(valtionosuusRahoitteinen))
-        ))
 
-        putOpiskeluoikeus(defaultOpiskeluoikeus.copy(suoritukset = List(suoritus), tila = tila)) {
+        putOpiskeluoikeus(henkilö = KoskiSpecificMockOppijat.tyhjä, opiskeluoikeus = defaultOpiskeluoikeus.copy(suoritukset = List(suoritus))) {
           verifyResponseStatusOk()
         }
       }
@@ -991,7 +987,7 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
     arviointi = arviointiHyvä(),
   )
 
-  lazy val yhtTutkinnonOsanSuoritusVVTK22 = yhteisenTutkinnonOsanSuoritus("101053", "Viestintä- ja vuorovaikutusosaaminen", k3, 2).copy(
+  def yhtTutkinnonOsanSuoritusVVAI22(koodiArvo: String = "101053") = yhteisenTutkinnonOsanSuoritus(koodiArvo, "Viestintä- ja vuorovaikutusosaaminen", k3, 2).copy(
     osasuoritukset = Some(List(
       YhteisenTutkinnonOsanOsaAlueenSuoritus(koulutusmoduuli = AmmatillisenTutkinnonViestintäJaVuorovaikutusKielivalinnalla(Koodistokoodiviite("VVAI22", "ammatillisenoppiaineet"), Koodistokoodiviite("EN", "kielivalikoima"), pakollinen = true, Some(LaajuusOsaamispisteissä(2))), arviointi = Some(List(arviointiKiitettävä)))
     )),

--- a/validaation_muutoshistoria.md
+++ b/validaation_muutoshistoria.md
@@ -4,7 +4,7 @@
 - Korjattu vapaan sivistystyön kotoutumiskoulutuksen (ops 2022) ohjauksen osasuorituksen validoinnit vastaamaan perustetta
 
 ## 5.7.2022
-- Ammatillisen yhteisen tutkinnon osan osa-alueen koodi VVAI22 sallitaan vain 1.8.2022 jälkeen alkaneille opiskeluoikeuksille.
+- Ammatillisen yhteisen tutkinnon osan osa-alueen koodi VVAI22 sallitaan vain suoritukselle, jonka perusteen voimaantulon päivä on 1.8.2022 tai sen jälkeen.
 
 ## 4.7.2022
 - Sallitaan muuttuneet ammatillisen koulutuksen yhteisten tutkinnon osien koodit:


### PR DESCRIPTION
Koodi voidaan siirtää vain jos suorituksen perusteen
voimaantulon päivä on 1.8.2022 tai sen jälkeen.