### PR TITLE
TOR-1800: Valpas: nivelvaiheen taulukon alareunasta katoaa tietoa

### DIFF
--- a/valpas-web/src/style/spacing.less
+++ b/valpas-web/src/style/spacing.less
@@ -1,6 +1,6 @@
 // Default paddings for containers etc.
 
-@page-padding: 2rem;
+@page-padding: 2rem 2rem 8rem 2rem;
 
 @padding-h: 1.2rem;
 @padding-v: 1rem;

--- a/valpas-web/src/views/hakutilanne/HakutilanneView.less
+++ b/valpas-web/src/views/hakutilanne/HakutilanneView.less
@@ -1,7 +1,3 @@
-.hakutilanneview__view {
-  padding-bottom: 8rem; // Alapalkille tyhjää tilaa
-}
-
 .hakutilanneview__view .card__body {
   padding-bottom: 8rem !important; // Tyhjää tilaa viimeisen hakutuloksen jälkeen
 }

--- a/valpas-web/src/views/hakutilanne/NivelvaiheenHakutilanneView.tsx
+++ b/valpas-web/src/views/hakutilanne/NivelvaiheenHakutilanneView.tsx
@@ -32,6 +32,10 @@ import { HakutilanneNavigation } from "./HakutilanneNavigation"
 import { NivelvaiheenHakutilanneTable } from "./NivelvaiheenHakutilanneTable"
 import { useOppijaSelect } from "./useOppijaSelect"
 import { useNivelvaiheenOppijatData } from "./useOppijatData"
+import "./HakutilanneView.less"
+import bem from "bem-ts"
+
+const b = bem("hakutilanneview")
 
 const organisaatioTyyppi = "OPPILAITOS"
 const organisaatioHakuRooli = "OPPILAITOS_HAKEUTUMINEN"
@@ -103,7 +107,7 @@ export const NivelvaiheenHakutilanneView = withRequiresHakeutumisenValvonta(
     const { setSelectedOppijaOids, selectedOppijat } = useOppijaSelect(data)
 
     return (
-      <Page>
+      <Page className={b("view")}>
         <OrganisaatioValitsin
           organisaatioTyyppi={organisaatioTyyppi}
           organisaatioHierarkia={organisaatiot}


### PR DESCRIPTION
Samalla kaikille sivuille tuli nyt alareunaan marginaalia,
jotta sama vahinko ei tapahtuisi jakossa niin helposti ja
sivuja on muutenkin mukavampi skrollata.
