### PR TITLE
AWS-depsupäivitykset

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <scalatra.version>2.8.2</scalatra.version>
     <http4s.version>0.23.12</http4s.version>
     <json4s.version>4.0.5</json4s.version>
-    <awssdk.version>2.17.244</awssdk.version>
+    <awssdk.version>2.17.246</awssdk.version>
     <jetty.version>9.4.47.v20220610</jetty.version>
     <prometheus.client.version>0.16.0</prometheus.client.version>
     <scoverage.plugin.version>1.1.1</scoverage.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-sts</artifactId>
-      <version>1.12.274</version>
+      <version>1.12.275</version>
     </dependency>
     <!-- test deps -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -319,7 +319,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-dynamodb</artifactId>
-      <version>1.12.273</version>
+      <version>1.12.276</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
Yhdistetty seuraavat päivitykset yhteen pullariin testaamisen nopeuttamiseksi:

- fix: upgrade software.amazon.awssdk:s3 from 2.17.244 to 2.17.246
- fix: upgrade com.amazonaws:aws-java-sdk-sts from 1.12.274 to 1.12.275
- fix: upgrade com.amazonaws:aws-java-sdk-dynamodb from 1.12.273 to 1.12.276
