### PR TITLE
TOR-1775 mahdollista mock-koodistojen versiointi

### DIFF
--- a/src/main/resources/mockdata/koodisto/koodistot/koulutus_11.json
+++ b/src/main/resources/mockdata/koodisto/koodistot/koulutus_11.json
@@ -1,0 +1,23 @@
+{
+  "koodistoUri" : "koulutus",
+  "versio" : 11,
+  "metadata" : [ {
+    "kieli" : "FI",
+    "nimi" : "koulutus",
+    "kuvaus" : "Koodistoa ylläpitävät Tuija Koskela (Opetushallitus,  Ammatillinen osaaminen yksikkö)  ammatillisen koulutuksen osalta ja Outi Kivipelto (Opetushallitus, Oppijanpalvelut yksikkö) korkeakoulujen osalta. Koodistoa käytetään mm. hakujen koulutustarjonnassa, KOSKEn tiedonsiirroissa, OIVAssa ja OKM Virta-palvelussa. Tilastokeskus vastaa koodiston koodituksesta. Koodeja ylläpidetään käsin. Koodiston ja Tilastokeskuksen välillä ei ole integraatiota."
+  }, {
+    "kieli" : "SV",
+    "nimi" : "koulutus",
+    "kuvaus" : "koulutus"
+  }, {
+    "kieli" : "EN",
+    "nimi" : "koulutus",
+    "kuvaus" : "koulutus"
+  } ],
+  "codesGroupUri" : "http://koulutuskoodistot",
+  "voimassaAlkuPvm" : "2019-06-06",
+  "organisaatioOid" : "1.2.246.562.10.00000000001",
+  "withinCodes" : [ ],
+  "tila" : "LUONNOS",
+  "version" : 7
+}

--- a/src/main/resources/mockdata/koodisto/koodit/koulutus_11.json
+++ b/src/main/resources/mockdata/koodisto/koodit/koulutus_11.json
@@ -14,7 +14,7 @@
     "lyhytNimi" : "Vocational teacher education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_000002",
   "koodiArvo" : "000002",
@@ -30,7 +30,7 @@
     "lyhytNimi" : "Vocational special needs teacher education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_000003",
   "koodiArvo" : "000003",
@@ -47,7 +47,7 @@
     "lyhytNimi" : "Vocational guidance councelor education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_001101",
   "koodiArvo" : "001101",
@@ -61,7 +61,7 @@
     "nimi" : "Pre-Primary Education in Comprehensive Schools",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_001102",
   "koodiArvo" : "001102",
@@ -75,7 +75,7 @@
     "nimi" : "Pre-Primary Education in Day-Care Centres",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_010001",
   "koodiArvo" : "010001",
@@ -88,7 +88,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_020075",
   "koodiArvo" : "020075",
@@ -101,7 +101,7 @@
     "lyhytNimi" : "Påbyggnadsundervisning efter den grundläggande utbildningen",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_038411",
   "koodiArvo" : "038411",
@@ -118,7 +118,7 @@
     "lyhytNimi" : "Domestic education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_039993",
   "koodiArvo" : "039993",
@@ -157,7 +157,7 @@
     "lyhytNimi" : "Utbildning som orienterar och förbereder för grundläggande yrkesutbildning",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_039997",
   "koodiArvo" : "039997",
@@ -170,7 +170,7 @@
     "lyhytNimi" : "Förberedande gymnasieutbildning för invandrare och personer med annat modersmål än finska och svenska",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_039998",
   "koodiArvo" : "039998",
@@ -183,7 +183,7 @@
     "lyhytNimi" : "Utbildning som förbereder invandrare för yrkesutbildning",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_039999",
   "koodiArvo" : "039999",
@@ -196,7 +196,7 @@
     "lyhytNimi" : "Utbildning som handleder  för arbete och ett självständigt liv",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_099999",
   "koodiArvo" : "099999",
@@ -209,7 +209,7 @@
     "lyhytNimi" : "Fritt bildningsarbete ",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_999909",
   "koodiArvo" : "999909",
@@ -265,7 +265,7 @@
     "lyhytNimi" : "Pre-Primary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_101000",
   "koodiArvo" : "101000",
@@ -282,7 +282,7 @@
     "lyhytNimi" : "General Education, Primary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_101100",
   "koodiArvo" : "101100",
@@ -299,7 +299,7 @@
     "lyhytNimi" : "Primary School",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_101151",
   "koodiArvo" : "101151",
@@ -316,7 +316,7 @@
     "lyhytNimi" : "Primary School",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_101152",
   "koodiArvo" : "101152",
@@ -333,7 +333,7 @@
     "lyhytNimi" : "Civic School",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_101900",
   "koodiArvo" : "101900",
@@ -350,7 +350,7 @@
     "lyhytNimi" : "Other General Education, Primary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_101999",
   "koodiArvo" : "101999",
@@ -367,7 +367,7 @@
     "lyhytNimi" : "Other or Unknown General Education, Primary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_110000",
   "koodiArvo" : "110000",
@@ -384,7 +384,7 @@
     "lyhytNimi" : "Pre-Primary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_201000",
   "koodiArvo" : "201000",
@@ -401,7 +401,7 @@
     "lyhytNimi" : "General Education, Lower Secondary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_201100",
   "koodiArvo" : "201100",
@@ -418,7 +418,7 @@
     "lyhytNimi" : "Comprehensive School",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_201101",
   "koodiArvo" : "201101",
@@ -435,7 +435,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_201200",
   "koodiArvo" : "201200",
@@ -452,7 +452,7 @@
     "lyhytNimi" : "Middle School",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_201251",
   "koodiArvo" : "201251",
@@ -469,7 +469,7 @@
     "lyhytNimi" : "Middle School",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_201900",
   "koodiArvo" : "201900",
@@ -486,7 +486,7 @@
     "lyhytNimi" : "Other General Education, Lower Secondary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_201999",
   "koodiArvo" : "201999",
@@ -503,7 +503,7 @@
     "lyhytNimi" : "Other or Unknown General School, Lower Secondary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_301000",
   "koodiArvo" : "301000",
@@ -520,7 +520,7 @@
     "lyhytNimi" : "Matriculation Examination",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_301100",
   "koodiArvo" : "301100",
@@ -537,7 +537,7 @@
     "lyhytNimi" : "Matriculation Examination",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_301101",
   "koodiArvo" : "301101",
@@ -554,7 +554,7 @@
     "lyhytNimi" : "Matriculation Examination",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_301102",
   "koodiArvo" : "301102",
@@ -571,7 +571,7 @@
     "lyhytNimi" : "International Baccalaureate Examination",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_301103",
   "koodiArvo" : "301103",
@@ -588,7 +588,7 @@
     "lyhytNimi" : "Deutsche Internationale Abitur; Reifeprüfung",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_301104",
   "koodiArvo" : "301104",
@@ -605,7 +605,7 @@
     "lyhytNimi" : "European Baccalaureate Examination",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_301199",
   "koodiArvo" : "301199",
@@ -622,7 +622,7 @@
     "lyhytNimi" : "Other or Unknown Matriculation Examination",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_309000",
   "koodiArvo" : "309000",
@@ -639,7 +639,7 @@
     "lyhytNimi" : "Other General Education, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_309900",
   "koodiArvo" : "309900",
@@ -656,7 +656,7 @@
     "lyhytNimi" : "Other General Education, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_309901",
   "koodiArvo" : "309901",
@@ -673,7 +673,7 @@
     "lyhytNimi" : "Upper Secondary General Level Examination (Åland)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_309902",
   "koodiArvo" : "309902",
@@ -686,7 +686,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_309999",
   "koodiArvo" : "309999",
@@ -703,7 +703,7 @@
     "lyhytNimi" : "Other or Unknown General Education, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_311000",
   "koodiArvo" : "311000",
@@ -720,7 +720,7 @@
     "lyhytNimi" : "Teacher Education, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_311100",
   "koodiArvo" : "311100",
@@ -737,7 +737,7 @@
     "lyhytNimi" : "Teacher Education, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_311101",
   "koodiArvo" : "311101",
@@ -754,7 +754,7 @@
     "lyhytNimi" : "Driving Instructor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_311199",
   "koodiArvo" : "311199",
@@ -771,7 +771,7 @@
     "lyhytNimi" : "Other or Unknown Teacher Education, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_317000",
   "koodiArvo" : "317000",
@@ -788,7 +788,7 @@
     "lyhytNimi" : "Teacher Education, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_317100",
   "koodiArvo" : "317100",
@@ -805,7 +805,7 @@
     "lyhytNimi" : "Teacher Education, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_317101",
   "koodiArvo" : "317101",
@@ -822,7 +822,7 @@
     "lyhytNimi" : "Driving Instructors, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321000",
   "koodiArvo" : "321000",
@@ -839,7 +839,7 @@
     "lyhytNimi" : "Vocational Education and Training in Arts, Crafts and Design, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321100",
   "koodiArvo" : "321100",
@@ -856,7 +856,7 @@
     "lyhytNimi" : "Artisan, Vocational Education and Training in Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321101",
   "koodiArvo" : "321101",
@@ -873,7 +873,7 @@
     "lyhytNimi" : "Artisan, Crafts and Design, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321141",
   "koodiArvo" : "321141",
@@ -890,7 +890,7 @@
     "lyhytNimi" : "Vocational qualification in Arts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_321151",
   "koodiArvo" : "321151",
@@ -907,7 +907,7 @@
     "lyhytNimi" : "Artisan, Graphics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321152",
   "koodiArvo" : "321152",
@@ -924,7 +924,7 @@
     "lyhytNimi" : "Artisan, Stone Cutter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321153",
   "koodiArvo" : "321153",
@@ -941,7 +941,7 @@
     "lyhytNimi" : "Artisan, Goldsmith",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321154",
   "koodiArvo" : "321154",
@@ -958,7 +958,7 @@
     "lyhytNimi" : "Artisan, Weaver",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321155",
   "koodiArvo" : "321155",
@@ -975,7 +975,7 @@
     "lyhytNimi" : "Artisan, Painter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321156",
   "koodiArvo" : "321156",
@@ -992,7 +992,7 @@
     "lyhytNimi" : "Artisan, Metalsmith",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321157",
   "koodiArvo" : "321157",
@@ -1009,7 +1009,7 @@
     "lyhytNimi" : "Artisan, Dressmaker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321158",
   "koodiArvo" : "321158",
@@ -1026,7 +1026,7 @@
     "lyhytNimi" : "Artisan, Joiner",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321159",
   "koodiArvo" : "321159",
@@ -1043,7 +1043,7 @@
     "lyhytNimi" : "Artisan, Builder",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321160",
   "koodiArvo" : "321160",
@@ -1060,7 +1060,7 @@
     "lyhytNimi" : "Artisan, Sami Crafts Maker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321161",
   "koodiArvo" : "321161",
@@ -1077,7 +1077,7 @@
     "lyhytNimi" : "Artisan, Potter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321199",
   "koodiArvo" : "321199",
@@ -1094,7 +1094,7 @@
     "lyhytNimi" : "Artisan, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321200",
   "koodiArvo" : "321200",
@@ -1111,7 +1111,7 @@
     "lyhytNimi" : "Vocational Education and Training in Music",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321201",
   "koodiArvo" : "321201",
@@ -1128,7 +1128,7 @@
     "lyhytNimi" : "Piano Tuner, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321202",
   "koodiArvo" : "321202",
@@ -1145,7 +1145,7 @@
     "lyhytNimi" : "Church Organist, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321203",
   "koodiArvo" : "321203",
@@ -1162,7 +1162,7 @@
     "lyhytNimi" : "Dance Musician, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321204",
   "koodiArvo" : "321204",
@@ -1179,7 +1179,7 @@
     "lyhytNimi" : "Vocational qualification in Music",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321251",
   "koodiArvo" : "321251",
@@ -1196,7 +1196,7 @@
     "lyhytNimi" : "Diploma for Orthodox Cantor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321252",
   "koodiArvo" : "321252",
@@ -1213,7 +1213,7 @@
     "lyhytNimi" : "Military Musician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321299",
   "koodiArvo" : "321299",
@@ -1230,7 +1230,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Music",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321300",
   "koodiArvo" : "321300",
@@ -1247,7 +1247,7 @@
     "lyhytNimi" : "Vocational Education and Training in Fine Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321301",
   "koodiArvo" : "321301",
@@ -1264,7 +1264,7 @@
     "lyhytNimi" : "Visual Expression, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321351",
   "koodiArvo" : "321351",
@@ -1281,7 +1281,7 @@
     "lyhytNimi" : "Visual Artist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321399",
   "koodiArvo" : "321399",
@@ -1298,7 +1298,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Fine Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321500",
   "koodiArvo" : "321500",
@@ -1315,7 +1315,7 @@
     "lyhytNimi" : "Vocational Education and Training in Theatre and Dance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321501",
   "koodiArvo" : "321501",
@@ -1332,7 +1332,7 @@
     "lyhytNimi" : "Vocational qualification in Dance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321599",
   "koodiArvo" : "321599",
@@ -1349,7 +1349,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Theatre and Dance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321600",
   "koodiArvo" : "321600",
@@ -1366,7 +1366,7 @@
     "lyhytNimi" : "Vocational Education and Training in Communications",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321601",
   "koodiArvo" : "321601",
@@ -1383,7 +1383,7 @@
     "lyhytNimi" : "Communications, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321602",
   "koodiArvo" : "321602",
@@ -1400,7 +1400,7 @@
     "lyhytNimi" : "Audiovisual Communication, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321603",
   "koodiArvo" : "321603",
@@ -1447,7 +1447,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Communications",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321900",
   "koodiArvo" : "321900",
@@ -1464,7 +1464,7 @@
     "lyhytNimi" : "Other Vocational Education and Training in Arts, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321901",
   "koodiArvo" : "321901",
@@ -1481,7 +1481,7 @@
     "lyhytNimi" : "Sign Language Instruction, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321902",
   "koodiArvo" : "321902",
@@ -1498,7 +1498,7 @@
     "lyhytNimi" : "Vocational qualification in Circus Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321951",
   "koodiArvo" : "321951",
@@ -1515,7 +1515,7 @@
     "lyhytNimi" : "Graphic Design, Vocational Education and Training",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321952",
   "koodiArvo" : "321952",
@@ -1532,7 +1532,7 @@
     "lyhytNimi" : "Ornamental Wood Carver",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321953",
   "koodiArvo" : "321953",
@@ -1549,7 +1549,7 @@
     "lyhytNimi" : "Advertising Designer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321954",
   "koodiArvo" : "321954",
@@ -1566,7 +1566,7 @@
     "lyhytNimi" : "Fashion Design, Vocational Education and Training",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321955",
   "koodiArvo" : "321955",
@@ -1583,7 +1583,7 @@
     "lyhytNimi" : "Photography, Vocational Education and Training",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321956",
   "koodiArvo" : "321956",
@@ -1600,7 +1600,7 @@
     "lyhytNimi" : "Basic Course in Workshop Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321957",
   "koodiArvo" : "321957",
@@ -1617,7 +1617,7 @@
     "lyhytNimi" : "Technical Operator",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321958",
   "koodiArvo" : "321958",
@@ -1634,7 +1634,7 @@
     "lyhytNimi" : "Television Producer's Assistant",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_321999",
   "koodiArvo" : "321999",
@@ -1651,7 +1651,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Arts, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324000",
   "koodiArvo" : "324000",
@@ -1668,7 +1668,7 @@
     "lyhytNimi" : "Further Qualification in Arts, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324100",
   "koodiArvo" : "324100",
@@ -1685,7 +1685,7 @@
     "lyhytNimi" : "Further Qualification in Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324101",
   "koodiArvo" : "324101",
@@ -1702,7 +1702,7 @@
     "lyhytNimi" : "Gunsmith, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324102",
   "koodiArvo" : "324102",
@@ -1719,7 +1719,7 @@
     "lyhytNimi" : "Silversmith, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324103",
   "koodiArvo" : "324103",
@@ -1736,7 +1736,7 @@
     "lyhytNimi" : "Engraver, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324104",
   "koodiArvo" : "324104",
@@ -1753,7 +1753,7 @@
     "lyhytNimi" : "Ceramist, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324105",
   "koodiArvo" : "324105",
@@ -1770,7 +1770,7 @@
     "lyhytNimi" : "Stonecutter, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324106",
   "koodiArvo" : "324106",
@@ -1787,7 +1787,7 @@
     "lyhytNimi" : "Ornamental Wood Carving, Further Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324107",
   "koodiArvo" : "324107",
@@ -1804,7 +1804,7 @@
     "lyhytNimi" : "Gilder, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324108",
   "koodiArvo" : "324108",
@@ -1821,7 +1821,7 @@
     "lyhytNimi" : "Goldsmith, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324109",
   "koodiArvo" : "324109",
@@ -1838,7 +1838,7 @@
     "lyhytNimi" : "Glassblower, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324110",
   "koodiArvo" : "324110",
@@ -1855,7 +1855,7 @@
     "lyhytNimi" : "Animal, Plant and Geological Conservation, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324111",
   "koodiArvo" : "324111",
@@ -1872,7 +1872,7 @@
     "lyhytNimi" : "Painter, Further Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324112",
   "koodiArvo" : "324112",
@@ -1889,7 +1889,7 @@
     "lyhytNimi" : "Model-Builder, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324113",
   "koodiArvo" : "324113",
@@ -1906,7 +1906,7 @@
     "lyhytNimi" : "Knitter, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324114",
   "koodiArvo" : "324114",
@@ -1923,7 +1923,7 @@
     "lyhytNimi" : "Joiner, Further Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324115",
   "koodiArvo" : "324115",
@@ -1940,7 +1940,7 @@
     "lyhytNimi" : "Restorer, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324116",
   "koodiArvo" : "324116",
@@ -1957,7 +1957,7 @@
     "lyhytNimi" : "Romany Culture Instructor, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324117",
   "koodiArvo" : "324117",
@@ -1974,7 +1974,7 @@
     "lyhytNimi" : "Further vocational qualification in Sami Crafts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324118",
   "koodiArvo" : "324118",
@@ -1991,7 +1991,7 @@
     "lyhytNimi" : "Potter, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324119",
   "koodiArvo" : "324119",
@@ -2008,7 +2008,7 @@
     "lyhytNimi" : "Blacksmith, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324120",
   "koodiArvo" : "324120",
@@ -2025,7 +2025,7 @@
     "lyhytNimi" : "Musical Instrument Builder, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324121",
   "koodiArvo" : "324121",
@@ -2042,7 +2042,7 @@
     "lyhytNimi" : "Studio Weaver, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324122",
   "koodiArvo" : "324122",
@@ -2059,7 +2059,7 @@
     "lyhytNimi" : "Studio Dressmaker, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324123",
   "koodiArvo" : "324123",
@@ -2076,7 +2076,7 @@
     "lyhytNimi" : "Boat-Builder, Further Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324124",
   "koodiArvo" : "324124",
@@ -2093,7 +2093,7 @@
     "lyhytNimi" : "Dyer, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324125",
   "koodiArvo" : "324125",
@@ -2110,7 +2110,7 @@
     "lyhytNimi" : "Joiner, Further Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324126",
   "koodiArvo" : "324126",
@@ -2127,7 +2127,7 @@
     "lyhytNimi" : "Textiles, Further Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324127",
   "koodiArvo" : "324127",
@@ -2144,7 +2144,7 @@
     "lyhytNimi" : "Further Qualification in Clothing, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324128",
   "koodiArvo" : "324128",
@@ -2161,7 +2161,7 @@
     "lyhytNimi" : "Handicrafts, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324129",
   "koodiArvo" : "324129",
@@ -2178,7 +2178,7 @@
     "lyhytNimi" : "Interior Design, Further Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324130",
   "koodiArvo" : "324130",
@@ -2212,7 +2212,7 @@
     "lyhytNimi" : "Taideteollisuusalan at",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_324199",
   "koodiArvo" : "324199",
@@ -2229,7 +2229,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324200",
   "koodiArvo" : "324200",
@@ -2246,7 +2246,7 @@
     "lyhytNimi" : "Music, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324201",
   "koodiArvo" : "324201",
@@ -2263,7 +2263,7 @@
     "lyhytNimi" : "Further vocational qualification for Music Producers",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324300",
   "koodiArvo" : "324300",
@@ -2280,7 +2280,7 @@
     "lyhytNimi" : "Further Qualification in Fine Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324301",
   "koodiArvo" : "324301",
@@ -2297,7 +2297,7 @@
     "lyhytNimi" : "Photography, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324399",
   "koodiArvo" : "324399",
@@ -2314,7 +2314,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Fine Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324500",
   "koodiArvo" : "324500",
@@ -2331,7 +2331,7 @@
     "lyhytNimi" : "Further Qualification in Theatre and Dance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324501",
   "koodiArvo" : "324501",
@@ -2348,7 +2348,7 @@
     "lyhytNimi" : "Stage Assistant, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324502",
   "koodiArvo" : "324502",
@@ -2361,7 +2361,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324503",
   "koodiArvo" : "324503",
@@ -2378,7 +2378,7 @@
     "lyhytNimi" : "Further vocational qualification in Stage and Theatre Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_324599",
   "koodiArvo" : "324599",
@@ -2395,7 +2395,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Theatre and Dance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324600",
   "koodiArvo" : "324600",
@@ -2412,7 +2412,7 @@
     "lyhytNimi" : "Further Qualification in Communications",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324601",
   "koodiArvo" : "324601",
@@ -2429,7 +2429,7 @@
     "lyhytNimi" : "Audiovisual Communication, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_324602",
   "koodiArvo" : "324602",
@@ -2463,7 +2463,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Communication",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327000",
   "koodiArvo" : "327000",
@@ -2480,7 +2480,7 @@
     "lyhytNimi" : "Specialist Qualification in Arts, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327100",
   "koodiArvo" : "327100",
@@ -2497,7 +2497,7 @@
     "lyhytNimi" : "Specialist Qualification in Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327101",
   "koodiArvo" : "327101",
@@ -2510,7 +2510,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327102",
   "koodiArvo" : "327102",
@@ -2527,7 +2527,7 @@
     "lyhytNimi" : "Silversmith, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327103",
   "koodiArvo" : "327103",
@@ -2544,7 +2544,7 @@
     "lyhytNimi" : "Engraver, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327104",
   "koodiArvo" : "327104",
@@ -2561,7 +2561,7 @@
     "lyhytNimi" : "Ceramist, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327105",
   "koodiArvo" : "327105",
@@ -2578,7 +2578,7 @@
     "lyhytNimi" : "Stonecutter, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327106",
   "koodiArvo" : "327106",
@@ -2595,7 +2595,7 @@
     "lyhytNimi" : "Ornamental Wood Carving, Specialist Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327107",
   "koodiArvo" : "327107",
@@ -2608,7 +2608,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327108",
   "koodiArvo" : "327108",
@@ -2625,7 +2625,7 @@
     "lyhytNimi" : "Goldsmith, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327109",
   "koodiArvo" : "327109",
@@ -2638,7 +2638,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327110",
   "koodiArvo" : "327110",
@@ -2655,7 +2655,7 @@
     "lyhytNimi" : "Painter, Specialist Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327111",
   "koodiArvo" : "327111",
@@ -2672,7 +2672,7 @@
     "lyhytNimi" : "Model-Builder, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327112",
   "koodiArvo" : "327112",
@@ -2689,7 +2689,7 @@
     "lyhytNimi" : "Knitter, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327113",
   "koodiArvo" : "327113",
@@ -2706,7 +2706,7 @@
     "lyhytNimi" : "Joiner, Specialist Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327114",
   "koodiArvo" : "327114",
@@ -2719,7 +2719,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327115",
   "koodiArvo" : "327115",
@@ -2732,7 +2732,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327116",
   "koodiArvo" : "327116",
@@ -2749,7 +2749,7 @@
     "lyhytNimi" : "Sami Crafts, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327117",
   "koodiArvo" : "327117",
@@ -2766,7 +2766,7 @@
     "lyhytNimi" : "Potter, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327118",
   "koodiArvo" : "327118",
@@ -2779,7 +2779,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327119",
   "koodiArvo" : "327119",
@@ -2792,7 +2792,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327120",
   "koodiArvo" : "327120",
@@ -2809,7 +2809,7 @@
     "lyhytNimi" : "Studio Weaver, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327121",
   "koodiArvo" : "327121",
@@ -2826,7 +2826,7 @@
     "lyhytNimi" : "Studio Dressmaker, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327122",
   "koodiArvo" : "327122",
@@ -2843,7 +2843,7 @@
     "lyhytNimi" : "Boat-Builder, Specialist Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327123",
   "koodiArvo" : "327123",
@@ -2860,7 +2860,7 @@
     "lyhytNimi" : "Dyer, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327124",
   "koodiArvo" : "327124",
@@ -2877,7 +2877,7 @@
     "lyhytNimi" : "Joiner, Specialist Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327125",
   "koodiArvo" : "327125",
@@ -2894,7 +2894,7 @@
     "lyhytNimi" : "Textiles, Specialist Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327126",
   "koodiArvo" : "327126",
@@ -2911,7 +2911,7 @@
     "lyhytNimi" : "Specialist Qualification in Clothing, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327127",
   "koodiArvo" : "327127",
@@ -2928,7 +2928,7 @@
     "lyhytNimi" : "Interior Design, Specialist Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327128",
   "koodiArvo" : "327128",
@@ -2941,7 +2941,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327130",
   "koodiArvo" : "327130",
@@ -2971,7 +2971,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327300",
   "koodiArvo" : "327300",
@@ -2988,7 +2988,7 @@
     "lyhytNimi" : "Specialist Qualification in Fine Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327301",
   "koodiArvo" : "327301",
@@ -3001,7 +3001,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327302",
   "koodiArvo" : "327302",
@@ -3018,7 +3018,7 @@
     "lyhytNimi" : "Audiovisual Communication, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327399",
   "koodiArvo" : "327399",
@@ -3035,7 +3035,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Fine Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327500",
   "koodiArvo" : "327500",
@@ -3052,7 +3052,7 @@
     "lyhytNimi" : "Specialist Qualification in Theatre and Dance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327501",
   "koodiArvo" : "327501",
@@ -3069,7 +3069,7 @@
     "lyhytNimi" : "Make-up Artist, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327502",
   "koodiArvo" : "327502",
@@ -3086,7 +3086,7 @@
     "lyhytNimi" : "Theatre Technology, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327503",
   "koodiArvo" : "327503",
@@ -3099,7 +3099,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327504",
   "koodiArvo" : "327504",
@@ -3112,7 +3112,7 @@
     "lyhytNimi" : "Specialyrkesexamen inom föreställnings- och teaterteknik",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_327599",
   "koodiArvo" : "327599",
@@ -3129,7 +3129,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Theatre and Dance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327600",
   "koodiArvo" : "327600",
@@ -3146,7 +3146,7 @@
     "lyhytNimi" : "Specialist Qualification in Communications",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327601",
   "koodiArvo" : "327601",
@@ -3159,7 +3159,7 @@
     "lyhytNimi" : "Specialyrkesexamen inom mediebranschen",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_327699",
   "koodiArvo" : "327699",
@@ -3176,7 +3176,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Communications",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_329000",
   "koodiArvo" : "329000",
@@ -3193,7 +3193,7 @@
     "lyhytNimi" : "Other Education in Humanities and Arts, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_329900",
   "koodiArvo" : "329900",
@@ -3210,7 +3210,7 @@
     "lyhytNimi" : "Other Education in Humanities and Arts, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_329999",
   "koodiArvo" : "329999",
@@ -3227,7 +3227,7 @@
     "lyhytNimi" : "Other or Unknown Education in Humanities and Arts, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_331000",
   "koodiArvo" : "331000",
@@ -3244,7 +3244,7 @@
     "lyhytNimi" : "Vocational Education and Training in Business and Administration, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_331100",
   "koodiArvo" : "331100",
@@ -3261,7 +3261,7 @@
     "lyhytNimi" : "Vocational Qualification in Business and Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_331101",
   "koodiArvo" : "331101",
@@ -3278,7 +3278,7 @@
     "lyhytNimi" : "Vocational qualification in Business",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_331102",
   "koodiArvo" : "331102",
@@ -3295,7 +3295,7 @@
     "lyhytNimi" : "Certificate in Business and Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_331151",
   "koodiArvo" : "331151",
@@ -3312,7 +3312,7 @@
     "lyhytNimi" : "Certificate in Business and Administration, Unspecialised",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_331152",
   "koodiArvo" : "331152",
@@ -3329,7 +3329,7 @@
     "lyhytNimi" : "Certificate in Business and Administration, Accounting",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_331153",
   "koodiArvo" : "331153",
@@ -3346,7 +3346,7 @@
     "lyhytNimi" : "Certificate in Business and Administration, Sales",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_331157",
   "koodiArvo" : "331157",
@@ -3363,7 +3363,7 @@
     "lyhytNimi" : "Certificate in Business and Administration, Office Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_331161",
   "koodiArvo" : "331161",
@@ -3380,7 +3380,7 @@
     "lyhytNimi" : "Certificate in Business and Administration, Stock Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_331162",
   "koodiArvo" : "331162",
@@ -3397,7 +3397,7 @@
     "lyhytNimi" : "Certificate in Business and Administration, General Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_331199",
   "koodiArvo" : "331199",
@@ -3414,7 +3414,7 @@
     "lyhytNimi" : "Certificate in Business and Administration, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_331900",
   "koodiArvo" : "331900",
@@ -3431,7 +3431,7 @@
     "lyhytNimi" : "Other Vocational Education and Training in Business and Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_331901",
   "koodiArvo" : "331901",
@@ -3448,7 +3448,7 @@
     "lyhytNimi" : "Storage and Transportation, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_331951",
   "koodiArvo" : "331951",
@@ -3465,7 +3465,7 @@
     "lyhytNimi" : "Sales Assistant",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_331952",
   "koodiArvo" : "331952",
@@ -3482,7 +3482,7 @@
     "lyhytNimi" : "Window Dresser",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_331953",
   "koodiArvo" : "331953",
@@ -3499,7 +3499,7 @@
     "lyhytNimi" : "Warehouse Operative",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_331954",
   "koodiArvo" : "331954",
@@ -3516,7 +3516,7 @@
     "lyhytNimi" : "Insurance, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_331955",
   "koodiArvo" : "331955",
@@ -3533,7 +3533,7 @@
     "lyhytNimi" : "Social Security, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_331956",
   "koodiArvo" : "331956",
@@ -3550,7 +3550,7 @@
     "lyhytNimi" : "Health Care Secretary",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_331999",
   "koodiArvo" : "331999",
@@ -3567,7 +3567,7 @@
     "lyhytNimi" : "Other or Unknown Education in Business and Administration, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334000",
   "koodiArvo" : "334000",
@@ -3584,7 +3584,7 @@
     "lyhytNimi" : "Further Qualification in Business and Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334100",
   "koodiArvo" : "334100",
@@ -3601,7 +3601,7 @@
     "lyhytNimi" : "Further Qualification in Business and Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334101",
   "koodiArvo" : "334101",
@@ -3618,7 +3618,7 @@
     "lyhytNimi" : "Car Salesperson, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334102",
   "koodiArvo" : "334102",
@@ -3635,7 +3635,7 @@
     "lyhytNimi" : "Foreign Trade, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334103",
   "koodiArvo" : "334103",
@@ -3652,7 +3652,7 @@
     "lyhytNimi" : "FVQ in Property Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334104",
   "koodiArvo" : "334104",
@@ -3669,7 +3669,7 @@
     "lyhytNimi" : "Further vocational qualification in Marketing Communications",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334105",
   "koodiArvo" : "334105",
@@ -3686,7 +3686,7 @@
     "lyhytNimi" : "Sales, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334106",
   "koodiArvo" : "334106",
@@ -3703,7 +3703,7 @@
     "lyhytNimi" : "Secretarial Studies, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334107",
   "koodiArvo" : "334107",
@@ -3720,7 +3720,7 @@
     "lyhytNimi" : "Window Dresser, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334108",
   "koodiArvo" : "334108",
@@ -3737,7 +3737,7 @@
     "lyhytNimi" : "Parts Salesperson, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334109",
   "koodiArvo" : "334109",
@@ -3754,7 +3754,7 @@
     "lyhytNimi" : "Warehouse Operations, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334111",
   "koodiArvo" : "334111",
@@ -3771,7 +3771,7 @@
     "lyhytNimi" : "Porter, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334112",
   "koodiArvo" : "334112",
@@ -3788,7 +3788,7 @@
     "lyhytNimi" : "Further vocational qualification for Entrepreneurs",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334113",
   "koodiArvo" : "334113",
@@ -3805,7 +3805,7 @@
     "lyhytNimi" : "Further vocational qualification in Information and Library Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334114",
   "koodiArvo" : "334114",
@@ -3822,7 +3822,7 @@
     "lyhytNimi" : "Business Administration, Financing and Accounting, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334115",
   "koodiArvo" : "334115",
@@ -3839,7 +3839,7 @@
     "lyhytNimi" : "Finanssialan ammattitutkinto",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334116",
   "koodiArvo" : "334116",
@@ -3856,7 +3856,7 @@
     "lyhytNimi" : "Messaging and Logistics Services, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334117",
   "koodiArvo" : "334117",
@@ -3873,7 +3873,7 @@
     "lyhytNimi" : "Records and Archives Management, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334118",
   "koodiArvo" : "334118",
@@ -3890,7 +3890,7 @@
     "lyhytNimi" : "Estate Agency Services, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334119",
   "koodiArvo" : "334119",
@@ -3907,7 +3907,7 @@
     "lyhytNimi" : "Further vocational qualification in Customs",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334120",
   "koodiArvo" : "334120",
@@ -3924,7 +3924,7 @@
     "lyhytNimi" : "Further vocational qualification in First-Level Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_334145",
   "koodiArvo" : "334145",
@@ -3941,7 +3941,7 @@
     "lyhytNimi" : "Further vocational qualification in Business",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_334146",
   "koodiArvo" : "334146",
@@ -3958,7 +3958,7 @@
     "lyhytNimi" : "FVQ in Service Logistics",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_334199",
   "koodiArvo" : "334199",
@@ -3975,7 +3975,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Business and Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_337000",
   "koodiArvo" : "337000",
@@ -3992,7 +3992,7 @@
     "lyhytNimi" : "Specialist Qualification in Business and Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_337100",
   "koodiArvo" : "337100",
@@ -4009,7 +4009,7 @@
     "lyhytNimi" : "Specialist Qualification in Business and Administartion",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_337101",
   "koodiArvo" : "337101",
@@ -4026,7 +4026,7 @@
     "lyhytNimi" : "Management, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_337102",
   "koodiArvo" : "337102",
@@ -4039,7 +4039,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_337103",
   "koodiArvo" : "337103",
@@ -4056,7 +4056,7 @@
     "lyhytNimi" : "Shipbroker, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_337104",
   "koodiArvo" : "337104",
@@ -4069,7 +4069,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_337106",
   "koodiArvo" : "337106",
@@ -4082,7 +4082,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_337107",
   "koodiArvo" : "337107",
@@ -4095,7 +4095,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_337108",
   "koodiArvo" : "337108",
@@ -4108,7 +4108,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_337109",
   "koodiArvo" : "337109",
@@ -4121,7 +4121,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_337110",
   "koodiArvo" : "337110",
@@ -4134,7 +4134,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_337111",
   "koodiArvo" : "337111",
@@ -4147,7 +4147,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_337112",
   "koodiArvo" : "337112",
@@ -4160,7 +4160,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_337113",
   "koodiArvo" : "337113",
@@ -4173,7 +4173,7 @@
     "lyhytNimi" : "Specialyrkesexamen inom fastighetsförvaltning",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_337199",
   "koodiArvo" : "337199",
@@ -4190,7 +4190,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Business and Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_339000",
   "koodiArvo" : "339000",
@@ -4207,7 +4207,7 @@
     "lyhytNimi" : "Other Education in Social Sciences and Business, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_339900",
   "koodiArvo" : "339900",
@@ -4224,7 +4224,7 @@
     "lyhytNimi" : "Other Education in Social Sciences and Business, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_339901",
   "koodiArvo" : "339901",
@@ -4241,7 +4241,7 @@
     "lyhytNimi" : "Other or Unknown Education in Business and Administration, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_339902",
   "koodiArvo" : "339902",
@@ -4258,7 +4258,7 @@
     "lyhytNimi" : "Other or Unknown Education in Clerical Work",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_339999",
   "koodiArvo" : "339999",
@@ -4275,7 +4275,7 @@
     "lyhytNimi" : "Other or Unknown Education in Social Sciences and Business, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_341000",
   "koodiArvo" : "341000",
@@ -4292,7 +4292,7 @@
     "lyhytNimi" : "Vocational Education and Training in Information Technology, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_341100",
   "koodiArvo" : "341100",
@@ -4309,7 +4309,7 @@
     "lyhytNimi" : "Vocational Education and Training in Information Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_341101",
   "koodiArvo" : "341101",
@@ -4326,7 +4326,7 @@
     "lyhytNimi" : "Vocational qualification in Information and Communications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_341102",
   "koodiArvo" : "341102",
@@ -4360,7 +4360,7 @@
     "lyhytNimi" : "Keyboard Operator",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_341152",
   "koodiArvo" : "341152",
@@ -4377,7 +4377,7 @@
     "lyhytNimi" : "Programmer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_341153",
   "koodiArvo" : "341153",
@@ -4394,7 +4394,7 @@
     "lyhytNimi" : "Operator",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_341199",
   "koodiArvo" : "341199",
@@ -4411,7 +4411,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Information Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_344000",
   "koodiArvo" : "344000",
@@ -4428,7 +4428,7 @@
     "lyhytNimi" : "Further Qualification in Information Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_344100",
   "koodiArvo" : "344100",
@@ -4445,7 +4445,7 @@
     "lyhytNimi" : "Further Qualification in Information Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_344101",
   "koodiArvo" : "344101",
@@ -4462,7 +4462,7 @@
     "lyhytNimi" : "Further vocational qualification in Information and Communication Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_344102",
   "koodiArvo" : "344102",
@@ -4479,7 +4479,7 @@
     "lyhytNimi" : "Further Qualification of  PC Support Specialist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_344103",
   "koodiArvo" : "344103",
@@ -4513,7 +4513,7 @@
     "lyhytNimi" : "Specialist Qualification in Information Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_347100",
   "koodiArvo" : "347100",
@@ -4530,7 +4530,7 @@
     "lyhytNimi" : "Specialist Qualification in Information Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_347101",
   "koodiArvo" : "347101",
@@ -4547,7 +4547,7 @@
     "lyhytNimi" : "Information and Communications Technology, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351000",
   "koodiArvo" : "351000",
@@ -4564,7 +4564,7 @@
     "lyhytNimi" : "Vocational Education and Training in Technology, Upper Secondary Level Education (Metalwork, Heating, Vehicles, Electrics, IT, Chemistry and Wood)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351100",
   "koodiArvo" : "351100",
@@ -4581,7 +4581,7 @@
     "lyhytNimi" : "Vocational Education and Training in Metalwork and Machinery",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351101",
   "koodiArvo" : "351101",
@@ -4598,7 +4598,7 @@
     "lyhytNimi" : "Metalwork and Machinery, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351102",
   "koodiArvo" : "351102",
@@ -4615,7 +4615,7 @@
     "lyhytNimi" : "Machining, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351103",
   "koodiArvo" : "351103",
@@ -4632,7 +4632,7 @@
     "lyhytNimi" : "Mechanical Fitter, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351104",
   "koodiArvo" : "351104",
@@ -4649,7 +4649,7 @@
     "lyhytNimi" : "Sheet-Metal Work and Welding, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351105",
   "koodiArvo" : "351105",
@@ -4666,7 +4666,7 @@
     "lyhytNimi" : "Watchmaker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351106",
   "koodiArvo" : "351106",
@@ -4683,7 +4683,7 @@
     "lyhytNimi" : "Watchmaking and Micromechanics, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351107",
   "koodiArvo" : "351107",
@@ -4700,7 +4700,7 @@
     "lyhytNimi" : "Vocational qualification in Mining",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351108",
   "koodiArvo" : "351108",
@@ -4717,7 +4717,7 @@
     "lyhytNimi" : "Vocational Qualification in Mechanical Engineering and Production Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_351151",
   "koodiArvo" : "351151",
@@ -4734,7 +4734,7 @@
     "lyhytNimi" : "Mechanical Fitter/Machinist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351152",
   "koodiArvo" : "351152",
@@ -4751,7 +4751,7 @@
     "lyhytNimi" : "Precision Mechanic",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351153",
   "koodiArvo" : "351153",
@@ -4768,7 +4768,7 @@
     "lyhytNimi" : "Service Fitter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351154",
   "koodiArvo" : "351154",
@@ -4785,7 +4785,7 @@
     "lyhytNimi" : "Miner",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351156",
   "koodiArvo" : "351156",
@@ -4802,7 +4802,7 @@
     "lyhytNimi" : "Mechanical Fitter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351157",
   "koodiArvo" : "351157",
@@ -4819,7 +4819,7 @@
     "lyhytNimi" : "Machine Repairer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351158",
   "koodiArvo" : "351158",
@@ -4836,7 +4836,7 @@
     "lyhytNimi" : "Machine Operator, Machine Attendant",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351159",
   "koodiArvo" : "351159",
@@ -4853,7 +4853,7 @@
     "lyhytNimi" : "Machinist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351160",
   "koodiArvo" : "351160",
@@ -4870,7 +4870,7 @@
     "lyhytNimi" : "Master Mechanic",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351161",
   "koodiArvo" : "351161",
@@ -4887,7 +4887,7 @@
     "lyhytNimi" : "Plant Fitter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351162",
   "koodiArvo" : "351162",
@@ -4904,7 +4904,7 @@
     "lyhytNimi" : "Plater-Welder",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351164",
   "koodiArvo" : "351164",
@@ -4921,7 +4921,7 @@
     "lyhytNimi" : "Mechanic, Workshop Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351165",
   "koodiArvo" : "351165",
@@ -4938,7 +4938,7 @@
     "lyhytNimi" : "Mechanic, Production Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351166",
   "koodiArvo" : "351166",
@@ -4955,7 +4955,7 @@
     "lyhytNimi" : "Mechanic, Machine Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351167",
   "koodiArvo" : "351167",
@@ -4972,7 +4972,7 @@
     "lyhytNimi" : "Mechanic, Foundry Patternmaking",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351168",
   "koodiArvo" : "351168",
@@ -4989,7 +4989,7 @@
     "lyhytNimi" : "Mechanic, Casting Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351169",
   "koodiArvo" : "351169",
@@ -5006,7 +5006,7 @@
     "lyhytNimi" : "Metal Worker, Metallurgical Worker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351171",
   "koodiArvo" : "351171",
@@ -5023,7 +5023,7 @@
     "lyhytNimi" : "Sewing-Machine Mechanic",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351172",
   "koodiArvo" : "351172",
@@ -5040,7 +5040,7 @@
     "lyhytNimi" : "Blacksmith",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351173",
   "koodiArvo" : "351173",
@@ -5057,7 +5057,7 @@
     "lyhytNimi" : "Textile Machine Mechanic",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351174",
   "koodiArvo" : "351174",
@@ -5074,7 +5074,7 @@
     "lyhytNimi" : "Instrument Maker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351199",
   "koodiArvo" : "351199",
@@ -5091,7 +5091,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Metalwork and Machinery",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351200",
   "koodiArvo" : "351200",
@@ -5108,7 +5108,7 @@
     "lyhytNimi" : "Vocational Education and Training in Heating and Ventilation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351201",
   "koodiArvo" : "351201",
@@ -5125,7 +5125,7 @@
     "lyhytNimi" : "Heating and Ventilation Engineering, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351202",
   "koodiArvo" : "351202",
@@ -5142,7 +5142,7 @@
     "lyhytNimi" : "Real Estate Maintenance, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351203",
   "koodiArvo" : "351203",
@@ -5159,7 +5159,7 @@
     "lyhytNimi" : "Vocational qualification in Building Maintenance Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351204",
   "koodiArvo" : "351204",
@@ -5176,7 +5176,7 @@
     "lyhytNimi" : "Property Maintenance Services, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351251",
   "koodiArvo" : "351251",
@@ -5193,7 +5193,7 @@
     "lyhytNimi" : "Ventilation Pipefitter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351252",
   "koodiArvo" : "351252",
@@ -5210,7 +5210,7 @@
     "lyhytNimi" : "Property Maintenance Operative",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351253",
   "koodiArvo" : "351253",
@@ -5227,7 +5227,7 @@
     "lyhytNimi" : "Pipefitter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351299",
   "koodiArvo" : "351299",
@@ -5244,7 +5244,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Heating and Ventilation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351300",
   "koodiArvo" : "351300",
@@ -5261,24 +5261,24 @@
     "lyhytNimi" : "Vocational Education and Training in Vehicles and Transportation",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351301",
   "koodiArvo" : "351301",
   "metadata" : [ {
-    "nimi" : "Ajoneuvoalan perustutkinto",
-    "lyhytNimi" : "Ajoneuvoalan perustutkinto",
+    "nimi" : "Autoalan perustutkinto",
+    "lyhytNimi" : "Autoalan perustutkinto",
     "kieli" : "FI"
   }, {
-    "nimi" : "Grundexamen inom fordonsbranschen",
-    "lyhytNimi" : "Grundexamen inom fordonsbranschen",
+    "nimi" : "Grundexamen inom bilbranschen",
+    "lyhytNimi" : "Grundexamen inom bilbranschen",
     "kieli" : "SV"
   }, {
     "nimi" : "Vocational qualification in the Vehicle Sector",
     "lyhytNimi" : "Vocational qualification in the Vehicle Sector",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351302",
   "koodiArvo" : "351302",
@@ -5295,7 +5295,7 @@
     "lyhytNimi" : "Vehicle Mechanic, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351303",
   "koodiArvo" : "351303",
@@ -5312,7 +5312,7 @@
     "lyhytNimi" : "Vehicle Body Repairer, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351304",
   "koodiArvo" : "351304",
@@ -5329,7 +5329,7 @@
     "lyhytNimi" : "Vehicle Painter, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351305",
   "koodiArvo" : "351305",
@@ -5346,7 +5346,7 @@
     "lyhytNimi" : "Ship's Mechanic, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351306",
   "koodiArvo" : "351306",
@@ -5363,7 +5363,7 @@
     "lyhytNimi" : "Aircraft Maintenance Technician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351307",
   "koodiArvo" : "351307",
@@ -5380,7 +5380,7 @@
     "lyhytNimi" : "Vocational qualification in Aircraft Maintenance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351351",
   "koodiArvo" : "351351",
@@ -5397,7 +5397,7 @@
     "lyhytNimi" : "Vehicle Service Mechanic",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351352",
   "koodiArvo" : "351352",
@@ -5414,7 +5414,7 @@
     "lyhytNimi" : "Diesel Mechanic",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351353",
   "koodiArvo" : "351353",
@@ -5431,7 +5431,7 @@
     "lyhytNimi" : "Ship's Mechanical Fitter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351354",
   "koodiArvo" : "351354",
@@ -5448,7 +5448,7 @@
     "lyhytNimi" : "Ship's Pipefitter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351355",
   "koodiArvo" : "351355",
@@ -5465,7 +5465,7 @@
     "lyhytNimi" : "Aircraft Service Mechanic",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351356",
   "koodiArvo" : "351356",
@@ -5482,7 +5482,7 @@
     "lyhytNimi" : "Excavation Machinery Mechanic",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351357",
   "koodiArvo" : "351357",
@@ -5499,7 +5499,7 @@
     "lyhytNimi" : "Mechanic, Vehicle Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351358",
   "koodiArvo" : "351358",
@@ -5516,7 +5516,7 @@
     "lyhytNimi" : "Mechanic, Vehicle Body Repairing",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351359",
   "koodiArvo" : "351359",
@@ -5533,7 +5533,7 @@
     "lyhytNimi" : "Mechanic, Vehicle Painting",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351360",
   "koodiArvo" : "351360",
@@ -5550,7 +5550,7 @@
     "lyhytNimi" : "Mechanic, Vehicles",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351361",
   "koodiArvo" : "351361",
@@ -5567,7 +5567,7 @@
     "lyhytNimi" : "Engine Mechanic",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351362",
   "koodiArvo" : "351362",
@@ -5584,7 +5584,7 @@
     "lyhytNimi" : "Power Tool Mechanic",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351363",
   "koodiArvo" : "351363",
@@ -5601,7 +5601,7 @@
     "lyhytNimi" : "Agricultural Mechanic",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351364",
   "koodiArvo" : "351364",
@@ -5618,7 +5618,7 @@
     "lyhytNimi" : "Forest Machine Mechanic",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351399",
   "koodiArvo" : "351399",
@@ -5635,7 +5635,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Vehicles and Transportation",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351400",
   "koodiArvo" : "351400",
@@ -5652,7 +5652,7 @@
     "lyhytNimi" : "Vocational Education and Training in Electrical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351401",
   "koodiArvo" : "351401",
@@ -5669,7 +5669,7 @@
     "lyhytNimi" : "Electrical Engineering, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351402",
   "koodiArvo" : "351402",
@@ -5686,7 +5686,7 @@
     "lyhytNimi" : "Electrical Power Engineering, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351403",
   "koodiArvo" : "351403",
@@ -5703,7 +5703,7 @@
     "lyhytNimi" : "Automation Technology, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351404",
   "koodiArvo" : "351404",
@@ -5720,7 +5720,7 @@
     "lyhytNimi" : "Ship's Electrician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351406",
   "koodiArvo" : "351406",
@@ -5737,7 +5737,7 @@
     "lyhytNimi" : "Aircraft Electronics Assembler",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351407",
   "koodiArvo" : "351407",
@@ -5754,7 +5754,7 @@
     "lyhytNimi" : "Vocational qualification in Electrical Engineering and Automation Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351451",
   "koodiArvo" : "351451",
@@ -5771,7 +5771,7 @@
     "lyhytNimi" : "Vehicle Electrician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351452",
   "koodiArvo" : "351452",
@@ -5788,7 +5788,7 @@
     "lyhytNimi" : "Electronics Assembler",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351453",
   "koodiArvo" : "351453",
@@ -5805,7 +5805,7 @@
     "lyhytNimi" : "Instrument and Instrumentation Mechanic",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351454",
   "koodiArvo" : "351454",
@@ -5822,7 +5822,7 @@
     "lyhytNimi" : "Aircraft Electrician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351455",
   "koodiArvo" : "351455",
@@ -5839,7 +5839,7 @@
     "lyhytNimi" : "Mechanic, Automation Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351456",
   "koodiArvo" : "351456",
@@ -5856,7 +5856,7 @@
     "lyhytNimi" : "Mechanic, Electrical Power Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351457",
   "koodiArvo" : "351457",
@@ -5873,7 +5873,7 @@
     "lyhytNimi" : "Telephone Mechanic",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351458",
   "koodiArvo" : "351458",
@@ -5890,7 +5890,7 @@
     "lyhytNimi" : "Radio and Television Mechanic",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351459",
   "koodiArvo" : "351459",
@@ -5907,7 +5907,7 @@
     "lyhytNimi" : "Electrician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351460",
   "koodiArvo" : "351460",
@@ -5924,7 +5924,7 @@
     "lyhytNimi" : "Electric Machine Mechanic",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351461",
   "koodiArvo" : "351461",
@@ -5941,7 +5941,7 @@
     "lyhytNimi" : "Power Plant Mechanic",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351462",
   "koodiArvo" : "351462",
@@ -5958,7 +5958,7 @@
     "lyhytNimi" : "Power Electronics Mechanic",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351463",
   "koodiArvo" : "351463",
@@ -5975,7 +5975,7 @@
     "lyhytNimi" : "Industrial Electrician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351499",
   "koodiArvo" : "351499",
@@ -5992,7 +5992,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Electrical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351500",
   "koodiArvo" : "351500",
@@ -6009,7 +6009,7 @@
     "lyhytNimi" : "Vocational Education and Training in Information Technology and Telecommunications",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351501",
   "koodiArvo" : "351501",
@@ -6026,7 +6026,7 @@
     "lyhytNimi" : "Information Technology, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351502",
   "koodiArvo" : "351502",
@@ -6043,7 +6043,7 @@
     "lyhytNimi" : "Vocational qualification in Information and Telecommunications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351551",
   "koodiArvo" : "351551",
@@ -6060,7 +6060,7 @@
     "lyhytNimi" : "Mechanic, Information Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351552",
   "koodiArvo" : "351552",
@@ -6077,7 +6077,7 @@
     "lyhytNimi" : "Radio Operator",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351599",
   "koodiArvo" : "351599",
@@ -6094,7 +6094,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Information Technology and Telecommunications",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351600",
   "koodiArvo" : "351600",
@@ -6111,7 +6111,7 @@
     "lyhytNimi" : "Vocational Education and Training in Paper Industry and Chemical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351601",
   "koodiArvo" : "351601",
@@ -6128,7 +6128,7 @@
     "lyhytNimi" : "Chemical Engineering, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351602",
   "koodiArvo" : "351602",
@@ -6145,7 +6145,7 @@
     "lyhytNimi" : "Paper Industry, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351603",
   "koodiArvo" : "351603",
@@ -6162,7 +6162,7 @@
     "lyhytNimi" : "Vocational qualification in Laboratory Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351604",
   "koodiArvo" : "351604",
@@ -6179,7 +6179,7 @@
     "lyhytNimi" : "Chemical Engineering, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351605",
   "koodiArvo" : "351605",
@@ -6196,7 +6196,7 @@
     "lyhytNimi" : "Vocational qualification in the Process Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351651",
   "koodiArvo" : "351651",
@@ -6213,7 +6213,7 @@
     "lyhytNimi" : "Process Operator",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351652",
   "koodiArvo" : "351652",
@@ -6230,7 +6230,7 @@
     "lyhytNimi" : "Laboratory Technician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351653",
   "koodiArvo" : "351653",
@@ -6247,7 +6247,7 @@
     "lyhytNimi" : "Laboratory Assistant, Chemistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351654",
   "koodiArvo" : "351654",
@@ -6264,7 +6264,7 @@
     "lyhytNimi" : "Laboratory Assistant, Pharmaceutical Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351655",
   "koodiArvo" : "351655",
@@ -6281,7 +6281,7 @@
     "lyhytNimi" : "Pulp and Paper Industry, Vocational Education and Training",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351656",
   "koodiArvo" : "351656",
@@ -6298,7 +6298,7 @@
     "lyhytNimi" : "Paper Process Operator",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351699",
   "koodiArvo" : "351699",
@@ -6315,7 +6315,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Paper Industry and Chemical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351700",
   "koodiArvo" : "351700",
@@ -6332,7 +6332,7 @@
     "lyhytNimi" : "Vocational Education and Training in Wood Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351701",
   "koodiArvo" : "351701",
@@ -6349,7 +6349,7 @@
     "lyhytNimi" : "Wood Processing, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351702",
   "koodiArvo" : "351702",
@@ -6366,7 +6366,7 @@
     "lyhytNimi" : "Blade Maintenance, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351703",
   "koodiArvo" : "351703",
@@ -6383,7 +6383,7 @@
     "lyhytNimi" : "Vocational Qualification in Boat Building",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351704",
   "koodiArvo" : "351704",
@@ -6400,7 +6400,7 @@
     "lyhytNimi" : "Upholstery, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351741",
   "koodiArvo" : "351741",
@@ -6417,7 +6417,7 @@
     "lyhytNimi" : "Vocational qualification in the Wood Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_451741",
   "koodiArvo" : "451741",
@@ -6451,7 +6451,7 @@
     "lyhytNimi" : "Panel Industry Process Operator",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351752",
   "koodiArvo" : "351752",
@@ -6468,7 +6468,7 @@
     "lyhytNimi" : "Mechanic, Wood Industry Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351753",
   "koodiArvo" : "351753",
@@ -6485,7 +6485,7 @@
     "lyhytNimi" : "Mechanical Wood Processing, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351754",
   "koodiArvo" : "351754",
@@ -6502,7 +6502,7 @@
     "lyhytNimi" : "Surface Treatment Finisher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351755",
   "koodiArvo" : "351755",
@@ -6519,7 +6519,7 @@
     "lyhytNimi" : "Joiner",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351756",
   "koodiArvo" : "351756",
@@ -6536,7 +6536,7 @@
     "lyhytNimi" : "Wood Industry Blade and Instrument Fitter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351757",
   "koodiArvo" : "351757",
@@ -6547,7 +6547,7 @@
     "nimi" : "Sahatyönjohtaja",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_351758",
   "koodiArvo" : "351758",
@@ -6564,7 +6564,7 @@
     "lyhytNimi" : "Sawmill Process Operator",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351759",
   "koodiArvo" : "351759",
@@ -6581,7 +6581,7 @@
     "lyhytNimi" : "Boat-Builder",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351760",
   "koodiArvo" : "351760",
@@ -6598,7 +6598,7 @@
     "lyhytNimi" : "Upholsterer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351799",
   "koodiArvo" : "351799",
@@ -6615,7 +6615,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Wood Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351800",
   "koodiArvo" : "351800",
@@ -6632,7 +6632,7 @@
     "lyhytNimi" : "Vocational Education and Training in Surface Treatment Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351801",
   "koodiArvo" : "351801",
@@ -6649,7 +6649,7 @@
     "lyhytNimi" : "Industrial Surface Treatment, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351802",
   "koodiArvo" : "351802",
@@ -6666,7 +6666,7 @@
     "lyhytNimi" : "Special Surface Treatment, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351803",
   "koodiArvo" : "351803",
@@ -6683,7 +6683,7 @@
     "lyhytNimi" : "Painting, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351804",
   "koodiArvo" : "351804",
@@ -6700,7 +6700,7 @@
     "lyhytNimi" : "Special Painting, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351805",
   "koodiArvo" : "351805",
@@ -6717,7 +6717,7 @@
     "lyhytNimi" : "Vocational qualification in Surface Treatment Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351851",
   "koodiArvo" : "351851",
@@ -6734,7 +6734,7 @@
     "lyhytNimi" : "Painter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351852",
   "koodiArvo" : "351852",
@@ -6751,7 +6751,7 @@
     "lyhytNimi" : "Metal Painter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_351899",
   "koodiArvo" : "351899",
@@ -6768,7 +6768,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Surface Treatment Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352000",
   "koodiArvo" : "352000",
@@ -6785,7 +6785,7 @@
     "lyhytNimi" : "Vocational Education and Training in Technology, Upper Secondary Level Education (Food, Construction, Land Survey, Textiles and Graphics)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352100",
   "koodiArvo" : "352100",
@@ -6802,7 +6802,7 @@
     "lyhytNimi" : "Vocational Education and Training in Food Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352101",
   "koodiArvo" : "352101",
@@ -6819,7 +6819,7 @@
     "lyhytNimi" : "Vocational qualification in Food Production",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352102",
   "koodiArvo" : "352102",
@@ -6836,7 +6836,7 @@
     "lyhytNimi" : "Confectioner",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352103",
   "koodiArvo" : "352103",
@@ -6853,7 +6853,7 @@
     "lyhytNimi" : "Milk Processing, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352104",
   "koodiArvo" : "352104",
@@ -6870,7 +6870,7 @@
     "lyhytNimi" : "Dairyperson",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352151",
   "koodiArvo" : "352151",
@@ -6887,7 +6887,7 @@
     "lyhytNimi" : "Food Industry Laboratory Assistant",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352152",
   "koodiArvo" : "352152",
@@ -6904,7 +6904,7 @@
     "lyhytNimi" : "Industrial Food Processor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352153",
   "koodiArvo" : "352153",
@@ -6921,7 +6921,7 @@
     "lyhytNimi" : "Baker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352154",
   "koodiArvo" : "352154",
@@ -6938,7 +6938,7 @@
     "lyhytNimi" : "Meat Industry Technician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352155",
   "koodiArvo" : "352155",
@@ -6955,7 +6955,7 @@
     "lyhytNimi" : "Meat Processing Worker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352156",
   "koodiArvo" : "352156",
@@ -6972,7 +6972,7 @@
     "lyhytNimi" : "Milk Processor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352157",
   "koodiArvo" : "352157",
@@ -6989,7 +6989,7 @@
     "lyhytNimi" : "Miller, Mill Worker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352199",
   "koodiArvo" : "352199",
@@ -7006,7 +7006,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Food Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352200",
   "koodiArvo" : "352200",
@@ -7023,7 +7023,7 @@
     "lyhytNimi" : "Vocational Education and Training in Construction Technology and Community Development and Maintenance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352201",
   "koodiArvo" : "352201",
@@ -7040,7 +7040,7 @@
     "lyhytNimi" : "Vocational qualification in Construction",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352251",
   "koodiArvo" : "352251",
@@ -7057,7 +7057,7 @@
     "lyhytNimi" : "Concrete Builder",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352252",
   "koodiArvo" : "352252",
@@ -7074,7 +7074,7 @@
     "lyhytNimi" : "Carpenter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352253",
   "koodiArvo" : "352253",
@@ -7091,7 +7091,7 @@
     "lyhytNimi" : "Bricklayer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352254",
   "koodiArvo" : "352254",
@@ -7108,7 +7108,7 @@
     "lyhytNimi" : "Builder",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352255",
   "koodiArvo" : "352255",
@@ -7125,7 +7125,7 @@
     "lyhytNimi" : "Community Development and Maintenance Builder",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352299",
   "koodiArvo" : "352299",
@@ -7142,7 +7142,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Construction Technology and Community Development and Maintenance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352300",
   "koodiArvo" : "352300",
@@ -7159,7 +7159,7 @@
     "lyhytNimi" : "Vocational Education and Training in Land Survey Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352301",
   "koodiArvo" : "352301",
@@ -7176,7 +7176,7 @@
     "lyhytNimi" : "Vocational qualification in Land Surveying",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352302",
   "koodiArvo" : "352302",
@@ -7193,7 +7193,7 @@
     "lyhytNimi" : "Surveyor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352351",
   "koodiArvo" : "352351",
@@ -7210,7 +7210,7 @@
     "lyhytNimi" : "Mechanic, Land Survey Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352399",
   "koodiArvo" : "352399",
@@ -7227,7 +7227,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Land Survey Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352400",
   "koodiArvo" : "352400",
@@ -7244,7 +7244,7 @@
     "lyhytNimi" : "Vocational Education and Training in Textiles and Clothing",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352401",
   "koodiArvo" : "352401",
@@ -7261,7 +7261,7 @@
     "lyhytNimi" : "Textiles and Clothing, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352402",
   "koodiArvo" : "352402",
@@ -7278,7 +7278,7 @@
     "lyhytNimi" : "Dressmaker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352403",
   "koodiArvo" : "352403",
@@ -7295,7 +7295,7 @@
     "lyhytNimi" : "Tailor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352404",
   "koodiArvo" : "352404",
@@ -7312,7 +7312,7 @@
     "lyhytNimi" : "Milliner",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352405",
   "koodiArvo" : "352405",
@@ -7329,7 +7329,7 @@
     "lyhytNimi" : "Shoemaking, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352406",
   "koodiArvo" : "352406",
@@ -7346,7 +7346,7 @@
     "lyhytNimi" : "Fur Production, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352407",
   "koodiArvo" : "352407",
@@ -7363,7 +7363,7 @@
     "lyhytNimi" : "Textiles, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352408",
   "koodiArvo" : "352408",
@@ -7380,7 +7380,7 @@
     "lyhytNimi" : "Clothing, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352441",
   "koodiArvo" : "352441",
@@ -7397,7 +7397,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_352451",
   "koodiArvo" : "352451",
@@ -7414,7 +7414,7 @@
     "lyhytNimi" : "Shoemaker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352452",
   "koodiArvo" : "352452",
@@ -7431,7 +7431,7 @@
     "lyhytNimi" : "Patternmaker-Cutter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352453",
   "koodiArvo" : "352453",
@@ -7448,7 +7448,7 @@
     "lyhytNimi" : "Spinner",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352454",
   "koodiArvo" : "352454",
@@ -7465,7 +7465,7 @@
     "lyhytNimi" : "Weaver",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352455",
   "koodiArvo" : "352455",
@@ -7482,7 +7482,7 @@
     "lyhytNimi" : "Cutter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352456",
   "koodiArvo" : "352456",
@@ -7499,7 +7499,7 @@
     "lyhytNimi" : "Patternmaker, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352457",
   "koodiArvo" : "352457",
@@ -7516,7 +7516,7 @@
     "lyhytNimi" : "Milliner, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352458",
   "koodiArvo" : "352458",
@@ -7533,7 +7533,7 @@
     "lyhytNimi" : "Hosiery Worker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352459",
   "koodiArvo" : "352459",
@@ -7550,7 +7550,7 @@
     "lyhytNimi" : "Dressmaker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352460",
   "koodiArvo" : "352460",
@@ -7567,7 +7567,7 @@
     "lyhytNimi" : "Garment Maker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352461",
   "koodiArvo" : "352461",
@@ -7584,7 +7584,7 @@
     "lyhytNimi" : "Dressmaker, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352462",
   "koodiArvo" : "352462",
@@ -7601,7 +7601,7 @@
     "lyhytNimi" : "Textiles Maker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352463",
   "koodiArvo" : "352463",
@@ -7618,7 +7618,7 @@
     "lyhytNimi" : "Industrial Dressmaker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352464",
   "koodiArvo" : "352464",
@@ -7635,7 +7635,7 @@
     "lyhytNimi" : "Fur Garment Producer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352465",
   "koodiArvo" : "352465",
@@ -7646,7 +7646,7 @@
     "nimi" : "Vaatetusteknikko",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_352466",
   "koodiArvo" : "352466",
@@ -7663,7 +7663,7 @@
     "lyhytNimi" : "Tailor, Model Garment Maker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352499",
   "koodiArvo" : "352499",
@@ -7680,7 +7680,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Textiles and Clothing",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352500",
   "koodiArvo" : "352500",
@@ -7697,7 +7697,7 @@
     "lyhytNimi" : "Vocational Education and Training in Graphics Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352501",
   "koodiArvo" : "352501",
@@ -7714,7 +7714,7 @@
     "lyhytNimi" : "Graphic Arts Technology, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352502",
   "koodiArvo" : "352502",
@@ -7731,7 +7731,7 @@
     "lyhytNimi" : "Image Processing, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352503",
   "koodiArvo" : "352503",
@@ -7748,7 +7748,7 @@
     "lyhytNimi" : "Publishing and Printing, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352551",
   "koodiArvo" : "352551",
@@ -7765,7 +7765,7 @@
     "lyhytNimi" : "Print-Shop Foreman",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352552",
   "koodiArvo" : "352552",
@@ -7782,7 +7782,7 @@
     "lyhytNimi" : "Bookprinting, Vocational Education and Training",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352553",
   "koodiArvo" : "352553",
@@ -7799,7 +7799,7 @@
     "lyhytNimi" : "Image Processor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352554",
   "koodiArvo" : "352554",
@@ -7816,7 +7816,7 @@
     "lyhytNimi" : "Mechanic, Bindery",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352555",
   "koodiArvo" : "352555",
@@ -7833,7 +7833,7 @@
     "lyhytNimi" : "Mechanic, Preparation of Printing Surface",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352556",
   "koodiArvo" : "352556",
@@ -7850,7 +7850,7 @@
     "lyhytNimi" : "Mechanic, Printing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352557",
   "koodiArvo" : "352557",
@@ -7867,7 +7867,7 @@
     "lyhytNimi" : "Text Processor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352558",
   "koodiArvo" : "352558",
@@ -7884,7 +7884,7 @@
     "lyhytNimi" : "Photographic Laboratory Assistant",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352599",
   "koodiArvo" : "352599",
@@ -7901,7 +7901,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Graphics Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352900",
   "koodiArvo" : "352900",
@@ -7918,7 +7918,7 @@
     "lyhytNimi" : "Other Vocational Education and Training in Technology, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352901",
   "koodiArvo" : "352901",
@@ -7935,7 +7935,7 @@
     "lyhytNimi" : "Technical Draughtsman, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352902",
   "koodiArvo" : "352902",
@@ -7952,7 +7952,7 @@
     "lyhytNimi" : "Plastics and Rubber Technology, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352903",
   "koodiArvo" : "352903",
@@ -7969,7 +7969,7 @@
     "lyhytNimi" : "Vocational qualification in Technical Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352951",
   "koodiArvo" : "352951",
@@ -7986,7 +7986,7 @@
     "lyhytNimi" : "Machine Draughtsman",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352952",
   "koodiArvo" : "352952",
@@ -8003,7 +8003,7 @@
     "lyhytNimi" : "Construction Draughtsman",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352953",
   "koodiArvo" : "352953",
@@ -8020,7 +8020,7 @@
     "lyhytNimi" : "Electrical Draughtsman",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352954",
   "koodiArvo" : "352954",
@@ -8037,7 +8037,7 @@
     "lyhytNimi" : "Brush Maker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352955",
   "koodiArvo" : "352955",
@@ -8054,7 +8054,7 @@
     "lyhytNimi" : "Basket Weaver",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352956",
   "koodiArvo" : "352956",
@@ -8071,7 +8071,7 @@
     "lyhytNimi" : "Glass Worker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352957",
   "koodiArvo" : "352957",
@@ -8088,7 +8088,7 @@
     "lyhytNimi" : "Plastic and Rubber Industry, Vocational Education and Training",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_352999",
   "koodiArvo" : "352999",
@@ -8105,7 +8105,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Technology, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354000",
   "koodiArvo" : "354000",
@@ -8122,7 +8122,7 @@
     "lyhytNimi" : "Further Qualification in Technology (Metalwork, Heating and Ventilation, Vehicles, Electrics, IT, Chemistry, Wood Industry and Surface Treatment)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354100",
   "koodiArvo" : "354100",
@@ -8139,7 +8139,7 @@
     "lyhytNimi" : "Further Qualification in Metalwork and Machinery",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354101",
   "koodiArvo" : "354101",
@@ -8156,7 +8156,7 @@
     "lyhytNimi" : "Welder, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354102",
   "koodiArvo" : "354102",
@@ -8173,7 +8173,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354103",
   "koodiArvo" : "354103",
@@ -8190,7 +8190,7 @@
     "lyhytNimi" : "Mechanical Fitter, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354104",
   "koodiArvo" : "354104",
@@ -8207,7 +8207,7 @@
     "lyhytNimi" : "Machinist, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354105",
   "koodiArvo" : "354105",
@@ -8224,7 +8224,7 @@
     "lyhytNimi" : "Plate and Sheet Metal Technology, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354106",
   "koodiArvo" : "354106",
@@ -8241,7 +8241,7 @@
     "lyhytNimi" : "Locksmith, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354107",
   "koodiArvo" : "354107",
@@ -8258,7 +8258,7 @@
     "lyhytNimi" : "Construction Sheet-Metal Worker, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354108",
   "koodiArvo" : "354108",
@@ -8275,7 +8275,7 @@
     "lyhytNimi" : "Casting Technology, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354109",
   "koodiArvo" : "354109",
@@ -8292,7 +8292,7 @@
     "lyhytNimi" : "Foundry Patternmaking, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354110",
   "koodiArvo" : "354110",
@@ -8309,7 +8309,7 @@
     "lyhytNimi" : "Base Metal Industry, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354111",
   "koodiArvo" : "354111",
@@ -8326,7 +8326,7 @@
     "lyhytNimi" : "Lift Mechanic, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354112",
   "koodiArvo" : "354112",
@@ -8343,7 +8343,7 @@
     "lyhytNimi" : "Instrument Maker, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354113",
   "koodiArvo" : "354113",
@@ -8360,7 +8360,7 @@
     "lyhytNimi" : "Further vocational qualification in Mining",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354114",
   "koodiArvo" : "354114",
@@ -8377,7 +8377,7 @@
     "lyhytNimi" : "Further Qualification in the Ship-building Sector",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354115",
   "koodiArvo" : "354115",
@@ -8394,7 +8394,7 @@
     "lyhytNimi" : "Maintenance, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354116",
   "koodiArvo" : "354116",
@@ -8424,7 +8424,7 @@
     "lyhytNimi" : "Further vocational qualification in Machine Mechanics and Maintenance",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_354199",
   "koodiArvo" : "354199",
@@ -8441,7 +8441,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Metalwork and Machinery",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354200",
   "koodiArvo" : "354200",
@@ -8458,7 +8458,7 @@
     "lyhytNimi" : "Further Qualification in Heating and Ventilation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354201",
   "koodiArvo" : "354201",
@@ -8475,7 +8475,7 @@
     "lyhytNimi" : "Ventilation Pipefitter, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354202",
   "koodiArvo" : "354202",
@@ -8492,7 +8492,7 @@
     "lyhytNimi" : "District Heating Fitter, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354203",
   "koodiArvo" : "354203",
@@ -8509,7 +8509,7 @@
     "lyhytNimi" : "Property Maintenance Operative, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354204",
   "koodiArvo" : "354204",
@@ -8522,7 +8522,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_354205",
   "koodiArvo" : "354205",
@@ -8539,7 +8539,7 @@
     "lyhytNimi" : "Refrigeration Fitting, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354206",
   "koodiArvo" : "354206",
@@ -8556,7 +8556,7 @@
     "lyhytNimi" : "Chimneysweep, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354207",
   "koodiArvo" : "354207",
@@ -8573,7 +8573,7 @@
     "lyhytNimi" : "Pipefitter, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354208",
   "koodiArvo" : "354208",
@@ -8590,7 +8590,7 @@
     "lyhytNimi" : "Pipe Insulation, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354209",
   "koodiArvo" : "354209",
@@ -8607,7 +8607,7 @@
     "lyhytNimi" : "Technical Insulation, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354210",
   "koodiArvo" : "354210",
@@ -8624,7 +8624,7 @@
     "lyhytNimi" : "Industrial Insulation, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354211",
   "koodiArvo" : "354211",
@@ -8641,7 +8641,7 @@
     "lyhytNimi" : "Industrial Pipefitter, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354212",
   "koodiArvo" : "354212",
@@ -8658,7 +8658,7 @@
     "lyhytNimi" : "Ventilation System Cleaning, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354245",
   "koodiArvo" : "354245",
@@ -8675,7 +8675,7 @@
     "lyhytNimi" : "Talotekniikan at",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_354299",
   "koodiArvo" : "354299",
@@ -8692,7 +8692,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Heating and Ventilation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354300",
   "koodiArvo" : "354300",
@@ -8709,7 +8709,7 @@
     "lyhytNimi" : "Further Qualification in Vehicles and Transportation",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354301",
   "koodiArvo" : "354301",
@@ -8726,7 +8726,7 @@
     "lyhytNimi" : "Vehicle Crane Operator, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354302",
   "koodiArvo" : "354302",
@@ -8743,7 +8743,7 @@
     "lyhytNimi" : "Vehicle Body Mechanic, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354303",
   "koodiArvo" : "354303",
@@ -8760,7 +8760,7 @@
     "lyhytNimi" : "Vehicle Mechanic, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354305",
   "koodiArvo" : "354305",
@@ -8777,7 +8777,7 @@
     "lyhytNimi" : "Vehicle Electrician, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354306",
   "koodiArvo" : "354306",
@@ -8794,7 +8794,7 @@
     "lyhytNimi" : "Diesel Mechanic, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354307",
   "koodiArvo" : "354307",
@@ -8811,7 +8811,7 @@
     "lyhytNimi" : "Vehicle Painter, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354308",
   "koodiArvo" : "354308",
@@ -8828,7 +8828,7 @@
     "lyhytNimi" : "Earthmover Driver, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354309",
   "koodiArvo" : "354309",
@@ -8845,7 +8845,7 @@
     "lyhytNimi" : "Small Machinery Mechanic, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354310",
   "koodiArvo" : "354310",
@@ -8862,7 +8862,7 @@
     "lyhytNimi" : "Heavy Vehicle Mechanic, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354311",
   "koodiArvo" : "354311",
@@ -8879,7 +8879,7 @@
     "lyhytNimi" : "Agricultural Mechanic, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354312",
   "koodiArvo" : "354312",
@@ -8896,7 +8896,7 @@
     "lyhytNimi" : "Car Mechanics, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354313",
   "koodiArvo" : "354313",
@@ -8913,7 +8913,7 @@
     "lyhytNimi" : "Aircraft Technology, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354314",
   "koodiArvo" : "354314",
@@ -8930,7 +8930,7 @@
     "lyhytNimi" : "Tyre Industry, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354315",
   "koodiArvo" : "354315",
@@ -8947,7 +8947,7 @@
     "lyhytNimi" : "Further Qualification for Motor Vehicle and Transport Sector Managers",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354345",
   "koodiArvo" : "354345",
@@ -8964,7 +8964,7 @@
     "lyhytNimi" : "Further vocational qualification in the Motor Vehicles Sector",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_354399",
   "koodiArvo" : "354399",
@@ -8981,7 +8981,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Vehicles and Transportation",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354400",
   "koodiArvo" : "354400",
@@ -8998,7 +8998,7 @@
     "lyhytNimi" : "Further Qualification in Electrical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354401",
   "koodiArvo" : "354401",
@@ -9015,7 +9015,7 @@
     "lyhytNimi" : "Automation Assembler, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354402",
   "koodiArvo" : "354402",
@@ -9032,7 +9032,7 @@
     "lyhytNimi" : "Electronics Assembler, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354403",
   "koodiArvo" : "354403",
@@ -9049,7 +9049,7 @@
     "lyhytNimi" : "Household Appliance Fitter, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354404",
   "koodiArvo" : "354404",
@@ -9066,7 +9066,7 @@
     "lyhytNimi" : "Heating Equipment Fitter, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354405",
   "koodiArvo" : "354405",
@@ -9083,7 +9083,7 @@
     "lyhytNimi" : "Electrician, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354406",
   "koodiArvo" : "354406",
@@ -9100,7 +9100,7 @@
     "lyhytNimi" : "Electrical Network Engineering, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354407",
   "koodiArvo" : "354407",
@@ -9117,7 +9117,7 @@
     "lyhytNimi" : "Eletronics and Power Industry, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354408",
   "koodiArvo" : "354408",
@@ -9134,7 +9134,7 @@
     "lyhytNimi" : "Power Plant Operator, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354409",
   "koodiArvo" : "354409",
@@ -9151,7 +9151,7 @@
     "lyhytNimi" : "Rail Traffic Safety Device Fitter, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354445",
   "koodiArvo" : "354445",
@@ -9168,7 +9168,7 @@
     "lyhytNimi" : "FVQ in Electrical Engineering and Automation Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_354446",
   "koodiArvo" : "354446",
@@ -9185,7 +9185,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_354499",
   "koodiArvo" : "354499",
@@ -9202,7 +9202,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Electrical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354500",
   "koodiArvo" : "354500",
@@ -9219,7 +9219,7 @@
     "lyhytNimi" : "Further Qualification in Information Technology and Telecommunications",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354501",
   "koodiArvo" : "354501",
@@ -9236,7 +9236,7 @@
     "lyhytNimi" : "Computer Mechanic, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354502",
   "koodiArvo" : "354502",
@@ -9253,7 +9253,7 @@
     "lyhytNimi" : "Telecommunications Fitter, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354503",
   "koodiArvo" : "354503",
@@ -9270,7 +9270,7 @@
     "lyhytNimi" : "Further vocational qualification in Information and Telecommunications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354599",
   "koodiArvo" : "354599",
@@ -9287,7 +9287,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Information Technology and Telecommunications",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354600",
   "koodiArvo" : "354600",
@@ -9304,7 +9304,7 @@
     "lyhytNimi" : "Further Qualification in Paper Industry and Chemical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354601",
   "koodiArvo" : "354601",
@@ -9321,7 +9321,7 @@
     "lyhytNimi" : "Chemical Engineering, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354602",
   "koodiArvo" : "354602",
@@ -9338,7 +9338,7 @@
     "lyhytNimi" : "Rubber Processing, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354603",
   "koodiArvo" : "354603",
@@ -9355,7 +9355,7 @@
     "lyhytNimi" : "Plastics Technology, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354604",
   "koodiArvo" : "354604",
@@ -9372,7 +9372,7 @@
     "lyhytNimi" : "Paper Industry, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354605",
   "koodiArvo" : "354605",
@@ -9389,7 +9389,7 @@
     "lyhytNimi" : "Glass and Ceramics, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354645",
   "koodiArvo" : "354645",
@@ -9406,7 +9406,7 @@
     "lyhytNimi" : "Further vocational qualification in Laboratory and Measurement Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_354646",
   "koodiArvo" : "354646",
@@ -9423,7 +9423,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_354699",
   "koodiArvo" : "354699",
@@ -9440,7 +9440,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Paper Industry and Chemical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354700",
   "koodiArvo" : "354700",
@@ -9457,7 +9457,7 @@
     "lyhytNimi" : "Further Qualification in Wood Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354701",
   "koodiArvo" : "354701",
@@ -9474,7 +9474,7 @@
     "lyhytNimi" : "Ornamental Wood Carving, Further Qualification, Process, Chemical and Materials Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354702",
   "koodiArvo" : "354702",
@@ -9491,7 +9491,7 @@
     "lyhytNimi" : "Wood-Based Panel Technology, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354703",
   "koodiArvo" : "354703",
@@ -9508,7 +9508,7 @@
     "lyhytNimi" : "Joiner, Further Qualification, Process, Chemical and Materials Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354704",
   "koodiArvo" : "354704",
@@ -9525,7 +9525,7 @@
     "lyhytNimi" : "Sawmill and Panel Industry Maintenance, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354705",
   "koodiArvo" : "354705",
@@ -9542,7 +9542,7 @@
     "lyhytNimi" : "Sawmill Industry, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354706",
   "koodiArvo" : "354706",
@@ -9559,7 +9559,7 @@
     "lyhytNimi" : "Industrial Joiner, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354707",
   "koodiArvo" : "354707",
@@ -9576,7 +9576,7 @@
     "lyhytNimi" : "Sharp Tool Maintenance, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354708",
   "koodiArvo" : "354708",
@@ -9593,7 +9593,7 @@
     "lyhytNimi" : "Further vocational qualificaiton in Boat Building",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354709",
   "koodiArvo" : "354709",
@@ -9610,7 +9610,7 @@
     "lyhytNimi" : "Upholsterer, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354710",
   "koodiArvo" : "354710",
@@ -9627,7 +9627,7 @@
     "lyhytNimi" : "Further Qualification in the Wood Product Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354745",
   "koodiArvo" : "354745",
@@ -9644,7 +9644,7 @@
     "lyhytNimi" : "Puuteollisuuden at",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_354799",
   "koodiArvo" : "354799",
@@ -9661,7 +9661,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Wood Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354800",
   "koodiArvo" : "354800",
@@ -9678,7 +9678,7 @@
     "lyhytNimi" : "Further Qualification in Surface Treatment Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354801",
   "koodiArvo" : "354801",
@@ -9695,7 +9695,7 @@
     "lyhytNimi" : "Corrosion Prevention Painting, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354802",
   "koodiArvo" : "354802",
@@ -9712,7 +9712,7 @@
     "lyhytNimi" : "Floor Layer, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354803",
   "koodiArvo" : "354803",
@@ -9729,7 +9729,7 @@
     "lyhytNimi" : "Painter, Further Qualification, Process, Chemical and Materials Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354804",
   "koodiArvo" : "354804",
@@ -9746,7 +9746,7 @@
     "lyhytNimi" : "Industrial Surface Treatment, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_354845",
   "koodiArvo" : "354845",
@@ -9763,7 +9763,7 @@
     "lyhytNimi" : "Pintakäsittelyalan at",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_354899",
   "koodiArvo" : "354899",
@@ -9780,7 +9780,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Surface Treatment Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355000",
   "koodiArvo" : "355000",
@@ -9797,7 +9797,7 @@
     "lyhytNimi" : "Further Qualification in Technology (Food Industry, Construction Technology, Land Survey Technology, Textiles and Graphic Technology)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355100",
   "koodiArvo" : "355100",
@@ -9814,7 +9814,7 @@
     "lyhytNimi" : "Further Qualification in Food Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355101",
   "koodiArvo" : "355101",
@@ -9831,7 +9831,7 @@
     "lyhytNimi" : "Confectioner, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355102",
   "koodiArvo" : "355102",
@@ -9848,7 +9848,7 @@
     "lyhytNimi" : "Baker, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355103",
   "koodiArvo" : "355103",
@@ -9865,7 +9865,7 @@
     "lyhytNimi" : "Meat Processing, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355104",
   "koodiArvo" : "355104",
@@ -9882,7 +9882,7 @@
     "lyhytNimi" : "Food Processing, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355105",
   "koodiArvo" : "355105",
@@ -9899,7 +9899,7 @@
     "lyhytNimi" : "Food Industry, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355106",
   "koodiArvo" : "355106",
@@ -9916,7 +9916,7 @@
     "lyhytNimi" : "Meat Industry, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355107",
   "koodiArvo" : "355107",
@@ -9933,7 +9933,7 @@
     "lyhytNimi" : "Milk Processing, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355108",
   "koodiArvo" : "355108",
@@ -9950,7 +9950,7 @@
     "lyhytNimi" : "Bakery Industry, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355109",
   "koodiArvo" : "355109",
@@ -9967,7 +9967,7 @@
     "lyhytNimi" : "Dairy Industry, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355110",
   "koodiArvo" : "355110",
@@ -9984,7 +9984,7 @@
     "lyhytNimi" : "Meat Inspection, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355145",
   "koodiArvo" : "355145",
@@ -10001,7 +10001,7 @@
     "lyhytNimi" : "Elintarvikejalostuksen at",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_355146",
   "koodiArvo" : "355146",
@@ -10018,7 +10018,7 @@
     "lyhytNimi" : "Leipomoalan at",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_355199",
   "koodiArvo" : "355199",
@@ -10035,7 +10035,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Food Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355200",
   "koodiArvo" : "355200",
@@ -10052,7 +10052,7 @@
     "lyhytNimi" : "Further Qualification in Construction Technology and Community Development and Maintenance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355201",
   "koodiArvo" : "355201",
@@ -10069,7 +10069,7 @@
     "lyhytNimi" : "Further vocational qualification in Commercial Diving",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355202",
   "koodiArvo" : "355202",
@@ -10086,7 +10086,7 @@
     "lyhytNimi" : "Carpenter, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355203",
   "koodiArvo" : "355203",
@@ -10103,7 +10103,7 @@
     "lyhytNimi" : "Glass Working, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355204",
   "koodiArvo" : "355204",
@@ -10120,7 +10120,7 @@
     "lyhytNimi" : "Bricklayer, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355205",
   "koodiArvo" : "355205",
@@ -10137,7 +10137,7 @@
     "lyhytNimi" : "Construction Machinery Operator, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355206",
   "koodiArvo" : "355206",
@@ -10154,7 +10154,7 @@
     "lyhytNimi" : "Construction Worker, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355207",
   "koodiArvo" : "355207",
@@ -10171,7 +10171,7 @@
     "lyhytNimi" : "Construction Machinery Operator, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355208",
   "koodiArvo" : "355208",
@@ -10188,7 +10188,7 @@
     "lyhytNimi" : "Construction Product Industry, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355209",
   "koodiArvo" : "355209",
@@ -10205,7 +10205,7 @@
     "lyhytNimi" : "Further vocational qualification in Building Construction",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355210",
   "koodiArvo" : "355210",
@@ -10222,7 +10222,7 @@
     "lyhytNimi" : "Further vocational qualification in Infrastructure Construction",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355211",
   "koodiArvo" : "355211",
@@ -10239,7 +10239,7 @@
     "lyhytNimi" : "Further vocational qualification in the Building Products Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355212",
   "koodiArvo" : "355212",
@@ -10256,7 +10256,7 @@
     "lyhytNimi" : "Water Supply and Sewerage, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355299",
   "koodiArvo" : "355299",
@@ -10273,7 +10273,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Construction Technology and Community Development and Maintenance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355300",
   "koodiArvo" : "355300",
@@ -10290,7 +10290,7 @@
     "lyhytNimi" : "Land Surveying, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355301",
   "koodiArvo" : "355301",
@@ -10307,7 +10307,7 @@
     "lyhytNimi" : "Further vocational qualification in Land Surveying",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355400",
   "koodiArvo" : "355400",
@@ -10324,7 +10324,7 @@
     "lyhytNimi" : "Further Qualification in Textiles and Clothing",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355401",
   "koodiArvo" : "355401",
@@ -10341,7 +10341,7 @@
     "lyhytNimi" : "Millinery, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355402",
   "koodiArvo" : "355402",
@@ -10358,7 +10358,7 @@
     "lyhytNimi" : "Leather-Dressing, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355403",
   "koodiArvo" : "355403",
@@ -10375,7 +10375,7 @@
     "lyhytNimi" : "Sewingmachine Mechanic, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355404",
   "koodiArvo" : "355404",
@@ -10392,7 +10392,7 @@
     "lyhytNimi" : "Dressmaker, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355405",
   "koodiArvo" : "355405",
@@ -10409,7 +10409,7 @@
     "lyhytNimi" : "Shoemaking, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355406",
   "koodiArvo" : "355406",
@@ -10426,7 +10426,7 @@
     "lyhytNimi" : "Textile Mechanic, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355407",
   "koodiArvo" : "355407",
@@ -10443,7 +10443,7 @@
     "lyhytNimi" : "Fur-Dressing, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355408",
   "koodiArvo" : "355408",
@@ -10460,7 +10460,7 @@
     "lyhytNimi" : "Tailoring, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355409",
   "koodiArvo" : "355409",
@@ -10477,7 +10477,7 @@
     "lyhytNimi" : "Textiles Technology, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355410",
   "koodiArvo" : "355410",
@@ -10494,7 +10494,7 @@
     "lyhytNimi" : "Bags and Leather Goods Production, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355411",
   "koodiArvo" : "355411",
@@ -10511,7 +10511,7 @@
     "lyhytNimi" : "Footwear Industry, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355412",
   "koodiArvo" : "355412",
@@ -10528,7 +10528,7 @@
     "lyhytNimi" : "Textiles, Further Qualification, Textiles and Clothing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355413",
   "koodiArvo" : "355413",
@@ -10545,7 +10545,7 @@
     "lyhytNimi" : "Clothing, Further Qualification, Textiles and Clothing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355445",
   "koodiArvo" : "355445",
@@ -10562,7 +10562,7 @@
     "lyhytNimi" : "Further vocational qualification in the Textiles and Fashion Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_355499",
   "koodiArvo" : "355499",
@@ -10579,7 +10579,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Textiles and Clothing",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355500",
   "koodiArvo" : "355500",
@@ -10596,7 +10596,7 @@
     "lyhytNimi" : "Further Qualification in Graphics Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355501",
   "koodiArvo" : "355501",
@@ -10613,7 +10613,7 @@
     "lyhytNimi" : "Bindery Operator, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355502",
   "koodiArvo" : "355502",
@@ -10630,7 +10630,7 @@
     "lyhytNimi" : "Bookbinding, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355503",
   "koodiArvo" : "355503",
@@ -10647,7 +10647,7 @@
     "lyhytNimi" : "Printing, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355504",
   "koodiArvo" : "355504",
@@ -10664,7 +10664,7 @@
     "lyhytNimi" : "Printing Surface Preparation, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355505",
   "koodiArvo" : "355505",
@@ -10681,7 +10681,7 @@
     "lyhytNimi" : "Digital Printer, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355599",
   "koodiArvo" : "355599",
@@ -10698,7 +10698,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Graphics Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355645",
   "koodiArvo" : "355645",
@@ -10715,7 +10715,7 @@
     "lyhytNimi" : "Further vocational qualification in Production Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_355900",
   "koodiArvo" : "355900",
@@ -10732,7 +10732,7 @@
     "lyhytNimi" : "Other Further Qualification in Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355901",
   "koodiArvo" : "355901",
@@ -10749,7 +10749,7 @@
     "lyhytNimi" : "Technical Design, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355902",
   "koodiArvo" : "355902",
@@ -10766,7 +10766,7 @@
     "lyhytNimi" : "Waste and Recycling Managemant, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355903",
   "koodiArvo" : "355903",
@@ -10783,7 +10783,7 @@
     "lyhytNimi" : "Rolling Stock Maintenance, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355904",
   "koodiArvo" : "355904",
@@ -10800,7 +10800,7 @@
     "lyhytNimi" : "Interior Design, Further Qualification, Technology and Transport",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355905",
   "koodiArvo" : "355905",
@@ -10817,7 +10817,7 @@
     "lyhytNimi" : "Measuring and Calibration, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355906",
   "koodiArvo" : "355906",
@@ -10834,7 +10834,7 @@
     "lyhytNimi" : "Wind Power Technicians, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_355945",
   "koodiArvo" : "355945",
@@ -10851,7 +10851,7 @@
     "lyhytNimi" : "FVQ in Sustainability and Environmental Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_355999",
   "koodiArvo" : "355999",
@@ -10868,7 +10868,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357000",
   "koodiArvo" : "357000",
@@ -10885,7 +10885,7 @@
     "lyhytNimi" : "Specialist Qualification in Technology (Metalwork, Heating and Ventilation, Vehicles, Electrics, IT, Chemistry, Wood Industry and Surface Treatment)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357100",
   "koodiArvo" : "357100",
@@ -10902,7 +10902,7 @@
     "lyhytNimi" : "Specialist Qualification in Metalwork and Machinery",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357101",
   "koodiArvo" : "357101",
@@ -10915,7 +10915,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357102",
   "koodiArvo" : "357102",
@@ -10928,7 +10928,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357103",
   "koodiArvo" : "357103",
@@ -10941,7 +10941,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357104",
   "koodiArvo" : "357104",
@@ -10954,7 +10954,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357105",
   "koodiArvo" : "357105",
@@ -10967,7 +10967,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357106",
   "koodiArvo" : "357106",
@@ -10980,7 +10980,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357107",
   "koodiArvo" : "357107",
@@ -10993,7 +10993,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357108",
   "koodiArvo" : "357108",
@@ -11006,7 +11006,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357109",
   "koodiArvo" : "357109",
@@ -11019,7 +11019,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357110",
   "koodiArvo" : "357110",
@@ -11032,7 +11032,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357111",
   "koodiArvo" : "357111",
@@ -11045,7 +11045,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357112",
   "koodiArvo" : "357112",
@@ -11062,7 +11062,7 @@
     "lyhytNimi" : "Specialist Qualification for Industrial Managers",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357199",
   "koodiArvo" : "357199",
@@ -11079,7 +11079,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Metalwork and Machinery",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357200",
   "koodiArvo" : "357200",
@@ -11096,7 +11096,7 @@
     "lyhytNimi" : "Specialist Qualification in Heating and Ventilation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357201",
   "koodiArvo" : "357201",
@@ -11109,7 +11109,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357202",
   "koodiArvo" : "357202",
@@ -11126,7 +11126,7 @@
     "lyhytNimi" : "District Heating Fitter, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357203",
   "koodiArvo" : "357203",
@@ -11139,7 +11139,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357204",
   "koodiArvo" : "357204",
@@ -11152,7 +11152,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357205",
   "koodiArvo" : "357205",
@@ -11165,7 +11165,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357206",
   "koodiArvo" : "357206",
@@ -11178,7 +11178,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357207",
   "koodiArvo" : "357207",
@@ -11191,7 +11191,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357299",
   "koodiArvo" : "357299",
@@ -11208,7 +11208,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Heating and Ventilation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357300",
   "koodiArvo" : "357300",
@@ -11225,7 +11225,7 @@
     "lyhytNimi" : "Specialist Qualification in Vehicles and Transportation",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357301",
   "koodiArvo" : "357301",
@@ -11238,7 +11238,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357302",
   "koodiArvo" : "357302",
@@ -11251,7 +11251,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357303",
   "koodiArvo" : "357303",
@@ -11264,7 +11264,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357304",
   "koodiArvo" : "357304",
@@ -11277,7 +11277,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357305",
   "koodiArvo" : "357305",
@@ -11290,7 +11290,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357306",
   "koodiArvo" : "357306",
@@ -11303,7 +11303,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357307",
   "koodiArvo" : "357307",
@@ -11320,7 +11320,7 @@
     "lyhytNimi" : "Aircraft Technology, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357399",
   "koodiArvo" : "357399",
@@ -11337,7 +11337,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Vehicles and Transportation",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357400",
   "koodiArvo" : "357400",
@@ -11354,7 +11354,7 @@
     "lyhytNimi" : "Specialist Qualification in Electrical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357401",
   "koodiArvo" : "357401",
@@ -11367,7 +11367,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357402",
   "koodiArvo" : "357402",
@@ -11384,7 +11384,7 @@
     "lyhytNimi" : "Electronics Assembler, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357403",
   "koodiArvo" : "357403",
@@ -11397,7 +11397,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357404",
   "koodiArvo" : "357404",
@@ -11410,7 +11410,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357405",
   "koodiArvo" : "357405",
@@ -11436,7 +11436,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_357499",
   "koodiArvo" : "357499",
@@ -11453,7 +11453,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Electrical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357500",
   "koodiArvo" : "357500",
@@ -11470,7 +11470,7 @@
     "lyhytNimi" : "Specialist Qualification in Information Technology and Telecommunications",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357501",
   "koodiArvo" : "357501",
@@ -11487,7 +11487,7 @@
     "lyhytNimi" : "Computer Mechanic, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357502",
   "koodiArvo" : "357502",
@@ -11504,7 +11504,7 @@
     "lyhytNimi" : "Telecommunications Fitter, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357503",
   "koodiArvo" : "357503",
@@ -11521,7 +11521,7 @@
     "lyhytNimi" : "Specialist Qualification in Information and Telecommunications",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357599",
   "koodiArvo" : "357599",
@@ -11538,7 +11538,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Information Technology and Telecommunications",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357600",
   "koodiArvo" : "357600",
@@ -11555,7 +11555,7 @@
     "lyhytNimi" : "Specialist Qualification in Paper Industry and Chemical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357601",
   "koodiArvo" : "357601",
@@ -11568,7 +11568,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357602",
   "koodiArvo" : "357602",
@@ -11581,7 +11581,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357603",
   "koodiArvo" : "357603",
@@ -11594,7 +11594,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357699",
   "koodiArvo" : "357699",
@@ -11611,7 +11611,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Paper Industry and Chemical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357700",
   "koodiArvo" : "357700",
@@ -11628,7 +11628,7 @@
     "lyhytNimi" : "Specialist Qualification in Wood Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357701",
   "koodiArvo" : "357701",
@@ -11645,7 +11645,7 @@
     "lyhytNimi" : "Ornamental Wood Carving, Specialist Qualification, Process, Chemical and Materials Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357702",
   "koodiArvo" : "357702",
@@ -11658,7 +11658,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357703",
   "koodiArvo" : "357703",
@@ -11675,7 +11675,7 @@
     "lyhytNimi" : "Joiner, Specialist Qualification, Process, Chemical and Materials Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357704",
   "koodiArvo" : "357704",
@@ -11692,7 +11692,7 @@
     "lyhytNimi" : "Sawmill and Panel Industry, Specialist Qualification in Maintenance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357705",
   "koodiArvo" : "357705",
@@ -11705,7 +11705,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357706",
   "koodiArvo" : "357706",
@@ -11722,7 +11722,7 @@
     "lyhytNimi" : "Sharp Tool Maintenance, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357707",
   "koodiArvo" : "357707",
@@ -11739,7 +11739,7 @@
     "lyhytNimi" : "Specialist Qualification in the Boat-building Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357708",
   "koodiArvo" : "357708",
@@ -11752,7 +11752,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357709",
   "koodiArvo" : "357709",
@@ -11769,7 +11769,7 @@
     "lyhytNimi" : "Specialist Qualification in the Wood Product Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357799",
   "koodiArvo" : "357799",
@@ -11786,7 +11786,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Wood Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357800",
   "koodiArvo" : "357800",
@@ -11803,7 +11803,7 @@
     "lyhytNimi" : "Specialist Qualification in Surface Treatment Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357801",
   "koodiArvo" : "357801",
@@ -11816,7 +11816,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357802",
   "koodiArvo" : "357802",
@@ -11833,7 +11833,7 @@
     "lyhytNimi" : "Painter, Specialist Qualification (Process, Chemical and Materials Engineering)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357803",
   "koodiArvo" : "357803",
@@ -11846,7 +11846,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_357899",
   "koodiArvo" : "357899",
@@ -11863,7 +11863,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Surface Treatment Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358000",
   "koodiArvo" : "358000",
@@ -11880,7 +11880,7 @@
     "lyhytNimi" : "Specialist Qualification in Technology (Food Industry, Construction Technology, Land Survey Technology, Textiles and Graphic Technology)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358100",
   "koodiArvo" : "358100",
@@ -11897,7 +11897,7 @@
     "lyhytNimi" : "Specialist Qualification in Food Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358101",
   "koodiArvo" : "358101",
@@ -11910,7 +11910,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358102",
   "koodiArvo" : "358102",
@@ -11923,7 +11923,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358103",
   "koodiArvo" : "358103",
@@ -11936,7 +11936,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358199",
   "koodiArvo" : "358199",
@@ -11953,7 +11953,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Food Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358200",
   "koodiArvo" : "358200",
@@ -11970,7 +11970,7 @@
     "lyhytNimi" : "Specialist Qualification in Construction Technology and Community Development and Maintenance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358201",
   "koodiArvo" : "358201",
@@ -11987,7 +11987,7 @@
     "lyhytNimi" : "Carpenter, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358202",
   "koodiArvo" : "358202",
@@ -12004,7 +12004,7 @@
     "lyhytNimi" : "Bricklayer, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358203",
   "koodiArvo" : "358203",
@@ -12021,7 +12021,7 @@
     "lyhytNimi" : "Construction, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358204",
   "koodiArvo" : "358204",
@@ -12034,7 +12034,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358205",
   "koodiArvo" : "358205",
@@ -12051,7 +12051,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Building Construction",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358206",
   "koodiArvo" : "358206",
@@ -12068,7 +12068,7 @@
     "lyhytNimi" : "Infrastucture Construction, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358207",
   "koodiArvo" : "358207",
@@ -12098,7 +12098,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Construction Technology and Community Development and Maintenance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358400",
   "koodiArvo" : "358400",
@@ -12115,7 +12115,7 @@
     "lyhytNimi" : "Specialist Qualification in Textiles and Clothing",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358401",
   "koodiArvo" : "358401",
@@ -12132,7 +12132,7 @@
     "lyhytNimi" : "Millinery, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358402",
   "koodiArvo" : "358402",
@@ -12149,7 +12149,7 @@
     "lyhytNimi" : "Dressmaking, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358403",
   "koodiArvo" : "358403",
@@ -12166,7 +12166,7 @@
     "lyhytNimi" : "Dressmaker, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358404",
   "koodiArvo" : "358404",
@@ -12183,7 +12183,7 @@
     "lyhytNimi" : "Shoemaking, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358405",
   "koodiArvo" : "358405",
@@ -12196,7 +12196,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358406",
   "koodiArvo" : "358406",
@@ -12213,7 +12213,7 @@
     "lyhytNimi" : "Tailoring, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358407",
   "koodiArvo" : "358407",
@@ -12230,7 +12230,7 @@
     "lyhytNimi" : "Patternmaker, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358408",
   "koodiArvo" : "358408",
@@ -12243,7 +12243,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358409",
   "koodiArvo" : "358409",
@@ -12256,7 +12256,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358410",
   "koodiArvo" : "358410",
@@ -12269,7 +12269,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358411",
   "koodiArvo" : "358411",
@@ -12286,7 +12286,7 @@
     "lyhytNimi" : "Textiles, Specialist Qualification, Textiles and Clothing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358412",
   "koodiArvo" : "358412",
@@ -12303,7 +12303,7 @@
     "lyhytNimi" : "Clothing, Specialist Qualification, Textiles and Clothing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358499",
   "koodiArvo" : "358499",
@@ -12320,7 +12320,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Textiles and Clothing",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358500",
   "koodiArvo" : "358500",
@@ -12337,7 +12337,7 @@
     "lyhytNimi" : "Specialist Qualification in Graphics Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358502",
   "koodiArvo" : "358502",
@@ -12350,7 +12350,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358503",
   "koodiArvo" : "358503",
@@ -12363,7 +12363,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358504",
   "koodiArvo" : "358504",
@@ -12380,7 +12380,7 @@
     "lyhytNimi" : "Printing, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358505",
   "koodiArvo" : "358505",
@@ -12397,7 +12397,7 @@
     "lyhytNimi" : "Rotary Printing, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358506",
   "koodiArvo" : "358506",
@@ -12414,7 +12414,7 @@
     "lyhytNimi" : "Page Layout, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358507",
   "koodiArvo" : "358507",
@@ -12431,7 +12431,7 @@
     "lyhytNimi" : "Printing Technology, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358508",
   "koodiArvo" : "358508",
@@ -12448,7 +12448,7 @@
     "lyhytNimi" : "Print-Shop Supervisor, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358599",
   "koodiArvo" : "358599",
@@ -12465,7 +12465,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Graphics Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358900",
   "koodiArvo" : "358900",
@@ -12482,7 +12482,7 @@
     "lyhytNimi" : "Other Specialist Qualification in Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358901",
   "koodiArvo" : "358901",
@@ -12495,7 +12495,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358902",
   "koodiArvo" : "358902",
@@ -12512,7 +12512,7 @@
     "lyhytNimi" : "Specialist Qualification in Product Development",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358903",
   "koodiArvo" : "358903",
@@ -12529,7 +12529,7 @@
     "lyhytNimi" : "Interior Design, Specialist Qualification, Technology and Transport",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358904",
   "koodiArvo" : "358904",
@@ -12546,7 +12546,7 @@
     "lyhytNimi" : "Environmental Management, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_358999",
   "koodiArvo" : "358999",
@@ -12563,7 +12563,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_359000",
   "koodiArvo" : "359000",
@@ -12580,7 +12580,7 @@
     "lyhytNimi" : "Other Education in Technology, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_359900",
   "koodiArvo" : "359900",
@@ -12597,7 +12597,7 @@
     "lyhytNimi" : "Other Education in Technology, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_359999",
   "koodiArvo" : "359999",
@@ -12614,7 +12614,7 @@
     "lyhytNimi" : "Other or Unknown Education in Technology, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361000",
   "koodiArvo" : "361000",
@@ -12631,7 +12631,7 @@
     "lyhytNimi" : "Vocational Education and Training in Agriculture and Forestry, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361100",
   "koodiArvo" : "361100",
@@ -12648,7 +12648,7 @@
     "lyhytNimi" : "Vocational Education and Training in Agriculture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361101",
   "koodiArvo" : "361101",
@@ -12665,7 +12665,7 @@
     "lyhytNimi" : "Vocational qualification in Agriculture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361102",
   "koodiArvo" : "361102",
@@ -12682,7 +12682,7 @@
     "lyhytNimi" : "Fur Production, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361103",
   "koodiArvo" : "361103",
@@ -12699,7 +12699,7 @@
     "lyhytNimi" : "Rural Entrepreneur",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361104",
   "koodiArvo" : "361104",
@@ -12716,7 +12716,7 @@
     "lyhytNimi" : "Vocational qualification in Horse Care and Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361151",
   "koodiArvo" : "361151",
@@ -12733,7 +12733,7 @@
     "lyhytNimi" : "Groom",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361152",
   "koodiArvo" : "361152",
@@ -12750,7 +12750,7 @@
     "lyhytNimi" : "Horse Trainer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361153",
   "koodiArvo" : "361153",
@@ -12767,7 +12767,7 @@
     "lyhytNimi" : "Husbandry Proprietor School",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361154",
   "koodiArvo" : "361154",
@@ -12784,7 +12784,7 @@
     "lyhytNimi" : "Cattle Inspector",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361156",
   "koodiArvo" : "361156",
@@ -12801,7 +12801,7 @@
     "lyhytNimi" : "Farming School",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361157",
   "koodiArvo" : "361157",
@@ -12818,7 +12818,7 @@
     "lyhytNimi" : "Agricultural School (Agricultural Technician)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361158",
   "koodiArvo" : "361158",
@@ -12835,7 +12835,7 @@
     "lyhytNimi" : "Agricultural Technical School (Farm Machinery Technician)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361160",
   "koodiArvo" : "361160",
@@ -12852,7 +12852,7 @@
     "lyhytNimi" : "Relief Worker - Livestock Person",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361162",
   "koodiArvo" : "361162",
@@ -12869,7 +12869,7 @@
     "lyhytNimi" : "Small Holder's School",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361163",
   "koodiArvo" : "361163",
@@ -12886,7 +12886,7 @@
     "lyhytNimi" : "Reindeer Breeder",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361164",
   "koodiArvo" : "361164",
@@ -12903,7 +12903,7 @@
     "lyhytNimi" : "Artificial Inseminator",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361165",
   "koodiArvo" : "361165",
@@ -12920,7 +12920,7 @@
     "lyhytNimi" : "Poultry Worker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361166",
   "koodiArvo" : "361166",
@@ -12937,7 +12937,7 @@
     "lyhytNimi" : "Pig House Worker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361167",
   "koodiArvo" : "361167",
@@ -12954,7 +12954,7 @@
     "lyhytNimi" : "Fur Farm Worker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361168",
   "koodiArvo" : "361168",
@@ -12971,7 +12971,7 @@
     "lyhytNimi" : "Farmer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361169",
   "koodiArvo" : "361169",
@@ -12988,7 +12988,7 @@
     "lyhytNimi" : "Farmer-Machinery Repairer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361199",
   "koodiArvo" : "361199",
@@ -13005,7 +13005,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Agriculture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361200",
   "koodiArvo" : "361200",
@@ -13022,7 +13022,7 @@
     "lyhytNimi" : "Vocational Education and Training in Horticulture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361201",
   "koodiArvo" : "361201",
@@ -13039,7 +13039,7 @@
     "lyhytNimi" : "Vocational qualification in Horticulture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361251",
   "koodiArvo" : "361251",
@@ -13056,7 +13056,7 @@
     "lyhytNimi" : "Assistant Gardener",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361252",
   "koodiArvo" : "361252",
@@ -13073,7 +13073,7 @@
     "lyhytNimi" : "Florist, Vocational Education and Training",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361254",
   "koodiArvo" : "361254",
@@ -13090,7 +13090,7 @@
     "lyhytNimi" : "Horticultural Worker (formerly Gardening Assistant)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361255",
   "koodiArvo" : "361255",
@@ -13107,7 +13107,7 @@
     "lyhytNimi" : "Gardener",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361299",
   "koodiArvo" : "361299",
@@ -13124,7 +13124,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Horticulture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361300",
   "koodiArvo" : "361300",
@@ -13141,7 +13141,7 @@
     "lyhytNimi" : "Vocational Education and Training in Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361301",
   "koodiArvo" : "361301",
@@ -13158,7 +13158,7 @@
     "lyhytNimi" : "Vocational qualification in Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361302",
   "koodiArvo" : "361302",
@@ -13175,7 +13175,7 @@
     "lyhytNimi" : "Forest Machine Operator",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361351",
   "koodiArvo" : "361351",
@@ -13192,7 +13192,7 @@
     "lyhytNimi" : "Forest Worker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361352",
   "koodiArvo" : "361352",
@@ -13209,7 +13209,7 @@
     "lyhytNimi" : "Mechanic, Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361354",
   "koodiArvo" : "361354",
@@ -13226,7 +13226,7 @@
     "lyhytNimi" : "Forestry Producer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361356",
   "koodiArvo" : "361356",
@@ -13237,7 +13237,7 @@
     "nimi" : "Metsätyönjohtaja",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_361399",
   "koodiArvo" : "361399",
@@ -13254,7 +13254,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361400",
   "koodiArvo" : "361400",
@@ -13271,7 +13271,7 @@
     "lyhytNimi" : "Vocational Education and Training in Fishery",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361401",
   "koodiArvo" : "361401",
@@ -13288,7 +13288,7 @@
     "lyhytNimi" : "Vocational qualification in Fishery",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361451",
   "koodiArvo" : "361451",
@@ -13305,7 +13305,7 @@
     "lyhytNimi" : "Fish Processor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361452",
   "koodiArvo" : "361452",
@@ -13322,7 +13322,7 @@
     "lyhytNimi" : "Fish Farmer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361453",
   "koodiArvo" : "361453",
@@ -13339,7 +13339,7 @@
     "lyhytNimi" : "Fisher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361454",
   "koodiArvo" : "361454",
@@ -13356,7 +13356,7 @@
     "lyhytNimi" : "Fishing Grounds Worker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361499",
   "koodiArvo" : "361499",
@@ -13373,7 +13373,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Fishery",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361900",
   "koodiArvo" : "361900",
@@ -13390,7 +13390,7 @@
     "lyhytNimi" : "Other Vocational Education and Training in Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361901",
   "koodiArvo" : "361901",
@@ -13407,7 +13407,7 @@
     "lyhytNimi" : "Natural and Forest Livelihoods, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361902",
   "koodiArvo" : "361902",
@@ -13424,7 +13424,7 @@
     "lyhytNimi" : "Vocational qualification in Natural and Environmental Protection",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361951",
   "koodiArvo" : "361951",
@@ -13441,7 +13441,7 @@
     "lyhytNimi" : "Natural Economy and Forestry Practitioner",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_361999",
   "koodiArvo" : "361999",
@@ -13458,7 +13458,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364000",
   "koodiArvo" : "364000",
@@ -13475,7 +13475,7 @@
     "lyhytNimi" : "Further Qualification in Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364100",
   "koodiArvo" : "364100",
@@ -13492,7 +13492,7 @@
     "lyhytNimi" : "Further Qualification in Agriculture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364101",
   "koodiArvo" : "364101",
@@ -13509,7 +13509,7 @@
     "lyhytNimi" : "Horse Trainer, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364102",
   "koodiArvo" : "364102",
@@ -13526,7 +13526,7 @@
     "lyhytNimi" : "Farm Animal Husbandry and Welfare, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364103",
   "koodiArvo" : "364103",
@@ -13543,7 +13543,7 @@
     "lyhytNimi" : "Farrier, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364104",
   "koodiArvo" : "364104",
@@ -13560,7 +13560,7 @@
     "lyhytNimi" : "Organic Crop and Livestock Production, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364105",
   "koodiArvo" : "364105",
@@ -13577,7 +13577,7 @@
     "lyhytNimi" : "Further vocational qualification in Reindeer Farming",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364106",
   "koodiArvo" : "364106",
@@ -13594,7 +13594,7 @@
     "lyhytNimi" : "Artificial Insemination, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364107",
   "koodiArvo" : "364107",
@@ -13611,7 +13611,7 @@
     "lyhytNimi" : "Farmer, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364108",
   "koodiArvo" : "364108",
@@ -13628,7 +13628,7 @@
     "lyhytNimi" : "Riding Instructor, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364109",
   "koodiArvo" : "364109",
@@ -13645,7 +13645,7 @@
     "lyhytNimi" : "Apiarist, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364145",
   "koodiArvo" : "364145",
@@ -13662,7 +13662,7 @@
     "lyhytNimi" : "Further Vocational Qualification in Horse Care and Management",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_364146",
   "koodiArvo" : "364146",
@@ -13679,7 +13679,7 @@
     "lyhytNimi" : "Maatalousalan at",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_364199",
   "koodiArvo" : "364199",
@@ -13696,7 +13696,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Agriculture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364200",
   "koodiArvo" : "364200",
@@ -13713,7 +13713,7 @@
     "lyhytNimi" : "Further Qualification in Horticulture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364201",
   "koodiArvo" : "364201",
@@ -13730,7 +13730,7 @@
     "lyhytNimi" : "Floristry, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364202",
   "koodiArvo" : "364202",
@@ -13747,7 +13747,7 @@
     "lyhytNimi" : "Further Qualification in the Landscaping Sector",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364203",
   "koodiArvo" : "364203",
@@ -13764,7 +13764,7 @@
     "lyhytNimi" : "Wine Production, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364204",
   "koodiArvo" : "364204",
@@ -13781,7 +13781,7 @@
     "lyhytNimi" : "Nursery Gardening, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364205",
   "koodiArvo" : "364205",
@@ -13798,7 +13798,7 @@
     "lyhytNimi" : "Interior plantscaping, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364245",
   "koodiArvo" : "364245",
@@ -13815,7 +13815,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_364299",
   "koodiArvo" : "364299",
@@ -13832,7 +13832,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Horticulture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364300",
   "koodiArvo" : "364300",
@@ -13849,7 +13849,7 @@
     "lyhytNimi" : "Further Qualification in Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364301",
   "koodiArvo" : "364301",
@@ -13866,7 +13866,7 @@
     "lyhytNimi" : "Forest Machine Mechanic, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364302",
   "koodiArvo" : "364302",
@@ -13883,7 +13883,7 @@
     "lyhytNimi" : "Forestry Entrepreneur, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364303",
   "koodiArvo" : "364303",
@@ -13900,7 +13900,7 @@
     "lyhytNimi" : "Forestry, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364304",
   "koodiArvo" : "364304",
@@ -13917,7 +13917,7 @@
     "lyhytNimi" : "Bio-Energy, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364305",
   "koodiArvo" : "364305",
@@ -13934,7 +13934,7 @@
     "lyhytNimi" : "Forest Machine Operator, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364306",
   "koodiArvo" : "364306",
@@ -13951,7 +13951,7 @@
     "lyhytNimi" : "Forest Worker, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364307",
   "koodiArvo" : "364307",
@@ -13968,7 +13968,7 @@
     "lyhytNimi" : "Timber Lorry Transport, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364308",
   "koodiArvo" : "364308",
@@ -13985,7 +13985,7 @@
     "lyhytNimi" : "Arboriculture, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364309",
   "koodiArvo" : "364309",
@@ -14002,7 +14002,7 @@
     "lyhytNimi" : "Multiple Use of Forests, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364345",
   "koodiArvo" : "364345",
@@ -14019,7 +14019,7 @@
     "lyhytNimi" : "Further vocational qualification in Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_364399",
   "koodiArvo" : "364399",
@@ -14036,7 +14036,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364400",
   "koodiArvo" : "364400",
@@ -14053,7 +14053,7 @@
     "lyhytNimi" : "Further Qualification in Fishery",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364401",
   "koodiArvo" : "364401",
@@ -14070,7 +14070,7 @@
     "lyhytNimi" : "Fish Processing, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364402",
   "koodiArvo" : "364402",
@@ -14087,7 +14087,7 @@
     "lyhytNimi" : "Fish Farming, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364403",
   "koodiArvo" : "364403",
@@ -14104,7 +14104,7 @@
     "lyhytNimi" : "Fishing Guide, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364445",
   "koodiArvo" : "364445",
@@ -14121,7 +14121,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_364499",
   "koodiArvo" : "364499",
@@ -14138,7 +14138,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Fishery",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364900",
   "koodiArvo" : "364900",
@@ -14155,7 +14155,7 @@
     "lyhytNimi" : "Other Further Qualification in Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364901",
   "koodiArvo" : "364901",
@@ -14172,7 +14172,7 @@
     "lyhytNimi" : "Golf Course Maintenance, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364902",
   "koodiArvo" : "364902",
@@ -14189,7 +14189,7 @@
     "lyhytNimi" : "FVC  in Animal Care",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364903",
   "koodiArvo" : "364903",
@@ -14206,7 +14206,7 @@
     "lyhytNimi" : "Wilderness Guide, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364904",
   "koodiArvo" : "364904",
@@ -14223,7 +14223,7 @@
     "lyhytNimi" : "Hiking and Nature Guide Services, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364905",
   "koodiArvo" : "364905",
@@ -14240,7 +14240,7 @@
     "lyhytNimi" : "Rural Tourism, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364906",
   "koodiArvo" : "364906",
@@ -14257,7 +14257,7 @@
     "lyhytNimi" : "Nature-Based Production, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_364946",
   "koodiArvo" : "364946",
@@ -14274,7 +14274,7 @@
     "lyhytNimi" : "FVQ in Nature-based Services",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_364999",
   "koodiArvo" : "364999",
@@ -14291,7 +14291,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367000",
   "koodiArvo" : "367000",
@@ -14308,7 +14308,7 @@
     "lyhytNimi" : "Specialist Qualification in Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367100",
   "koodiArvo" : "367100",
@@ -14325,7 +14325,7 @@
     "lyhytNimi" : "Specialist Qualification in Agriculture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367101",
   "koodiArvo" : "367101",
@@ -14338,7 +14338,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367102",
   "koodiArvo" : "367102",
@@ -14351,7 +14351,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367103",
   "koodiArvo" : "367103",
@@ -14364,7 +14364,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367104",
   "koodiArvo" : "367104",
@@ -14377,7 +14377,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367199",
   "koodiArvo" : "367199",
@@ -14394,7 +14394,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Agriculture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367200",
   "koodiArvo" : "367200",
@@ -14411,7 +14411,7 @@
     "lyhytNimi" : "Specialist Qualification in Horticulture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367201",
   "koodiArvo" : "367201",
@@ -14424,7 +14424,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367202",
   "koodiArvo" : "367202",
@@ -14441,7 +14441,7 @@
     "lyhytNimi" : "Nursery Gardening, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367203",
   "koodiArvo" : "367203",
@@ -14454,7 +14454,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367299",
   "koodiArvo" : "367299",
@@ -14471,7 +14471,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Horticulture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367300",
   "koodiArvo" : "367300",
@@ -14488,7 +14488,7 @@
     "lyhytNimi" : "Specialist Qualification in Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367301",
   "koodiArvo" : "367301",
@@ -14501,7 +14501,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367302",
   "koodiArvo" : "367302",
@@ -14514,7 +14514,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367303",
   "koodiArvo" : "367303",
@@ -14531,7 +14531,7 @@
     "lyhytNimi" : "Forestry Adviser, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367304",
   "koodiArvo" : "367304",
@@ -14544,7 +14544,7 @@
     "lyhytNimi" : "Specialyrkesexamen i virkesdrivning",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367305",
   "koodiArvo" : "367305",
@@ -14561,7 +14561,7 @@
     "lyhytNimi" : "Multiple Use of Forests, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367306",
   "koodiArvo" : "367306",
@@ -14578,7 +14578,7 @@
     "lyhytNimi" : "Forest Worker, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367399",
   "koodiArvo" : "367399",
@@ -14595,7 +14595,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367900",
   "koodiArvo" : "367900",
@@ -14612,7 +14612,7 @@
     "lyhytNimi" : "Other Specialist Qualification in Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367901",
   "koodiArvo" : "367901",
@@ -14625,7 +14625,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367902",
   "koodiArvo" : "367902",
@@ -14638,7 +14638,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367903",
   "koodiArvo" : "367903",
@@ -14655,7 +14655,7 @@
     "lyhytNimi" : "Specialist Qualification in Rural Development",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367904",
   "koodiArvo" : "367904",
@@ -14668,7 +14668,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367905",
   "koodiArvo" : "367905",
@@ -14681,7 +14681,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_367999",
   "koodiArvo" : "367999",
@@ -14698,7 +14698,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_369000",
   "koodiArvo" : "369000",
@@ -14715,7 +14715,7 @@
     "lyhytNimi" : "Other Education in Agriculture and Forestry, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_369900",
   "koodiArvo" : "369900",
@@ -14732,7 +14732,7 @@
     "lyhytNimi" : "Other Education in Agriculture and Forestry, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_369999",
   "koodiArvo" : "369999",
@@ -14749,7 +14749,7 @@
     "lyhytNimi" : "Other or Unknown Education in Agriculture and Forestry, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_371000",
   "koodiArvo" : "371000",
@@ -14766,7 +14766,7 @@
     "lyhytNimi" : "Vocational Education and Training in Health and Welfare, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_371100",
   "koodiArvo" : "371100",
@@ -14783,7 +14783,7 @@
     "lyhytNimi" : "Vocational Education and Training in Social and Health Care",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_371101",
   "koodiArvo" : "371101",
@@ -14800,7 +14800,7 @@
     "lyhytNimi" : "Vocational qualification in Social and Health Care",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_371104",
   "koodiArvo" : "371104",
@@ -14817,7 +14817,7 @@
     "lyhytNimi" : "Pharmaceutical Assistant",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_371109",
   "koodiArvo" : "371109",
@@ -14834,7 +14834,7 @@
     "lyhytNimi" : "Vocational qualification in Dental Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_371110",
   "koodiArvo" : "371110",
@@ -14851,7 +14851,7 @@
     "lyhytNimi" : "Vocational Qualification in Pharmaceutics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_371113",
   "koodiArvo" : "371113",
@@ -14885,7 +14885,7 @@
     "lyhytNimi" : "Practical Nurse",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_371160",
   "koodiArvo" : "371160",
@@ -14902,7 +14902,7 @@
     "lyhytNimi" : "Practical Dental Nurse",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_371163",
   "koodiArvo" : "371163",
@@ -14919,7 +14919,7 @@
     "lyhytNimi" : "Chiropodist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_371164",
   "koodiArvo" : "371164",
@@ -14936,7 +14936,7 @@
     "lyhytNimi" : "Practical Mental Nurse",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_371165",
   "koodiArvo" : "371165",
@@ -14953,7 +14953,7 @@
     "lyhytNimi" : "Hospital and Ambulance Attendant",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_371166",
   "koodiArvo" : "371166",
@@ -14970,7 +14970,7 @@
     "lyhytNimi" : "Reception and Ward Clerk",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_371167",
   "koodiArvo" : "371167",
@@ -14987,7 +14987,7 @@
     "lyhytNimi" : "Practical Nurse for the Mentally Retarded",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_371168",
   "koodiArvo" : "371168",
@@ -15004,7 +15004,7 @@
     "lyhytNimi" : "Children's Nurse",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_371169",
   "koodiArvo" : "371169",
@@ -15021,7 +15021,7 @@
     "lyhytNimi" : "Kindergarten Practical Nurse",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_371170",
   "koodiArvo" : "371170",
@@ -15038,7 +15038,7 @@
     "lyhytNimi" : "Home Care Assistant",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_371171",
   "koodiArvo" : "371171",
@@ -15055,7 +15055,7 @@
     "lyhytNimi" : "Masseur/Masseuse",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_371172",
   "koodiArvo" : "371172",
@@ -15072,7 +15072,7 @@
     "lyhytNimi" : "Practical Rehabilitation Nurse",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_371199",
   "koodiArvo" : "371199",
@@ -15089,7 +15089,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_374000",
   "koodiArvo" : "374000",
@@ -15106,7 +15106,7 @@
     "lyhytNimi" : "Further Qualification in Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_374100",
   "koodiArvo" : "374100",
@@ -15123,7 +15123,7 @@
     "lyhytNimi" : "Further Qualification in Social and Health Care",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_374111",
   "koodiArvo" : "374111",
@@ -15140,7 +15140,7 @@
     "lyhytNimi" : "Further vocational qualification in Massage",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_374112",
   "koodiArvo" : "374112",
@@ -15157,7 +15157,7 @@
     "lyhytNimi" : "Special Needs Assistant in Educational Institutions, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_374113",
   "koodiArvo" : "374113",
@@ -15174,7 +15174,7 @@
     "lyhytNimi" : "Equipment Maintenance, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_374114",
   "koodiArvo" : "374114",
@@ -15191,7 +15191,7 @@
     "lyhytNimi" : "Child Minder, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_374115",
   "koodiArvo" : "374115",
@@ -15208,7 +15208,7 @@
     "lyhytNimi" : "Further Vocational Qualification in Mental Health and Intoxicant Abuse Welfare Work",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_374116",
   "koodiArvo" : "374116",
@@ -15225,7 +15225,7 @@
     "lyhytNimi" : "Ambulance Service, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_374117",
   "koodiArvo" : "374117",
@@ -15242,7 +15242,7 @@
     "lyhytNimi" : "Chiropodist, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_374118",
   "koodiArvo" : "374118",
@@ -15259,7 +15259,7 @@
     "lyhytNimi" : "Special Needs Instruction for Children and Young People, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_374119",
   "koodiArvo" : "374119",
@@ -15276,7 +15276,7 @@
     "lyhytNimi" : "Optical Mechanic, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_374120",
   "koodiArvo" : "374120",
@@ -15293,7 +15293,7 @@
     "lyhytNimi" : "Morning and Afternoon Activity Instruction for School Children, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_374121",
   "koodiArvo" : "374121",
@@ -15310,7 +15310,7 @@
     "lyhytNimi" : "Autopsy Assistant, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_374122",
   "koodiArvo" : "374122",
@@ -15327,7 +15327,7 @@
     "lyhytNimi" : "Further vocational qualification in Intellectual Disability Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_374123",
   "koodiArvo" : "374123",
@@ -15344,7 +15344,7 @@
     "lyhytNimi" : "Orthopaedic Casting, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_374124",
   "koodiArvo" : "374124",
@@ -15361,7 +15361,7 @@
     "lyhytNimi" : "Further vocational qualification in Learning Support and Morning and Afternoon Club Activity / Instruction at School",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_374147",
   "koodiArvo" : "374147",
@@ -15378,7 +15378,7 @@
     "lyhytNimi" : "Further vocational qualification in Health Care",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_374199",
   "koodiArvo" : "374199",
@@ -15395,7 +15395,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_377000",
   "koodiArvo" : "377000",
@@ -15412,7 +15412,7 @@
     "lyhytNimi" : "Specialist Qualification in Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_377100",
   "koodiArvo" : "377100",
@@ -15429,7 +15429,7 @@
     "lyhytNimi" : "Specialist Qualification in Social and Health Care",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_377101",
   "koodiArvo" : "377101",
@@ -15442,7 +15442,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_377102",
   "koodiArvo" : "377102",
@@ -15455,7 +15455,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_377103",
   "koodiArvo" : "377103",
@@ -15468,7 +15468,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_377104",
   "koodiArvo" : "377104",
@@ -15485,7 +15485,7 @@
     "lyhytNimi" : "Psychiatric Care, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_377105",
   "koodiArvo" : "377105",
@@ -15502,7 +15502,7 @@
     "lyhytNimi" : "Care for the Elderly, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_377106",
   "koodiArvo" : "377106",
@@ -15519,7 +15519,7 @@
     "lyhytNimi" : "Learning Support and Morning and Afternoon Club Activity Instruction at School, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_377107",
   "koodiArvo" : "377107",
@@ -15532,7 +15532,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_377108",
   "koodiArvo" : "377108",
@@ -15545,7 +15545,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_377109",
   "koodiArvo" : "377109",
@@ -15558,7 +15558,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_377110",
   "koodiArvo" : "377110",
@@ -15571,7 +15571,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_377111",
   "koodiArvo" : "377111",
@@ -15605,7 +15605,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_379000",
   "koodiArvo" : "379000",
@@ -15622,7 +15622,7 @@
     "lyhytNimi" : "Other Education in Health and Welfare, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_379900",
   "koodiArvo" : "379900",
@@ -15639,7 +15639,7 @@
     "lyhytNimi" : "Other Education in Health and Welfare, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_379999",
   "koodiArvo" : "379999",
@@ -15656,7 +15656,7 @@
     "lyhytNimi" : "Other or Unknown Education in Health and Welfare, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381000",
   "koodiArvo" : "381000",
@@ -15673,7 +15673,7 @@
     "lyhytNimi" : "Vocational Education and Training in Services, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381100",
   "koodiArvo" : "381100",
@@ -15690,7 +15690,7 @@
     "lyhytNimi" : "Vocational Education and Training in Hotel, Catering and Home Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381101",
   "koodiArvo" : "381101",
@@ -15707,7 +15707,7 @@
     "lyhytNimi" : "Hotel, Restaurant and Catering Service, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381102",
   "koodiArvo" : "381102",
@@ -15724,7 +15724,7 @@
     "lyhytNimi" : "Sales and Customer Service, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381103",
   "koodiArvo" : "381103",
@@ -15741,7 +15741,7 @@
     "lyhytNimi" : "Catering Services, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381104",
   "koodiArvo" : "381104",
@@ -15758,7 +15758,7 @@
     "lyhytNimi" : "Home Economics and Cleaning Services, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381105",
   "koodiArvo" : "381105",
@@ -15775,7 +15775,7 @@
     "lyhytNimi" : "Textiles Care Operative",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381106",
   "koodiArvo" : "381106",
@@ -15792,7 +15792,7 @@
     "lyhytNimi" : "Vocational Qualification in Tourism Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381107",
   "koodiArvo" : "381107",
@@ -15809,7 +15809,7 @@
     "lyhytNimi" : "Catering, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381108",
   "koodiArvo" : "381108",
@@ -15826,7 +15826,7 @@
     "lyhytNimi" : "Hotel and Restaurant, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381109",
   "koodiArvo" : "381109",
@@ -15843,7 +15843,7 @@
     "lyhytNimi" : "Household and Consumer Services, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381111",
   "koodiArvo" : "381111",
@@ -15860,7 +15860,7 @@
     "lyhytNimi" : "Cleaning Services, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381112",
   "koodiArvo" : "381112",
@@ -15877,7 +15877,7 @@
     "lyhytNimi" : "Hotel, Restaurant and Catering Services, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381113",
   "koodiArvo" : "381113",
@@ -15894,7 +15894,7 @@
     "lyhytNimi" : "Househould and Cleaning Services, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381141",
   "koodiArvo" : "381141",
@@ -15911,7 +15911,7 @@
     "lyhytNimi" : "Vocational qualification in Cleaning and Property Services",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_381142",
   "koodiArvo" : "381142",
@@ -15928,7 +15928,7 @@
     "lyhytNimi" : "Vocational qualification in Restaurant and Catering Services",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_381151",
   "koodiArvo" : "381151",
@@ -15945,7 +15945,7 @@
     "lyhytNimi" : "Hotel Receptionist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381152",
   "koodiArvo" : "381152",
@@ -15962,7 +15962,7 @@
     "lyhytNimi" : "Education in Cafe and Restaurant Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381153",
   "koodiArvo" : "381153",
@@ -15979,7 +15979,7 @@
     "lyhytNimi" : "Cafe Manager",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381154",
   "koodiArvo" : "381154",
@@ -15996,7 +15996,7 @@
     "lyhytNimi" : "Cook",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381155",
   "koodiArvo" : "381155",
@@ -16013,7 +16013,7 @@
     "lyhytNimi" : "Cook and Cold Buffet Manager",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381156",
   "koodiArvo" : "381156",
@@ -16030,7 +16030,7 @@
     "lyhytNimi" : "Housekeeper",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381157",
   "koodiArvo" : "381157",
@@ -16047,7 +16047,7 @@
     "lyhytNimi" : "Domestic Science School",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381159",
   "koodiArvo" : "381159",
@@ -16064,7 +16064,7 @@
     "lyhytNimi" : "Certificate in Institutional Cleaning",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381160",
   "koodiArvo" : "381160",
@@ -16081,7 +16081,7 @@
     "lyhytNimi" : "Ship's Cook",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381161",
   "koodiArvo" : "381161",
@@ -16098,7 +16098,7 @@
     "lyhytNimi" : "Farm Housewifery, School of Domestic Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381162",
   "koodiArvo" : "381162",
@@ -16115,7 +16115,7 @@
     "lyhytNimi" : "Education in Tourism, Upper Secondary Level",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381163",
   "koodiArvo" : "381163",
@@ -16132,7 +16132,7 @@
     "lyhytNimi" : "Mess Steward, Basic Education in Ship Catering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381164",
   "koodiArvo" : "381164",
@@ -16149,7 +16149,7 @@
     "lyhytNimi" : "Porter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381165",
   "koodiArvo" : "381165",
@@ -16166,7 +16166,7 @@
     "lyhytNimi" : "Basic Education in Restaurant Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381166",
   "koodiArvo" : "381166",
@@ -16183,7 +16183,7 @@
     "lyhytNimi" : "Restaurant Cook",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381167",
   "koodiArvo" : "381167",
@@ -16200,7 +16200,7 @@
     "lyhytNimi" : "Restaurant Cook",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381168",
   "koodiArvo" : "381168",
@@ -16217,7 +16217,7 @@
     "lyhytNimi" : "Restaurant Cold Buffet Manager",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381169",
   "koodiArvo" : "381169",
@@ -16234,7 +16234,7 @@
     "lyhytNimi" : "Restaurant Cashier",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381170",
   "koodiArvo" : "381170",
@@ -16251,7 +16251,7 @@
     "lyhytNimi" : "Line of Restaurant Kitchen Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381171",
   "koodiArvo" : "381171",
@@ -16268,7 +16268,7 @@
     "lyhytNimi" : "Catering Worker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381172",
   "koodiArvo" : "381172",
@@ -16285,7 +16285,7 @@
     "lyhytNimi" : "Catering Services, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381173",
   "koodiArvo" : "381173",
@@ -16302,7 +16302,7 @@
     "lyhytNimi" : "Food Economist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381174",
   "koodiArvo" : "381174",
@@ -16319,7 +16319,7 @@
     "lyhytNimi" : "Basic Education in Institutional Catering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381175",
   "koodiArvo" : "381175",
@@ -16336,7 +16336,7 @@
     "lyhytNimi" : "Cook, Institutional Catering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381176",
   "koodiArvo" : "381176",
@@ -16353,7 +16353,7 @@
     "lyhytNimi" : "Waiter/Waitress",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381199",
   "koodiArvo" : "381199",
@@ -16370,7 +16370,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Hotel, Restaurant and Catering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381200",
   "koodiArvo" : "381200",
@@ -16387,7 +16387,7 @@
     "lyhytNimi" : "Vocational Education and Training in Leisure Activities and Youth Work",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381201",
   "koodiArvo" : "381201",
@@ -16404,7 +16404,7 @@
     "lyhytNimi" : "Youth and Leisure Instruction, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381202",
   "koodiArvo" : "381202",
@@ -16421,7 +16421,7 @@
     "lyhytNimi" : "Children's Instructor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381203",
   "koodiArvo" : "381203",
@@ -16438,7 +16438,7 @@
     "lyhytNimi" : "Vocational qualification in Sports Instruction",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381204",
   "koodiArvo" : "381204",
@@ -16455,7 +16455,7 @@
     "lyhytNimi" : "Child Care and Education and Family Welfare, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381241",
   "koodiArvo" : "381241",
@@ -16472,7 +16472,7 @@
     "lyhytNimi" : "Vocational Qualification in Education and Guidance",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_381251",
   "koodiArvo" : "381251",
@@ -16489,7 +16489,7 @@
     "lyhytNimi" : "Leader of Leisure Time Activities",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381252",
   "koodiArvo" : "381252",
@@ -16506,7 +16506,7 @@
     "lyhytNimi" : "Church Youth and Social Work, Upper Secondary Level",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381253",
   "koodiArvo" : "381253",
@@ -16523,7 +16523,7 @@
     "lyhytNimi" : "Youth Organiser, Education in Youth Work, Upper Secondary Level",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381254",
   "koodiArvo" : "381254",
@@ -16540,7 +16540,7 @@
     "lyhytNimi" : "Line of Education in Cultural Activities (Folk High School)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381299",
   "koodiArvo" : "381299",
@@ -16557,7 +16557,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Leisure Activities and Youth Work",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381300",
   "koodiArvo" : "381300",
@@ -16574,7 +16574,7 @@
     "lyhytNimi" : "Vocational Education and Training in Beauty Care",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381301",
   "koodiArvo" : "381301",
@@ -16591,7 +16591,7 @@
     "lyhytNimi" : "Hairdresser",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381302",
   "koodiArvo" : "381302",
@@ -16608,7 +16608,7 @@
     "lyhytNimi" : "Beauty Therapist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381303",
   "koodiArvo" : "381303",
@@ -16625,7 +16625,7 @@
     "lyhytNimi" : "Hairdressing, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381304",
   "koodiArvo" : "381304",
@@ -16642,7 +16642,7 @@
     "lyhytNimi" : "Beauty Care, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381342",
   "koodiArvo" : "381342",
@@ -16659,7 +16659,7 @@
     "lyhytNimi" : "Vocational qualification in Hairdressing and Beauty Care",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_381351",
   "koodiArvo" : "381351",
@@ -16676,7 +16676,7 @@
     "lyhytNimi" : "Ladies' Hairdresser",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381352",
   "koodiArvo" : "381352",
@@ -16693,7 +16693,7 @@
     "lyhytNimi" : "Men's Hairdresser",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381399",
   "koodiArvo" : "381399",
@@ -16710,7 +16710,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Beauty Care",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381400",
   "koodiArvo" : "381400",
@@ -16727,7 +16727,7 @@
     "lyhytNimi" : "Vocational Education and Training in Traffic and Seafaring",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381401",
   "koodiArvo" : "381401",
@@ -16744,7 +16744,7 @@
     "lyhytNimi" : "Transportation, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381402",
   "koodiArvo" : "381402",
@@ -16761,7 +16761,7 @@
     "lyhytNimi" : "Vocational Qualification in Seafaring",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381403",
   "koodiArvo" : "381403",
@@ -16778,7 +16778,7 @@
     "lyhytNimi" : "Skipper-Engineer Officer, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381404",
   "koodiArvo" : "381404",
@@ -16795,7 +16795,7 @@
     "lyhytNimi" : "Air Traffic Controller",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381405",
   "koodiArvo" : "381405",
@@ -16812,7 +16812,7 @@
     "lyhytNimi" : "Commercial Pilot",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381406",
   "koodiArvo" : "381406",
@@ -16829,7 +16829,7 @@
     "lyhytNimi" : "Deck Officer (II/I)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381407",
   "koodiArvo" : "381407",
@@ -16846,7 +16846,7 @@
     "lyhytNimi" : "Watchkeeping Engineer Officer (III/I)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381408",
   "koodiArvo" : "381408",
@@ -16863,7 +16863,7 @@
     "lyhytNimi" : "Vocational qualification in Logistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381409",
   "koodiArvo" : "381409",
@@ -16880,7 +16880,7 @@
     "lyhytNimi" : "Repairer, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381410",
   "koodiArvo" : "381410",
@@ -16897,7 +16897,7 @@
     "lyhytNimi" : "Air Traffic Control, Vocational Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381451",
   "koodiArvo" : "381451",
@@ -16914,7 +16914,7 @@
     "lyhytNimi" : "Stevedore",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381452",
   "koodiArvo" : "381452",
@@ -16931,7 +16931,7 @@
     "lyhytNimi" : "Deck Hand",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381453",
   "koodiArvo" : "381453",
@@ -16948,7 +16948,7 @@
     "lyhytNimi" : "Engineer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381454",
   "koodiArvo" : "381454",
@@ -16965,7 +16965,7 @@
     "lyhytNimi" : "Heavy Truck Driver",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381455",
   "koodiArvo" : "381455",
@@ -16982,7 +16982,7 @@
     "lyhytNimi" : "Ship's Engine Mechanic",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381456",
   "koodiArvo" : "381456",
@@ -16999,7 +16999,7 @@
     "lyhytNimi" : "Skipper",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381457",
   "koodiArvo" : "381457",
@@ -17016,7 +17016,7 @@
     "lyhytNimi" : "Bus Driver",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381458",
   "koodiArvo" : "381458",
@@ -17033,7 +17033,7 @@
     "lyhytNimi" : "Mechanic, Driving and Transport Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381459",
   "koodiArvo" : "381459",
@@ -17050,7 +17050,7 @@
     "lyhytNimi" : "Able Seaman, g.p.",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381460",
   "koodiArvo" : "381460",
@@ -17067,7 +17067,7 @@
     "lyhytNimi" : "Boatswain",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381461",
   "koodiArvo" : "381461",
@@ -17084,7 +17084,7 @@
     "lyhytNimi" : "Preparatory Education of Seafaring Crew",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381499",
   "koodiArvo" : "381499",
@@ -17101,7 +17101,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Traffic and Seafaring",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381500",
   "koodiArvo" : "381500",
@@ -17118,7 +17118,7 @@
     "lyhytNimi" : "Vocational Education and Training in Safety and Security",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381501",
   "koodiArvo" : "381501",
@@ -17135,7 +17135,7 @@
     "lyhytNimi" : "Fire Fighter Diploma",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381502",
   "koodiArvo" : "381502",
@@ -17152,7 +17152,7 @@
     "lyhytNimi" : "Lower Fire Officer´s Diploma",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381503",
   "koodiArvo" : "381503",
@@ -17169,7 +17169,7 @@
     "lyhytNimi" : "Emergency Response Centre Operator Diploma",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381504",
   "koodiArvo" : "381504",
@@ -17186,7 +17186,7 @@
     "lyhytNimi" : "Vocational qualification in Safety and Security",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381512",
   "koodiArvo" : "381512",
@@ -17203,7 +17203,7 @@
     "lyhytNimi" : "Police Cadet",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381513",
   "koodiArvo" : "381513",
@@ -17220,7 +17220,7 @@
     "lyhytNimi" : "Tertiary Degree in Police Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381514",
   "koodiArvo" : "381514",
@@ -17237,7 +17237,7 @@
     "lyhytNimi" : "Vocational Qualification in Police Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381521",
   "koodiArvo" : "381521",
@@ -17254,7 +17254,7 @@
     "lyhytNimi" : "Basic Examination in Prison Service",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381522",
   "koodiArvo" : "381522",
@@ -17271,7 +17271,7 @@
     "lyhytNimi" : "Prison Administration Examination",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381531",
   "koodiArvo" : "381531",
@@ -17288,7 +17288,7 @@
     "lyhytNimi" : "Prison Officer (Industrial Security Guard)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381599",
   "koodiArvo" : "381599",
@@ -17305,7 +17305,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Safety and Security",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381600",
   "koodiArvo" : "381600",
@@ -17322,7 +17322,7 @@
     "lyhytNimi" : "Vocational Education and Training in Military Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381601",
   "koodiArvo" : "381601",
@@ -17339,7 +17339,7 @@
     "lyhytNimi" : "Warrant Officer, Lower Diploma Examination",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381602",
   "koodiArvo" : "381602",
@@ -17356,7 +17356,7 @@
     "lyhytNimi" : "Warrant Officer, Higher Diploma Examination",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381604",
   "koodiArvo" : "381604",
@@ -17373,7 +17373,7 @@
     "lyhytNimi" : "Frontier Guard",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381605",
   "koodiArvo" : "381605",
@@ -17390,7 +17390,7 @@
     "lyhytNimi" : "Coast Guard",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381699",
   "koodiArvo" : "381699",
@@ -17407,7 +17407,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Military Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381900",
   "koodiArvo" : "381900",
@@ -17424,7 +17424,7 @@
     "lyhytNimi" : "Other Vocational Education and Training in Services, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_381999",
   "koodiArvo" : "381999",
@@ -17441,7 +17441,7 @@
     "lyhytNimi" : "Other or Unknown Vocational Education and Training in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384000",
   "koodiArvo" : "384000",
@@ -17458,7 +17458,7 @@
     "lyhytNimi" : "Further Qualification in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384100",
   "koodiArvo" : "384100",
@@ -17475,7 +17475,7 @@
     "lyhytNimi" : "Further Qualification in Hotel, Catering and Home Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384101",
   "koodiArvo" : "384101",
@@ -17492,7 +17492,7 @@
     "lyhytNimi" : "Hotel Receptionist, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384102",
   "koodiArvo" : "384102",
@@ -17509,7 +17509,7 @@
     "lyhytNimi" : "Cook, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384103",
   "koodiArvo" : "384103",
@@ -17526,7 +17526,7 @@
     "lyhytNimi" : "Institutional Cleaning, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384104",
   "koodiArvo" : "384104",
@@ -17543,7 +17543,7 @@
     "lyhytNimi" : "Tourism Industry, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384105",
   "koodiArvo" : "384105",
@@ -17560,7 +17560,7 @@
     "lyhytNimi" : "Tourist Guide, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384106",
   "koodiArvo" : "384106",
@@ -17577,7 +17577,7 @@
     "lyhytNimi" : "Waiter/Waitress, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384107",
   "koodiArvo" : "384107",
@@ -17594,7 +17594,7 @@
     "lyhytNimi" : "Sales and Customer Service, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384108",
   "koodiArvo" : "384108",
@@ -17611,7 +17611,7 @@
     "lyhytNimi" : "Cook, Institutional Catering, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384109",
   "koodiArvo" : "384109",
@@ -17628,7 +17628,7 @@
     "lyhytNimi" : "Restaurant Cookery, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384110",
   "koodiArvo" : "384110",
@@ -17645,7 +17645,7 @@
     "lyhytNimi" : "Travel Services, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384111",
   "koodiArvo" : "384111",
@@ -17662,7 +17662,7 @@
     "lyhytNimi" : "Tourism Activities, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384112",
   "koodiArvo" : "384112",
@@ -17679,7 +17679,7 @@
     "lyhytNimi" : "Further vocational qualification in Guide Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384113",
   "koodiArvo" : "384113",
@@ -17696,7 +17696,7 @@
     "lyhytNimi" : "Textiles Care, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384114",
   "koodiArvo" : "384114",
@@ -17713,7 +17713,7 @@
     "lyhytNimi" : "Household Services, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384145",
   "koodiArvo" : "384145",
@@ -17730,7 +17730,7 @@
     "lyhytNimi" : "Further Vocational Qualification in Cleaning and Property Services",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_384146",
   "koodiArvo" : "384146",
@@ -17747,7 +17747,7 @@
     "lyhytNimi" : "Further vocational qualification in Tourism Services",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_384147",
   "koodiArvo" : "384147",
@@ -17764,7 +17764,7 @@
     "lyhytNimi" : "Further vocational qualification in Restaurant Customer Service",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_384148",
   "koodiArvo" : "384148",
@@ -17781,7 +17781,7 @@
     "lyhytNimi" : "Further vocational qualification in Food Services",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_384199",
   "koodiArvo" : "384199",
@@ -17798,7 +17798,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Hotel, Catering and Home Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384200",
   "koodiArvo" : "384200",
@@ -17815,7 +17815,7 @@
     "lyhytNimi" : "Further Qualification in Leisure Activities and Youth Work",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384201",
   "koodiArvo" : "384201",
@@ -17832,7 +17832,7 @@
     "lyhytNimi" : "Further vocational qualification for Community Interpreting",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384202",
   "koodiArvo" : "384202",
@@ -17849,7 +17849,7 @@
     "lyhytNimi" : "Further vocational qualification in Sports Facilities Maintenance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384203",
   "koodiArvo" : "384203",
@@ -17866,7 +17866,7 @@
     "lyhytNimi" : "Verger, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384204",
   "koodiArvo" : "384204",
@@ -17883,7 +17883,7 @@
     "lyhytNimi" : "Further vocational qualification in Physical Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384205",
   "koodiArvo" : "384205",
@@ -17900,7 +17900,7 @@
     "lyhytNimi" : "Coaching, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384246",
   "koodiArvo" : "384246",
@@ -17917,7 +17917,7 @@
     "lyhytNimi" : "Further vocational qualification in Education and Guidance",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_384247",
   "koodiArvo" : "384247",
@@ -17930,7 +17930,7 @@
     "lyhytNimi" : "YE i församlings- och begravningsservice",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_384248",
   "koodiArvo" : "384248",
@@ -17947,7 +17947,7 @@
     "lyhytNimi" : "Further vocational qualification in Sports and Coaching",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_384299",
   "koodiArvo" : "384299",
@@ -17964,7 +17964,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Leisure Activities and Youth Work",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384300",
   "koodiArvo" : "384300",
@@ -17981,7 +17981,7 @@
     "lyhytNimi" : "Further Qualification in Beauty Care",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384301",
   "koodiArvo" : "384301",
@@ -17998,7 +17998,7 @@
     "lyhytNimi" : "Hairdressing, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384400",
   "koodiArvo" : "384400",
@@ -18015,7 +18015,7 @@
     "lyhytNimi" : "Further Qualification in Traffic and Seafaring",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384401",
   "koodiArvo" : "384401",
@@ -18032,7 +18032,7 @@
     "lyhytNimi" : "Further vocational qualification in Cargo Handling",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384402",
   "koodiArvo" : "384402",
@@ -18049,7 +18049,7 @@
     "lyhytNimi" : "Bus Driver, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384403",
   "koodiArvo" : "384403",
@@ -18066,7 +18066,7 @@
     "lyhytNimi" : "Driver of Articulated Vehicles, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384404",
   "koodiArvo" : "384404",
@@ -18083,7 +18083,7 @@
     "lyhytNimi" : "Service Station Attendant, Further Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384405",
   "koodiArvo" : "384405",
@@ -18100,7 +18100,7 @@
     "lyhytNimi" : "Further vocational qualification in Airport Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384445",
   "koodiArvo" : "384445",
@@ -18117,7 +18117,7 @@
     "lyhytNimi" : "Further Vocational Qualification in Seafaring",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_384446",
   "koodiArvo" : "384446",
@@ -18134,7 +18134,7 @@
     "lyhytNimi" : "Further vocational qualification in the Transport Sector",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_384499",
   "koodiArvo" : "384499",
@@ -18151,7 +18151,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Traffic and Seafaring",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384500",
   "koodiArvo" : "384500",
@@ -18168,7 +18168,7 @@
     "lyhytNimi" : "Further Qualification in Safety and Security",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384501",
   "koodiArvo" : "384501",
@@ -18185,7 +18185,7 @@
     "lyhytNimi" : "Further vocational qualification in the Security Sector",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384599",
   "koodiArvo" : "384599",
@@ -18202,7 +18202,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Safety and Security",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384900",
   "koodiArvo" : "384900",
@@ -18219,7 +18219,7 @@
     "lyhytNimi" : "Other Further Qualification in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_384999",
   "koodiArvo" : "384999",
@@ -18236,7 +18236,7 @@
     "lyhytNimi" : "Other or Unknown Further Qualification in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387000",
   "koodiArvo" : "387000",
@@ -18253,7 +18253,7 @@
     "lyhytNimi" : "Specialist Qualification in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387100",
   "koodiArvo" : "387100",
@@ -18270,7 +18270,7 @@
     "lyhytNimi" : "Specialist Qualification in Hotel, Catering and Home Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387101",
   "koodiArvo" : "387101",
@@ -18283,7 +18283,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387102",
   "koodiArvo" : "387102",
@@ -18296,7 +18296,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387103",
   "koodiArvo" : "387103",
@@ -18309,7 +18309,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387104",
   "koodiArvo" : "387104",
@@ -18322,7 +18322,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387105",
   "koodiArvo" : "387105",
@@ -18335,7 +18335,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387106",
   "koodiArvo" : "387106",
@@ -18348,7 +18348,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387199",
   "koodiArvo" : "387199",
@@ -18365,7 +18365,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Hotel, Catering and Home Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387200",
   "koodiArvo" : "387200",
@@ -18382,7 +18382,7 @@
     "lyhytNimi" : "Specialist Qualification in Leisure Activities and Youth Work",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387201",
   "koodiArvo" : "387201",
@@ -18395,7 +18395,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387202",
   "koodiArvo" : "387202",
@@ -18408,7 +18408,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387203",
   "koodiArvo" : "387203",
@@ -18421,7 +18421,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387299",
   "koodiArvo" : "387299",
@@ -18438,7 +18438,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Leisure Activities and Youth Work",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387300",
   "koodiArvo" : "387300",
@@ -18455,7 +18455,7 @@
     "lyhytNimi" : "Specialist Qualification in Beauty Care",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387301",
   "koodiArvo" : "387301",
@@ -18472,7 +18472,7 @@
     "lyhytNimi" : "Ladies' Hairdressing, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387302",
   "koodiArvo" : "387302",
@@ -18489,7 +18489,7 @@
     "lyhytNimi" : "Men's Hairdressing, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387303",
   "koodiArvo" : "387303",
@@ -18502,7 +18502,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387304",
   "koodiArvo" : "387304",
@@ -18515,7 +18515,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387399",
   "koodiArvo" : "387399",
@@ -18532,7 +18532,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Beauty Care",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387400",
   "koodiArvo" : "387400",
@@ -18549,7 +18549,7 @@
     "lyhytNimi" : "Specialist Qualification in Traffic and Seafaring",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387401",
   "koodiArvo" : "387401",
@@ -18562,7 +18562,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387499",
   "koodiArvo" : "387499",
@@ -18579,7 +18579,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Traffic and Seafaring",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387500",
   "koodiArvo" : "387500",
@@ -18596,7 +18596,7 @@
     "lyhytNimi" : "Specialist Qualification in Safety and Security",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387501",
   "koodiArvo" : "387501",
@@ -18613,7 +18613,7 @@
     "lyhytNimi" : "Security Officer, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387599",
   "koodiArvo" : "387599",
@@ -18630,7 +18630,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Safety and Security",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387900",
   "koodiArvo" : "387900",
@@ -18647,7 +18647,7 @@
     "lyhytNimi" : "Other Specialist Qualification in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_387999",
   "koodiArvo" : "387999",
@@ -18664,7 +18664,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_389000",
   "koodiArvo" : "389000",
@@ -18681,7 +18681,7 @@
     "lyhytNimi" : "Other Education in Services, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_389900",
   "koodiArvo" : "389900",
@@ -18698,7 +18698,7 @@
     "lyhytNimi" : "Other Education in Services, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_389911",
   "koodiArvo" : "389911",
@@ -18715,7 +18715,7 @@
     "lyhytNimi" : "Other or Unknown Education in Hotel, Catering and Home Economics, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_389914",
   "koodiArvo" : "389914",
@@ -18732,7 +18732,7 @@
     "lyhytNimi" : "Other or Unknown Education in Traffic and Seafaring, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_389915",
   "koodiArvo" : "389915",
@@ -18749,7 +18749,7 @@
     "lyhytNimi" : "Other or Unknown Education in Safety and Security, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_389916",
   "koodiArvo" : "389916",
@@ -18766,7 +18766,7 @@
     "lyhytNimi" : "Other or Unknown Education in Military Science, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_389999",
   "koodiArvo" : "389999",
@@ -18783,7 +18783,7 @@
     "lyhytNimi" : "Other or Unknown Education in Services, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_399000",
   "koodiArvo" : "399000",
@@ -18800,7 +18800,7 @@
     "lyhytNimi" : "Other Education, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_399900",
   "koodiArvo" : "399900",
@@ -18817,7 +18817,7 @@
     "lyhytNimi" : "Other Education, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_399999",
   "koodiArvo" : "399999",
@@ -18834,7 +18834,7 @@
     "lyhytNimi" : "Other or Unknown Education, Upper Secondary Level Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_417000",
   "koodiArvo" : "417000",
@@ -18851,7 +18851,7 @@
     "lyhytNimi" : "Teacher Education, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_417100",
   "koodiArvo" : "417100",
@@ -18868,7 +18868,7 @@
     "lyhytNimi" : "Teacher Education, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_417101",
   "koodiArvo" : "417101",
@@ -18885,7 +18885,7 @@
     "lyhytNimi" : "Specialist vocational qualification for Driving Instructors",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427000",
   "koodiArvo" : "427000",
@@ -18902,7 +18902,7 @@
     "lyhytNimi" : "Specialist Qualification in Arts, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427100",
   "koodiArvo" : "427100",
@@ -18919,7 +18919,7 @@
     "lyhytNimi" : "Specialist Qualification in Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427101",
   "koodiArvo" : "427101",
@@ -18932,7 +18932,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427102",
   "koodiArvo" : "427102",
@@ -18949,7 +18949,7 @@
     "lyhytNimi" : "Silversmith, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427103",
   "koodiArvo" : "427103",
@@ -18966,7 +18966,7 @@
     "lyhytNimi" : "Engraver, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427104",
   "koodiArvo" : "427104",
@@ -18983,7 +18983,7 @@
     "lyhytNimi" : "Ceramist, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427105",
   "koodiArvo" : "427105",
@@ -19000,7 +19000,7 @@
     "lyhytNimi" : "Stonecutter, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427106",
   "koodiArvo" : "427106",
@@ -19017,7 +19017,7 @@
     "lyhytNimi" : "Ornamental Wood Carving, Specialist Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427107",
   "koodiArvo" : "427107",
@@ -19030,7 +19030,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427108",
   "koodiArvo" : "427108",
@@ -19047,7 +19047,7 @@
     "lyhytNimi" : "Goldsmith, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427109",
   "koodiArvo" : "427109",
@@ -19060,7 +19060,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427110",
   "koodiArvo" : "427110",
@@ -19077,7 +19077,7 @@
     "lyhytNimi" : "Painter, Specialist Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427111",
   "koodiArvo" : "427111",
@@ -19094,7 +19094,7 @@
     "lyhytNimi" : "Model-Builder, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427112",
   "koodiArvo" : "427112",
@@ -19111,7 +19111,7 @@
     "lyhytNimi" : "Knitter, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427113",
   "koodiArvo" : "427113",
@@ -19128,7 +19128,7 @@
     "lyhytNimi" : "Joiner, Specialist Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427114",
   "koodiArvo" : "427114",
@@ -19141,7 +19141,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427115",
   "koodiArvo" : "427115",
@@ -19154,7 +19154,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427116",
   "koodiArvo" : "427116",
@@ -19171,7 +19171,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Sámi Crafts",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427117",
   "koodiArvo" : "427117",
@@ -19188,7 +19188,7 @@
     "lyhytNimi" : "Potter, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427118",
   "koodiArvo" : "427118",
@@ -19201,7 +19201,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427119",
   "koodiArvo" : "427119",
@@ -19214,7 +19214,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427120",
   "koodiArvo" : "427120",
@@ -19231,7 +19231,7 @@
     "lyhytNimi" : "Studio Weaver, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427121",
   "koodiArvo" : "427121",
@@ -19248,7 +19248,7 @@
     "lyhytNimi" : "Studio Dressmaker, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427122",
   "koodiArvo" : "427122",
@@ -19265,7 +19265,7 @@
     "lyhytNimi" : "Boat-Builder, Specialist Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427123",
   "koodiArvo" : "427123",
@@ -19282,7 +19282,7 @@
     "lyhytNimi" : "Dyer, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427124",
   "koodiArvo" : "427124",
@@ -19299,7 +19299,7 @@
     "lyhytNimi" : "Joiner, Specialist Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427125",
   "koodiArvo" : "427125",
@@ -19316,7 +19316,7 @@
     "lyhytNimi" : "Textiles, Specialist Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427126",
   "koodiArvo" : "427126",
@@ -19333,7 +19333,7 @@
     "lyhytNimi" : "Specialist Qualification in Clothing, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427127",
   "koodiArvo" : "427127",
@@ -19350,7 +19350,7 @@
     "lyhytNimi" : "Interior Design, Specialist Qualification, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427128",
   "koodiArvo" : "427128",
@@ -19363,7 +19363,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427130",
   "koodiArvo" : "427130",
@@ -19376,7 +19376,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427141",
   "koodiArvo" : "427141",
@@ -19393,7 +19393,7 @@
     "lyhytNimi" : "Taideteollisuusalan eat",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427199",
   "koodiArvo" : "427199",
@@ -19410,7 +19410,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427300",
   "koodiArvo" : "427300",
@@ -19427,7 +19427,7 @@
     "lyhytNimi" : "Specialist Qualification in Fine Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427301",
   "koodiArvo" : "427301",
@@ -19440,7 +19440,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427302",
   "koodiArvo" : "427302",
@@ -19457,7 +19457,7 @@
     "lyhytNimi" : "Audiovisual Communication, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427399",
   "koodiArvo" : "427399",
@@ -19474,7 +19474,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Fine Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427500",
   "koodiArvo" : "427500",
@@ -19491,7 +19491,7 @@
     "lyhytNimi" : "Specialist Qualification in Theatre and Dance",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427501",
   "koodiArvo" : "427501",
@@ -19508,7 +19508,7 @@
     "lyhytNimi" : "Make-up Artist, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427502",
   "koodiArvo" : "427502",
@@ -19525,7 +19525,7 @@
     "lyhytNimi" : "Theatre Technology, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427503",
   "koodiArvo" : "427503",
@@ -19538,7 +19538,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427504",
   "koodiArvo" : "427504",
@@ -19555,7 +19555,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Stage and Theatre Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427599",
   "koodiArvo" : "427599",
@@ -19572,7 +19572,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Theatre and Dance",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427600",
   "koodiArvo" : "427600",
@@ -19589,7 +19589,7 @@
     "lyhytNimi" : "Specialist Qualification in Communications",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427601",
   "koodiArvo" : "427601",
@@ -19606,7 +19606,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Media",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_427699",
   "koodiArvo" : "427699",
@@ -19623,7 +19623,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Communications",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_437000",
   "koodiArvo" : "437000",
@@ -19640,7 +19640,7 @@
     "lyhytNimi" : "Specialist Qualification in Business and Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_437100",
   "koodiArvo" : "437100",
@@ -19657,7 +19657,7 @@
     "lyhytNimi" : "Specialist Qualification in Business and Administartion",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_437101",
   "koodiArvo" : "437101",
@@ -19674,7 +19674,7 @@
     "lyhytNimi" : "Management, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_437102",
   "koodiArvo" : "437102",
@@ -19687,7 +19687,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_437103",
   "koodiArvo" : "437103",
@@ -19704,7 +19704,7 @@
     "lyhytNimi" : "Shipbroker, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_437104",
   "koodiArvo" : "437104",
@@ -19717,7 +19717,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_437106",
   "koodiArvo" : "437106",
@@ -19730,7 +19730,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_437107",
   "koodiArvo" : "437107",
@@ -19743,7 +19743,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_437108",
   "koodiArvo" : "437108",
@@ -19756,7 +19756,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_437109",
   "koodiArvo" : "437109",
@@ -19773,7 +19773,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_437110",
   "koodiArvo" : "437110",
@@ -19786,7 +19786,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_437111",
   "koodiArvo" : "437111",
@@ -19803,7 +19803,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_437112",
   "koodiArvo" : "437112",
@@ -19820,7 +19820,7 @@
     "lyhytNimi" : "Specialist vocational qualification for Business Advisers",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_437113",
   "koodiArvo" : "437113",
@@ -19837,7 +19837,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Property Management",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_437141",
   "koodiArvo" : "437141",
@@ -19854,7 +19854,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Leadership and Business Management",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_437142",
   "koodiArvo" : "437142",
@@ -19871,7 +19871,7 @@
     "lyhytNimi" : "SVQ in Business",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_437143",
   "koodiArvo" : "437143",
@@ -19888,7 +19888,7 @@
     "lyhytNimi" : "SVQ in Service Logistics",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_437199",
   "koodiArvo" : "437199",
@@ -19905,7 +19905,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Business and Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_447000",
   "koodiArvo" : "447000",
@@ -19922,7 +19922,7 @@
     "lyhytNimi" : "Specialist Qualification in Information Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_447100",
   "koodiArvo" : "447100",
@@ -19939,7 +19939,7 @@
     "lyhytNimi" : "Specialist Qualification in Information Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_447101",
   "koodiArvo" : "447101",
@@ -19956,7 +19956,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Information and Communications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_447102",
   "koodiArvo" : "447102",
@@ -19990,7 +19990,7 @@
     "lyhytNimi" : "Specialist Qualification in Technology (Metalwork, Heating and Ventilation, Vehicles, Electrics, IT, Chemistry, Wood Industry and Surface Treatment)",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457100",
   "koodiArvo" : "457100",
@@ -20007,7 +20007,7 @@
     "lyhytNimi" : "Specialist Qualification in Metalwork and Machinery",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457101",
   "koodiArvo" : "457101",
@@ -20020,7 +20020,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457102",
   "koodiArvo" : "457102",
@@ -20033,7 +20033,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457103",
   "koodiArvo" : "457103",
@@ -20046,7 +20046,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457104",
   "koodiArvo" : "457104",
@@ -20059,7 +20059,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457105",
   "koodiArvo" : "457105",
@@ -20072,7 +20072,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457106",
   "koodiArvo" : "457106",
@@ -20085,7 +20085,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457107",
   "koodiArvo" : "457107",
@@ -20098,7 +20098,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457108",
   "koodiArvo" : "457108",
@@ -20111,7 +20111,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457109",
   "koodiArvo" : "457109",
@@ -20124,7 +20124,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457110",
   "koodiArvo" : "457110",
@@ -20137,7 +20137,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457111",
   "koodiArvo" : "457111",
@@ -20150,7 +20150,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457112",
   "koodiArvo" : "457112",
@@ -20167,7 +20167,7 @@
     "lyhytNimi" : "Specialist vocational qualification in First-Level Management in Production",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457141",
   "koodiArvo" : "457141",
@@ -20184,7 +20184,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Machine Mechanics and Maintenance",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457199",
   "koodiArvo" : "457199",
@@ -20201,7 +20201,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Metalwork and Machinery",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457200",
   "koodiArvo" : "457200",
@@ -20218,7 +20218,7 @@
     "lyhytNimi" : "Specialist Qualification in Heating and Ventilation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457201",
   "koodiArvo" : "457201",
@@ -20231,7 +20231,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457202",
   "koodiArvo" : "457202",
@@ -20248,7 +20248,7 @@
     "lyhytNimi" : "District Heating Fitter, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457203",
   "koodiArvo" : "457203",
@@ -20261,7 +20261,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457204",
   "koodiArvo" : "457204",
@@ -20274,7 +20274,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457205",
   "koodiArvo" : "457205",
@@ -20287,7 +20287,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457206",
   "koodiArvo" : "457206",
@@ -20300,7 +20300,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457207",
   "koodiArvo" : "457207",
@@ -20313,7 +20313,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457241",
   "koodiArvo" : "457241",
@@ -20326,7 +20326,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457299",
   "koodiArvo" : "457299",
@@ -20343,7 +20343,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Heating and Ventilation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457300",
   "koodiArvo" : "457300",
@@ -20360,7 +20360,7 @@
     "lyhytNimi" : "Specialist Qualification in Vehicles and Transportation",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457301",
   "koodiArvo" : "457301",
@@ -20373,7 +20373,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457302",
   "koodiArvo" : "457302",
@@ -20386,7 +20386,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457303",
   "koodiArvo" : "457303",
@@ -20399,7 +20399,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457304",
   "koodiArvo" : "457304",
@@ -20412,7 +20412,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457305",
   "koodiArvo" : "457305",
@@ -20429,7 +20429,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457306",
   "koodiArvo" : "457306",
@@ -20442,7 +20442,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457307",
   "koodiArvo" : "457307",
@@ -20459,7 +20459,7 @@
     "lyhytNimi" : "Aircraft Technology, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457341",
   "koodiArvo" : "457341",
@@ -20476,7 +20476,7 @@
     "lyhytNimi" : "Specialist vocational qualification in the Motor Vehicles Sector",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457399",
   "koodiArvo" : "457399",
@@ -20493,7 +20493,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Vehicles and Transportation",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457400",
   "koodiArvo" : "457400",
@@ -20510,7 +20510,7 @@
     "lyhytNimi" : "Specialist Qualification in Electrical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457401",
   "koodiArvo" : "457401",
@@ -20523,7 +20523,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457402",
   "koodiArvo" : "457402",
@@ -20540,7 +20540,7 @@
     "lyhytNimi" : "Electronics Assembler, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457403",
   "koodiArvo" : "457403",
@@ -20553,7 +20553,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457404",
   "koodiArvo" : "457404",
@@ -20566,7 +20566,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457405",
   "koodiArvo" : "457405",
@@ -20583,7 +20583,7 @@
     "lyhytNimi" : "Specialist vocational qualification for Electro-technical Officers",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457406",
   "koodiArvo" : "457406",
@@ -20600,7 +20600,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457441",
   "koodiArvo" : "457441",
@@ -20617,7 +20617,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457442",
   "koodiArvo" : "457442",
@@ -20634,7 +20634,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Electrical Engineering and Automation Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457499",
   "koodiArvo" : "457499",
@@ -20651,7 +20651,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Electrical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457500",
   "koodiArvo" : "457500",
@@ -20668,7 +20668,7 @@
     "lyhytNimi" : "Specialist Qualification in Information Technology and Telecommunications",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457501",
   "koodiArvo" : "457501",
@@ -20685,7 +20685,7 @@
     "lyhytNimi" : "Computer Mechanic, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457502",
   "koodiArvo" : "457502",
@@ -20702,7 +20702,7 @@
     "lyhytNimi" : "Telecommunications Fitter, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457503",
   "koodiArvo" : "457503",
@@ -20719,7 +20719,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Information and Telecommunications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457599",
   "koodiArvo" : "457599",
@@ -20736,7 +20736,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Information Technology and Telecommunications",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457600",
   "koodiArvo" : "457600",
@@ -20753,7 +20753,7 @@
     "lyhytNimi" : "Specialist Qualification in Paper Industry and Chemical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457601",
   "koodiArvo" : "457601",
@@ -20766,7 +20766,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457602",
   "koodiArvo" : "457602",
@@ -20783,7 +20783,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457603",
   "koodiArvo" : "457603",
@@ -20796,7 +20796,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457641",
   "koodiArvo" : "457641",
@@ -20813,7 +20813,7 @@
     "lyhytNimi" : "Specialist vocational qualification in the Process Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457699",
   "koodiArvo" : "457699",
@@ -20830,7 +20830,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Paper Industry and Chemical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457700",
   "koodiArvo" : "457700",
@@ -20847,7 +20847,7 @@
     "lyhytNimi" : "Specialist Qualification in Wood Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457701",
   "koodiArvo" : "457701",
@@ -20864,7 +20864,7 @@
     "lyhytNimi" : "Ornamental Wood Carving, Specialist Qualification, Process, Chemical and Materials Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457702",
   "koodiArvo" : "457702",
@@ -20877,7 +20877,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457703",
   "koodiArvo" : "457703",
@@ -20894,7 +20894,7 @@
     "lyhytNimi" : "Joiner, Specialist Qualification, Process, Chemical and Materials Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457704",
   "koodiArvo" : "457704",
@@ -20911,7 +20911,7 @@
     "lyhytNimi" : "Sawmill and Panel Industry, Specialist Qualification in Maintenance",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457705",
   "koodiArvo" : "457705",
@@ -20924,7 +20924,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457706",
   "koodiArvo" : "457706",
@@ -20941,7 +20941,7 @@
     "lyhytNimi" : "Sharp Tool Maintenance, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457707",
   "koodiArvo" : "457707",
@@ -20958,7 +20958,7 @@
     "lyhytNimi" : "Specialist vocational qualification in the Boat-Building",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457708",
   "koodiArvo" : "457708",
@@ -20971,7 +20971,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457709",
   "koodiArvo" : "457709",
@@ -20988,7 +20988,7 @@
     "lyhytNimi" : "Specialist Qualification in the Wood Product Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457741",
   "koodiArvo" : "457741",
@@ -21001,7 +21001,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457799",
   "koodiArvo" : "457799",
@@ -21018,7 +21018,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Wood Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457800",
   "koodiArvo" : "457800",
@@ -21035,7 +21035,7 @@
     "lyhytNimi" : "Specialist Qualification in Surface Treatment Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457801",
   "koodiArvo" : "457801",
@@ -21048,7 +21048,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457802",
   "koodiArvo" : "457802",
@@ -21065,7 +21065,7 @@
     "lyhytNimi" : "Painter, Specialist Qualification (Process, Chemical and Materials Engineering)",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457803",
   "koodiArvo" : "457803",
@@ -21078,7 +21078,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457841",
   "koodiArvo" : "457841",
@@ -21095,7 +21095,7 @@
     "lyhytNimi" : "Pintakäsittelyalan eat",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_457899",
   "koodiArvo" : "457899",
@@ -21112,7 +21112,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Surface Treatment Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458000",
   "koodiArvo" : "458000",
@@ -21129,7 +21129,7 @@
     "lyhytNimi" : "Specialist Qualification in Technology (Food Industry, Construction Technology, Land Survey Technology, Textiles and Graphic Technology)",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458100",
   "koodiArvo" : "458100",
@@ -21146,7 +21146,7 @@
     "lyhytNimi" : "Specialist Qualification in Food Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458101",
   "koodiArvo" : "458101",
@@ -21159,7 +21159,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458102",
   "koodiArvo" : "458102",
@@ -21172,7 +21172,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458103",
   "koodiArvo" : "458103",
@@ -21189,7 +21189,7 @@
     "lyhytNimi" : "Food Technology, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458141",
   "koodiArvo" : "458141",
@@ -21206,7 +21206,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458199",
   "koodiArvo" : "458199",
@@ -21223,7 +21223,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Food Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458200",
   "koodiArvo" : "458200",
@@ -21240,7 +21240,7 @@
     "lyhytNimi" : "Specialist Qualification in Construction Technology and Community Development and Maintenance",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458201",
   "koodiArvo" : "458201",
@@ -21257,7 +21257,7 @@
     "lyhytNimi" : "Carpenter, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458202",
   "koodiArvo" : "458202",
@@ -21274,7 +21274,7 @@
     "lyhytNimi" : "Bricklayer, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458203",
   "koodiArvo" : "458203",
@@ -21291,7 +21291,7 @@
     "lyhytNimi" : "Construction, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458204",
   "koodiArvo" : "458204",
@@ -21308,7 +21308,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458205",
   "koodiArvo" : "458205",
@@ -21325,7 +21325,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Building Construction",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458206",
   "koodiArvo" : "458206",
@@ -21342,7 +21342,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Infrastructure Construction",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458207",
   "koodiArvo" : "458207",
@@ -21355,7 +21355,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458241",
   "koodiArvo" : "458241",
@@ -21372,7 +21372,7 @@
     "lyhytNimi" : "SVQ for Construction Site Managers",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458299",
   "koodiArvo" : "458299",
@@ -21389,7 +21389,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Construction Technology and Community Development and Maintenance",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458400",
   "koodiArvo" : "458400",
@@ -21406,7 +21406,7 @@
     "lyhytNimi" : "Specialist Qualification in Textiles and Clothing",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458401",
   "koodiArvo" : "458401",
@@ -21423,7 +21423,7 @@
     "lyhytNimi" : "Millinery, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458402",
   "koodiArvo" : "458402",
@@ -21440,7 +21440,7 @@
     "lyhytNimi" : "Dressmaking, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458403",
   "koodiArvo" : "458403",
@@ -21457,7 +21457,7 @@
     "lyhytNimi" : "Dressmaker, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458404",
   "koodiArvo" : "458404",
@@ -21474,7 +21474,7 @@
     "lyhytNimi" : "Shoemaking, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458405",
   "koodiArvo" : "458405",
@@ -21487,7 +21487,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458406",
   "koodiArvo" : "458406",
@@ -21504,7 +21504,7 @@
     "lyhytNimi" : "Tailoring, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458407",
   "koodiArvo" : "458407",
@@ -21521,7 +21521,7 @@
     "lyhytNimi" : "Patternmaker, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458408",
   "koodiArvo" : "458408",
@@ -21534,7 +21534,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458409",
   "koodiArvo" : "458409",
@@ -21547,7 +21547,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458410",
   "koodiArvo" : "458410",
@@ -21560,7 +21560,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458411",
   "koodiArvo" : "458411",
@@ -21577,7 +21577,7 @@
     "lyhytNimi" : "Textiles, Specialist Qualification, Textiles and Clothing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458412",
   "koodiArvo" : "458412",
@@ -21594,7 +21594,7 @@
     "lyhytNimi" : "Clothing, Specialist Qualification, Textiles and Clothing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458441",
   "koodiArvo" : "458441",
@@ -21611,7 +21611,7 @@
     "lyhytNimi" : "Specialist vocational qualification in the Textiles and Fashion Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458499",
   "koodiArvo" : "458499",
@@ -21628,7 +21628,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Textiles and Clothing",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458500",
   "koodiArvo" : "458500",
@@ -21645,7 +21645,7 @@
     "lyhytNimi" : "Specialist Qualification in Graphics Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458502",
   "koodiArvo" : "458502",
@@ -21658,7 +21658,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458503",
   "koodiArvo" : "458503",
@@ -21671,7 +21671,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458504",
   "koodiArvo" : "458504",
@@ -21688,7 +21688,7 @@
     "lyhytNimi" : "Printing, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458505",
   "koodiArvo" : "458505",
@@ -21705,7 +21705,7 @@
     "lyhytNimi" : "Rotary Printing, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458506",
   "koodiArvo" : "458506",
@@ -21722,7 +21722,7 @@
     "lyhytNimi" : "Page Layout, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458507",
   "koodiArvo" : "458507",
@@ -21739,7 +21739,7 @@
     "lyhytNimi" : "Printing Technology, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458508",
   "koodiArvo" : "458508",
@@ -21756,7 +21756,7 @@
     "lyhytNimi" : "Print-Shop Supervisor, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458599",
   "koodiArvo" : "458599",
@@ -21773,7 +21773,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Graphics Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458641",
   "koodiArvo" : "458641",
@@ -21790,7 +21790,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Production Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458900",
   "koodiArvo" : "458900",
@@ -21807,7 +21807,7 @@
     "lyhytNimi" : "Other Specialist Qualification in Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458901",
   "koodiArvo" : "458901",
@@ -21820,7 +21820,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458902",
   "koodiArvo" : "458902",
@@ -21837,7 +21837,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Product Development",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458903",
   "koodiArvo" : "458903",
@@ -21854,7 +21854,7 @@
     "lyhytNimi" : "Interior Design, Specialist Qualification, Technology and Transport",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458904",
   "koodiArvo" : "458904",
@@ -21871,7 +21871,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Sustainability and Environmental Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_458999",
   "koodiArvo" : "458999",
@@ -21888,7 +21888,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467000",
   "koodiArvo" : "467000",
@@ -21905,7 +21905,7 @@
     "lyhytNimi" : "Specialist Qualification in Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467100",
   "koodiArvo" : "467100",
@@ -21922,7 +21922,7 @@
     "lyhytNimi" : "Specialist Qualification in Agriculture",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467101",
   "koodiArvo" : "467101",
@@ -21935,7 +21935,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467102",
   "koodiArvo" : "467102",
@@ -21952,7 +21952,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467103",
   "koodiArvo" : "467103",
@@ -21965,7 +21965,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467104",
   "koodiArvo" : "467104",
@@ -21978,7 +21978,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467141",
   "koodiArvo" : "467141",
@@ -21995,7 +21995,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467142",
   "koodiArvo" : "467142",
@@ -22012,7 +22012,7 @@
     "lyhytNimi" : "Hevostalouden eat",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467199",
   "koodiArvo" : "467199",
@@ -22029,7 +22029,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Agriculture",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467200",
   "koodiArvo" : "467200",
@@ -22046,7 +22046,7 @@
     "lyhytNimi" : "Specialist Qualification in Horticulture",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467201",
   "koodiArvo" : "467201",
@@ -22059,7 +22059,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467202",
   "koodiArvo" : "467202",
@@ -22076,7 +22076,7 @@
     "lyhytNimi" : "Nursery Gardening, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467203",
   "koodiArvo" : "467203",
@@ -22093,7 +22093,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467241",
   "koodiArvo" : "467241",
@@ -22110,7 +22110,7 @@
     "lyhytNimi" : "Puutarha-alan eat",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467299",
   "koodiArvo" : "467299",
@@ -22127,7 +22127,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Horticulture",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467300",
   "koodiArvo" : "467300",
@@ -22144,7 +22144,7 @@
     "lyhytNimi" : "Specialist Qualification in Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467301",
   "koodiArvo" : "467301",
@@ -22157,7 +22157,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467302",
   "koodiArvo" : "467302",
@@ -22170,7 +22170,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467303",
   "koodiArvo" : "467303",
@@ -22187,7 +22187,7 @@
     "lyhytNimi" : "Forestry Adviser, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467304",
   "koodiArvo" : "467304",
@@ -22204,7 +22204,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467305",
   "koodiArvo" : "467305",
@@ -22221,7 +22221,7 @@
     "lyhytNimi" : "Multiple Use of Forests, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467306",
   "koodiArvo" : "467306",
@@ -22238,7 +22238,7 @@
     "lyhytNimi" : "Forest Worker, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467342",
   "koodiArvo" : "467342",
@@ -22255,7 +22255,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467399",
   "koodiArvo" : "467399",
@@ -22272,7 +22272,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467441",
   "koodiArvo" : "467441",
@@ -22289,7 +22289,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Fishery",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467900",
   "koodiArvo" : "467900",
@@ -22306,7 +22306,7 @@
     "lyhytNimi" : "Other Specialist Qualification in Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467901",
   "koodiArvo" : "467901",
@@ -22319,7 +22319,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467902",
   "koodiArvo" : "467902",
@@ -22332,7 +22332,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467903",
   "koodiArvo" : "467903",
@@ -22349,7 +22349,7 @@
     "lyhytNimi" : "Specialist Qualification in Rural Development",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467904",
   "koodiArvo" : "467904",
@@ -22366,7 +22366,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467905",
   "koodiArvo" : "467905",
@@ -22383,7 +22383,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Animal Care",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467942",
   "koodiArvo" : "467942",
@@ -22400,7 +22400,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Nature-based Services",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_467999",
   "koodiArvo" : "467999",
@@ -22417,7 +22417,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_477000",
   "koodiArvo" : "477000",
@@ -22434,7 +22434,7 @@
     "lyhytNimi" : "Specialist Qualification in Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_477100",
   "koodiArvo" : "477100",
@@ -22451,7 +22451,7 @@
     "lyhytNimi" : "Specialist Qualification in Social and Health Care",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_477101",
   "koodiArvo" : "477101",
@@ -22468,7 +22468,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Massage",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_477102",
   "koodiArvo" : "477102",
@@ -22485,7 +22485,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Interpreting for Persons with Speech Impairments",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_477103",
   "koodiArvo" : "477103",
@@ -22502,7 +22502,7 @@
     "lyhytNimi" : "Orthopaedic Technician, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_477104",
   "koodiArvo" : "477104",
@@ -22519,7 +22519,7 @@
     "lyhytNimi" : "Psychiatric Care, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_477105",
   "koodiArvo" : "477105",
@@ -22536,7 +22536,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Care for the Elderly",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_477106",
   "koodiArvo" : "477106",
@@ -22549,7 +22549,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_477107",
   "koodiArvo" : "477107",
@@ -22562,7 +22562,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_477108",
   "koodiArvo" : "477108",
@@ -22575,7 +22575,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_477109",
   "koodiArvo" : "477109",
@@ -22588,7 +22588,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_477110",
   "koodiArvo" : "477110",
@@ -22601,7 +22601,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_477111",
   "koodiArvo" : "477111",
@@ -22618,7 +22618,7 @@
     "lyhytNimi" : "Specialist Qualification in Mental Health and Intoxicant Abuse Welfare Work",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_477143",
   "koodiArvo" : "477143",
@@ -22631,7 +22631,7 @@
     "lyhytNimi" : "SYE i rehabiliterings- stöd- och handledningstjänster",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_477199",
   "koodiArvo" : "477199",
@@ -22648,7 +22648,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487000",
   "koodiArvo" : "487000",
@@ -22665,7 +22665,7 @@
     "lyhytNimi" : "Specialist Qualification in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487100",
   "koodiArvo" : "487100",
@@ -22682,7 +22682,7 @@
     "lyhytNimi" : "Specialist Qualification in Hotel, Catering and Home Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487101",
   "koodiArvo" : "487101",
@@ -22695,7 +22695,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487102",
   "koodiArvo" : "487102",
@@ -22712,7 +22712,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Special Diet Services",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487103",
   "koodiArvo" : "487103",
@@ -22729,7 +22729,7 @@
     "lyhytNimi" : "Specialist vocational qualification in First-Level Management in the Hotel and Catering Sector",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487104",
   "koodiArvo" : "487104",
@@ -22742,7 +22742,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487105",
   "koodiArvo" : "487105",
@@ -22755,7 +22755,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487106",
   "koodiArvo" : "487106",
@@ -22768,7 +22768,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487141",
   "koodiArvo" : "487141",
@@ -22785,7 +22785,7 @@
     "lyhytNimi" : "Specialist Vocational Qualification in Cleaning and Property Services",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487199",
   "koodiArvo" : "487199",
@@ -22802,7 +22802,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Hotel, Catering and Home Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487200",
   "koodiArvo" : "487200",
@@ -22819,7 +22819,7 @@
     "lyhytNimi" : "Specialist Qualification in Leisure Activities and Youth Work",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487201",
   "koodiArvo" : "487201",
@@ -22832,7 +22832,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487202",
   "koodiArvo" : "487202",
@@ -22849,7 +22849,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Coaching",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487203",
   "koodiArvo" : "487203",
@@ -22866,7 +22866,7 @@
     "lyhytNimi" : "Specialist Vocational Qualification in Court Interpreting",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487241",
   "koodiArvo" : "487241",
@@ -22883,7 +22883,7 @@
     "lyhytNimi" : "Specialist vocational qualification in Education and Guidance",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487244",
   "koodiArvo" : "487244",
@@ -22896,7 +22896,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487299",
   "koodiArvo" : "487299",
@@ -22913,7 +22913,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Leisure Activities and Youth Work",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487300",
   "koodiArvo" : "487300",
@@ -22930,7 +22930,7 @@
     "lyhytNimi" : "Specialist Qualification in Beauty Care",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487301",
   "koodiArvo" : "487301",
@@ -22947,7 +22947,7 @@
     "lyhytNimi" : "Ladies' Hairdressing, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487302",
   "koodiArvo" : "487302",
@@ -22964,7 +22964,7 @@
     "lyhytNimi" : "Men's Hairdressing, Specialist Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487303",
   "koodiArvo" : "487303",
@@ -22977,7 +22977,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487304",
   "koodiArvo" : "487304",
@@ -22994,7 +22994,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487341",
   "koodiArvo" : "487341",
@@ -23011,7 +23011,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487399",
   "koodiArvo" : "487399",
@@ -23028,7 +23028,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Beauty Care",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487400",
   "koodiArvo" : "487400",
@@ -23045,7 +23045,7 @@
     "lyhytNimi" : "Specialist Qualification in Traffic and Seafaring",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487401",
   "koodiArvo" : "487401",
@@ -23058,7 +23058,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487499",
   "koodiArvo" : "487499",
@@ -23075,7 +23075,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Traffic and Seafaring",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487500",
   "koodiArvo" : "487500",
@@ -23092,7 +23092,7 @@
     "lyhytNimi" : "Specialist Qualification in Safety and Security",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487501",
   "koodiArvo" : "487501",
@@ -23109,7 +23109,7 @@
     "lyhytNimi" : "Specialist vocational qualification for Security Officers",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487599",
   "koodiArvo" : "487599",
@@ -23126,7 +23126,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Safety and Security",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487900",
   "koodiArvo" : "487900",
@@ -23143,7 +23143,7 @@
     "lyhytNimi" : "Other Specialist Qualification in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_487999",
   "koodiArvo" : "487999",
@@ -23160,7 +23160,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Qualification in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_511000",
   "koodiArvo" : "511000",
@@ -23177,7 +23177,7 @@
     "lyhytNimi" : "Teacher Education, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511151",
   "koodiArvo" : "511151",
@@ -23190,7 +23190,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_511200",
   "koodiArvo" : "511200",
@@ -23207,7 +23207,7 @@
     "lyhytNimi" : "Vocational Subject Teacher, Vocational School",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511251",
   "koodiArvo" : "511251",
@@ -23224,7 +23224,7 @@
     "lyhytNimi" : "Vocational Subject Teacher, Hotel and Restaurant Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511252",
   "koodiArvo" : "511252",
@@ -23241,7 +23241,7 @@
     "lyhytNimi" : "Vocational Subject Teacher, Needlework and Dressmaking",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511253",
   "koodiArvo" : "511253",
@@ -23258,7 +23258,7 @@
     "lyhytNimi" : "Vocational Subject Teacher, Hairdressing and Beauty Therapy",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511254",
   "koodiArvo" : "511254",
@@ -23275,7 +23275,7 @@
     "lyhytNimi" : "Vocational Subject Teacher, Food Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511299",
   "koodiArvo" : "511299",
@@ -23292,7 +23292,7 @@
     "lyhytNimi" : "Vocational Subject Teacher, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511300",
   "koodiArvo" : "511300",
@@ -23309,7 +23309,7 @@
     "lyhytNimi" : "Handicrafts Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511351",
   "koodiArvo" : "511351",
@@ -23326,7 +23326,7 @@
     "lyhytNimi" : "Handicrafts Teacher, Weaving",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511352",
   "koodiArvo" : "511352",
@@ -23343,7 +23343,7 @@
     "lyhytNimi" : "Handicrafts Teacher, Metalwork, Machine Repairing",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511353",
   "koodiArvo" : "511353",
@@ -23360,7 +23360,7 @@
     "lyhytNimi" : "Handicrafts Teacher, Needlework",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511354",
   "koodiArvo" : "511354",
@@ -23377,7 +23377,7 @@
     "lyhytNimi" : "Handicrafts Teacher, Woodwork",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511399",
   "koodiArvo" : "511399",
@@ -23394,7 +23394,7 @@
     "lyhytNimi" : "Handicrafts Teacher, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511400",
   "koodiArvo" : "511400",
@@ -23411,7 +23411,7 @@
     "lyhytNimi" : "Home Economics Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511451",
   "koodiArvo" : "511451",
@@ -23428,7 +23428,7 @@
     "lyhytNimi" : "Home Economics Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511500",
   "koodiArvo" : "511500",
@@ -23445,7 +23445,7 @@
     "lyhytNimi" : "Kindergarten Teacher (-1985)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511501",
   "koodiArvo" : "511501",
@@ -23462,7 +23462,7 @@
     "lyhytNimi" : "Kindergarten Teacher (-1985)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511600",
   "koodiArvo" : "511600",
@@ -23479,7 +23479,7 @@
     "lyhytNimi" : "Music Teacher, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511601",
   "koodiArvo" : "511601",
@@ -23496,7 +23496,7 @@
     "lyhytNimi" : "Diploma in Music Pedagogy",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511602",
   "koodiArvo" : "511602",
@@ -23513,7 +23513,7 @@
     "lyhytNimi" : "Diploma in Music Instruction",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511603",
   "koodiArvo" : "511603",
@@ -23530,7 +23530,7 @@
     "lyhytNimi" : "Music Playschool Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511604",
   "koodiArvo" : "511604",
@@ -23547,7 +23547,7 @@
     "lyhytNimi" : "Music College Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511605",
   "koodiArvo" : "511605",
@@ -23564,7 +23564,7 @@
     "lyhytNimi" : "Music School Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511606",
   "koodiArvo" : "511606",
@@ -23581,7 +23581,7 @@
     "lyhytNimi" : "Pop and Jazz Music Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511900",
   "koodiArvo" : "511900",
@@ -23598,7 +23598,7 @@
     "lyhytNimi" : "Other Teacher Education, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511901",
   "koodiArvo" : "511901",
@@ -23609,7 +23609,7 @@
     "nimi" : "Musiikkipedagogi",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_511902",
   "koodiArvo" : "511902",
@@ -23620,7 +23620,7 @@
     "nimi" : "Musiikinohjaaja",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_511903",
   "koodiArvo" : "511903",
@@ -23637,7 +23637,7 @@
     "lyhytNimi" : "Riding Instructor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511904",
   "koodiArvo" : "511904",
@@ -23654,7 +23654,7 @@
     "lyhytNimi" : "Nursing Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511905",
   "koodiArvo" : "511905",
@@ -23671,7 +23671,7 @@
     "lyhytNimi" : "Diploma in Dance Instruction",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_511999",
   "koodiArvo" : "511999",
@@ -23688,7 +23688,7 @@
     "lyhytNimi" : "Other or Unknown Teacher Education, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521000",
   "koodiArvo" : "521000",
@@ -23705,7 +23705,7 @@
     "lyhytNimi" : "Education in Arts, Crafts and Design, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521100",
   "koodiArvo" : "521100",
@@ -23722,7 +23722,7 @@
     "lyhytNimi" : "Diploma in Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521101",
   "koodiArvo" : "521101",
@@ -23739,7 +23739,7 @@
     "lyhytNimi" : "Diploma in Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521151",
   "koodiArvo" : "521151",
@@ -23756,7 +23756,7 @@
     "lyhytNimi" : "Diploma in Crafts and Design, Graphics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521152",
   "koodiArvo" : "521152",
@@ -23773,7 +23773,7 @@
     "lyhytNimi" : "Diploma in Crafts and Design, Furniture Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521153",
   "koodiArvo" : "521153",
@@ -23790,7 +23790,7 @@
     "lyhytNimi" : "Diploma in Crafts and Design, Pottery",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521154",
   "koodiArvo" : "521154",
@@ -23807,7 +23807,7 @@
     "lyhytNimi" : "Diploma in Crafts and Design, Restorer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521155",
   "koodiArvo" : "521155",
@@ -23824,7 +23824,7 @@
     "lyhytNimi" : "Diploma in Crafts and Design, Weaving",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521156",
   "koodiArvo" : "521156",
@@ -23841,7 +23841,7 @@
     "lyhytNimi" : "Diploma in Crafts and Design, Goldsmith",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521157",
   "koodiArvo" : "521157",
@@ -23858,7 +23858,7 @@
     "lyhytNimi" : "Diploma in Crafts and Design, Metalwork",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521158",
   "koodiArvo" : "521158",
@@ -23875,7 +23875,7 @@
     "lyhytNimi" : "Diploma in Crafts and Design, Needlework",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521159",
   "koodiArvo" : "521159",
@@ -23892,7 +23892,7 @@
     "lyhytNimi" : "Diploma in Crafts and Design, Wood Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521160",
   "koodiArvo" : "521160",
@@ -23909,7 +23909,7 @@
     "lyhytNimi" : "Diploma in Crafts and Design, Interior Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521161",
   "koodiArvo" : "521161",
@@ -23926,7 +23926,7 @@
     "lyhytNimi" : "Diploma in Crafts and Design, Textiles",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521162",
   "koodiArvo" : "521162",
@@ -23943,7 +23943,7 @@
     "lyhytNimi" : "Diploma in Crafts and Design, Industrial Fashion Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521163",
   "koodiArvo" : "521163",
@@ -23960,7 +23960,7 @@
     "lyhytNimi" : "Diploma in Crafts and Design, Clothing",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521164",
   "koodiArvo" : "521164",
@@ -23977,7 +23977,7 @@
     "lyhytNimi" : "Diploma in Crafts and Design, Photography",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521165",
   "koodiArvo" : "521165",
@@ -23994,7 +23994,7 @@
     "lyhytNimi" : "Diploma in Crafts and Design, Videography",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521199",
   "koodiArvo" : "521199",
@@ -24011,7 +24011,7 @@
     "lyhytNimi" : "Diploma in Crafts and Design, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521200",
   "koodiArvo" : "521200",
@@ -24028,7 +24028,7 @@
     "lyhytNimi" : "Education in Music, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521201",
   "koodiArvo" : "521201",
@@ -24045,7 +24045,7 @@
     "lyhytNimi" : "Musician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521251",
   "koodiArvo" : "521251",
@@ -24062,7 +24062,7 @@
     "lyhytNimi" : "Cantor-Organist Examination",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521252",
   "koodiArvo" : "521252",
@@ -24079,7 +24079,7 @@
     "lyhytNimi" : "Orchestra Musician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521253",
   "koodiArvo" : "521253",
@@ -24096,7 +24096,7 @@
     "lyhytNimi" : "Pop and Jazz Musician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521254",
   "koodiArvo" : "521254",
@@ -24113,7 +24113,7 @@
     "lyhytNimi" : "Leader of a Musical Ensemble",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521299",
   "koodiArvo" : "521299",
@@ -24130,7 +24130,7 @@
     "lyhytNimi" : "Other or Unknown Education in Music, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521300",
   "koodiArvo" : "521300",
@@ -24147,7 +24147,7 @@
     "lyhytNimi" : "Education in Fine Arts, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521301",
   "koodiArvo" : "521301",
@@ -24164,7 +24164,7 @@
     "lyhytNimi" : "Diploma in Visual Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521351",
   "koodiArvo" : "521351",
@@ -24181,7 +24181,7 @@
     "lyhytNimi" : "Artist Painter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521352",
   "koodiArvo" : "521352",
@@ -24198,7 +24198,7 @@
     "lyhytNimi" : "Sculptor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521353",
   "koodiArvo" : "521353",
@@ -24215,7 +24215,7 @@
     "lyhytNimi" : "Graphic Artist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521399",
   "koodiArvo" : "521399",
@@ -24232,7 +24232,7 @@
     "lyhytNimi" : "Other or Unknown Education in Fine Arts, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521500",
   "koodiArvo" : "521500",
@@ -24249,7 +24249,7 @@
     "lyhytNimi" : "Education in Theatre and Dance, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521551",
   "koodiArvo" : "521551",
@@ -24260,7 +24260,7 @@
     "nimi" : "Ammattinäyttelijä",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_521552",
   "koodiArvo" : "521552",
@@ -24271,7 +24271,7 @@
     "nimi" : "Teatterilavastaja",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_521554",
   "koodiArvo" : "521554",
@@ -24288,7 +24288,7 @@
     "lyhytNimi" : "Dance Artist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521555",
   "koodiArvo" : "521555",
@@ -24305,7 +24305,7 @@
     "lyhytNimi" : "Diploma in Drama Instruction",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521599",
   "koodiArvo" : "521599",
@@ -24322,7 +24322,7 @@
     "lyhytNimi" : "Other or Unknown Education in Theatre and Dance, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521600",
   "koodiArvo" : "521600",
@@ -24339,7 +24339,7 @@
     "lyhytNimi" : "Diploma in Media Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521601",
   "koodiArvo" : "521601",
@@ -24356,7 +24356,7 @@
     "lyhytNimi" : "Diploma in Media Technology, Unspecialised",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521651",
   "koodiArvo" : "521651",
@@ -24373,7 +24373,7 @@
     "lyhytNimi" : "Diploma in Media Technology, Visual Expression",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521652",
   "koodiArvo" : "521652",
@@ -24390,7 +24390,7 @@
     "lyhytNimi" : "Diploma in Media Technology, Production",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521653",
   "koodiArvo" : "521653",
@@ -24407,7 +24407,7 @@
     "lyhytNimi" : "Diploma in Media Technology, Lighting",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_521654",
   "koodiArvo" : "521654",
@@ -24424,7 +24424,7 @@
     "lyhytNimi" : "Diploma in Media Technology, Sound Effects",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_529000",
   "koodiArvo" : "529000",
@@ -24441,7 +24441,7 @@
     "lyhytNimi" : "Other Education in Humanities and Arts, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_529900",
   "koodiArvo" : "529900",
@@ -24458,7 +24458,7 @@
     "lyhytNimi" : "Other Education in Humanities and Arts, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_529901",
   "koodiArvo" : "529901",
@@ -24475,7 +24475,7 @@
     "lyhytNimi" : "Diploma of Sign Language Interpreter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_529999",
   "koodiArvo" : "529999",
@@ -24492,7 +24492,7 @@
     "lyhytNimi" : "Other or Unknown Education in Humanities and Arts, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_531000",
   "koodiArvo" : "531000",
@@ -24509,7 +24509,7 @@
     "lyhytNimi" : "Education in Business and Administration, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_531100",
   "koodiArvo" : "531100",
@@ -24526,7 +24526,7 @@
     "lyhytNimi" : "Diploma in Business and Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_531101",
   "koodiArvo" : "531101",
@@ -24543,7 +24543,7 @@
     "lyhytNimi" : "Diploma in Business and Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_531151",
   "koodiArvo" : "531151",
@@ -24560,7 +24560,7 @@
     "lyhytNimi" : "Diploma in Business and Administration, Economics and Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_531154",
   "koodiArvo" : "531154",
@@ -24577,7 +24577,7 @@
     "lyhytNimi" : "Diploma in Business and Administration, Secretarial and Language Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_531157",
   "koodiArvo" : "531157",
@@ -24594,7 +24594,7 @@
     "lyhytNimi" : "Diploma in Business and Administration, Data Processing",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_531158",
   "koodiArvo" : "531158",
@@ -24611,7 +24611,7 @@
     "lyhytNimi" : "Diploma in Business and Administration, Business Economics and Marketing",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_531159",
   "koodiArvo" : "531159",
@@ -24628,7 +24628,7 @@
     "lyhytNimi" : "Diploma in Business and Administration, Library and Information Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_531160",
   "koodiArvo" : "531160",
@@ -24645,7 +24645,7 @@
     "lyhytNimi" : "Diploma in Business and Administration, Tourism",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_531163",
   "koodiArvo" : "531163",
@@ -24662,7 +24662,7 @@
     "lyhytNimi" : "Diploma in Business and Administration, Unspecialised",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_531199",
   "koodiArvo" : "531199",
@@ -24679,7 +24679,7 @@
     "lyhytNimi" : "Diploma in Business and Administration, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_531400",
   "koodiArvo" : "531400",
@@ -24696,7 +24696,7 @@
     "lyhytNimi" : "Secretarial Studies, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_531401",
   "koodiArvo" : "531401",
@@ -24713,7 +24713,7 @@
     "lyhytNimi" : "Diploma in Secretarial Studies, Business Administration and Public Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_531402",
   "koodiArvo" : "531402",
@@ -24730,7 +24730,7 @@
     "lyhytNimi" : "Diploma in Secretarial Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_531499",
   "koodiArvo" : "531499",
@@ -24747,7 +24747,7 @@
     "lyhytNimi" : "Other or Unknown Education in Secretarial Studies, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_539000",
   "koodiArvo" : "539000",
@@ -24764,7 +24764,7 @@
     "lyhytNimi" : "Other Education in Social Sciences and Business, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_539900",
   "koodiArvo" : "539900",
@@ -24781,7 +24781,7 @@
     "lyhytNimi" : "Other Education in Social Sciences and Business, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_539901",
   "koodiArvo" : "539901",
@@ -24798,7 +24798,7 @@
     "lyhytNimi" : "Journalist (Sanoma Oy)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_539951",
   "koodiArvo" : "539951",
@@ -24815,7 +24815,7 @@
     "lyhytNimi" : "Marketing School",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_539952",
   "koodiArvo" : "539952",
@@ -24832,7 +24832,7 @@
     "lyhytNimi" : "Export Marketer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_539999",
   "koodiArvo" : "539999",
@@ -24849,7 +24849,7 @@
     "lyhytNimi" : "Other or Unknown Education in Social Sciences and Business, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_541000",
   "koodiArvo" : "541000",
@@ -24866,7 +24866,7 @@
     "lyhytNimi" : "Education in Information Technology, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_541100",
   "koodiArvo" : "541100",
@@ -24883,7 +24883,7 @@
     "lyhytNimi" : "Education in Information Technology, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_541101",
   "koodiArvo" : "541101",
@@ -24900,7 +24900,7 @@
     "lyhytNimi" : "Diploma in Business Information Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_541152",
   "koodiArvo" : "541152",
@@ -24917,7 +24917,7 @@
     "lyhytNimi" : "Data Processing Analyst",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_541199",
   "koodiArvo" : "541199",
@@ -24934,7 +24934,7 @@
     "lyhytNimi" : "Other or Unknown Education in Information Technology, Lowest Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551000",
   "koodiArvo" : "551000",
@@ -24951,7 +24951,7 @@
     "lyhytNimi" : "Technician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551100",
   "koodiArvo" : "551100",
@@ -24968,7 +24968,7 @@
     "lyhytNimi" : "Technician Engineer, Mechanical Engineering and Transportation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551101",
   "koodiArvo" : "551101",
@@ -24985,7 +24985,7 @@
     "lyhytNimi" : "Technician Engineer, Mechanical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551103",
   "koodiArvo" : "551103",
@@ -25002,7 +25002,7 @@
     "lyhytNimi" : "Technician Engineer, Heating and Ventilation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551104",
   "koodiArvo" : "551104",
@@ -25019,7 +25019,7 @@
     "lyhytNimi" : "Technician Engineer, Transportation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551200",
   "koodiArvo" : "551200",
@@ -25036,7 +25036,7 @@
     "lyhytNimi" : "Technician Engineer, Electrical Engineering and Automation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551201",
   "koodiArvo" : "551201",
@@ -25053,7 +25053,7 @@
     "lyhytNimi" : "Technician Engineer, Electrical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551202",
   "koodiArvo" : "551202",
@@ -25070,7 +25070,7 @@
     "lyhytNimi" : "Technician Engineer, Automation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551300",
   "koodiArvo" : "551300",
@@ -25087,7 +25087,7 @@
     "lyhytNimi" : "Technician Engineer, Information Technology and Telecommunications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551301",
   "koodiArvo" : "551301",
@@ -25104,7 +25104,7 @@
     "lyhytNimi" : "Technician Engineer, Information Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551302",
   "koodiArvo" : "551302",
@@ -25121,7 +25121,7 @@
     "lyhytNimi" : "Technician Engineer, Telecommunications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551400",
   "koodiArvo" : "551400",
@@ -25138,7 +25138,7 @@
     "lyhytNimi" : "Technician Engineer, Process Engineering and Materials Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551401",
   "koodiArvo" : "551401",
@@ -25155,7 +25155,7 @@
     "lyhytNimi" : "Technician Engineer, Chemistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551402",
   "koodiArvo" : "551402",
@@ -25172,7 +25172,7 @@
     "lyhytNimi" : "Technician Engineer, Process Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551403",
   "koodiArvo" : "551403",
@@ -25189,7 +25189,7 @@
     "lyhytNimi" : "Technician Engineer, Environmental Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551404",
   "koodiArvo" : "551404",
@@ -25206,7 +25206,7 @@
     "lyhytNimi" : "Technician Engineer, Paper Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551405",
   "koodiArvo" : "551405",
@@ -25223,7 +25223,7 @@
     "lyhytNimi" : "Technician Engineer, Wood Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551406",
   "koodiArvo" : "551406",
@@ -25240,7 +25240,7 @@
     "lyhytNimi" : "Technician Engineer, Surface Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551411",
   "koodiArvo" : "551411",
@@ -25257,7 +25257,7 @@
     "lyhytNimi" : "Technician Engineer, Food Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551500",
   "koodiArvo" : "551500",
@@ -25274,7 +25274,7 @@
     "lyhytNimi" : "Technician Engineer, Building Construction and Surveying Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551501",
   "koodiArvo" : "551501",
@@ -25291,7 +25291,7 @@
     "lyhytNimi" : "Technician Engineer, Building Construction, Community Development",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551502",
   "koodiArvo" : "551502",
@@ -25308,7 +25308,7 @@
     "lyhytNimi" : "Technician Engineer, Surveying Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551900",
   "koodiArvo" : "551900",
@@ -25325,7 +25325,7 @@
     "lyhytNimi" : "Technician Engineer, Other Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551901",
   "koodiArvo" : "551901",
@@ -25342,7 +25342,7 @@
     "lyhytNimi" : "Technician Engineer, Textiles and Clothing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551902",
   "koodiArvo" : "551902",
@@ -25359,7 +25359,7 @@
     "lyhytNimi" : "Technician Engineer, Printing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_551999",
   "koodiArvo" : "551999",
@@ -25376,7 +25376,7 @@
     "lyhytNimi" : "Technician, Other or Unknown Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_559000",
   "koodiArvo" : "559000",
@@ -25393,7 +25393,7 @@
     "lyhytNimi" : "Other Education in Technology, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_559900",
   "koodiArvo" : "559900",
@@ -25410,7 +25410,7 @@
     "lyhytNimi" : "Other Education in Technology, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_559901",
   "koodiArvo" : "559901",
@@ -25427,7 +25427,7 @@
     "lyhytNimi" : "Furrier",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_559902",
   "koodiArvo" : "559902",
@@ -25444,7 +25444,7 @@
     "lyhytNimi" : "Working Technology Analyst",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_559903",
   "koodiArvo" : "559903",
@@ -25461,7 +25461,7 @@
     "lyhytNimi" : "Technician Engineer, Dairy Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_559904",
   "koodiArvo" : "559904",
@@ -25478,7 +25478,7 @@
     "lyhytNimi" : "Laboratory Assistant (Diploma)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_559905",
   "koodiArvo" : "559905",
@@ -25495,7 +25495,7 @@
     "lyhytNimi" : "Sawmill Foreman",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_559906",
   "koodiArvo" : "559906",
@@ -25512,7 +25512,7 @@
     "lyhytNimi" : "Clothing Technician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_559999",
   "koodiArvo" : "559999",
@@ -25529,7 +25529,7 @@
     "lyhytNimi" : "Other or Unknown Education in Technology, Lowest Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561000",
   "koodiArvo" : "561000",
@@ -25546,7 +25546,7 @@
     "lyhytNimi" : "Education in Agriculture and Forestry, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561100",
   "koodiArvo" : "561100",
@@ -25563,7 +25563,7 @@
     "lyhytNimi" : "Diploma in Agriculture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561101",
   "koodiArvo" : "561101",
@@ -25580,7 +25580,7 @@
     "lyhytNimi" : "Diploma in Agriculture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561151",
   "koodiArvo" : "561151",
@@ -25597,7 +25597,7 @@
     "lyhytNimi" : "Diploma in Agriculture, Unspecialised",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561152",
   "koodiArvo" : "561152",
@@ -25614,7 +25614,7 @@
     "lyhytNimi" : "Diploma in Agriculture, Livestock Production",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561153",
   "koodiArvo" : "561153",
@@ -25631,7 +25631,7 @@
     "lyhytNimi" : "Diploma in Agriculture, Agriculture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561154",
   "koodiArvo" : "561154",
@@ -25648,7 +25648,7 @@
     "lyhytNimi" : "Diploma in Agriculture, Youth Consulting and Ancillary Activities",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561199",
   "koodiArvo" : "561199",
@@ -25665,7 +25665,7 @@
     "lyhytNimi" : "Diploma in Agriculture, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561200",
   "koodiArvo" : "561200",
@@ -25682,7 +25682,7 @@
     "lyhytNimi" : "Diploma in Horticulture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561201",
   "koodiArvo" : "561201",
@@ -25699,7 +25699,7 @@
     "lyhytNimi" : "Diploma in Horticulture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561251",
   "koodiArvo" : "561251",
@@ -25716,7 +25716,7 @@
     "lyhytNimi" : "Diploma in Horticulture, Landscape Gardening",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561252",
   "koodiArvo" : "561252",
@@ -25733,7 +25733,7 @@
     "lyhytNimi" : "Diploma in Horticulture, Production and Marketing",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561299",
   "koodiArvo" : "561299",
@@ -25750,7 +25750,7 @@
     "lyhytNimi" : "Diploma in Horticulture, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561400",
   "koodiArvo" : "561400",
@@ -25767,7 +25767,7 @@
     "lyhytNimi" : "Diploma in Fishery",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561401",
   "koodiArvo" : "561401",
@@ -25784,7 +25784,7 @@
     "lyhytNimi" : "Diploma in Fishery",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561900",
   "koodiArvo" : "561900",
@@ -25801,7 +25801,7 @@
     "lyhytNimi" : "Other Education in Agriculture and Forestry, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561951",
   "koodiArvo" : "561951",
@@ -25818,7 +25818,7 @@
     "lyhytNimi" : "Technician Engineer, Agriculture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561952",
   "koodiArvo" : "561952",
@@ -25835,7 +25835,7 @@
     "lyhytNimi" : "Technician Engineer, Young Farmers' Clubs",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561953",
   "koodiArvo" : "561953",
@@ -25852,7 +25852,7 @@
     "lyhytNimi" : "Technician Engineer, Animal Husbandry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561954",
   "koodiArvo" : "561954",
@@ -25869,7 +25869,7 @@
     "lyhytNimi" : "Technician Engineer, Gardening",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561955",
   "koodiArvo" : "561955",
@@ -25886,7 +25886,7 @@
     "lyhytNimi" : "Technician Engineer, Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561956",
   "koodiArvo" : "561956",
@@ -25903,7 +25903,7 @@
     "lyhytNimi" : "Technician Engineer, Forest Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561957",
   "koodiArvo" : "561957",
@@ -25920,7 +25920,7 @@
     "lyhytNimi" : "Forest Foreman",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_561999",
   "koodiArvo" : "561999",
@@ -25937,7 +25937,7 @@
     "lyhytNimi" : "Other or Unknown Education in Agriculture and Forestry, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571000",
   "koodiArvo" : "571000",
@@ -25954,7 +25954,7 @@
     "lyhytNimi" : "Education in Health and Welfare, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571100",
   "koodiArvo" : "571100",
@@ -25971,7 +25971,7 @@
     "lyhytNimi" : "Education in Health Care, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571101",
   "koodiArvo" : "571101",
@@ -25988,7 +25988,7 @@
     "lyhytNimi" : "Nurse",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571103",
   "koodiArvo" : "571103",
@@ -26005,7 +26005,7 @@
     "lyhytNimi" : "Public Health Nurse",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571104",
   "koodiArvo" : "571104",
@@ -26022,7 +26022,7 @@
     "lyhytNimi" : "Medical Laboratory Technologist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571105",
   "koodiArvo" : "571105",
@@ -26039,7 +26039,7 @@
     "lyhytNimi" : "Radiographer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571106",
   "koodiArvo" : "571106",
@@ -26056,7 +26056,7 @@
     "lyhytNimi" : "Midwife",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571107",
   "koodiArvo" : "571107",
@@ -26073,7 +26073,7 @@
     "lyhytNimi" : "Dental Hygienist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571108",
   "koodiArvo" : "571108",
@@ -26090,7 +26090,7 @@
     "lyhytNimi" : "Dental Technician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571112",
   "koodiArvo" : "571112",
@@ -26107,7 +26107,7 @@
     "lyhytNimi" : "Physiotherapist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571152",
   "koodiArvo" : "571152",
@@ -26124,7 +26124,7 @@
     "lyhytNimi" : "Deaconess",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571154",
   "koodiArvo" : "571154",
@@ -26141,7 +26141,7 @@
     "lyhytNimi" : "Hospital Laboratory Assistant",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571160",
   "koodiArvo" : "571160",
@@ -26158,7 +26158,7 @@
     "lyhytNimi" : "Dental Nurse",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571161",
   "koodiArvo" : "571161",
@@ -26175,7 +26175,7 @@
     "lyhytNimi" : "Optometrist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571164",
   "koodiArvo" : "571164",
@@ -26192,7 +26192,7 @@
     "lyhytNimi" : "Occupational Therapist, Specialist Occupational Therapist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571165",
   "koodiArvo" : "571165",
@@ -26209,7 +26209,7 @@
     "lyhytNimi" : "Orthopeadic Technician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571199",
   "koodiArvo" : "571199",
@@ -26226,7 +26226,7 @@
     "lyhytNimi" : "Other or Unknown Education in Health and Welfare, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571200",
   "koodiArvo" : "571200",
@@ -26243,7 +26243,7 @@
     "lyhytNimi" : "Education in Social Services, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571201",
   "koodiArvo" : "571201",
@@ -26260,7 +26260,7 @@
     "lyhytNimi" : "Diploma in Social Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571202",
   "koodiArvo" : "571202",
@@ -26277,7 +26277,7 @@
     "lyhytNimi" : "Deacon (Diploma)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571253",
   "koodiArvo" : "571253",
@@ -26294,7 +26294,7 @@
     "lyhytNimi" : "Social Welfare Worker",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571254",
   "koodiArvo" : "571254",
@@ -26311,7 +26311,7 @@
     "lyhytNimi" : "Social Educator",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571255",
   "koodiArvo" : "571255",
@@ -26328,7 +26328,7 @@
     "lyhytNimi" : "Social Instructor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571267",
   "koodiArvo" : "571267",
@@ -26345,7 +26345,7 @@
     "lyhytNimi" : "Instructor for the Mentally Retarded",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571299",
   "koodiArvo" : "571299",
@@ -26362,7 +26362,7 @@
     "lyhytNimi" : "Other or Unknown Education in Health and Welfare, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571800",
   "koodiArvo" : "571800",
@@ -26379,7 +26379,7 @@
     "lyhytNimi" : "Diploma in Pharmacy",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571801",
   "koodiArvo" : "571801",
@@ -26396,7 +26396,7 @@
     "lyhytNimi" : "Diploma in Pharmacy",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571900",
   "koodiArvo" : "571900",
@@ -26413,7 +26413,7 @@
     "lyhytNimi" : "Other Education in Health and Welfare, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_571999",
   "koodiArvo" : "571999",
@@ -26430,7 +26430,7 @@
     "lyhytNimi" : "Other or Unknown Education in Health and Welfare, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581000",
   "koodiArvo" : "581000",
@@ -26447,7 +26447,7 @@
     "lyhytNimi" : "Education in Services, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581100",
   "koodiArvo" : "581100",
@@ -26464,7 +26464,7 @@
     "lyhytNimi" : "Education in Hotel, Catering and Home Economics, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581101",
   "koodiArvo" : "581101",
@@ -26481,7 +26481,7 @@
     "lyhytNimi" : "Diploma in Hotel, Restaurant and Catering Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581102",
   "koodiArvo" : "581102",
@@ -26498,7 +26498,7 @@
     "lyhytNimi" : "Diploma in Home Economics and Cleaning Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581103",
   "koodiArvo" : "581103",
@@ -26515,7 +26515,7 @@
     "lyhytNimi" : "Technician Engineer, Laundry Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581104",
   "koodiArvo" : "581104",
@@ -26532,7 +26532,7 @@
     "lyhytNimi" : "Education in Tourism, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581151",
   "koodiArvo" : "581151",
@@ -26549,7 +26549,7 @@
     "lyhytNimi" : "Manager, Hotels and Restaurants",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581152",
   "koodiArvo" : "581152",
@@ -26566,7 +26566,7 @@
     "lyhytNimi" : "Home Economics Technician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581153",
   "koodiArvo" : "581153",
@@ -26583,7 +26583,7 @@
     "lyhytNimi" : "Nutritional Technician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581154",
   "koodiArvo" : "581154",
@@ -26600,7 +26600,7 @@
     "lyhytNimi" : "Diploma in Hotel and Restaurant Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581155",
   "koodiArvo" : "581155",
@@ -26617,7 +26617,7 @@
     "lyhytNimi" : "Cleaning Technician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581156",
   "koodiArvo" : "581156",
@@ -26634,7 +26634,7 @@
     "lyhytNimi" : "Manager, Institutional Catering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581199",
   "koodiArvo" : "581199",
@@ -26651,7 +26651,7 @@
     "lyhytNimi" : "Other or Unknown Education in Hotel, Catering and Home Economics, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581200",
   "koodiArvo" : "581200",
@@ -26668,7 +26668,7 @@
     "lyhytNimi" : "Education in Leisure Activities and Youth Work, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581201",
   "koodiArvo" : "581201",
@@ -26685,7 +26685,7 @@
     "lyhytNimi" : "Diploma in Youth and Leisure Instruction",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581202",
   "koodiArvo" : "581202",
@@ -26702,7 +26702,7 @@
     "lyhytNimi" : "Diploma of Youth Work Leader of the Church",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581203",
   "koodiArvo" : "581203",
@@ -26719,7 +26719,7 @@
     "lyhytNimi" : "Diploma in Cultural Activities Instruction",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581204",
   "koodiArvo" : "581204",
@@ -26736,7 +26736,7 @@
     "lyhytNimi" : "Cultural Secretary",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581205",
   "koodiArvo" : "581205",
@@ -26753,7 +26753,7 @@
     "lyhytNimi" : "Temperance Secretary",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581207",
   "koodiArvo" : "581207",
@@ -26770,7 +26770,7 @@
     "lyhytNimi" : "Diploma in Sports Instruction",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581251",
   "koodiArvo" : "581251",
@@ -26787,7 +26787,7 @@
     "lyhytNimi" : "Diploma in Hobby Instruction",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581299",
   "koodiArvo" : "581299",
@@ -26804,7 +26804,7 @@
     "lyhytNimi" : "Other or Unknown Education in Leisure Activity and Youth Work, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581300",
   "koodiArvo" : "581300",
@@ -26821,7 +26821,7 @@
     "lyhytNimi" : "Education in Beauty Care, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581301",
   "koodiArvo" : "581301",
@@ -26838,7 +26838,7 @@
     "lyhytNimi" : "Diploma of Specialist Hairdresser",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581302",
   "koodiArvo" : "581302",
@@ -26855,7 +26855,7 @@
     "lyhytNimi" : "Diploma of Specialist Beauty Therapist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581399",
   "koodiArvo" : "581399",
@@ -26872,7 +26872,7 @@
     "lyhytNimi" : "Other or Unknown Education in Beauty Care, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581400",
   "koodiArvo" : "581400",
@@ -26889,7 +26889,7 @@
     "lyhytNimi" : "Education in Traffic and Seafaring, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581401",
   "koodiArvo" : "581401",
@@ -26906,7 +26906,7 @@
     "lyhytNimi" : "Diploma in Seafaring, Deck Officer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581451",
   "koodiArvo" : "581451",
@@ -26923,7 +26923,7 @@
     "lyhytNimi" : "Stevedore Technician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581499",
   "koodiArvo" : "581499",
@@ -26940,7 +26940,7 @@
     "lyhytNimi" : "Other or Unknown Education in Traffic and Seafaring, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581500",
   "koodiArvo" : "581500",
@@ -26957,7 +26957,7 @@
     "lyhytNimi" : "Education in Safety and Security, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581501",
   "koodiArvo" : "581501",
@@ -26974,7 +26974,7 @@
     "lyhytNimi" : "Fire Officer´s Diploma",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581514",
   "koodiArvo" : "581514",
@@ -26991,7 +26991,7 @@
     "lyhytNimi" : "Police Sergeant's Examination",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581515",
   "koodiArvo" : "581515",
@@ -27008,7 +27008,7 @@
     "lyhytNimi" : "Police Commisoner's Qualification",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581516",
   "koodiArvo" : "581516",
@@ -27025,7 +27025,7 @@
     "lyhytNimi" : "Police Sergeant's Examination, Part A",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581599",
   "koodiArvo" : "581599",
@@ -27042,7 +27042,7 @@
     "lyhytNimi" : "Other or Unknown Education in Safety and Security, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581600",
   "koodiArvo" : "581600",
@@ -27059,7 +27059,7 @@
     "lyhytNimi" : "Education in Military Science, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581601",
   "koodiArvo" : "581601",
@@ -27076,7 +27076,7 @@
     "lyhytNimi" : "Course of Lieutenant",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581602",
   "koodiArvo" : "581602",
@@ -27093,7 +27093,7 @@
     "lyhytNimi" : "Warrant Officer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581603",
   "koodiArvo" : "581603",
@@ -27110,7 +27110,7 @@
     "lyhytNimi" : "Postgraduate Degree of Warrant Officer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581604",
   "koodiArvo" : "581604",
@@ -27127,7 +27127,7 @@
     "lyhytNimi" : "Postgraduate Degree of Reserve Officer (Basic Studies of Commissioned Officer)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581699",
   "koodiArvo" : "581699",
@@ -27144,7 +27144,7 @@
     "lyhytNimi" : "Other or Unknown Education in Military Science, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581900",
   "koodiArvo" : "581900",
@@ -27161,7 +27161,7 @@
     "lyhytNimi" : "Other Education in Services, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_581999",
   "koodiArvo" : "581999",
@@ -27178,7 +27178,7 @@
     "lyhytNimi" : "Other or Unknown Education in Services, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_599000",
   "koodiArvo" : "599000",
@@ -27195,7 +27195,7 @@
     "lyhytNimi" : "Other Education, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_599900",
   "koodiArvo" : "599900",
@@ -27212,7 +27212,7 @@
     "lyhytNimi" : "Other Education, Lowest Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_599999",
   "koodiArvo" : "599999",
@@ -27229,7 +27229,7 @@
     "lyhytNimi" : "Other or Unknown Education, Lowest Level Tertiary Eduation",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_600039",
   "koodiArvo" : "600039",
@@ -27318,7 +27318,7 @@
     "lyhytNimi" : "Bachelor of Arts (Polytechnic), Teacher Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_611100",
   "koodiArvo" : "611100",
@@ -27335,7 +27335,7 @@
     "lyhytNimi" : "Bachelor of Arts (Polytechnic), Music Teacher Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_611101",
   "koodiArvo" : "611101",
@@ -27352,7 +27352,7 @@
     "lyhytNimi" : "Bachelor of Culture and Arts (Polytechnic), Music Educator",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_611200",
   "koodiArvo" : "611200",
@@ -27369,7 +27369,7 @@
     "lyhytNimi" : "Bachelor of Culture and Arts (Polytechnic), Theatre and Dance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_611201",
   "koodiArvo" : "611201",
@@ -27386,7 +27386,7 @@
     "lyhytNimi" : "Bachelor of Culture and Arts (Polytechnic), Dance Instruction",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_612000",
   "koodiArvo" : "612000",
@@ -27403,7 +27403,7 @@
     "lyhytNimi" : "Bachelor of Arts (Education)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_612100",
   "koodiArvo" : "612100",
@@ -27420,7 +27420,7 @@
     "lyhytNimi" : "Bachelor of Arts (Education), Teacher Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_612101",
   "koodiArvo" : "612101",
@@ -27437,7 +27437,7 @@
     "lyhytNimi" : "Bachelor of Arts (Education), Kindergarten Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_612102",
   "koodiArvo" : "612102",
@@ -27454,7 +27454,7 @@
     "lyhytNimi" : "Bachelor of Arts (Education), Class Teacher (no Teacher Competence)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_612103",
   "koodiArvo" : "612103",
@@ -27471,7 +27471,7 @@
     "lyhytNimi" : "Bachelor of Arts (Education), Special Education Teacher  (no Teacher Competence)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_612104",
   "koodiArvo" : "612104",
@@ -27488,7 +27488,7 @@
     "lyhytNimi" : "Bachelor of Arts (Education), Home Economics Teacher (no Teacher Competence)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_612105",
   "koodiArvo" : "612105",
@@ -27505,7 +27505,7 @@
     "lyhytNimi" : "Bachelor of Arts (Education), Crafts Teacher  (no Teacher Competence)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_612106",
   "koodiArvo" : "612106",
@@ -27518,7 +27518,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_612107",
   "koodiArvo" : "612107",
@@ -27535,7 +27535,7 @@
     "lyhytNimi" : "Bachelor of Arts (Education), Study Guidance Counsellor (no Teacher Competence)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_612108",
   "koodiArvo" : "612108",
@@ -27552,7 +27552,7 @@
     "lyhytNimi" : "Bachelor of Arts (Education), Music Teacher (no Teacher Competence)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_612199",
   "koodiArvo" : "612199",
@@ -27569,7 +27569,7 @@
     "lyhytNimi" : "Bachelor of Arts (Education), Other or Unknown Teacher Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_612200",
   "koodiArvo" : "612200",
@@ -27586,7 +27586,7 @@
     "lyhytNimi" : "Bachelor of Arts (Education), Educational Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_612201",
   "koodiArvo" : "612201",
@@ -27603,7 +27603,7 @@
     "lyhytNimi" : "Bachelor of Arts (Education), Educational Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_612202",
   "koodiArvo" : "612202",
@@ -27620,7 +27620,7 @@
     "lyhytNimi" : "Bachelor of Arts (Education), Adult Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_612203",
   "koodiArvo" : "612203",
@@ -27637,7 +27637,7 @@
     "lyhytNimi" : "Bachelor of Arts (Education), Special Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_612204",
   "koodiArvo" : "612204",
@@ -27654,7 +27654,7 @@
     "lyhytNimi" : "Bachelor of Arts (Education), Early Childhood Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_612205",
   "koodiArvo" : "612205",
@@ -27671,7 +27671,7 @@
     "lyhytNimi" : "Bachelor of Arts (Education), Textiles and Related Crafts, Technical Work and Home Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_612299",
   "koodiArvo" : "612299",
@@ -27688,7 +27688,7 @@
     "lyhytNimi" : "Bachelor of Arts (Education), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_612900",
   "koodiArvo" : "612900",
@@ -27705,7 +27705,7 @@
     "lyhytNimi" : "Other Education in Educational Science, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_612999",
   "koodiArvo" : "612999",
@@ -27722,7 +27722,7 @@
     "lyhytNimi" : "Other or Unknown Education in Educational Science, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613000",
   "koodiArvo" : "613000",
@@ -27739,7 +27739,7 @@
     "lyhytNimi" : "Teacher Education, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613100",
   "koodiArvo" : "613100",
@@ -27756,7 +27756,7 @@
     "lyhytNimi" : "Kindergarten Teacher (1986-)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613101",
   "koodiArvo" : "613101",
@@ -27773,7 +27773,7 @@
     "lyhytNimi" : "Kindergarten Teacher (1986-)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613200",
   "koodiArvo" : "613200",
@@ -27790,7 +27790,7 @@
     "lyhytNimi" : "Class Teacher at Comprehensive School",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613201",
   "koodiArvo" : "613201",
@@ -27807,7 +27807,7 @@
     "lyhytNimi" : "Class Teacher at Comprehensive School",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613300",
   "koodiArvo" : "613300",
@@ -27824,7 +27824,7 @@
     "lyhytNimi" : "Subject Teacher at Comprehensive School",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613352",
   "koodiArvo" : "613352",
@@ -27841,7 +27841,7 @@
     "lyhytNimi" : "Subject Teacher in Swedish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613353",
   "koodiArvo" : "613353",
@@ -27858,7 +27858,7 @@
     "lyhytNimi" : "Subject Teacher in English Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613354",
   "koodiArvo" : "613354",
@@ -27875,7 +27875,7 @@
     "lyhytNimi" : "Teacher in Home Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613355",
   "koodiArvo" : "613355",
@@ -27892,7 +27892,7 @@
     "lyhytNimi" : "Teacher in Textile Handicraft",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613356",
   "koodiArvo" : "613356",
@@ -27909,7 +27909,7 @@
     "lyhytNimi" : "Teacher in Home Economics and Textile Handicraft",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613357",
   "koodiArvo" : "613357",
@@ -27926,7 +27926,7 @@
     "lyhytNimi" : "Technical Handicraft Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613399",
   "koodiArvo" : "613399",
@@ -27943,7 +27943,7 @@
     "lyhytNimi" : "Other or Unknown Comprehensive School Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613400",
   "koodiArvo" : "613400",
@@ -27960,7 +27960,7 @@
     "lyhytNimi" : "Special Education Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613401",
   "koodiArvo" : "613401",
@@ -27977,7 +27977,7 @@
     "lyhytNimi" : "Special Kindergarten Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613402",
   "koodiArvo" : "613402",
@@ -27994,7 +27994,7 @@
     "lyhytNimi" : "Special Education Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613500",
   "koodiArvo" : "613500",
@@ -28011,7 +28011,7 @@
     "lyhytNimi" : "Guidance Counsellor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613501",
   "koodiArvo" : "613501",
@@ -28028,7 +28028,7 @@
     "lyhytNimi" : "Guidance Counsellor, Comprehensive and Upper Secondary School",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613502",
   "koodiArvo" : "613502",
@@ -28039,7 +28039,7 @@
     "nimi" : "Ammatillisten oppilaitosten opinto-ohjaaja",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_613600",
   "koodiArvo" : "613600",
@@ -28056,7 +28056,7 @@
     "lyhytNimi" : "Music Teacher, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613601",
   "koodiArvo" : "613601",
@@ -28067,7 +28067,7 @@
     "nimi" : "Musiikkileikkikoulun opettaja",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_613602",
   "koodiArvo" : "613602",
@@ -28078,7 +28078,7 @@
     "nimi" : "Musiikkiopiston opettaja",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_613603",
   "koodiArvo" : "613603",
@@ -28089,7 +28089,7 @@
     "nimi" : "Musiikkioppilaitoksen opettaja",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_613604",
   "koodiArvo" : "613604",
@@ -28100,7 +28100,7 @@
     "nimi" : "Pop- ja jazzmusiikin opettaja",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_613651",
   "koodiArvo" : "613651",
@@ -28117,7 +28117,7 @@
     "lyhytNimi" : "University Examination of Pedagogics in Music Theory",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613652",
   "koodiArvo" : "613652",
@@ -28134,7 +28134,7 @@
     "lyhytNimi" : "Music Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613653",
   "koodiArvo" : "613653",
@@ -28151,7 +28151,7 @@
     "lyhytNimi" : "University Examination of Vocal and Instrumental Pedagogics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613654",
   "koodiArvo" : "613654",
@@ -28168,7 +28168,7 @@
     "lyhytNimi" : "Higher Music Teacher Examination",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613699",
   "koodiArvo" : "613699",
@@ -28185,7 +28185,7 @@
     "lyhytNimi" : "Other or Unknown Music Teacher Education, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613800",
   "koodiArvo" : "613800",
@@ -28202,7 +28202,7 @@
     "lyhytNimi" : "Primary and Civic School Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613811",
   "koodiArvo" : "613811",
@@ -28219,7 +28219,7 @@
     "lyhytNimi" : "Primary School Teacher, Civic School Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613900",
   "koodiArvo" : "613900",
@@ -28236,7 +28236,7 @@
     "lyhytNimi" : "Other Teacher Education, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613901",
   "koodiArvo" : "613901",
@@ -28247,7 +28247,7 @@
     "nimi" : "Sairaanhoidonopettaja",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_613902",
   "koodiArvo" : "613902",
@@ -28258,7 +28258,7 @@
     "nimi" : "Tanssinopettaja",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_613951",
   "koodiArvo" : "613951",
@@ -28275,7 +28275,7 @@
     "lyhytNimi" : "Bachelor of Sport and Health Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613952",
   "koodiArvo" : "613952",
@@ -28292,7 +28292,7 @@
     "lyhytNimi" : "Steiner Kindergarten Early Years Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_613999",
   "koodiArvo" : "613999",
@@ -28309,7 +28309,7 @@
     "lyhytNimi" : "Other or Unknown Teacher Education, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621000",
   "koodiArvo" : "621000",
@@ -28326,7 +28326,7 @@
     "lyhytNimi" : "Bachelor of Arts (Polytechnic), Humanities, Arts and Culture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621100",
   "koodiArvo" : "621100",
@@ -28343,7 +28343,7 @@
     "lyhytNimi" : "Bachelor of Arts (Polytechnic), Crafts, Design and Conservation",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621101",
   "koodiArvo" : "621101",
@@ -28360,7 +28360,7 @@
     "lyhytNimi" : "Bachelor of Culture and Arts (Polytechnic), Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621102",
   "koodiArvo" : "621102",
@@ -28377,7 +28377,7 @@
     "lyhytNimi" : "Bachelor of Culture and Arts (Polytechnic), Designer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621103",
   "koodiArvo" : "621103",
@@ -28394,7 +28394,7 @@
     "lyhytNimi" : "Bachelor of Culture and Arts (Polytechnic), Conservator",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621104",
   "koodiArvo" : "621104",
@@ -28411,7 +28411,7 @@
     "lyhytNimi" : "Bachelor of Culture and Arts (Polytechnic), Fashion Designer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621199",
   "koodiArvo" : "621199",
@@ -28428,7 +28428,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic Bachelor's Degree in Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621200",
   "koodiArvo" : "621200",
@@ -28445,7 +28445,7 @@
     "lyhytNimi" : "Bachelor of Arts (Polytechnic), Music",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621201",
   "koodiArvo" : "621201",
@@ -28462,7 +28462,7 @@
     "lyhytNimi" : "Bachelor of Culture and Arts (Polytechnic), Musician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621299",
   "koodiArvo" : "621299",
@@ -28479,7 +28479,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic Bachelor's Degree, Music",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621300",
   "koodiArvo" : "621300",
@@ -28496,7 +28496,7 @@
     "lyhytNimi" : "Bachelor of Culture and Arts (Polytechnic), Visual Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621301",
   "koodiArvo" : "621301",
@@ -28513,7 +28513,7 @@
     "lyhytNimi" : "Bachelor of Culture and Arts (Polytechnic), Visual Artist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621399",
   "koodiArvo" : "621399",
@@ -28530,7 +28530,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic Bachelor's Degree in Fine Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621500",
   "koodiArvo" : "621500",
@@ -28547,7 +28547,7 @@
     "lyhytNimi" : "Bachelor of Culture and Arts (Polytechnic), Theatre and Dance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621501",
   "koodiArvo" : "621501",
@@ -28564,7 +28564,7 @@
     "lyhytNimi" : "Bachelor of Culture and Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621502",
   "koodiArvo" : "621502",
@@ -28598,7 +28598,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic Bachelor's Degree, Theatre and Dance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621600",
   "koodiArvo" : "621600",
@@ -28615,7 +28615,7 @@
     "lyhytNimi" : "Bachelor of Culture and Arts (Polytechnic), Media",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621601",
   "koodiArvo" : "621601",
@@ -28632,7 +28632,7 @@
     "lyhytNimi" : "Bachelor of Culture and Arts (Polytechnic), Media",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621700",
   "koodiArvo" : "621700",
@@ -28649,7 +28649,7 @@
     "lyhytNimi" : "Bachelor of Arts (Polytechnic), Humanities, Arts and Culture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621701",
   "koodiArvo" : "621701",
@@ -28666,7 +28666,7 @@
     "lyhytNimi" : "Bachelor of Humanities (Polytechnic), Sign Language Interpreter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621702",
   "koodiArvo" : "621702",
@@ -28683,7 +28683,7 @@
     "lyhytNimi" : "Bachelor of Culture and Arts (Polytechnic), Cultural Manager",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621703",
   "koodiArvo" : "621703",
@@ -28700,7 +28700,7 @@
     "lyhytNimi" : "Bachelor of Humanities (Polytechnic), Community Educator",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621704",
   "koodiArvo" : "621704",
@@ -28717,7 +28717,7 @@
     "lyhytNimi" : "Bachelor of Humanities",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621799",
   "koodiArvo" : "621799",
@@ -28734,7 +28734,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic Bachelor's Degree, Humanities",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621900",
   "koodiArvo" : "621900",
@@ -28751,7 +28751,7 @@
     "lyhytNimi" : "Other Polytechnic Bachelor's Degree in Humanities, Arts and Culture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_621999",
   "koodiArvo" : "621999",
@@ -28768,7 +28768,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic Bachelor's Degree, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622000",
   "koodiArvo" : "622000",
@@ -28785,7 +28785,7 @@
     "lyhytNimi" : "Education in Arts, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622100",
   "koodiArvo" : "622100",
@@ -28802,7 +28802,7 @@
     "lyhytNimi" : "Education in Arts, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622101",
   "koodiArvo" : "622101",
@@ -28819,7 +28819,7 @@
     "lyhytNimi" : "Bachelor of Arts (Art and Design)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622199",
   "koodiArvo" : "622199",
@@ -28836,7 +28836,7 @@
     "lyhytNimi" : "Other or Unknown Education in Arts, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622200",
   "koodiArvo" : "622200",
@@ -28853,7 +28853,7 @@
     "lyhytNimi" : "Education in Music, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622201",
   "koodiArvo" : "622201",
@@ -28870,7 +28870,7 @@
     "lyhytNimi" : "Bachelor of Music",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622251",
   "koodiArvo" : "622251",
@@ -28887,7 +28887,7 @@
     "lyhytNimi" : "Higher Cantor-Organist Examination",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622252",
   "koodiArvo" : "622252",
@@ -28904,7 +28904,7 @@
     "lyhytNimi" : "University Diploma in Music",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622253",
   "koodiArvo" : "622253",
@@ -28921,7 +28921,7 @@
     "lyhytNimi" : "University Diploma in Opera Singing",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622299",
   "koodiArvo" : "622299",
@@ -28938,7 +28938,7 @@
     "lyhytNimi" : "Other or Unknown Education in Music, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622300",
   "koodiArvo" : "622300",
@@ -28955,7 +28955,7 @@
     "lyhytNimi" : "Education in Fine Arts, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622301",
   "koodiArvo" : "622301",
@@ -28972,7 +28972,7 @@
     "lyhytNimi" : "Bachelor of Fine Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622399",
   "koodiArvo" : "622399",
@@ -28989,7 +28989,7 @@
     "lyhytNimi" : "Other or Unknown Education in Fine Arts, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622500",
   "koodiArvo" : "622500",
@@ -29006,7 +29006,7 @@
     "lyhytNimi" : "Education in Theatre and Dance, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622501",
   "koodiArvo" : "622501",
@@ -29023,7 +29023,7 @@
     "lyhytNimi" : "Bachelor of Arts (Theatre and Drama)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622502",
   "koodiArvo" : "622502",
@@ -29040,7 +29040,7 @@
     "lyhytNimi" : "Bachelor of Arts (Dance)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622551",
   "koodiArvo" : "622551",
@@ -29057,7 +29057,7 @@
     "lyhytNimi" : "Dramaturg",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622552",
   "koodiArvo" : "622552",
@@ -29074,7 +29074,7 @@
     "lyhytNimi" : "Theatre Director",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622553",
   "koodiArvo" : "622553",
@@ -29091,7 +29091,7 @@
     "lyhytNimi" : "University Diploma in Theatre and Drama",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622554",
   "koodiArvo" : "622554",
@@ -29108,7 +29108,7 @@
     "lyhytNimi" : "University Diploma in Theatre and Drama",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622555",
   "koodiArvo" : "622555",
@@ -29125,7 +29125,7 @@
     "lyhytNimi" : "Scenograph",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622599",
   "koodiArvo" : "622599",
@@ -29142,7 +29142,7 @@
     "lyhytNimi" : "Other or Unknown Education in Theatre and Dance, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622900",
   "koodiArvo" : "622900",
@@ -29159,7 +29159,7 @@
     "lyhytNimi" : "Other Education in Arts, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622951",
   "koodiArvo" : "622951",
@@ -29176,7 +29176,7 @@
     "lyhytNimi" : "Diploma of Institute of Industrial Art",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_622999",
   "koodiArvo" : "622999",
@@ -29193,7 +29193,7 @@
     "lyhytNimi" : "Other or Unknown Education in Arts, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623000",
   "koodiArvo" : "623000",
@@ -29210,7 +29210,7 @@
     "lyhytNimi" : "Bachelor of Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623100",
   "koodiArvo" : "623100",
@@ -29227,7 +29227,7 @@
     "lyhytNimi" : "Bachelor of Arts, Linguistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623101",
   "koodiArvo" : "623101",
@@ -29244,7 +29244,7 @@
     "lyhytNimi" : "Bachelor of Arts, Finnish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623102",
   "koodiArvo" : "623102",
@@ -29261,7 +29261,7 @@
     "lyhytNimi" : "Bachelor of Arts, Swedish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623103",
   "koodiArvo" : "623103",
@@ -29278,7 +29278,7 @@
     "lyhytNimi" : "Bachelor of Arts, English Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623104",
   "koodiArvo" : "623104",
@@ -29295,7 +29295,7 @@
     "lyhytNimi" : "Bachelor of Arts, German Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623105",
   "koodiArvo" : "623105",
@@ -29312,7 +29312,7 @@
     "lyhytNimi" : "Bachelor of Arts, French Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623106",
   "koodiArvo" : "623106",
@@ -29329,7 +29329,7 @@
     "lyhytNimi" : "Bachelor of Arts, Russian Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623107",
   "koodiArvo" : "623107",
@@ -29346,7 +29346,7 @@
     "lyhytNimi" : "Bachelor of Arts, Spanish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623108",
   "koodiArvo" : "623108",
@@ -29363,7 +29363,7 @@
     "lyhytNimi" : "Bachelor of Arts, Italian Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623109",
   "koodiArvo" : "623109",
@@ -29380,7 +29380,7 @@
     "lyhytNimi" : "Bachelor of Arts, Sami Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623110",
   "koodiArvo" : "623110",
@@ -29397,7 +29397,7 @@
     "lyhytNimi" : "Bachelor of Arts, Finno-Ugrian Languages",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623111",
   "koodiArvo" : "623111",
@@ -29414,7 +29414,7 @@
     "lyhytNimi" : "Bachelor of Arts, Hungarian Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623112",
   "koodiArvo" : "623112",
@@ -29431,7 +29431,7 @@
     "lyhytNimi" : "Bachelor of Arts, Baltic Languages",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623113",
   "koodiArvo" : "623113",
@@ -29448,7 +29448,7 @@
     "lyhytNimi" : "Bachelor of Arts, Classical Languages",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623114",
   "koodiArvo" : "623114",
@@ -29465,7 +29465,7 @@
     "lyhytNimi" : "Bachelor of Arts, Slavonic Languages",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623115",
   "koodiArvo" : "623115",
@@ -29482,7 +29482,7 @@
     "lyhytNimi" : "Bachelor of Arts, Sign Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623116",
   "koodiArvo" : "623116",
@@ -29516,7 +29516,7 @@
     "lyhytNimi" : "Bachelor of Arts, Other or Unknown Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623200",
   "koodiArvo" : "623200",
@@ -29533,7 +29533,7 @@
     "lyhytNimi" : "Bachelor of Arts, Translation and Interpretation",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623201",
   "koodiArvo" : "623201",
@@ -29550,7 +29550,7 @@
     "lyhytNimi" : "Bachelor of Arts, Translation and Interpretation, Finnish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623202",
   "koodiArvo" : "623202",
@@ -29567,7 +29567,7 @@
     "lyhytNimi" : "Bachelor of Arts, Translation and Interpretation, Swedish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623203",
   "koodiArvo" : "623203",
@@ -29584,7 +29584,7 @@
     "lyhytNimi" : "Bachelor of Arts, Translation and Interpretation, English Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623204",
   "koodiArvo" : "623204",
@@ -29601,7 +29601,7 @@
     "lyhytNimi" : "Bachelor of Arts, Translation and Interpretation, German Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623205",
   "koodiArvo" : "623205",
@@ -29618,7 +29618,7 @@
     "lyhytNimi" : "Bachelor of Arts, Translation and Interpretation, French Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623206",
   "koodiArvo" : "623206",
@@ -29635,7 +29635,7 @@
     "lyhytNimi" : "Bachelor of Arts, Translation and Interpretation, Russian Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623207",
   "koodiArvo" : "623207",
@@ -29652,7 +29652,7 @@
     "lyhytNimi" : "Bachelor of Arts, Translation and Interpretation, Spanish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623208",
   "koodiArvo" : "623208",
@@ -29669,7 +29669,7 @@
     "lyhytNimi" : "Bachelor of Arts, Translation and Interpretation, Italian Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623299",
   "koodiArvo" : "623299",
@@ -29686,7 +29686,7 @@
     "lyhytNimi" : "Bachelor of Arts, Other or Unknown Translation and Interpretation",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623300",
   "koodiArvo" : "623300",
@@ -29703,7 +29703,7 @@
     "lyhytNimi" : "Bachelor of Arts, History and Archeology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623301",
   "koodiArvo" : "623301",
@@ -29720,7 +29720,7 @@
     "lyhytNimi" : "Bachelor of Arts, History",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623302",
   "koodiArvo" : "623302",
@@ -29737,7 +29737,7 @@
     "lyhytNimi" : "Bachelor of Arts, Archeology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623400",
   "koodiArvo" : "623400",
@@ -29754,7 +29754,7 @@
     "lyhytNimi" : "Bachelor of Arts, Literature, Cultural Research and Linguistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623401",
   "koodiArvo" : "623401",
@@ -29771,7 +29771,7 @@
     "lyhytNimi" : "Bachelor of Arts, Literature",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623402",
   "koodiArvo" : "623402",
@@ -29788,7 +29788,7 @@
     "lyhytNimi" : "Bachelor of Arts, Cultural Research",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623403",
   "koodiArvo" : "623403",
@@ -29805,7 +29805,7 @@
     "lyhytNimi" : "Bachelor of Arts, Linguistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623404",
   "koodiArvo" : "623404",
@@ -29822,7 +29822,7 @@
     "lyhytNimi" : "Bachelor of Arts, Speech Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623405",
   "koodiArvo" : "623405",
@@ -29856,7 +29856,7 @@
     "lyhytNimi" : "Bachelor of Arts, Arts Research",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623501",
   "koodiArvo" : "623501",
@@ -29873,7 +29873,7 @@
     "lyhytNimi" : "Bachelor of Arts, Art History and Art Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623502",
   "koodiArvo" : "623502",
@@ -29890,7 +29890,7 @@
     "lyhytNimi" : "Bachelor of Arts, Musicology and Music Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623503",
   "koodiArvo" : "623503",
@@ -29907,7 +29907,7 @@
     "lyhytNimi" : "Bachelor of Arts, Theatre",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623599",
   "koodiArvo" : "623599",
@@ -29924,7 +29924,7 @@
     "lyhytNimi" : "Bachelor of Arts, Other or Unknown Arts Research",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623600",
   "koodiArvo" : "623600",
@@ -29941,7 +29941,7 @@
     "lyhytNimi" : "Bachelor of Arts, Communication and Information Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623601",
   "koodiArvo" : "623601",
@@ -29958,7 +29958,7 @@
     "lyhytNimi" : "Bachelor of Arts, Communication and Information Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623700",
   "koodiArvo" : "623700",
@@ -29975,7 +29975,7 @@
     "lyhytNimi" : "Bachelor of Arts, Philosophy",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623701",
   "koodiArvo" : "623701",
@@ -29992,7 +29992,7 @@
     "lyhytNimi" : "Bachelor of Arts, Philosophy (Humanities)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623900",
   "koodiArvo" : "623900",
@@ -30009,7 +30009,7 @@
     "lyhytNimi" : "Bachelor of Arts, Other Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_623999",
   "koodiArvo" : "623999",
@@ -30026,7 +30026,7 @@
     "lyhytNimi" : "Bachelor of Arts, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_624000",
   "koodiArvo" : "624000",
@@ -30043,7 +30043,7 @@
     "lyhytNimi" : "Education in Theology, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_624100",
   "koodiArvo" : "624100",
@@ -30060,7 +30060,7 @@
     "lyhytNimi" : "Education in Theology, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_624101",
   "koodiArvo" : "624101",
@@ -30077,7 +30077,7 @@
     "lyhytNimi" : "Bachelor of Theology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_624199",
   "koodiArvo" : "624199",
@@ -30094,7 +30094,7 @@
     "lyhytNimi" : "Other or Unknown Education in Theology, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_628000",
   "koodiArvo" : "628000",
@@ -30111,7 +30111,7 @@
     "lyhytNimi" : "Diploma in Translation (Language Insitute)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_628100",
   "koodiArvo" : "628100",
@@ -30128,7 +30128,7 @@
     "lyhytNimi" : "Diploma in Translation (Language Institute)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_628151",
   "koodiArvo" : "628151",
@@ -30145,7 +30145,7 @@
     "lyhytNimi" : "University Diploma in Translation, Swedish",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_628152",
   "koodiArvo" : "628152",
@@ -30162,7 +30162,7 @@
     "lyhytNimi" : "University Diploma in Translation, English",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_628153",
   "koodiArvo" : "628153",
@@ -30179,7 +30179,7 @@
     "lyhytNimi" : "University Diploma in Translation, German",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_628154",
   "koodiArvo" : "628154",
@@ -30196,7 +30196,7 @@
     "lyhytNimi" : "University Diploma in Translation, French",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_628155",
   "koodiArvo" : "628155",
@@ -30213,7 +30213,7 @@
     "lyhytNimi" : "University Diploma in Translation, Russian",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_628199",
   "koodiArvo" : "628199",
@@ -30230,7 +30230,7 @@
     "lyhytNimi" : "University Diploma in Translation, Other or Unknown Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_629000",
   "koodiArvo" : "629000",
@@ -30247,7 +30247,7 @@
     "lyhytNimi" : "Other Education in Humanities and Arts, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_629900",
   "koodiArvo" : "629900",
@@ -30264,7 +30264,7 @@
     "lyhytNimi" : "Other Education in Humanities and Arts, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_629999",
   "koodiArvo" : "629999",
@@ -30281,7 +30281,7 @@
     "lyhytNimi" : "Other or Unknown Education in Humanities and Arts, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_631000",
   "koodiArvo" : "631000",
@@ -30298,7 +30298,7 @@
     "lyhytNimi" : "Bachelor of Business Administration (Polytechnic), Business Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_631100",
   "koodiArvo" : "631100",
@@ -30315,7 +30315,7 @@
     "lyhytNimi" : "Bachelor of Business Administration (Polytechnic), Business Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_631101",
   "koodiArvo" : "631101",
@@ -30332,7 +30332,7 @@
     "lyhytNimi" : "Bachelor of Business Administration (Polytechnic), Economics, Administration and Marketing",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_631104",
   "koodiArvo" : "631104",
@@ -30349,7 +30349,7 @@
     "lyhytNimi" : "Bachelor of Business Administration (Polytechnic), Secretarial and Language Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_631107",
   "koodiArvo" : "631107",
@@ -30366,7 +30366,7 @@
     "lyhytNimi" : "Bachelor of Business Administration (Polytechnic), Data Processing",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_631108",
   "koodiArvo" : "631108",
@@ -30379,7 +30379,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_631109",
   "koodiArvo" : "631109",
@@ -30396,7 +30396,7 @@
     "lyhytNimi" : "Bachelor of Business Administration (Polytechnic), Library and Information Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_631110",
   "koodiArvo" : "631110",
@@ -30413,7 +30413,7 @@
     "lyhytNimi" : "Bachelor of Business Administration (Polytechnic), Tourism",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_631199",
   "koodiArvo" : "631199",
@@ -30430,7 +30430,7 @@
     "lyhytNimi" : "Bachelor of Business Administration (Polytechnic), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_632000",
   "koodiArvo" : "632000",
@@ -30447,7 +30447,7 @@
     "lyhytNimi" : "Education in Business, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_632100",
   "koodiArvo" : "632100",
@@ -30464,7 +30464,7 @@
     "lyhytNimi" : "Bachelor of Science (Economics and Business Administration)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_632101",
   "koodiArvo" : "632101",
@@ -30481,7 +30481,7 @@
     "lyhytNimi" : "Bachelor of Science (Economics and Business Administration), Business Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_632105",
   "koodiArvo" : "632105",
@@ -30498,7 +30498,7 @@
     "lyhytNimi" : "Bachelor of Science (Economics and Business Administration), Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_632114",
   "koodiArvo" : "632114",
@@ -30515,7 +30515,7 @@
     "lyhytNimi" : "Bachelor of Science (Economics and Business Administration), Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_632115",
   "koodiArvo" : "632115",
@@ -30532,7 +30532,7 @@
     "lyhytNimi" : "Bachelor of Science (Economics and Business Administration), Information Systems Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_632199",
   "koodiArvo" : "632199",
@@ -30549,7 +30549,7 @@
     "lyhytNimi" : "Bachelor of Science (Economics and Business Administration), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_632200",
   "koodiArvo" : "632200",
@@ -30566,7 +30566,7 @@
     "lyhytNimi" : "Bachelor of Science (Economics and Business Administration)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_632201",
   "koodiArvo" : "632201",
@@ -30583,7 +30583,7 @@
     "lyhytNimi" : "Bachelor of Science (Economics and Business Administration), Business Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_632205",
   "koodiArvo" : "632205",
@@ -30600,7 +30600,7 @@
     "lyhytNimi" : "Bachelor of Science (Economics and Business Administration), Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_632214",
   "koodiArvo" : "632214",
@@ -30617,7 +30617,7 @@
     "lyhytNimi" : "Bachelor of Science (Economics and Business Administration), Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_632215",
   "koodiArvo" : "632215",
@@ -30634,7 +30634,7 @@
     "lyhytNimi" : "Bachelor of Science (Economics and Business Administration), Information Systems Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_632299",
   "koodiArvo" : "632299",
@@ -30651,7 +30651,7 @@
     "lyhytNimi" : "Bachelor of Science (Economics and Business Administration), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_632400",
   "koodiArvo" : "632400",
@@ -30668,7 +30668,7 @@
     "lyhytNimi" : "University Diploma for Academic Secretary and Correspondent",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_632451",
   "koodiArvo" : "632451",
@@ -30685,7 +30685,7 @@
     "lyhytNimi" : "University Diploma for Academic Secretary",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_632452",
   "koodiArvo" : "632452",
@@ -30702,7 +30702,7 @@
     "lyhytNimi" : "University Diploma for Correspondent",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_632900",
   "koodiArvo" : "632900",
@@ -30719,7 +30719,7 @@
     "lyhytNimi" : "Other Education in Business, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_632999",
   "koodiArvo" : "632999",
@@ -30736,7 +30736,7 @@
     "lyhytNimi" : "Other or Unknown Education in Business, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633000",
   "koodiArvo" : "633000",
@@ -30753,7 +30753,7 @@
     "lyhytNimi" : "Education in Social Sciences, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633100",
   "koodiArvo" : "633100",
@@ -30770,7 +30770,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633101",
   "koodiArvo" : "633101",
@@ -30787,7 +30787,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences, Political Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633102",
   "koodiArvo" : "633102",
@@ -30804,7 +30804,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences, Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633103",
   "koodiArvo" : "633103",
@@ -30821,7 +30821,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences, Social Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633105",
   "koodiArvo" : "633105",
@@ -30838,7 +30838,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences, Psychology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633106",
   "koodiArvo" : "633106",
@@ -30855,7 +30855,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences, Communication Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633107",
   "koodiArvo" : "633107",
@@ -30872,7 +30872,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences, Philosophy",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633108",
   "koodiArvo" : "633108",
@@ -30889,7 +30889,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences, Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633199",
   "koodiArvo" : "633199",
@@ -30906,7 +30906,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633200",
   "koodiArvo" : "633200",
@@ -30923,7 +30923,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633201",
   "koodiArvo" : "633201",
@@ -30940,7 +30940,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences, Political Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633202",
   "koodiArvo" : "633202",
@@ -30957,7 +30957,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences, Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633203",
   "koodiArvo" : "633203",
@@ -30974,7 +30974,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences, Social Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633205",
   "koodiArvo" : "633205",
@@ -30991,7 +30991,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences, Psychology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633206",
   "koodiArvo" : "633206",
@@ -31008,7 +31008,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences, Communication Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633207",
   "koodiArvo" : "633207",
@@ -31025,7 +31025,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences, Philosophy",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633208",
   "koodiArvo" : "633208",
@@ -31042,7 +31042,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences, Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633209",
   "koodiArvo" : "633209",
@@ -31059,7 +31059,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences, Tourism",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633210",
   "koodiArvo" : "633210",
@@ -31076,7 +31076,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences, Regional and Environmental Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633299",
   "koodiArvo" : "633299",
@@ -31093,7 +31093,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633300",
   "koodiArvo" : "633300",
@@ -31110,7 +31110,7 @@
     "lyhytNimi" : "Bachelor of Administrative Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633301",
   "koodiArvo" : "633301",
@@ -31127,7 +31127,7 @@
     "lyhytNimi" : "Bachelor of Administrative Sciences, Administrative Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633310",
   "koodiArvo" : "633310",
@@ -31144,7 +31144,7 @@
     "lyhytNimi" : "Bachelor of Administrative Sciences, Regional and Environmental Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633399",
   "koodiArvo" : "633399",
@@ -31161,7 +31161,7 @@
     "lyhytNimi" : "Bachelor of Administrative Sciences, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633400",
   "koodiArvo" : "633400",
@@ -31178,7 +31178,7 @@
     "lyhytNimi" : "Bachelor of Arts, Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633401",
   "koodiArvo" : "633401",
@@ -31195,7 +31195,7 @@
     "lyhytNimi" : "Bachelor of Arts, Political Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633402",
   "koodiArvo" : "633402",
@@ -31212,7 +31212,7 @@
     "lyhytNimi" : "Bachelor of Arts, Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633403",
   "koodiArvo" : "633403",
@@ -31229,7 +31229,7 @@
     "lyhytNimi" : "Bachelor of Arts, Social Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633404",
   "koodiArvo" : "633404",
@@ -31246,7 +31246,7 @@
     "lyhytNimi" : "Bachelor of Arts, Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633405",
   "koodiArvo" : "633405",
@@ -31263,7 +31263,7 @@
     "lyhytNimi" : "Bachelor of Arts, Psychology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633407",
   "koodiArvo" : "633407",
@@ -31280,7 +31280,7 @@
     "lyhytNimi" : "Bachelor of Arts, Philosophy",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633408",
   "koodiArvo" : "633408",
@@ -31297,7 +31297,7 @@
     "lyhytNimi" : "Bachelor of Arts, Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633409",
   "koodiArvo" : "633409",
@@ -31314,7 +31314,7 @@
     "lyhytNimi" : "Bachelor of Arts, Computer Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633499",
   "koodiArvo" : "633499",
@@ -31331,7 +31331,7 @@
     "lyhytNimi" : "Bachelor of Arts, Social Sciences, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633500",
   "koodiArvo" : "633500",
@@ -31348,7 +31348,7 @@
     "lyhytNimi" : "Bachelor of Arts (Psychology)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633501",
   "koodiArvo" : "633501",
@@ -31365,7 +31365,7 @@
     "lyhytNimi" : "Bachelor of Arts (Psychology)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633600",
   "koodiArvo" : "633600",
@@ -31382,7 +31382,7 @@
     "lyhytNimi" : "University Diploma in Economics and Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633651",
   "koodiArvo" : "633651",
@@ -31399,7 +31399,7 @@
     "lyhytNimi" : "University Diploma in Economics and Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633900",
   "koodiArvo" : "633900",
@@ -31416,7 +31416,7 @@
     "lyhytNimi" : "Other Education in Social Sciences, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_633999",
   "koodiArvo" : "633999",
@@ -31433,7 +31433,7 @@
     "lyhytNimi" : "Other or Unknown Education in Social Sciences, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_634000",
   "koodiArvo" : "634000",
@@ -31450,7 +31450,7 @@
     "lyhytNimi" : "Education in Laws, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_634100",
   "koodiArvo" : "634100",
@@ -31467,7 +31467,7 @@
     "lyhytNimi" : "Education in Laws, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_634101",
   "koodiArvo" : "634101",
@@ -31484,7 +31484,7 @@
     "lyhytNimi" : "University Diploma in Law",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_634102",
   "koodiArvo" : "634102",
@@ -31501,7 +31501,7 @@
     "lyhytNimi" : "Bachelor of Laws",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_634199",
   "koodiArvo" : "634199",
@@ -31518,7 +31518,7 @@
     "lyhytNimi" : "Other or Unknown Education in Laws, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_639000",
   "koodiArvo" : "639000",
@@ -31535,7 +31535,7 @@
     "lyhytNimi" : "Other Education in Social Sciences and Business, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_639100",
   "koodiArvo" : "639100",
@@ -31552,7 +31552,7 @@
     "lyhytNimi" : "Other Education in Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_639151",
   "koodiArvo" : "639151",
@@ -31569,7 +31569,7 @@
     "lyhytNimi" : "University Diploma in Public Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_639152",
   "koodiArvo" : "639152",
@@ -31586,7 +31586,7 @@
     "lyhytNimi" : "University Diploma in Social Studies, Librarian",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_639153",
   "koodiArvo" : "639153",
@@ -31603,7 +31603,7 @@
     "lyhytNimi" : "University Diploma in Librarianship",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_639154",
   "koodiArvo" : "639154",
@@ -31620,7 +31620,7 @@
     "lyhytNimi" : "University Diploma in Local Government",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_639155",
   "koodiArvo" : "639155",
@@ -31637,7 +31637,7 @@
     "lyhytNimi" : "University Diploma in Youth Instruction",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_639156",
   "koodiArvo" : "639156",
@@ -31654,7 +31654,7 @@
     "lyhytNimi" : "University Diploma in Social Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_639157",
   "koodiArvo" : "639157",
@@ -31671,7 +31671,7 @@
     "lyhytNimi" : "University Diploma in Social Insurance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_639158",
   "koodiArvo" : "639158",
@@ -31688,7 +31688,7 @@
     "lyhytNimi" : "University Diploma in Journalism",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_639159",
   "koodiArvo" : "639159",
@@ -31705,7 +31705,7 @@
     "lyhytNimi" : "University Diploma in Taxation",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_639160",
   "koodiArvo" : "639160",
@@ -31722,7 +31722,7 @@
     "lyhytNimi" : "University Diploma in Social Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_639161",
   "koodiArvo" : "639161",
@@ -31739,7 +31739,7 @@
     "lyhytNimi" : "University Diploma in General Insurance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_639199",
   "koodiArvo" : "639199",
@@ -31756,7 +31756,7 @@
     "lyhytNimi" : "Other or Unknown Diploma or Education in Social Sciences or Public Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_639900",
   "koodiArvo" : "639900",
@@ -31773,7 +31773,7 @@
     "lyhytNimi" : "Other Education in Social Sciences and Business, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_639999",
   "koodiArvo" : "639999",
@@ -31790,7 +31790,7 @@
     "lyhytNimi" : "Other or Unknown Education in Social Sciences and Business, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642000",
   "koodiArvo" : "642000",
@@ -31807,7 +31807,7 @@
     "lyhytNimi" : "Bachelor of Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642100",
   "koodiArvo" : "642100",
@@ -31824,7 +31824,7 @@
     "lyhytNimi" : "Bachelor of Science, Mathematics and Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642101",
   "koodiArvo" : "642101",
@@ -31841,7 +31841,7 @@
     "lyhytNimi" : "Bachelor of Science, Mathematics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642102",
   "koodiArvo" : "642102",
@@ -31858,7 +31858,7 @@
     "lyhytNimi" : "Bachelor of Science, Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642200",
   "koodiArvo" : "642200",
@@ -31875,7 +31875,7 @@
     "lyhytNimi" : "Bachelor of Science, Computer Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642201",
   "koodiArvo" : "642201",
@@ -31892,7 +31892,7 @@
     "lyhytNimi" : "Bachelor of Science, Computer Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642300",
   "koodiArvo" : "642300",
@@ -31909,7 +31909,7 @@
     "lyhytNimi" : "Bachelor of Science, Physical Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642301",
   "koodiArvo" : "642301",
@@ -31926,7 +31926,7 @@
     "lyhytNimi" : "Bachelor of Science, Physics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642302",
   "koodiArvo" : "642302",
@@ -31943,7 +31943,7 @@
     "lyhytNimi" : "Bachelor of Science, Geophysics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642303",
   "koodiArvo" : "642303",
@@ -31960,7 +31960,7 @@
     "lyhytNimi" : "Bachelor of Science, Meteorology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642304",
   "koodiArvo" : "642304",
@@ -31977,7 +31977,7 @@
     "lyhytNimi" : "Bachelor of Science, Astronomy",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642400",
   "koodiArvo" : "642400",
@@ -31994,7 +31994,7 @@
     "lyhytNimi" : "Bachelor of Science, Chemistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642401",
   "koodiArvo" : "642401",
@@ -32011,7 +32011,7 @@
     "lyhytNimi" : "Bachelor of Science, Chemistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642500",
   "koodiArvo" : "642500",
@@ -32028,7 +32028,7 @@
     "lyhytNimi" : "Bachelor of Science, Geology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642501",
   "koodiArvo" : "642501",
@@ -32045,7 +32045,7 @@
     "lyhytNimi" : "Bachelor of Science, Geology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642600",
   "koodiArvo" : "642600",
@@ -32062,7 +32062,7 @@
     "lyhytNimi" : "Bachelor of Science, Geography",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642601",
   "koodiArvo" : "642601",
@@ -32079,7 +32079,7 @@
     "lyhytNimi" : "Bachelor of Science, Geography",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642700",
   "koodiArvo" : "642700",
@@ -32096,7 +32096,7 @@
     "lyhytNimi" : "Bachelor of Science, Biology, Biosciences, Biochemistry and Ecology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642701",
   "koodiArvo" : "642701",
@@ -32113,7 +32113,7 @@
     "lyhytNimi" : "Bachelor of Science, Biology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642702",
   "koodiArvo" : "642702",
@@ -32130,7 +32130,7 @@
     "lyhytNimi" : "Bachelor of Science, Biosciences, Biochemistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642703",
   "koodiArvo" : "642703",
@@ -32147,7 +32147,7 @@
     "lyhytNimi" : "Bachelor of Science, Environmental Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642704",
   "koodiArvo" : "642704",
@@ -32160,7 +32160,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_642900",
   "koodiArvo" : "642900",
@@ -32177,7 +32177,7 @@
     "lyhytNimi" : "Bachelor of Science, Other Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642901",
   "koodiArvo" : "642901",
@@ -32194,7 +32194,7 @@
     "lyhytNimi" : "Bachelor of Science, Philosophy",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_642999",
   "koodiArvo" : "642999",
@@ -32211,7 +32211,7 @@
     "lyhytNimi" : "Bachelor of Science, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_649000",
   "koodiArvo" : "649000",
@@ -32228,7 +32228,7 @@
     "lyhytNimi" : "Other Education in Natural Sciences, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_649900",
   "koodiArvo" : "649900",
@@ -32245,7 +32245,7 @@
     "lyhytNimi" : "Other Education in Natural Sciences, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_649999",
   "koodiArvo" : "649999",
@@ -32262,7 +32262,7 @@
     "lyhytNimi" : "Other or Unknown Education in Natural Sciences, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651000",
   "koodiArvo" : "651000",
@@ -32279,7 +32279,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651100",
   "koodiArvo" : "651100",
@@ -32296,7 +32296,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Mechanical Engineering and Transportation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651101",
   "koodiArvo" : "651101",
@@ -32313,7 +32313,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Mechanical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651102",
   "koodiArvo" : "651102",
@@ -32330,7 +32330,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Energy Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651103",
   "koodiArvo" : "651103",
@@ -32347,7 +32347,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Heating and Ventilation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651104",
   "koodiArvo" : "651104",
@@ -32364,7 +32364,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Transportation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651105",
   "koodiArvo" : "651105",
@@ -32381,7 +32381,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Navigation Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651199",
   "koodiArvo" : "651199",
@@ -32398,7 +32398,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_651200",
   "koodiArvo" : "651200",
@@ -32415,7 +32415,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Electrical Engineering and Automation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651201",
   "koodiArvo" : "651201",
@@ -32432,7 +32432,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Electrical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651202",
   "koodiArvo" : "651202",
@@ -32449,7 +32449,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Automation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651203",
   "koodiArvo" : "651203",
@@ -32466,7 +32466,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Electronic Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651299",
   "koodiArvo" : "651299",
@@ -32500,7 +32500,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Information Technology and Telecommunications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651301",
   "koodiArvo" : "651301",
@@ -32517,7 +32517,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Information Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651302",
   "koodiArvo" : "651302",
@@ -32534,7 +32534,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Telecommunications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651399",
   "koodiArvo" : "651399",
@@ -32551,7 +32551,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_651400",
   "koodiArvo" : "651400",
@@ -32568,7 +32568,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Process Engineering and Materials Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651401",
   "koodiArvo" : "651401",
@@ -32585,7 +32585,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Chemistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651402",
   "koodiArvo" : "651402",
@@ -32602,7 +32602,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Process Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651403",
   "koodiArvo" : "651403",
@@ -32619,7 +32619,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Environmental Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651404",
   "koodiArvo" : "651404",
@@ -32636,7 +32636,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Wood Processing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651408",
   "koodiArvo" : "651408",
@@ -32653,7 +32653,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Materials Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651409",
   "koodiArvo" : "651409",
@@ -32670,7 +32670,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Biotechnology, Food Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651410",
   "koodiArvo" : "651410",
@@ -32687,7 +32687,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Paper, Textiles, Chemistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651411",
   "koodiArvo" : "651411",
@@ -32700,7 +32700,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_651499",
   "koodiArvo" : "651499",
@@ -32717,7 +32717,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_651500",
   "koodiArvo" : "651500",
@@ -32734,7 +32734,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Building Construction and Surveying Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651501",
   "koodiArvo" : "651501",
@@ -32751,7 +32751,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Building Construction, Community Development",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651502",
   "koodiArvo" : "651502",
@@ -32768,7 +32768,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Surveying Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651503",
   "koodiArvo" : "651503",
@@ -32785,7 +32785,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Construction Architecture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651504",
   "koodiArvo" : "651504",
@@ -32802,7 +32802,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Environmental Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651599",
   "koodiArvo" : "651599",
@@ -32819,7 +32819,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_651600",
   "koodiArvo" : "651600",
@@ -32836,7 +32836,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Industrial Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651601",
   "koodiArvo" : "651601",
@@ -32853,7 +32853,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Industrial Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651602",
   "koodiArvo" : "651602",
@@ -32870,7 +32870,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Logistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651699",
   "koodiArvo" : "651699",
@@ -32887,7 +32887,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_651900",
   "koodiArvo" : "651900",
@@ -32904,7 +32904,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Other Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651901",
   "koodiArvo" : "651901",
@@ -32921,7 +32921,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Textiles and Clothing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651902",
   "koodiArvo" : "651902",
@@ -32938,7 +32938,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Graphics and Communications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_651903",
   "koodiArvo" : "651903",
@@ -32972,7 +32972,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Other or Unknown Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_652000",
   "koodiArvo" : "652000",
@@ -32989,7 +32989,7 @@
     "lyhytNimi" : "Other Polytechnic Bachelor's Degree in Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_652100",
   "koodiArvo" : "652100",
@@ -33006,7 +33006,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Building Construction",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_652101",
   "koodiArvo" : "652101",
@@ -33023,7 +33023,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Building Construction",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_652200",
   "koodiArvo" : "652200",
@@ -33040,7 +33040,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Environmental Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_652202",
   "koodiArvo" : "652202",
@@ -33057,7 +33057,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Environmental Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_652300",
   "koodiArvo" : "652300",
@@ -33074,7 +33074,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic),Textiles and Fashion Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_652301",
   "koodiArvo" : "652301",
@@ -33091,7 +33091,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic),Textiles and Fashion Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_652400",
   "koodiArvo" : "652400",
@@ -33108,7 +33108,7 @@
     "lyhytNimi" : "Bachelor of Laboratory Services (Polytechnic)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_652401",
   "koodiArvo" : "652401",
@@ -33125,7 +33125,7 @@
     "lyhytNimi" : "Bachelor of Laboratory Services (Polytechnic)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_652501",
   "koodiArvo" : "652501",
@@ -33142,7 +33142,7 @@
     "lyhytNimi" : "Bachelor of Construction Achitect",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_652900",
   "koodiArvo" : "652900",
@@ -33159,7 +33159,7 @@
     "lyhytNimi" : "Other Polytechnic Bachelor's Degree in Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_652999",
   "koodiArvo" : "652999",
@@ -33176,7 +33176,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic Bachelor's Degree in Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653000",
   "koodiArvo" : "653000",
@@ -33193,7 +33193,7 @@
     "lyhytNimi" : "Engineer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653100",
   "koodiArvo" : "653100",
@@ -33210,7 +33210,7 @@
     "lyhytNimi" : "Engineer, Mechanical Engineering, Energy Engineering and Transport Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653101",
   "koodiArvo" : "653101",
@@ -33227,7 +33227,7 @@
     "lyhytNimi" : "Engineer, Mechanical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653102",
   "koodiArvo" : "653102",
@@ -33244,7 +33244,7 @@
     "lyhytNimi" : "Engineer, Energy Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653103",
   "koodiArvo" : "653103",
@@ -33261,7 +33261,7 @@
     "lyhytNimi" : "Engineer, Heating and Ventilation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653104",
   "koodiArvo" : "653104",
@@ -33278,7 +33278,7 @@
     "lyhytNimi" : "Engineer, Transportation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653200",
   "koodiArvo" : "653200",
@@ -33295,7 +33295,7 @@
     "lyhytNimi" : "Engineer, Electrical Engineering and Automation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653201",
   "koodiArvo" : "653201",
@@ -33312,7 +33312,7 @@
     "lyhytNimi" : "Engineer, Electrical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653202",
   "koodiArvo" : "653202",
@@ -33329,7 +33329,7 @@
     "lyhytNimi" : "Engineer, Automation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653300",
   "koodiArvo" : "653300",
@@ -33346,7 +33346,7 @@
     "lyhytNimi" : "Engineer, Information Technology and Telecommunications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653301",
   "koodiArvo" : "653301",
@@ -33363,7 +33363,7 @@
     "lyhytNimi" : "Engineer, Information Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653302",
   "koodiArvo" : "653302",
@@ -33380,7 +33380,7 @@
     "lyhytNimi" : "Engineer, Telecommunications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653400",
   "koodiArvo" : "653400",
@@ -33397,7 +33397,7 @@
     "lyhytNimi" : "Engineer, Process Engineering and Materials Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653401",
   "koodiArvo" : "653401",
@@ -33414,7 +33414,7 @@
     "lyhytNimi" : "Engineer, Chemistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653402",
   "koodiArvo" : "653402",
@@ -33431,7 +33431,7 @@
     "lyhytNimi" : "Engineer, Process Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653403",
   "koodiArvo" : "653403",
@@ -33448,7 +33448,7 @@
     "lyhytNimi" : "Engineer, Environmental Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653404",
   "koodiArvo" : "653404",
@@ -33465,7 +33465,7 @@
     "lyhytNimi" : "Engineer, Paper Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653405",
   "koodiArvo" : "653405",
@@ -33482,7 +33482,7 @@
     "lyhytNimi" : "Engineer, Wood Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653409",
   "koodiArvo" : "653409",
@@ -33499,7 +33499,7 @@
     "lyhytNimi" : "Engineer, Biotechnology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653411",
   "koodiArvo" : "653411",
@@ -33516,7 +33516,7 @@
     "lyhytNimi" : "Engineer, Food Industry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653500",
   "koodiArvo" : "653500",
@@ -33533,7 +33533,7 @@
     "lyhytNimi" : "Engineer, Building Construction and Surveying Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653501",
   "koodiArvo" : "653501",
@@ -33550,7 +33550,7 @@
     "lyhytNimi" : "Engineer, Building Construction and Community Development",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653502",
   "koodiArvo" : "653502",
@@ -33567,7 +33567,7 @@
     "lyhytNimi" : "Engineer, Surveying Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653600",
   "koodiArvo" : "653600",
@@ -33584,7 +33584,7 @@
     "lyhytNimi" : "Engineer, Industrial Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653601",
   "koodiArvo" : "653601",
@@ -33601,7 +33601,7 @@
     "lyhytNimi" : "Engineer, Industrial Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653900",
   "koodiArvo" : "653900",
@@ -33618,7 +33618,7 @@
     "lyhytNimi" : "Engineer, Other Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653901",
   "koodiArvo" : "653901",
@@ -33635,7 +33635,7 @@
     "lyhytNimi" : "Engineer, Textiles and Clothing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653902",
   "koodiArvo" : "653902",
@@ -33652,7 +33652,7 @@
     "lyhytNimi" : "Engineer, Printing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_653999",
   "koodiArvo" : "653999",
@@ -33669,7 +33669,7 @@
     "lyhytNimi" : "Engineer, Other or Unknown Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_654000",
   "koodiArvo" : "654000",
@@ -33686,7 +33686,7 @@
     "lyhytNimi" : "Construction Architect",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_654100",
   "koodiArvo" : "654100",
@@ -33703,7 +33703,7 @@
     "lyhytNimi" : "Construction Architect",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_654101",
   "koodiArvo" : "654101",
@@ -33720,7 +33720,7 @@
     "lyhytNimi" : "Construction Architect",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655000",
   "koodiArvo" : "655000",
@@ -33737,7 +33737,7 @@
     "lyhytNimi" : "Bachelor of Science in Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655100",
   "koodiArvo" : "655100",
@@ -33754,7 +33754,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Mechanical Engineering and Energy Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655101",
   "koodiArvo" : "655101",
@@ -33771,7 +33771,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Mechanical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655102",
   "koodiArvo" : "655102",
@@ -33788,7 +33788,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Energy Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655200",
   "koodiArvo" : "655200",
@@ -33805,7 +33805,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Electrical Engineering and Automation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655201",
   "koodiArvo" : "655201",
@@ -33822,7 +33822,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Electrical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655202",
   "koodiArvo" : "655202",
@@ -33839,7 +33839,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Automation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655203",
   "koodiArvo" : "655203",
@@ -33856,7 +33856,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Engineering Physics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655204",
   "koodiArvo" : "655204",
@@ -33873,7 +33873,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Science and Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655300",
   "koodiArvo" : "655300",
@@ -33890,7 +33890,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Information Technology and Telecommunications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655301",
   "koodiArvo" : "655301",
@@ -33907,7 +33907,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Information Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655302",
   "koodiArvo" : "655302",
@@ -33924,7 +33924,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Telecommunications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655400",
   "koodiArvo" : "655400",
@@ -33941,7 +33941,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Process Engineering and Materials Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655401",
   "koodiArvo" : "655401",
@@ -33958,7 +33958,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Chemical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655402",
   "koodiArvo" : "655402",
@@ -33975,7 +33975,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Process Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655403",
   "koodiArvo" : "655403",
@@ -33992,7 +33992,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Environmental Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655404",
   "koodiArvo" : "655404",
@@ -34009,7 +34009,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Wood Processing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655408",
   "koodiArvo" : "655408",
@@ -34026,7 +34026,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Materials Technology, Rock Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655409",
   "koodiArvo" : "655409",
@@ -34043,7 +34043,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Biotechnology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655410",
   "koodiArvo" : "655410",
@@ -34073,7 +34073,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_655500",
   "koodiArvo" : "655500",
@@ -34090,7 +34090,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Building Construction and Surveying Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655501",
   "koodiArvo" : "655501",
@@ -34107,7 +34107,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Building Construction, Community Development",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655502",
   "koodiArvo" : "655502",
@@ -34124,7 +34124,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Surveying Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655600",
   "koodiArvo" : "655600",
@@ -34141,7 +34141,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Industrial Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655601",
   "koodiArvo" : "655601",
@@ -34158,7 +34158,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Industrial Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655800",
   "koodiArvo" : "655800",
@@ -34175,7 +34175,7 @@
     "lyhytNimi" : "Bachelor of Science (Architecture)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655801",
   "koodiArvo" : "655801",
@@ -34192,7 +34192,7 @@
     "lyhytNimi" : "Bachelor of Science (Architecture)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655900",
   "koodiArvo" : "655900",
@@ -34209,7 +34209,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Other Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655901",
   "koodiArvo" : "655901",
@@ -34226,7 +34226,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Textiles and Clothing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_655999",
   "koodiArvo" : "655999",
@@ -34243,7 +34243,7 @@
     "lyhytNimi" : "Bachelor of Science (Technology), Other or Unknown Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_659000",
   "koodiArvo" : "659000",
@@ -34260,7 +34260,7 @@
     "lyhytNimi" : "Other Education in Technology, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_659900",
   "koodiArvo" : "659900",
@@ -34277,7 +34277,7 @@
     "lyhytNimi" : "Other Education in Technology, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_659999",
   "koodiArvo" : "659999",
@@ -34294,7 +34294,7 @@
     "lyhytNimi" : "Other or Unknown Education in Technology, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_661000",
   "koodiArvo" : "661000",
@@ -34311,7 +34311,7 @@
     "lyhytNimi" : "Bachelor of Natural Resources (Polytechnic), Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_661100",
   "koodiArvo" : "661100",
@@ -34328,7 +34328,7 @@
     "lyhytNimi" : "Bachelor of Natural Resources (Polytechnic), Agronomist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_661101",
   "koodiArvo" : "661101",
@@ -34345,7 +34345,7 @@
     "lyhytNimi" : "Bachelor of Natural Resources (Polytechnic), Agronomist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_661200",
   "koodiArvo" : "661200",
@@ -34362,7 +34362,7 @@
     "lyhytNimi" : "Bachelor of Natural Resources (Polytechnic), Horticulturist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_661201",
   "koodiArvo" : "661201",
@@ -34379,7 +34379,7 @@
     "lyhytNimi" : "Bachelor of Natural Resources (Polytechnic), Horticulturist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_661300",
   "koodiArvo" : "661300",
@@ -34396,7 +34396,7 @@
     "lyhytNimi" : "Bachelor of Natural Resources (Polytechnic), Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_661301",
   "koodiArvo" : "661301",
@@ -34413,7 +34413,7 @@
     "lyhytNimi" : "Bachelor of Natural Resources (Polytechnic), Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_661400",
   "koodiArvo" : "661400",
@@ -34430,7 +34430,7 @@
     "lyhytNimi" : "Bachelor of Natural Recources (Polytechnic), Fishery",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_661401",
   "koodiArvo" : "661401",
@@ -34447,7 +34447,7 @@
     "lyhytNimi" : "Bachelor of Natural Recources (Polytechnic), Fishery",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_661500",
   "koodiArvo" : "661500",
@@ -34464,7 +34464,7 @@
     "lyhytNimi" : "Bachelor of Natural Resources (Polytechnic), Environmental planning",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_661501",
   "koodiArvo" : "661501",
@@ -34481,7 +34481,7 @@
     "lyhytNimi" : "Bachelor of Natural Resources (Polytechnic), Environmental planning",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_661900",
   "koodiArvo" : "661900",
@@ -34498,7 +34498,7 @@
     "lyhytNimi" : "Other Polytechnic Bachelor's Degree in Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_661999",
   "koodiArvo" : "661999",
@@ -34515,7 +34515,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic Bachelor's Degree in Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_662000",
   "koodiArvo" : "662000",
@@ -34532,7 +34532,7 @@
     "lyhytNimi" : "Education in Agriculture and Forestry, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_662100",
   "koodiArvo" : "662100",
@@ -34549,7 +34549,7 @@
     "lyhytNimi" : "Bachelor of Science (Agriculture and Forestry)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_662101",
   "koodiArvo" : "662101",
@@ -34566,7 +34566,7 @@
     "lyhytNimi" : "Bachelor of Science (Agriculture and Forestry), Agriculture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_662102",
   "koodiArvo" : "662102",
@@ -34583,7 +34583,7 @@
     "lyhytNimi" : "Bachelor of Science (Agriculture and Forestry), Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_662103",
   "koodiArvo" : "662103",
@@ -34600,7 +34600,7 @@
     "lyhytNimi" : "Bachelor of Science (Agriculture and Forestry), Environmental Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_662104",
   "koodiArvo" : "662104",
@@ -34617,7 +34617,7 @@
     "lyhytNimi" : "Bachelor of Science (Agriculture and Forestry), Household Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_662105",
   "koodiArvo" : "662105",
@@ -34634,7 +34634,7 @@
     "lyhytNimi" : "Bachelor of Science (Agriculture and Forestry), Biotechnology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_662151",
   "koodiArvo" : "662151",
@@ -34651,7 +34651,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_662199",
   "koodiArvo" : "662199",
@@ -34668,7 +34668,7 @@
     "lyhytNimi" : "Bachelor of Science (Agriculture and Forestry), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_662200",
   "koodiArvo" : "662200",
@@ -34685,7 +34685,7 @@
     "lyhytNimi" : "Bachelor of Food Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_662201",
   "koodiArvo" : "662201",
@@ -34702,7 +34702,7 @@
     "lyhytNimi" : "Bachelor of Food Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_662500",
   "koodiArvo" : "662500",
@@ -34719,7 +34719,7 @@
     "lyhytNimi" : "Forestry Engineer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_662551",
   "koodiArvo" : "662551",
@@ -34736,7 +34736,7 @@
     "lyhytNimi" : "Forestry Engineer, Unspecialised",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_662552",
   "koodiArvo" : "662552",
@@ -34753,7 +34753,7 @@
     "lyhytNimi" : "Forestry Engineer, Wood Trade",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_662599",
   "koodiArvo" : "662599",
@@ -34770,7 +34770,7 @@
     "lyhytNimi" : "Forestry Engineer, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_662900",
   "koodiArvo" : "662900",
@@ -34787,7 +34787,7 @@
     "lyhytNimi" : "Other Education in Agriculture and Forestry, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_662999",
   "koodiArvo" : "662999",
@@ -34804,7 +34804,7 @@
     "lyhytNimi" : "Other or Unknown Education in Agriculture and Forestry, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671000",
   "koodiArvo" : "671000",
@@ -34821,7 +34821,7 @@
     "lyhytNimi" : "Bachelor of Health Care and Social Services  (Polytechnic), Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671100",
   "koodiArvo" : "671100",
@@ -34838,7 +34838,7 @@
     "lyhytNimi" : "Bachelor of Health Care (Polytechnic), Health Care",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671101",
   "koodiArvo" : "671101",
@@ -34855,7 +34855,7 @@
     "lyhytNimi" : "Bachelor of Health Care (Polytechnic), Registered Nurse",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671103",
   "koodiArvo" : "671103",
@@ -34872,7 +34872,7 @@
     "lyhytNimi" : "Bachelor of Health Care (Polytechnic), Public Health Nurse",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671104",
   "koodiArvo" : "671104",
@@ -34889,7 +34889,7 @@
     "lyhytNimi" : "Bachelor of Health Care (Polytechnic), Biomedical Laboratory Technologist (Polytechnic)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671105",
   "koodiArvo" : "671105",
@@ -34906,7 +34906,7 @@
     "lyhytNimi" : "Bachelor of Health Care (Polytechnic), Radiographer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671106",
   "koodiArvo" : "671106",
@@ -34923,7 +34923,7 @@
     "lyhytNimi" : "Bachelor of Health Care (Polytechnic), Midwife",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671107",
   "koodiArvo" : "671107",
@@ -34940,7 +34940,7 @@
     "lyhytNimi" : "Bachelor of Health Care (Polytechnic), Dental Hygienist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671108",
   "koodiArvo" : "671108",
@@ -34957,7 +34957,7 @@
     "lyhytNimi" : "Bachelor of Health Care (Polytechnic), Dental Technician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671111",
   "koodiArvo" : "671111",
@@ -34974,7 +34974,7 @@
     "lyhytNimi" : "Bachelor of Health Care (Polytechnic), Optometrist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671112",
   "koodiArvo" : "671112",
@@ -34991,7 +34991,7 @@
     "lyhytNimi" : "Bachelor of Health Care (Polytechnic), Physiotherapist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671113",
   "koodiArvo" : "671113",
@@ -35008,7 +35008,7 @@
     "lyhytNimi" : "Bachelor of Health Care (Polytechnic), Podiatrist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671114",
   "koodiArvo" : "671114",
@@ -35025,7 +35025,7 @@
     "lyhytNimi" : "Bachelor of Health Care (Polytechnic), Occupational Therapist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671115",
   "koodiArvo" : "671115",
@@ -35042,7 +35042,7 @@
     "lyhytNimi" : "Bachelor of Health Care (Polytechnic), Orthotics-Prosthetics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671116",
   "koodiArvo" : "671116",
@@ -35059,7 +35059,7 @@
     "lyhytNimi" : "Bachelor of Health Care (Polytechnic), Emergency Nurse",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671117",
   "koodiArvo" : "671117",
@@ -35076,7 +35076,7 @@
     "lyhytNimi" : "Bachelor of Health Care (Polytechnic), Osteopath",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671118",
   "koodiArvo" : "671118",
@@ -35093,7 +35093,7 @@
     "lyhytNimi" : "Bachelor of Social Services and Health Care (Polytechnic), Rehabilitation Counsellor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671119",
   "koodiArvo" : "671119",
@@ -35110,7 +35110,7 @@
     "lyhytNimi" : "Bachelor of Health Care (Polytechnic), Naprapath",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671199",
   "koodiArvo" : "671199",
@@ -35127,7 +35127,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic Bachelor's Degree in Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671200",
   "koodiArvo" : "671200",
@@ -35144,7 +35144,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences (Polytechnic), Social Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671201",
   "koodiArvo" : "671201",
@@ -35161,7 +35161,7 @@
     "lyhytNimi" : "Bachelor of Social Sciences (Polytechnic), Social Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671202",
   "koodiArvo" : "671202",
@@ -35178,7 +35178,7 @@
     "lyhytNimi" : "Polytechnic Bachelor's  Degree in Health Care, Correctional Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671299",
   "koodiArvo" : "671299",
@@ -35195,7 +35195,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic Bachelor's Degree in Social Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671900",
   "koodiArvo" : "671900",
@@ -35212,7 +35212,7 @@
     "lyhytNimi" : "Other Polytechnic Bachelor's Degree in Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671901",
   "koodiArvo" : "671901",
@@ -35229,7 +35229,7 @@
     "lyhytNimi" : "Bachelor of Social Services and Health Care (Polytechnic), Geriatry Nurse",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_671999",
   "koodiArvo" : "671999",
@@ -35246,7 +35246,7 @@
     "lyhytNimi" : "Other or unknown Polytechnic Bachelor's Degree in Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_672000",
   "koodiArvo" : "672000",
@@ -35263,7 +35263,7 @@
     "lyhytNimi" : "Education in Health and Welfare, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_672100",
   "koodiArvo" : "672100",
@@ -35280,7 +35280,7 @@
     "lyhytNimi" : "Bachelor of Medicine",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_672101",
   "koodiArvo" : "672101",
@@ -35297,7 +35297,7 @@
     "lyhytNimi" : "Bachelor of Medicine",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_672200",
   "koodiArvo" : "672200",
@@ -35314,7 +35314,7 @@
     "lyhytNimi" : "Bachelor of Dentistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_672201",
   "koodiArvo" : "672201",
@@ -35331,7 +35331,7 @@
     "lyhytNimi" : "Bachelor of Dentistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_672300",
   "koodiArvo" : "672300",
@@ -35348,7 +35348,7 @@
     "lyhytNimi" : "Bachelor of Veterinary Medicine",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_672301",
   "koodiArvo" : "672301",
@@ -35365,7 +35365,7 @@
     "lyhytNimi" : "Bachelor of Veterinary Medicine",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_672400",
   "koodiArvo" : "672400",
@@ -35382,7 +35382,7 @@
     "lyhytNimi" : "Bachelor of Science (Pharmacy)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_672401",
   "koodiArvo" : "672401",
@@ -35399,7 +35399,7 @@
     "lyhytNimi" : "Bachelor of Science (Pharmacy)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_672500",
   "koodiArvo" : "672500",
@@ -35416,7 +35416,7 @@
     "lyhytNimi" : "Bachelor of Health Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_672501",
   "koodiArvo" : "672501",
@@ -35433,7 +35433,7 @@
     "lyhytNimi" : "Bachelor of Health Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_672600",
   "koodiArvo" : "672600",
@@ -35450,7 +35450,7 @@
     "lyhytNimi" : "Administrative Examination for Health Personnel",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_672651",
   "koodiArvo" : "672651",
@@ -35467,7 +35467,7 @@
     "lyhytNimi" : "Administrative Examination for Health Personnel",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_672900",
   "koodiArvo" : "672900",
@@ -35484,7 +35484,7 @@
     "lyhytNimi" : "Other Education in Health and Welfare, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_672999",
   "koodiArvo" : "672999",
@@ -35501,7 +35501,7 @@
     "lyhytNimi" : "Other or Unknown Education in Health and Welfare, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_681000",
   "koodiArvo" : "681000",
@@ -35518,7 +35518,7 @@
     "lyhytNimi" : "Polytechnic Bachelor's Degree in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_681100",
   "koodiArvo" : "681100",
@@ -35535,7 +35535,7 @@
     "lyhytNimi" : "Polytechnic Bachelor's Degree in Hotel, Catering and Home Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_681101",
   "koodiArvo" : "681101",
@@ -35552,7 +35552,7 @@
     "lyhytNimi" : "Bachelor of Hospitality Management (Polytechnic), Hotel and Restaurant",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_681102",
   "koodiArvo" : "681102",
@@ -35569,7 +35569,7 @@
     "lyhytNimi" : "Bachelor of Hospitality Management (Polytechnic), Tourism",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_681103",
   "koodiArvo" : "681103",
@@ -35586,7 +35586,7 @@
     "lyhytNimi" : "Bachelor of Hospitality Management (Polytechnic), Business Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_681104",
   "koodiArvo" : "681104",
@@ -35603,7 +35603,7 @@
     "lyhytNimi" : "Bachelor of Hospitality Management (Polytechnic), Cleaning and Domestic Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_681199",
   "koodiArvo" : "681199",
@@ -35620,7 +35620,7 @@
     "lyhytNimi" : "Bachelor of Hospitality Management (Polytechnic), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_681200",
   "koodiArvo" : "681200",
@@ -35637,7 +35637,7 @@
     "lyhytNimi" : "Polytechnic Bachelor's Degree in Leisure Activities and Sports Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_681201",
   "koodiArvo" : "681201",
@@ -35654,7 +35654,7 @@
     "lyhytNimi" : "Bachelor of Recreation Activity (Polytechnic)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_681202",
   "koodiArvo" : "681202",
@@ -35671,7 +35671,7 @@
     "lyhytNimi" : "Bachelor of Sports Studies, Sports Instructor (Polytechnic)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_681300",
   "koodiArvo" : "681300",
@@ -35688,7 +35688,7 @@
     "lyhytNimi" : "Polytechnic Bachelor's Degree in Beauty Care",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_681301",
   "koodiArvo" : "681301",
@@ -35705,7 +35705,7 @@
     "lyhytNimi" : "Bachelor of Beauty and Cosmetics (Polytechnic)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_681400",
   "koodiArvo" : "681400",
@@ -35722,7 +35722,7 @@
     "lyhytNimi" : "Polytechnic Bachelor's Degree in Seafaring",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_681401",
   "koodiArvo" : "681401",
@@ -35739,7 +35739,7 @@
     "lyhytNimi" : "Bachelor of Maritime Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_681500",
   "koodiArvo" : "681500",
@@ -35756,7 +35756,7 @@
     "lyhytNimi" : "Polytechnic Bachelor's Degree in Safety and Security",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_681501",
   "koodiArvo" : "681501",
@@ -35773,7 +35773,7 @@
     "lyhytNimi" : "Commanding Police Officer's Diploma (Polytechnic)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_681502",
   "koodiArvo" : "681502",
@@ -35790,7 +35790,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Fire Officer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_681503",
   "koodiArvo" : "681503",
@@ -35820,7 +35820,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_681900",
   "koodiArvo" : "681900",
@@ -35837,7 +35837,7 @@
     "lyhytNimi" : "Other Polytechnic Bachelor's Degree in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_681901",
   "koodiArvo" : "681901",
@@ -35854,7 +35854,7 @@
     "lyhytNimi" : "Bachelor of Business Administration (Polytechnic), Security Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_681999",
   "koodiArvo" : "681999",
@@ -35871,7 +35871,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic Bachelor's Degree in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_682000",
   "koodiArvo" : "682000",
@@ -35888,7 +35888,7 @@
     "lyhytNimi" : "Education in Services, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_682200",
   "koodiArvo" : "682200",
@@ -35905,7 +35905,7 @@
     "lyhytNimi" : "Bachelor of Science, Sport and Health Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_682201",
   "koodiArvo" : "682201",
@@ -35922,7 +35922,7 @@
     "lyhytNimi" : "Bachelor of Science, Sport and Health Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_682251",
   "koodiArvo" : "682251",
@@ -35939,7 +35939,7 @@
     "lyhytNimi" : "Bachelor of Sport and Health Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_682400",
   "koodiArvo" : "682400",
@@ -35956,7 +35956,7 @@
     "lyhytNimi" : "Education in Traffic and Seafaring, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_682401",
   "koodiArvo" : "682401",
@@ -35973,7 +35973,7 @@
     "lyhytNimi" : "Sea Captain",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_682402",
   "koodiArvo" : "682402",
@@ -35990,7 +35990,7 @@
     "lyhytNimi" : "Bachelor of Engineering (Polytechnic), Traffic",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_682499",
   "koodiArvo" : "682499",
@@ -36007,7 +36007,7 @@
     "lyhytNimi" : "Other or Unknown Education in Traffic and Seafaring, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_682600",
   "koodiArvo" : "682600",
@@ -36024,7 +36024,7 @@
     "lyhytNimi" : "Education in Military Science, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_682601",
   "koodiArvo" : "682601",
@@ -36041,7 +36041,7 @@
     "lyhytNimi" : "Bachelor of Arts (Military Science)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_682651",
   "koodiArvo" : "682651",
@@ -36058,7 +36058,7 @@
     "lyhytNimi" : "Officer's Examination (-1980)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_682900",
   "koodiArvo" : "682900",
@@ -36075,7 +36075,7 @@
     "lyhytNimi" : "Other Education in Services, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_682999",
   "koodiArvo" : "682999",
@@ -36092,7 +36092,7 @@
     "lyhytNimi" : "Other or Unknown Education in Services, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_691000",
   "koodiArvo" : "691000",
@@ -36109,7 +36109,7 @@
     "lyhytNimi" : "Other Bachelor's Degree (Polytechnic)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_691900",
   "koodiArvo" : "691900",
@@ -36126,7 +36126,7 @@
     "lyhytNimi" : "Other Bachelor's Degree (Polytechnic)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_691999",
   "koodiArvo" : "691999",
@@ -36143,7 +36143,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic Bachelor's Degree",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_692000",
   "koodiArvo" : "692000",
@@ -36160,7 +36160,7 @@
     "lyhytNimi" : "Bachelor of Arts, Other Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_692900",
   "koodiArvo" : "692900",
@@ -36177,7 +36177,7 @@
     "lyhytNimi" : "Bachelor of Arts, Other Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_692999",
   "koodiArvo" : "692999",
@@ -36194,7 +36194,7 @@
     "lyhytNimi" : "Bachelor of Arts, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_699000",
   "koodiArvo" : "699000",
@@ -36211,7 +36211,7 @@
     "lyhytNimi" : "Other Education, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_699900",
   "koodiArvo" : "699900",
@@ -36228,7 +36228,7 @@
     "lyhytNimi" : "Other Education, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_699999",
   "koodiArvo" : "699999",
@@ -36245,7 +36245,7 @@
     "lyhytNimi" : "Other or Unknown Education, Lower-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_711000",
   "koodiArvo" : "711000",
@@ -36262,7 +36262,7 @@
     "lyhytNimi" : "Master of Arts (Polytechnic), Teacher Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_711100",
   "koodiArvo" : "711100",
@@ -36279,7 +36279,7 @@
     "lyhytNimi" : "Master of Arts (Polytechnic) in Music Teacher Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_711101",
   "koodiArvo" : "711101",
@@ -36296,7 +36296,7 @@
     "lyhytNimi" : "Master of Culture and Arts (Polytechnic), Music Educator",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_711200",
   "koodiArvo" : "711200",
@@ -36313,7 +36313,7 @@
     "lyhytNimi" : "Master of Culture and Arts (Polytechnic) in Theatre and Dance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_711201",
   "koodiArvo" : "711201",
@@ -36330,7 +36330,7 @@
     "lyhytNimi" : "Master of Culture and Arts (Polytechnic), Dance Instructor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_712000",
   "koodiArvo" : "712000",
@@ -36347,7 +36347,7 @@
     "lyhytNimi" : "Master of Arts (Education)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_712100",
   "koodiArvo" : "712100",
@@ -36364,7 +36364,7 @@
     "lyhytNimi" : "Master of Arts (Education)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_712101",
   "koodiArvo" : "712101",
@@ -36381,7 +36381,7 @@
     "lyhytNimi" : "Master of Arts (Education), Class Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_712102",
   "koodiArvo" : "712102",
@@ -36398,7 +36398,7 @@
     "lyhytNimi" : "Master of Arts (Education), Special Education Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_712104",
   "koodiArvo" : "712104",
@@ -36415,7 +36415,7 @@
     "lyhytNimi" : "Master of Arts (Education), Home Economics Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_712105",
   "koodiArvo" : "712105",
@@ -36432,7 +36432,7 @@
     "lyhytNimi" : "Master of Arts (Education), Crafts Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_712107",
   "koodiArvo" : "712107",
@@ -36443,7 +36443,7 @@
     "nimi" : "Kasvatust. maist., teknisen työn opettaja",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_712108",
   "koodiArvo" : "712108",
@@ -36460,7 +36460,7 @@
     "lyhytNimi" : "Master of Arts (Education), Study Guidance Counsellor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_712109",
   "koodiArvo" : "712109",
@@ -36477,7 +36477,7 @@
     "lyhytNimi" : "Master of Arts (Education), Music Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_712199",
   "koodiArvo" : "712199",
@@ -36494,7 +36494,7 @@
     "lyhytNimi" : "Master of Arts (Education), Other or Unknown Teacher Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_712200",
   "koodiArvo" : "712200",
@@ -36511,7 +36511,7 @@
     "lyhytNimi" : "Master of Arts (Education)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_712201",
   "koodiArvo" : "712201",
@@ -36528,7 +36528,7 @@
     "lyhytNimi" : "Master of Arts (Education), Educational Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_712202",
   "koodiArvo" : "712202",
@@ -36545,7 +36545,7 @@
     "lyhytNimi" : "Master of Arts (Education), Adult Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_712203",
   "koodiArvo" : "712203",
@@ -36562,7 +36562,7 @@
     "lyhytNimi" : "Master of Arts (Education), Special Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_712204",
   "koodiArvo" : "712204",
@@ -36579,7 +36579,7 @@
     "lyhytNimi" : "Master of Arts (Education), Early Childhood Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_712205",
   "koodiArvo" : "712205",
@@ -36596,7 +36596,7 @@
     "lyhytNimi" : "Master of Arts (Education), Textiles and Related Crafts, Technical Work and Home Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_712299",
   "koodiArvo" : "712299",
@@ -36613,7 +36613,7 @@
     "lyhytNimi" : "Master of Arts (Education), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_719000",
   "koodiArvo" : "719000",
@@ -36630,7 +36630,7 @@
     "lyhytNimi" : "Other Education in Teacher Education and Educational Science, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_719900",
   "koodiArvo" : "719900",
@@ -36647,7 +36647,7 @@
     "lyhytNimi" : "Other Education in Teacher Education and Educational Science, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_719951",
   "koodiArvo" : "719951",
@@ -36664,7 +36664,7 @@
     "lyhytNimi" : "Art Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_719952",
   "koodiArvo" : "719952",
@@ -36681,7 +36681,7 @@
     "lyhytNimi" : "Steiner School Class Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_719953",
   "koodiArvo" : "719953",
@@ -36698,7 +36698,7 @@
     "lyhytNimi" : "Steiner School Arts Teacher",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_719999",
   "koodiArvo" : "719999",
@@ -36715,7 +36715,7 @@
     "lyhytNimi" : "Other or Unknown Education in Teacher Education and Educational Science, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721000",
   "koodiArvo" : "721000",
@@ -36732,7 +36732,7 @@
     "lyhytNimi" : "Master of Arts (Polytechnic), Humanities, Arts and Culture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721100",
   "koodiArvo" : "721100",
@@ -36749,7 +36749,7 @@
     "lyhytNimi" : "Master of Arts (Polytechnic), Crafts, Design and Conservation",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721101",
   "koodiArvo" : "721101",
@@ -36766,7 +36766,7 @@
     "lyhytNimi" : "Master of Culture and Arts (Polytechnic), Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721102",
   "koodiArvo" : "721102",
@@ -36783,7 +36783,7 @@
     "lyhytNimi" : "Master of Culture and Arts (Polytechnic), Designer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721103",
   "koodiArvo" : "721103",
@@ -36800,7 +36800,7 @@
     "lyhytNimi" : "Master of Culture and Arts (Polytechnic), Conservator",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721104",
   "koodiArvo" : "721104",
@@ -36817,7 +36817,7 @@
     "lyhytNimi" : "Master of Culture and Arts (Polytechnic), Fashion Designer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721199",
   "koodiArvo" : "721199",
@@ -36834,7 +36834,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic Master's Degree in Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721200",
   "koodiArvo" : "721200",
@@ -36851,7 +36851,7 @@
     "lyhytNimi" : "Master of Arts (Polytechnic), Music",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721201",
   "koodiArvo" : "721201",
@@ -36868,7 +36868,7 @@
     "lyhytNimi" : "Master of Culture and Arts (Polytechnic), Musician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721299",
   "koodiArvo" : "721299",
@@ -36885,7 +36885,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic  Master's Degree, Music",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721300",
   "koodiArvo" : "721300",
@@ -36902,7 +36902,7 @@
     "lyhytNimi" : "Master of Culture and Arts (Polytechnic), Visual Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721301",
   "koodiArvo" : "721301",
@@ -36919,7 +36919,7 @@
     "lyhytNimi" : "Master of Culture and Arts (Polytechnic), Visual Artist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721399",
   "koodiArvo" : "721399",
@@ -36936,7 +36936,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic  Master's Degree in Fine Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721500",
   "koodiArvo" : "721500",
@@ -36953,7 +36953,7 @@
     "lyhytNimi" : "Master of Culture and Arts (Polytechnic), Theatre and Dance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721501",
   "koodiArvo" : "721501",
@@ -36970,7 +36970,7 @@
     "lyhytNimi" : "Master of Culture and Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721502",
   "koodiArvo" : "721502",
@@ -37004,7 +37004,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic  Master's Degree, Theatre and Dance",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721600",
   "koodiArvo" : "721600",
@@ -37021,7 +37021,7 @@
     "lyhytNimi" : "Master of Culture and Arts (Polytechnic), Media",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721601",
   "koodiArvo" : "721601",
@@ -37038,7 +37038,7 @@
     "lyhytNimi" : "Master of Culture and Arts (Polytechnic), Media",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721700",
   "koodiArvo" : "721700",
@@ -37055,7 +37055,7 @@
     "lyhytNimi" : "Master of Arts (Polytechnic), Humanities, Arts and Culture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721701",
   "koodiArvo" : "721701",
@@ -37072,7 +37072,7 @@
     "lyhytNimi" : "Master of Humanities (Polytechnic), Sign Language Interpreter",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721702",
   "koodiArvo" : "721702",
@@ -37089,7 +37089,7 @@
     "lyhytNimi" : "Master of Culture and Arts (Polytechnic), Cultural Manager",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721703",
   "koodiArvo" : "721703",
@@ -37106,7 +37106,7 @@
     "lyhytNimi" : "Master of Humanities (Polytechnic), Community Educator",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721704",
   "koodiArvo" : "721704",
@@ -37119,7 +37119,7 @@
     "lyhytNimi" : "Tolk (h. YH)",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721799",
   "koodiArvo" : "721799",
@@ -37136,7 +37136,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic  Master's Degree, Humanities",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721900",
   "koodiArvo" : "721900",
@@ -37153,7 +37153,7 @@
     "lyhytNimi" : "Other Polytechnic  Master's Degree in Humanities, Arts and Culture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_721999",
   "koodiArvo" : "721999",
@@ -37170,7 +37170,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic  Master's Degree, Crafts and Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_722000",
   "koodiArvo" : "722000",
@@ -37187,7 +37187,7 @@
     "lyhytNimi" : "Education in Arts, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_722100",
   "koodiArvo" : "722100",
@@ -37204,7 +37204,7 @@
     "lyhytNimi" : "Master of Arts (Art and Design)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_722101",
   "koodiArvo" : "722101",
@@ -37221,7 +37221,7 @@
     "lyhytNimi" : "Master of Arts (Art and Design)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_722900",
   "koodiArvo" : "722900",
@@ -37238,7 +37238,7 @@
     "lyhytNimi" : "Other Education in Arts, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_722951",
   "koodiArvo" : "722951",
@@ -37255,7 +37255,7 @@
     "lyhytNimi" : "Master of Arts, Film and Television Work",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_722952",
   "koodiArvo" : "722952",
@@ -37272,7 +37272,7 @@
     "lyhytNimi" : "Master of Arts, Graphic Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_722953",
   "koodiArvo" : "722953",
@@ -37289,7 +37289,7 @@
     "lyhytNimi" : "Master of Arts, Ceramic Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_722954",
   "koodiArvo" : "722954",
@@ -37306,7 +37306,7 @@
     "lyhytNimi" : "Master of Arts, Stage Art",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_722955",
   "koodiArvo" : "722955",
@@ -37323,7 +37323,7 @@
     "lyhytNimi" : "Master of Arts, Interior Decoration and Furniture Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_722956",
   "koodiArvo" : "722956",
@@ -37340,7 +37340,7 @@
     "lyhytNimi" : "Master of Arts, Technical Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_722957",
   "koodiArvo" : "722957",
@@ -37357,7 +37357,7 @@
     "lyhytNimi" : "Master of Arts, Textile Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_722958",
   "koodiArvo" : "722958",
@@ -37374,7 +37374,7 @@
     "lyhytNimi" : "Master of Arts, Dress Design",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_722959",
   "koodiArvo" : "722959",
@@ -37391,7 +37391,7 @@
     "lyhytNimi" : "Master of Arts, Photography (Applied Arts Education)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_722999",
   "koodiArvo" : "722999",
@@ -37408,7 +37408,7 @@
     "lyhytNimi" : "Other or Unkown Education in Arts, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_723000",
   "koodiArvo" : "723000",
@@ -37425,7 +37425,7 @@
     "lyhytNimi" : "Education in Music, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_723100",
   "koodiArvo" : "723100",
@@ -37442,7 +37442,7 @@
     "lyhytNimi" : "Master of Music",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_723101",
   "koodiArvo" : "723101",
@@ -37453,7 +37453,7 @@
     "nimi" : "Mus. maist., esittävä säveltaide",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_723102",
   "koodiArvo" : "723102",
@@ -37464,7 +37464,7 @@
     "nimi" : "Mus. maist., kirkkomusiikki",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_723103",
   "koodiArvo" : "723103",
@@ -37475,7 +37475,7 @@
     "nimi" : "Mus. maist., musiikkikasvatus",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_723111",
   "koodiArvo" : "723111",
@@ -37492,7 +37492,7 @@
     "lyhytNimi" : "Master of Music",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_723199",
   "koodiArvo" : "723199",
@@ -37503,7 +37503,7 @@
     "nimi" : "Mus. maist., muu tai tuntematon pääaineryhmä",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_723900",
   "koodiArvo" : "723900",
@@ -37520,7 +37520,7 @@
     "lyhytNimi" : "Other Education in Music, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_723951",
   "koodiArvo" : "723951",
@@ -37537,7 +37537,7 @@
     "lyhytNimi" : "Master of Arts (Music)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_723952",
   "koodiArvo" : "723952",
@@ -37554,7 +37554,7 @@
     "lyhytNimi" : "Military Bandmaster",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_723999",
   "koodiArvo" : "723999",
@@ -37571,7 +37571,7 @@
     "lyhytNimi" : "Other or Unknown Education in Music, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_724000",
   "koodiArvo" : "724000",
@@ -37588,7 +37588,7 @@
     "lyhytNimi" : "Education in Fine Arts, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_724100",
   "koodiArvo" : "724100",
@@ -37605,7 +37605,7 @@
     "lyhytNimi" : "Master of Fine Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_724101",
   "koodiArvo" : "724101",
@@ -37622,7 +37622,7 @@
     "lyhytNimi" : "Master of Fine Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_724900",
   "koodiArvo" : "724900",
@@ -37639,7 +37639,7 @@
     "lyhytNimi" : "Other Education in Fine Arts, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_724999",
   "koodiArvo" : "724999",
@@ -37656,7 +37656,7 @@
     "lyhytNimi" : "Other or Unknown Education in Fine Arts, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_725000",
   "koodiArvo" : "725000",
@@ -37673,7 +37673,7 @@
     "lyhytNimi" : "Education in Theatre and Dance, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_725100",
   "koodiArvo" : "725100",
@@ -37690,7 +37690,7 @@
     "lyhytNimi" : "Master of Arts (Theatre and Drama)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_725101",
   "koodiArvo" : "725101",
@@ -37701,7 +37701,7 @@
     "nimi" : "Teatt. maist., dramaturgia",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_725102",
   "koodiArvo" : "725102",
@@ -37712,7 +37712,7 @@
     "nimi" : "Teatt. maist., näyttelijäntyö",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_725103",
   "koodiArvo" : "725103",
@@ -37723,7 +37723,7 @@
     "nimi" : "Teatt. maist., ohjaajantyö",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_725104",
   "koodiArvo" : "725104",
@@ -37734,7 +37734,7 @@
     "nimi" : "Teatt. maist., valo- ja äänisuunnittelu",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_725111",
   "koodiArvo" : "725111",
@@ -37751,7 +37751,7 @@
     "lyhytNimi" : "Master of Arts (Theatre and Drama)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_725199",
   "koodiArvo" : "725199",
@@ -37762,7 +37762,7 @@
     "nimi" : "Teatt. maist., muu tai tuntematon pääaineryhmä",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_725200",
   "koodiArvo" : "725200",
@@ -37779,7 +37779,7 @@
     "lyhytNimi" : "Master of Arts (Dance)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_725201",
   "koodiArvo" : "725201",
@@ -37796,7 +37796,7 @@
     "lyhytNimi" : "Master of Arts (Dance)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_725900",
   "koodiArvo" : "725900",
@@ -37813,7 +37813,7 @@
     "lyhytNimi" : "Other Education in Theatre and Dance, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_725999",
   "koodiArvo" : "725999",
@@ -37830,7 +37830,7 @@
     "lyhytNimi" : "Other or Unknown Education in Theatre and Dance, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726000",
   "koodiArvo" : "726000",
@@ -37847,7 +37847,7 @@
     "lyhytNimi" : "Master of Arts, Humanities",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726100",
   "koodiArvo" : "726100",
@@ -37864,7 +37864,7 @@
     "lyhytNimi" : "Master of Arts, Linguistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726101",
   "koodiArvo" : "726101",
@@ -37881,7 +37881,7 @@
     "lyhytNimi" : "Master of Arts, Finnish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726102",
   "koodiArvo" : "726102",
@@ -37898,7 +37898,7 @@
     "lyhytNimi" : "Master of Arts, Swedish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726103",
   "koodiArvo" : "726103",
@@ -37915,7 +37915,7 @@
     "lyhytNimi" : "Master of Arts, English Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726104",
   "koodiArvo" : "726104",
@@ -37932,7 +37932,7 @@
     "lyhytNimi" : "Master of Arts, German Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726105",
   "koodiArvo" : "726105",
@@ -37949,7 +37949,7 @@
     "lyhytNimi" : "Master of Arts, French Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726106",
   "koodiArvo" : "726106",
@@ -37966,7 +37966,7 @@
     "lyhytNimi" : "Master of Arts, Russian Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726107",
   "koodiArvo" : "726107",
@@ -37983,7 +37983,7 @@
     "lyhytNimi" : "Master of Arts, Spanish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726108",
   "koodiArvo" : "726108",
@@ -38000,7 +38000,7 @@
     "lyhytNimi" : "Master of Arts, Italian Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726109",
   "koodiArvo" : "726109",
@@ -38017,7 +38017,7 @@
     "lyhytNimi" : "Master of Arts, Sami Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726110",
   "koodiArvo" : "726110",
@@ -38034,7 +38034,7 @@
     "lyhytNimi" : "Master of Arts, Finno-Ugrian Languages",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726111",
   "koodiArvo" : "726111",
@@ -38051,7 +38051,7 @@
     "lyhytNimi" : "Master of Arts, Hungarian Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726112",
   "koodiArvo" : "726112",
@@ -38068,7 +38068,7 @@
     "lyhytNimi" : "Master of Arts, Baltic Languages",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726113",
   "koodiArvo" : "726113",
@@ -38085,7 +38085,7 @@
     "lyhytNimi" : "Master of Arts, Classical Languages",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726114",
   "koodiArvo" : "726114",
@@ -38102,7 +38102,7 @@
     "lyhytNimi" : "Master of Arts, Slavonic Languages",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726115",
   "koodiArvo" : "726115",
@@ -38119,7 +38119,7 @@
     "lyhytNimi" : "Master of Arts, Sign Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726116",
   "koodiArvo" : "726116",
@@ -38153,7 +38153,7 @@
     "lyhytNimi" : "Master of Arts, Other or Unknown Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726200",
   "koodiArvo" : "726200",
@@ -38170,7 +38170,7 @@
     "lyhytNimi" : "Master of Arts, Translation and Interpretation",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726201",
   "koodiArvo" : "726201",
@@ -38187,7 +38187,7 @@
     "lyhytNimi" : "Master of Arts, Translation and Interpretation, Finnish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726202",
   "koodiArvo" : "726202",
@@ -38204,7 +38204,7 @@
     "lyhytNimi" : "Master of Arts, Translation and Interpretation, Swedish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726203",
   "koodiArvo" : "726203",
@@ -38221,7 +38221,7 @@
     "lyhytNimi" : "Master of Arts, Translation and Interpretation, English Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726204",
   "koodiArvo" : "726204",
@@ -38238,7 +38238,7 @@
     "lyhytNimi" : "Master of Arts, Translation and Interpretation, German Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726205",
   "koodiArvo" : "726205",
@@ -38255,7 +38255,7 @@
     "lyhytNimi" : "Master of Arts, Translation and Interpretation, French Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726206",
   "koodiArvo" : "726206",
@@ -38272,7 +38272,7 @@
     "lyhytNimi" : "Master of Arts, Translation and Interpretation, Russian Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726207",
   "koodiArvo" : "726207",
@@ -38289,7 +38289,7 @@
     "lyhytNimi" : "Master of Arts, Translation and Interpretation, Spanish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726208",
   "koodiArvo" : "726208",
@@ -38306,7 +38306,7 @@
     "lyhytNimi" : "Master of Arts, Translation and Interpretation, Italian Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726299",
   "koodiArvo" : "726299",
@@ -38323,7 +38323,7 @@
     "lyhytNimi" : "Master of Arts, Other or Unknown Translation and Interpretation",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726300",
   "koodiArvo" : "726300",
@@ -38340,7 +38340,7 @@
     "lyhytNimi" : "Master of Arts, History and Archeology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726301",
   "koodiArvo" : "726301",
@@ -38357,7 +38357,7 @@
     "lyhytNimi" : "Master of Arts, History",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726302",
   "koodiArvo" : "726302",
@@ -38374,7 +38374,7 @@
     "lyhytNimi" : "Master of Arts, Archeology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726400",
   "koodiArvo" : "726400",
@@ -38391,7 +38391,7 @@
     "lyhytNimi" : "Master of Arts, Literature, Cultural Research and Linguistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726401",
   "koodiArvo" : "726401",
@@ -38408,7 +38408,7 @@
     "lyhytNimi" : "Master of Arts, Literature",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726402",
   "koodiArvo" : "726402",
@@ -38425,7 +38425,7 @@
     "lyhytNimi" : "Master of Arts, Cultural Research",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726403",
   "koodiArvo" : "726403",
@@ -38442,7 +38442,7 @@
     "lyhytNimi" : "Master of Arts, Linguistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726404",
   "koodiArvo" : "726404",
@@ -38459,7 +38459,7 @@
     "lyhytNimi" : "Master of Arts, Speech Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726405",
   "koodiArvo" : "726405",
@@ -38493,7 +38493,7 @@
     "lyhytNimi" : "Master of Arts, Arts Research",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726501",
   "koodiArvo" : "726501",
@@ -38510,7 +38510,7 @@
     "lyhytNimi" : "Master of Arts, Art History and Art Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726502",
   "koodiArvo" : "726502",
@@ -38527,7 +38527,7 @@
     "lyhytNimi" : "Master of Arts, Musicology and Music Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726503",
   "koodiArvo" : "726503",
@@ -38544,7 +38544,7 @@
     "lyhytNimi" : "Master of Arts, Theatre",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726599",
   "koodiArvo" : "726599",
@@ -38561,7 +38561,7 @@
     "lyhytNimi" : "Master of Arts, Other or Unknown Arts Research Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726600",
   "koodiArvo" : "726600",
@@ -38578,7 +38578,7 @@
     "lyhytNimi" : "Master of Arts, Communication and Information Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726601",
   "koodiArvo" : "726601",
@@ -38595,7 +38595,7 @@
     "lyhytNimi" : "Master of Arts, Communication and Information Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726700",
   "koodiArvo" : "726700",
@@ -38612,7 +38612,7 @@
     "lyhytNimi" : "Master of Arts, Philosophy (Humanities)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726701",
   "koodiArvo" : "726701",
@@ -38629,7 +38629,7 @@
     "lyhytNimi" : "Master of Arts, Philosophy (Humanities)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726900",
   "koodiArvo" : "726900",
@@ -38646,7 +38646,7 @@
     "lyhytNimi" : "Master of Arts, Other Field in Humanities",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_726999",
   "koodiArvo" : "726999",
@@ -38663,7 +38663,7 @@
     "lyhytNimi" : "Master of Arts, Other or Unknown Field in Humanities",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_727000",
   "koodiArvo" : "727000",
@@ -38680,7 +38680,7 @@
     "lyhytNimi" : "Education in Theology, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_727100",
   "koodiArvo" : "727100",
@@ -38697,7 +38697,7 @@
     "lyhytNimi" : "Master of Theology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_727101",
   "koodiArvo" : "727101",
@@ -38714,7 +38714,7 @@
     "lyhytNimi" : "Master of Theology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_727900",
   "koodiArvo" : "727900",
@@ -38731,7 +38731,7 @@
     "lyhytNimi" : "Other Education in Theology, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_727999",
   "koodiArvo" : "727999",
@@ -38748,7 +38748,7 @@
     "lyhytNimi" : "Other or Unknown Education in Theology, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_729000",
   "koodiArvo" : "729000",
@@ -38765,7 +38765,7 @@
     "lyhytNimi" : "Other Education in Humanities and Arts, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_729900",
   "koodiArvo" : "729900",
@@ -38782,7 +38782,7 @@
     "lyhytNimi" : "Other Education in Humanities and Arts, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_729999",
   "koodiArvo" : "729999",
@@ -38799,7 +38799,7 @@
     "lyhytNimi" : "Other or Unknown Education in Humanities and Arts, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_731000",
   "koodiArvo" : "731000",
@@ -38816,7 +38816,7 @@
     "lyhytNimi" : "Polytechnic Master's Degree in Business and Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_731100",
   "koodiArvo" : "731100",
@@ -38833,7 +38833,7 @@
     "lyhytNimi" : "Postgraduate Polytechnic Degree in Business and Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_731101",
   "koodiArvo" : "731101",
@@ -38850,7 +38850,7 @@
     "lyhytNimi" : "Postgraduate Polytechnic Degree in Business and Administration, Postgraduate Degree Programme in Entrepreneurship for Small, Medium-sized Businesses",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_731107",
   "koodiArvo" : "731107",
@@ -38861,7 +38861,7 @@
     "nimi" : "Tradenomi (ylempi AMK), tietojenkäsittely",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_731109",
   "koodiArvo" : "731109",
@@ -38878,7 +38878,7 @@
     "lyhytNimi" : "Master of Business Administration (Polytechnic), Library and Information Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_731199",
   "koodiArvo" : "731199",
@@ -38895,7 +38895,7 @@
     "lyhytNimi" : "Postgraduate Polytechnic Degree in Business and Administration, Other or Unknown Field of Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_731200",
   "koodiArvo" : "731200",
@@ -38912,7 +38912,7 @@
     "lyhytNimi" : "Master of Business Administration (Polytechnic) in Business and Administration",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_731201",
   "koodiArvo" : "731201",
@@ -38929,7 +38929,7 @@
     "lyhytNimi" : "Master of Business Administration (Polytechnic), Economics, Administration and Marketing",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_731207",
   "koodiArvo" : "731207",
@@ -38946,7 +38946,7 @@
     "lyhytNimi" : "Master of Business Administration (Polytechnic), Data Processing",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_731299",
   "koodiArvo" : "731299",
@@ -38963,7 +38963,7 @@
     "lyhytNimi" : "Master of Business Administration (Polytechnic), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732000",
   "koodiArvo" : "732000",
@@ -38980,7 +38980,7 @@
     "lyhytNimi" : "Education in Business, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732100",
   "koodiArvo" : "732100",
@@ -38997,7 +38997,7 @@
     "lyhytNimi" : "Master of Science (Business and Administration), Bachelor of Science (Business and Administration)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732101",
   "koodiArvo" : "732101",
@@ -39014,7 +39014,7 @@
     "lyhytNimi" : "Master of Science (Economics and Business Administration), Business Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732105",
   "koodiArvo" : "732105",
@@ -39031,7 +39031,7 @@
     "lyhytNimi" : "Master of Science (Economics and Business Administration), Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732114",
   "koodiArvo" : "732114",
@@ -39048,7 +39048,7 @@
     "lyhytNimi" : "Master of Science (Economics and Business Administration), Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732115",
   "koodiArvo" : "732115",
@@ -39065,7 +39065,7 @@
     "lyhytNimi" : "Master of Science (Economics and Business Administration), Information Systems Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732199",
   "koodiArvo" : "732199",
@@ -39082,7 +39082,7 @@
     "lyhytNimi" : "Master of Science (Economics and Business Administration), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732200",
   "koodiArvo" : "732200",
@@ -39099,7 +39099,7 @@
     "lyhytNimi" : "Master of Science (Economics and Business and Administration)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732201",
   "koodiArvo" : "732201",
@@ -39116,7 +39116,7 @@
     "lyhytNimi" : "Master of Science (Economics and Business Administration), Business Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732205",
   "koodiArvo" : "732205",
@@ -39133,7 +39133,7 @@
     "lyhytNimi" : "Master of Science (Economics and Business Administration), Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732214",
   "koodiArvo" : "732214",
@@ -39150,7 +39150,7 @@
     "lyhytNimi" : "Master of Science (Economics and Business Administration), Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732215",
   "koodiArvo" : "732215",
@@ -39167,7 +39167,7 @@
     "lyhytNimi" : "Master of Science (Economics and Business Administration), Information Systems Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732299",
   "koodiArvo" : "732299",
@@ -39184,7 +39184,7 @@
     "lyhytNimi" : "Master of Science (Economics and Business Administration), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732300",
   "koodiArvo" : "732300",
@@ -39201,7 +39201,7 @@
     "lyhytNimi" : "Master of Economic Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732351",
   "koodiArvo" : "732351",
@@ -39218,7 +39218,7 @@
     "lyhytNimi" : "Master of Science (Economics and Business Administration), Business Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732355",
   "koodiArvo" : "732355",
@@ -39235,7 +39235,7 @@
     "lyhytNimi" : "Master of Science (Economics and Business Administration), Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732364",
   "koodiArvo" : "732364",
@@ -39252,7 +39252,7 @@
     "lyhytNimi" : "Master of Science (Economics and Business Administration), Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732365",
   "koodiArvo" : "732365",
@@ -39269,7 +39269,7 @@
     "lyhytNimi" : "Master of Science (Economics and Business Administration), Information Systems Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732399",
   "koodiArvo" : "732399",
@@ -39286,7 +39286,7 @@
     "lyhytNimi" : "Master of Science (Economics and Business Administration), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732900",
   "koodiArvo" : "732900",
@@ -39303,7 +39303,7 @@
     "lyhytNimi" : "Other Education in Business, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_732999",
   "koodiArvo" : "732999",
@@ -39320,7 +39320,7 @@
     "lyhytNimi" : "Other or Unknown Education in Business, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733000",
   "koodiArvo" : "733000",
@@ -39337,7 +39337,7 @@
     "lyhytNimi" : "Education in Social Sciences, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733100",
   "koodiArvo" : "733100",
@@ -39354,7 +39354,7 @@
     "lyhytNimi" : "Master of Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733101",
   "koodiArvo" : "733101",
@@ -39371,7 +39371,7 @@
     "lyhytNimi" : "Master of Social Sciences, Political Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733102",
   "koodiArvo" : "733102",
@@ -39388,7 +39388,7 @@
     "lyhytNimi" : "Master of Social Sciences, Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733103",
   "koodiArvo" : "733103",
@@ -39405,7 +39405,7 @@
     "lyhytNimi" : "Master of Social Sciences, Social Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733105",
   "koodiArvo" : "733105",
@@ -39422,7 +39422,7 @@
     "lyhytNimi" : "Master of Social Sciences, Psychology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733106",
   "koodiArvo" : "733106",
@@ -39439,7 +39439,7 @@
     "lyhytNimi" : "Master of Social Sciences, Communication Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733107",
   "koodiArvo" : "733107",
@@ -39456,7 +39456,7 @@
     "lyhytNimi" : "Master of Social Sciences, Philosophy",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733108",
   "koodiArvo" : "733108",
@@ -39473,7 +39473,7 @@
     "lyhytNimi" : "Master of Social Sciences, Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733110",
   "koodiArvo" : "733110",
@@ -39490,7 +39490,7 @@
     "lyhytNimi" : "Master of Social Sciences, Regional and Environmental Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733111",
   "koodiArvo" : "733111",
@@ -39524,7 +39524,7 @@
     "lyhytNimi" : "Master of Social Sciences, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733200",
   "koodiArvo" : "733200",
@@ -39541,7 +39541,7 @@
     "lyhytNimi" : "Master of Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733201",
   "koodiArvo" : "733201",
@@ -39558,7 +39558,7 @@
     "lyhytNimi" : "Master of Social Sciences, Political Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733202",
   "koodiArvo" : "733202",
@@ -39575,7 +39575,7 @@
     "lyhytNimi" : "Master of Social Sciences, Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733203",
   "koodiArvo" : "733203",
@@ -39592,7 +39592,7 @@
     "lyhytNimi" : "Master of Social Sciences, Social Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733205",
   "koodiArvo" : "733205",
@@ -39609,7 +39609,7 @@
     "lyhytNimi" : "Master of Social Sciences, Psychology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733206",
   "koodiArvo" : "733206",
@@ -39626,7 +39626,7 @@
     "lyhytNimi" : "Master of Social Sciences, Communication Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733207",
   "koodiArvo" : "733207",
@@ -39643,7 +39643,7 @@
     "lyhytNimi" : "Master of Social Sciences, Philosophy",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733208",
   "koodiArvo" : "733208",
@@ -39660,7 +39660,7 @@
     "lyhytNimi" : "Master of Social Sciences, Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733209",
   "koodiArvo" : "733209",
@@ -39677,7 +39677,7 @@
     "lyhytNimi" : "Master of Social Sciences, Computer Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733210",
   "koodiArvo" : "733210",
@@ -39694,7 +39694,7 @@
     "lyhytNimi" : "Master of Social Sciences, Regional and Environmental Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733211",
   "koodiArvo" : "733211",
@@ -39711,7 +39711,7 @@
     "lyhytNimi" : "Master of Social Sciences, Tourism",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733299",
   "koodiArvo" : "733299",
@@ -39728,7 +39728,7 @@
     "lyhytNimi" : "Master of Social Sciences, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733300",
   "koodiArvo" : "733300",
@@ -39745,7 +39745,7 @@
     "lyhytNimi" : "Master of Administrative Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733301",
   "koodiArvo" : "733301",
@@ -39762,7 +39762,7 @@
     "lyhytNimi" : "Master of Administrative Sciences, Administrative Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733310",
   "koodiArvo" : "733310",
@@ -39779,7 +39779,7 @@
     "lyhytNimi" : "Master of Administrative Sciences, Regional and Environmental Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733399",
   "koodiArvo" : "733399",
@@ -39796,7 +39796,7 @@
     "lyhytNimi" : "Master of Administrative Sciences, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733400",
   "koodiArvo" : "733400",
@@ -39813,7 +39813,7 @@
     "lyhytNimi" : "Master of Arts, Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733401",
   "koodiArvo" : "733401",
@@ -39830,7 +39830,7 @@
     "lyhytNimi" : "Master of Arts, Political Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733402",
   "koodiArvo" : "733402",
@@ -39847,7 +39847,7 @@
     "lyhytNimi" : "Master of Arts, Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733403",
   "koodiArvo" : "733403",
@@ -39864,7 +39864,7 @@
     "lyhytNimi" : "Master of Arts, Social Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733404",
   "koodiArvo" : "733404",
@@ -39881,7 +39881,7 @@
     "lyhytNimi" : "Master of Arts, Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733405",
   "koodiArvo" : "733405",
@@ -39898,7 +39898,7 @@
     "lyhytNimi" : "Master of Arts, Psychology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733407",
   "koodiArvo" : "733407",
@@ -39915,7 +39915,7 @@
     "lyhytNimi" : "Master of Arts, Philosophy (Social Sciences)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733408",
   "koodiArvo" : "733408",
@@ -39932,7 +39932,7 @@
     "lyhytNimi" : "Master of Arts, Statistics (Social Sciences)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733409",
   "koodiArvo" : "733409",
@@ -39966,7 +39966,7 @@
     "lyhytNimi" : "Master of Arts, Social Sciences, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733500",
   "koodiArvo" : "733500",
@@ -39983,7 +39983,7 @@
     "lyhytNimi" : "Master of Arts (Psychology)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733501",
   "koodiArvo" : "733501",
@@ -40000,7 +40000,7 @@
     "lyhytNimi" : "Master of Arts (Psychology)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733600",
   "koodiArvo" : "733600",
@@ -40017,7 +40017,7 @@
     "lyhytNimi" : "Master of Administrative Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733651",
   "koodiArvo" : "733651",
@@ -40034,7 +40034,7 @@
     "lyhytNimi" : "Master of Administrative Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733900",
   "koodiArvo" : "733900",
@@ -40051,7 +40051,7 @@
     "lyhytNimi" : "Other Education in Social Sciences, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_733999",
   "koodiArvo" : "733999",
@@ -40068,7 +40068,7 @@
     "lyhytNimi" : "Other or Unknown Education in Social Sciences, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_734000",
   "koodiArvo" : "734000",
@@ -40085,7 +40085,7 @@
     "lyhytNimi" : "Education in Laws, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_734100",
   "koodiArvo" : "734100",
@@ -40102,7 +40102,7 @@
     "lyhytNimi" : "Master of Laws",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_734101",
   "koodiArvo" : "734101",
@@ -40119,7 +40119,7 @@
     "lyhytNimi" : "Master of Laws",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_734102",
   "koodiArvo" : "734102",
@@ -40136,7 +40136,7 @@
     "lyhytNimi" : "Master of International and Comparative Law",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_739000",
   "koodiArvo" : "739000",
@@ -40153,7 +40153,7 @@
     "lyhytNimi" : "Other Education in Social Sciences and Business, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_739900",
   "koodiArvo" : "739900",
@@ -40170,7 +40170,7 @@
     "lyhytNimi" : "Other Education in Social Sciences and Business, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_739999",
   "koodiArvo" : "739999",
@@ -40187,7 +40187,7 @@
     "lyhytNimi" : "Other or Unknown Education in Social Sciences and Business, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742000",
   "koodiArvo" : "742000",
@@ -40204,7 +40204,7 @@
     "lyhytNimi" : "Master of Science, Natural Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742100",
   "koodiArvo" : "742100",
@@ -40221,7 +40221,7 @@
     "lyhytNimi" : "Master of Science, Mathematics and Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742101",
   "koodiArvo" : "742101",
@@ -40238,7 +40238,7 @@
     "lyhytNimi" : "Master of Science, Mathematics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742102",
   "koodiArvo" : "742102",
@@ -40255,7 +40255,7 @@
     "lyhytNimi" : "Master of Science, Statistics (Natural Sciences)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742200",
   "koodiArvo" : "742200",
@@ -40272,7 +40272,7 @@
     "lyhytNimi" : "Master of Science, Computer Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742201",
   "koodiArvo" : "742201",
@@ -40289,7 +40289,7 @@
     "lyhytNimi" : "Master of Science, Computer Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742300",
   "koodiArvo" : "742300",
@@ -40306,7 +40306,7 @@
     "lyhytNimi" : "Master of Science, Physical Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742301",
   "koodiArvo" : "742301",
@@ -40323,7 +40323,7 @@
     "lyhytNimi" : "Master of Science, Physics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742302",
   "koodiArvo" : "742302",
@@ -40340,7 +40340,7 @@
     "lyhytNimi" : "Master of Science, Geophysics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742303",
   "koodiArvo" : "742303",
@@ -40357,7 +40357,7 @@
     "lyhytNimi" : "Master of Science, Meteorology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742304",
   "koodiArvo" : "742304",
@@ -40374,7 +40374,7 @@
     "lyhytNimi" : "Master of Science, Astronomy",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742400",
   "koodiArvo" : "742400",
@@ -40391,7 +40391,7 @@
     "lyhytNimi" : "Master of Science, Chemistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742401",
   "koodiArvo" : "742401",
@@ -40408,7 +40408,7 @@
     "lyhytNimi" : "Master of Science, Chemistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742500",
   "koodiArvo" : "742500",
@@ -40425,7 +40425,7 @@
     "lyhytNimi" : "Master of Science, Geology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742501",
   "koodiArvo" : "742501",
@@ -40442,7 +40442,7 @@
     "lyhytNimi" : "Master of Science, Geology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742600",
   "koodiArvo" : "742600",
@@ -40459,7 +40459,7 @@
     "lyhytNimi" : "Master of Science, Geography",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742601",
   "koodiArvo" : "742601",
@@ -40476,7 +40476,7 @@
     "lyhytNimi" : "Master of Science, Geography",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742700",
   "koodiArvo" : "742700",
@@ -40493,7 +40493,7 @@
     "lyhytNimi" : "Master of Science, Biology, Biosciences and Environmental Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742701",
   "koodiArvo" : "742701",
@@ -40510,7 +40510,7 @@
     "lyhytNimi" : "Master of Science, Biology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742702",
   "koodiArvo" : "742702",
@@ -40527,7 +40527,7 @@
     "lyhytNimi" : "Master of Science, Biosciences, Biochemistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742703",
   "koodiArvo" : "742703",
@@ -40544,7 +40544,7 @@
     "lyhytNimi" : "Master of Science, Environmental Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742704",
   "koodiArvo" : "742704",
@@ -40557,7 +40557,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_742900",
   "koodiArvo" : "742900",
@@ -40574,7 +40574,7 @@
     "lyhytNimi" : "Master of Science, Other Field in Natural Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742901",
   "koodiArvo" : "742901",
@@ -40591,7 +40591,7 @@
     "lyhytNimi" : "Master of Science, Philosophy (Natural Science)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_742999",
   "koodiArvo" : "742999",
@@ -40608,7 +40608,7 @@
     "lyhytNimi" : "Master of Science, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_749000",
   "koodiArvo" : "749000",
@@ -40625,7 +40625,7 @@
     "lyhytNimi" : "Other Education in Natural Sciences, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_749900",
   "koodiArvo" : "749900",
@@ -40642,7 +40642,7 @@
     "lyhytNimi" : "Other Education in Natural Sciences, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_749999",
   "koodiArvo" : "749999",
@@ -40659,7 +40659,7 @@
     "lyhytNimi" : "Other or Unknown Education in Natural Sciences, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750000",
   "koodiArvo" : "750000",
@@ -40676,7 +40676,7 @@
     "lyhytNimi" : "Polytechnic Master's Degree in Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750100",
   "koodiArvo" : "750100",
@@ -40693,7 +40693,7 @@
     "lyhytNimi" : "Postgraduate Polytechnic Degree in Technology and Transportation",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750101",
   "koodiArvo" : "750101",
@@ -40710,7 +40710,7 @@
     "lyhytNimi" : "Postgraduate Polytechnic Degree in Technology and Transportation, Postgraduate Degree Programme in Health Care Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750102",
   "koodiArvo" : "750102",
@@ -40727,7 +40727,7 @@
     "lyhytNimi" : "Postgraduate Polytechnic Degree in Technology and Transportation, Postgraduate Degree Programme in Renovation and Refurbishment",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750103",
   "koodiArvo" : "750103",
@@ -40744,7 +40744,7 @@
     "lyhytNimi" : "Postgraduate Polytechnic Degree in Technology and Transportation, Postgraduate Degree Programme in Competence Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750199",
   "koodiArvo" : "750199",
@@ -40761,7 +40761,7 @@
     "lyhytNimi" : "Postgraduate Polytechnic Degree in Technology and Transportation, Other Field of Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750200",
   "koodiArvo" : "750200",
@@ -40778,7 +40778,7 @@
     "lyhytNimi" : "Master of Engineering (Polytechnic), Mechanical Engineering and Energy Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750201",
   "koodiArvo" : "750201",
@@ -40795,7 +40795,7 @@
     "lyhytNimi" : "Master of Engineering (Polytechnic), Mechanical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750205",
   "koodiArvo" : "750205",
@@ -40808,7 +40808,7 @@
     "lyhytNimi" : "Ingenjör (h. YH), sjofart",
     "kieli" : "SV"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750300",
   "koodiArvo" : "750300",
@@ -40825,7 +40825,7 @@
     "lyhytNimi" : "Master of Engineering (Polytechnic), Electrical Engineering and Automation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750302",
   "koodiArvo" : "750302",
@@ -40842,7 +40842,7 @@
     "lyhytNimi" : "Master of Engineering (Polytechnic), Automation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750303",
   "koodiArvo" : "750303",
@@ -40859,7 +40859,7 @@
     "lyhytNimi" : "Master of Engineering (Polytechnic), Electronic Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750304",
   "koodiArvo" : "750304",
@@ -40890,7 +40890,7 @@
     "lyhytNimi" : "Master of Engineering (Polytechnic), Information Technology and Telecommunications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750401",
   "koodiArvo" : "750401",
@@ -40907,7 +40907,7 @@
     "lyhytNimi" : "Master of Engineering (Polytechnic), Information Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750500",
   "koodiArvo" : "750500",
@@ -40924,7 +40924,7 @@
     "lyhytNimi" : "Master of Engineering (Polytechnic), Process Engineering and Materials Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750503",
   "koodiArvo" : "750503",
@@ -40941,7 +40941,7 @@
     "lyhytNimi" : "Master of Engineering (Polytechnic), Environmental Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750505",
   "koodiArvo" : "750505",
@@ -40958,7 +40958,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_750506",
   "koodiArvo" : "750506",
@@ -40992,7 +40992,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_750600",
   "koodiArvo" : "750600",
@@ -41009,7 +41009,7 @@
     "lyhytNimi" : "Master of Engineering (Polytechnic), Building Construction",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750601",
   "koodiArvo" : "750601",
@@ -41026,7 +41026,7 @@
     "lyhytNimi" : "Master of Engineering (Polytechnic), Building Construction, Community Development",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750602",
   "koodiArvo" : "750602",
@@ -41043,7 +41043,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_750700",
   "koodiArvo" : "750700",
@@ -41060,7 +41060,7 @@
     "lyhytNimi" : "Master of Engineering (Polytechnic), Industrial Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750701",
   "koodiArvo" : "750701",
@@ -41077,7 +41077,7 @@
     "lyhytNimi" : "Master of Engineering (Polytechnic), Industrial Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750702",
   "koodiArvo" : "750702",
@@ -41094,7 +41094,7 @@
     "lyhytNimi" : "Master of Engineering (Polytechnic), Logistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750800",
   "koodiArvo" : "750800",
@@ -41111,7 +41111,7 @@
     "lyhytNimi" : "Master of Engineering (Polytechnic), Other Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750802",
   "koodiArvo" : "750802",
@@ -41128,7 +41128,7 @@
     "lyhytNimi" : "Master of Engineering (Polytechnic), Graphics and Communications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750803",
   "koodiArvo" : "750803",
@@ -41145,7 +41145,7 @@
     "lyhytNimi" : "Master of Engineering (Polytechnic), Technological Competence Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750804",
   "koodiArvo" : "750804",
@@ -41196,7 +41196,7 @@
     "lyhytNimi" : "Master of Engineering (Polytechnic), Other or Unknown Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750900",
   "koodiArvo" : "750900",
@@ -41213,7 +41213,7 @@
     "lyhytNimi" : "Other Polytechnic Master's Degree in Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_750904",
   "koodiArvo" : "750904",
@@ -41230,7 +41230,7 @@
     "lyhytNimi" : "Master of Engineering (Polytechnic), Laboratory Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751000",
   "koodiArvo" : "751000",
@@ -41247,7 +41247,7 @@
     "lyhytNimi" : "Master of Science in Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751100",
   "koodiArvo" : "751100",
@@ -41264,7 +41264,7 @@
     "lyhytNimi" : "Master of Science (Technology), Mechanical Engineering and Energy Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751101",
   "koodiArvo" : "751101",
@@ -41281,7 +41281,7 @@
     "lyhytNimi" : "Master of Science (Technology), Mechanical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751102",
   "koodiArvo" : "751102",
@@ -41298,7 +41298,7 @@
     "lyhytNimi" : "Master of Science (Technology), Energy Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751200",
   "koodiArvo" : "751200",
@@ -41315,7 +41315,7 @@
     "lyhytNimi" : "Master of Science (Technology), Electrical Engineering and Automation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751201",
   "koodiArvo" : "751201",
@@ -41332,7 +41332,7 @@
     "lyhytNimi" : "Master of Science (Technology), Electrical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751202",
   "koodiArvo" : "751202",
@@ -41349,7 +41349,7 @@
     "lyhytNimi" : "Master of Science (Technology), Automation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751203",
   "koodiArvo" : "751203",
@@ -41366,7 +41366,7 @@
     "lyhytNimi" : "Master of Science (Technology), Engineering Physics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751204",
   "koodiArvo" : "751204",
@@ -41383,7 +41383,7 @@
     "lyhytNimi" : "Master of Science (Technology), Science and Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751300",
   "koodiArvo" : "751300",
@@ -41400,7 +41400,7 @@
     "lyhytNimi" : "Master of Science (Technology), Information Technology and Telecommunications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751301",
   "koodiArvo" : "751301",
@@ -41417,7 +41417,7 @@
     "lyhytNimi" : "Master of Science (Technology), Information Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751302",
   "koodiArvo" : "751302",
@@ -41434,7 +41434,7 @@
     "lyhytNimi" : "Master of Science (Technology), Telecommunications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751400",
   "koodiArvo" : "751400",
@@ -41451,7 +41451,7 @@
     "lyhytNimi" : "Master of Science (Technology), Process Engineering and Materials Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751401",
   "koodiArvo" : "751401",
@@ -41468,7 +41468,7 @@
     "lyhytNimi" : "Master of Science (Technology), Chemical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751402",
   "koodiArvo" : "751402",
@@ -41485,7 +41485,7 @@
     "lyhytNimi" : "Master of Science (Technology), Process Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751403",
   "koodiArvo" : "751403",
@@ -41502,7 +41502,7 @@
     "lyhytNimi" : "Master of Science (Technology), Environmental Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751404",
   "koodiArvo" : "751404",
@@ -41519,7 +41519,7 @@
     "lyhytNimi" : "Master of Science (Technology), Wood Processing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751408",
   "koodiArvo" : "751408",
@@ -41536,7 +41536,7 @@
     "lyhytNimi" : "Master of Science (Technology), Materials Technology, Rock Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751409",
   "koodiArvo" : "751409",
@@ -41553,7 +41553,7 @@
     "lyhytNimi" : "Master of Science (Technology), Biotechnology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751410",
   "koodiArvo" : "751410",
@@ -41583,7 +41583,7 @@
     "lyhytNimi" : "Master of Science (Technology), Building Construction and Surveying Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751501",
   "koodiArvo" : "751501",
@@ -41600,7 +41600,7 @@
     "lyhytNimi" : "Master of Science (Technology), Building Construction, Community Development",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751502",
   "koodiArvo" : "751502",
@@ -41617,7 +41617,7 @@
     "lyhytNimi" : "Master of Science (Technology), Surveying Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751600",
   "koodiArvo" : "751600",
@@ -41634,7 +41634,7 @@
     "lyhytNimi" : "Master of Science (Technology), Industrial Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751601",
   "koodiArvo" : "751601",
@@ -41651,7 +41651,7 @@
     "lyhytNimi" : "Master of Science (Technology), Industrial Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751900",
   "koodiArvo" : "751900",
@@ -41668,7 +41668,7 @@
     "lyhytNimi" : "Master of Science (Technology), Other Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751901",
   "koodiArvo" : "751901",
@@ -41685,7 +41685,7 @@
     "lyhytNimi" : "Master of Science (Technology), Textiles and Clothing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_751999",
   "koodiArvo" : "751999",
@@ -41702,7 +41702,7 @@
     "lyhytNimi" : "Master of Science (Technology), Other or Unknown Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_754000",
   "koodiArvo" : "754000",
@@ -41719,7 +41719,7 @@
     "lyhytNimi" : "Master of Science (Architecture)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_754100",
   "koodiArvo" : "754100",
@@ -41736,7 +41736,7 @@
     "lyhytNimi" : "Master of Science (Architecture)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_754101",
   "koodiArvo" : "754101",
@@ -41753,7 +41753,7 @@
     "lyhytNimi" : "Master of Science (Architecture)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_754200",
   "koodiArvo" : "754200",
@@ -41770,7 +41770,7 @@
     "lyhytNimi" : "Master of Science (Landscape Architecture)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_754201",
   "koodiArvo" : "754201",
@@ -41787,7 +41787,7 @@
     "lyhytNimi" : "Master of Science (Landscape Architecture)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_759000",
   "koodiArvo" : "759000",
@@ -41804,7 +41804,7 @@
     "lyhytNimi" : "Other Education in Technology, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_759900",
   "koodiArvo" : "759900",
@@ -41821,7 +41821,7 @@
     "lyhytNimi" : "Other Education in Technology, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_759999",
   "koodiArvo" : "759999",
@@ -41838,7 +41838,7 @@
     "lyhytNimi" : "Other or Unknown Education in Technology, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_761000",
   "koodiArvo" : "761000",
@@ -41855,7 +41855,7 @@
     "lyhytNimi" : "Master of Natural Resources (Polytechnic), Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_761100",
   "koodiArvo" : "761100",
@@ -41872,7 +41872,7 @@
     "lyhytNimi" : "Master of Natural Resources (Polytechnic), Agronomist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_761101",
   "koodiArvo" : "761101",
@@ -41889,7 +41889,7 @@
     "lyhytNimi" : "Master of Natural Resources (Polytechnic), Agronomist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_761200",
   "koodiArvo" : "761200",
@@ -41906,7 +41906,7 @@
     "lyhytNimi" : "Master of Natural Resources(Polytechnic), Horticulturist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_761201",
   "koodiArvo" : "761201",
@@ -41923,7 +41923,7 @@
     "lyhytNimi" : "Master of Natural Resources (Polytechnic), Horticulturist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_761300",
   "koodiArvo" : "761300",
@@ -41940,7 +41940,7 @@
     "lyhytNimi" : "Master of Natural Resources (Polytechnic), Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_761301",
   "koodiArvo" : "761301",
@@ -41957,7 +41957,7 @@
     "lyhytNimi" : "Master of Natural Resources (Polytechnic), Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_761400",
   "koodiArvo" : "761400",
@@ -41974,7 +41974,7 @@
     "lyhytNimi" : "Master of Natural Recources (Polytechnic), Fishery",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_761401",
   "koodiArvo" : "761401",
@@ -41991,7 +41991,7 @@
     "lyhytNimi" : "Master of Natural Recources (Polytechnic), Fishery",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_761500",
   "koodiArvo" : "761500",
@@ -42008,7 +42008,7 @@
     "lyhytNimi" : "Master of Natural Resources (Polytechnic), Environmental planning",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_761501",
   "koodiArvo" : "761501",
@@ -42025,7 +42025,7 @@
     "lyhytNimi" : "Master of Natural Resources (Polytechnic), Environmental planning",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_761900",
   "koodiArvo" : "761900",
@@ -42042,7 +42042,7 @@
     "lyhytNimi" : "Other Polytechnic Master's Degree in Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_761999",
   "koodiArvo" : "761999",
@@ -42059,7 +42059,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic Master's Degree in Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_762000",
   "koodiArvo" : "762000",
@@ -42076,7 +42076,7 @@
     "lyhytNimi" : "Education in Agriculture and Forestry, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_762200",
   "koodiArvo" : "762200",
@@ -42093,7 +42093,7 @@
     "lyhytNimi" : "Master of Science (Agriculture and Forestry)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_762201",
   "koodiArvo" : "762201",
@@ -42110,7 +42110,7 @@
     "lyhytNimi" : "Master of Science (Agriculture and Forestry), Agriculture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_762202",
   "koodiArvo" : "762202",
@@ -42127,7 +42127,7 @@
     "lyhytNimi" : "Master of Science (Agriculture and Forestry), Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_762203",
   "koodiArvo" : "762203",
@@ -42144,7 +42144,7 @@
     "lyhytNimi" : "Master of Science (Agriculture and Forestry), Environmental Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_762204",
   "koodiArvo" : "762204",
@@ -42161,7 +42161,7 @@
     "lyhytNimi" : "Master of Science (Agriculture and Forestry), Household Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_762205",
   "koodiArvo" : "762205",
@@ -42178,7 +42178,7 @@
     "lyhytNimi" : "Master of Science (Agriculture and Forestry), Biotechnology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_762251",
   "koodiArvo" : "762251",
@@ -42195,7 +42195,7 @@
     "lyhytNimi" : "Master of Science (Agriculture and Forestry), Food Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_762299",
   "koodiArvo" : "762299",
@@ -42212,7 +42212,7 @@
     "lyhytNimi" : "Master of Science (Agriculture and Forestry), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_762300",
   "koodiArvo" : "762300",
@@ -42229,7 +42229,7 @@
     "lyhytNimi" : "Master of Food Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_762301",
   "koodiArvo" : "762301",
@@ -42246,7 +42246,7 @@
     "lyhytNimi" : "Master of Food Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_762400",
   "koodiArvo" : "762400",
@@ -42263,7 +42263,7 @@
     "lyhytNimi" : "Master of Science (Agriculture)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_762451",
   "koodiArvo" : "762451",
@@ -42280,7 +42280,7 @@
     "lyhytNimi" : "Master of Science (Agriculture)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_762500",
   "koodiArvo" : "762500",
@@ -42297,7 +42297,7 @@
     "lyhytNimi" : "Master of Science (Forestry)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_762551",
   "koodiArvo" : "762551",
@@ -42314,7 +42314,7 @@
     "lyhytNimi" : "Master of Science (Forestry)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_762900",
   "koodiArvo" : "762900",
@@ -42331,7 +42331,7 @@
     "lyhytNimi" : "Other Education in Agriculture and Forestry, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_762999",
   "koodiArvo" : "762999",
@@ -42348,7 +42348,7 @@
     "lyhytNimi" : "Other or Unknown Education in Agriculture and Forestry, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771000",
   "koodiArvo" : "771000",
@@ -42365,7 +42365,7 @@
     "lyhytNimi" : "Polytechnic Master's Degree in Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771100",
   "koodiArvo" : "771100",
@@ -42382,7 +42382,7 @@
     "lyhytNimi" : "Postgraduate Polytechnic Degree in Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771101",
   "koodiArvo" : "771101",
@@ -42399,7 +42399,7 @@
     "lyhytNimi" : "Postgraduate Polytechnic Degree in Health Care, Postgraduate Degree Programme in Health Care of Choric and Geriatric Patients",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771102",
   "koodiArvo" : "771102",
@@ -42416,7 +42416,7 @@
     "lyhytNimi" : "Postgraduate Polytechnic Degree in Health Care, Postgraduate Degree Programme in Health Promotion and Preventive Health Care",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771103",
   "koodiArvo" : "771103",
@@ -42433,7 +42433,7 @@
     "lyhytNimi" : "Postgraduate Polytechnic Degree in Health Care, Postgraduate Degree Programme in Social Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771199",
   "koodiArvo" : "771199",
@@ -42450,7 +42450,7 @@
     "lyhytNimi" : "Postgraduate Polytechnic Degree in Health Care, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771200",
   "koodiArvo" : "771200",
@@ -42467,7 +42467,7 @@
     "lyhytNimi" : "Master of Health Care (Polytechnic), Health Care",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771201",
   "koodiArvo" : "771201",
@@ -42484,7 +42484,7 @@
     "lyhytNimi" : "Master of Health Care (Polytechnic), Registered Nurse",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771203",
   "koodiArvo" : "771203",
@@ -42501,7 +42501,7 @@
     "lyhytNimi" : "Master of Health Care (Polytechnic), Public Health Nurse",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771204",
   "koodiArvo" : "771204",
@@ -42518,7 +42518,7 @@
     "lyhytNimi" : "Master of Health Care (Polytechnic), Biomedical Laboratory",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771205",
   "koodiArvo" : "771205",
@@ -42535,7 +42535,7 @@
     "lyhytNimi" : "Master of Health Care (Polytechnic), Radiographer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771206",
   "koodiArvo" : "771206",
@@ -42552,7 +42552,7 @@
     "lyhytNimi" : "Master of Health Care (Polytechnic), Midwife",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771207",
   "koodiArvo" : "771207",
@@ -42569,7 +42569,7 @@
     "lyhytNimi" : "Master of Health Care (Polytechnic), Dental Hygienist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771208",
   "koodiArvo" : "771208",
@@ -42586,7 +42586,7 @@
     "lyhytNimi" : "Master of Health Care (Polytechnic), Dental Technician",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771211",
   "koodiArvo" : "771211",
@@ -42603,7 +42603,7 @@
     "lyhytNimi" : "Master of Health Care (Polytechnic), Optometrist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771212",
   "koodiArvo" : "771212",
@@ -42620,7 +42620,7 @@
     "lyhytNimi" : "Master of Health Care (Polytechnic), Physiotherapist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771213",
   "koodiArvo" : "771213",
@@ -42637,7 +42637,7 @@
     "lyhytNimi" : "Master of Health Care (Polytechnic), Podiatrist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771214",
   "koodiArvo" : "771214",
@@ -42654,7 +42654,7 @@
     "lyhytNimi" : "Master of Health Care (Polytechnic), Occupational Therapist",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771215",
   "koodiArvo" : "771215",
@@ -42671,7 +42671,7 @@
     "lyhytNimi" : "Master of Health Care (Polytechnic), Orthotics-Prosthetics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771216",
   "koodiArvo" : "771216",
@@ -42688,7 +42688,7 @@
     "lyhytNimi" : "Master of Health Care (Polytechnic), Emergency Nurse",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771217",
   "koodiArvo" : "771217",
@@ -42705,7 +42705,7 @@
     "lyhytNimi" : "Master of Health Care (Polytechnic), Osteopath",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771218",
   "koodiArvo" : "771218",
@@ -42722,7 +42722,7 @@
     "lyhytNimi" : "Master of Social Services and Health Care (Polytechnic), Rehabilitation Counsellor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771219",
   "koodiArvo" : "771219",
@@ -42739,7 +42739,7 @@
     "lyhytNimi" : "Master of Health Care (Polytechnic), Naprapath",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771299",
   "koodiArvo" : "771299",
@@ -42756,7 +42756,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic Master's Degree in Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771300",
   "koodiArvo" : "771300",
@@ -42773,7 +42773,7 @@
     "lyhytNimi" : "Master of Social Services (Polytechnic), Social Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771301",
   "koodiArvo" : "771301",
@@ -42790,7 +42790,7 @@
     "lyhytNimi" : "Master of Social Services (Polytechnic), Social Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771399",
   "koodiArvo" : "771399",
@@ -42807,7 +42807,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic Master's  Degree in Social Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771900",
   "koodiArvo" : "771900",
@@ -42824,7 +42824,7 @@
     "lyhytNimi" : "Other Polytechnic Master's Degree in Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771901",
   "koodiArvo" : "771901",
@@ -42841,7 +42841,7 @@
     "lyhytNimi" : "Master of Social Services and Health Care (Polytechnic), Geriatry Nurse",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_771999",
   "koodiArvo" : "771999",
@@ -42858,7 +42858,7 @@
     "lyhytNimi" : "Other or unknown Polytechnic Master's Degree in Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_772000",
   "koodiArvo" : "772000",
@@ -42875,7 +42875,7 @@
     "lyhytNimi" : "Education in Health and Welfare, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_772100",
   "koodiArvo" : "772100",
@@ -42892,7 +42892,7 @@
     "lyhytNimi" : "Licentiate of Medicine",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_772101",
   "koodiArvo" : "772101",
@@ -42909,7 +42909,7 @@
     "lyhytNimi" : "Licentiate of Medicine",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_772200",
   "koodiArvo" : "772200",
@@ -42926,7 +42926,7 @@
     "lyhytNimi" : "Licentiate of Dentistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_772201",
   "koodiArvo" : "772201",
@@ -42943,7 +42943,7 @@
     "lyhytNimi" : "Licentiate of Dentistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_772300",
   "koodiArvo" : "772300",
@@ -42960,7 +42960,7 @@
     "lyhytNimi" : "Licentiate of Veterinary Medicine",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_772301",
   "koodiArvo" : "772301",
@@ -42977,7 +42977,7 @@
     "lyhytNimi" : "Licentiate of Veterinary Medicine",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_772400",
   "koodiArvo" : "772400",
@@ -42994,7 +42994,7 @@
     "lyhytNimi" : "Master of Science (Pharmacy)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_772401",
   "koodiArvo" : "772401",
@@ -43011,7 +43011,7 @@
     "lyhytNimi" : "Master of Science (Pharmacy)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_772451",
   "koodiArvo" : "772451",
@@ -43028,7 +43028,7 @@
     "lyhytNimi" : "Master of Science (Pharmacy)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_772500",
   "koodiArvo" : "772500",
@@ -43045,7 +43045,7 @@
     "lyhytNimi" : "Master of Health Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_772501",
   "koodiArvo" : "772501",
@@ -43062,7 +43062,7 @@
     "lyhytNimi" : "Master of Health Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_772601",
   "koodiArvo" : "772601",
@@ -43096,7 +43096,7 @@
     "lyhytNimi" : "Other Education in Health and Welfare, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_772999",
   "koodiArvo" : "772999",
@@ -43113,7 +43113,7 @@
     "lyhytNimi" : "Other or Unknown Education in Health and Welfare, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_775000",
   "koodiArvo" : "775000",
@@ -43130,7 +43130,7 @@
     "lyhytNimi" : "Specialist Training of Doctors",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_775100",
   "koodiArvo" : "775100",
@@ -43147,7 +43147,7 @@
     "lyhytNimi" : "Specialist Degree in Medicine",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_775101",
   "koodiArvo" : "775101",
@@ -43164,7 +43164,7 @@
     "lyhytNimi" : "Specialist Degree in Medicine",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_775200",
   "koodiArvo" : "775200",
@@ -43181,7 +43181,7 @@
     "lyhytNimi" : "Specialist Degree in Dentistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_775201",
   "koodiArvo" : "775201",
@@ -43198,7 +43198,7 @@
     "lyhytNimi" : "Specialist Degree in Dentistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_775300",
   "koodiArvo" : "775300",
@@ -43215,7 +43215,7 @@
     "lyhytNimi" : "Specialist Degree in Veterinary Medicine",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_775301",
   "koodiArvo" : "775301",
@@ -43232,7 +43232,7 @@
     "lyhytNimi" : "Specialist Degree in Veterinary Medicine",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_775900",
   "koodiArvo" : "775900",
@@ -43249,7 +43249,7 @@
     "lyhytNimi" : "Other Specialist Training of Doctors",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_775999",
   "koodiArvo" : "775999",
@@ -43266,7 +43266,7 @@
     "lyhytNimi" : "Other or Unknown Specialist Training of Doctors",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_781000",
   "koodiArvo" : "781000",
@@ -43283,7 +43283,7 @@
     "lyhytNimi" : "Polytechnic Master's Degree in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_781100",
   "koodiArvo" : "781100",
@@ -43300,7 +43300,7 @@
     "lyhytNimi" : "Polytechnic Master's Degree in Hotel, Catering and Home Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_781101",
   "koodiArvo" : "781101",
@@ -43317,7 +43317,7 @@
     "lyhytNimi" : "Master of Hospitality Management (Polytechnic), Hotel and Restaurant",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_781102",
   "koodiArvo" : "781102",
@@ -43334,7 +43334,7 @@
     "lyhytNimi" : "Master of Hospitality Management (Polytechnic), Tourism",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_781103",
   "koodiArvo" : "781103",
@@ -43351,7 +43351,7 @@
     "lyhytNimi" : "Master of Hospitality Management (Polytechnic), Business Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_781199",
   "koodiArvo" : "781199",
@@ -43368,7 +43368,7 @@
     "lyhytNimi" : "Master of Hospitality Management (Polytechnic), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_781200",
   "koodiArvo" : "781200",
@@ -43385,7 +43385,7 @@
     "lyhytNimi" : "Master of Sports Studies (Polytechnic)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_781202",
   "koodiArvo" : "781202",
@@ -43402,7 +43402,7 @@
     "lyhytNimi" : "Master of Sports Studies (Polytechnic), Sports Instructor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_781300",
   "koodiArvo" : "781300",
@@ -43419,7 +43419,7 @@
     "lyhytNimi" : "Master of Beauty and Cosmetics (Polytechnic)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_781301",
   "koodiArvo" : "781301",
@@ -43436,7 +43436,7 @@
     "lyhytNimi" : "Master of Beauty and Cosmetics (Polytechnic)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_781400",
   "koodiArvo" : "781400",
@@ -43453,7 +43453,7 @@
     "lyhytNimi" : "Polytechnic Master's Degree in Seafaring",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_781401",
   "koodiArvo" : "781401",
@@ -43470,7 +43470,7 @@
     "lyhytNimi" : "Master of Marine Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_781501",
   "koodiArvo" : "781501",
@@ -43483,7 +43483,7 @@
     "lyhytNimi" : "",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_781900",
   "koodiArvo" : "781900",
@@ -43500,7 +43500,7 @@
     "lyhytNimi" : "Other Polytechnic Master's Degree in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_781901",
   "koodiArvo" : "781901",
@@ -43517,7 +43517,7 @@
     "lyhytNimi" : "Master of Business Administration (Polytechnic), Security Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_781999",
   "koodiArvo" : "781999",
@@ -43534,7 +43534,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic Master's  Degree in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_782000",
   "koodiArvo" : "782000",
@@ -43551,7 +43551,7 @@
     "lyhytNimi" : "Education in Services, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_782200",
   "koodiArvo" : "782200",
@@ -43568,7 +43568,7 @@
     "lyhytNimi" : "Master of Science (Sport and Health Sciences)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_782201",
   "koodiArvo" : "782201",
@@ -43585,7 +43585,7 @@
     "lyhytNimi" : "Master of Science (Sport and Health Sciences)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_782600",
   "koodiArvo" : "782600",
@@ -43602,7 +43602,7 @@
     "lyhytNimi" : "Education in Military Science, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_782601",
   "koodiArvo" : "782601",
@@ -43619,7 +43619,7 @@
     "lyhytNimi" : "Officer (1981-)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_782602",
   "koodiArvo" : "782602",
@@ -43636,7 +43636,7 @@
     "lyhytNimi" : "General Staff Officer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_782603",
   "koodiArvo" : "782603",
@@ -43653,7 +43653,7 @@
     "lyhytNimi" : "Master of Arts (Military Science)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_782604",
   "koodiArvo" : "782604",
@@ -43670,7 +43670,7 @@
     "lyhytNimi" : "Senior Staff Officer",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_782900",
   "koodiArvo" : "782900",
@@ -43687,7 +43687,7 @@
     "lyhytNimi" : "Other Education in Services, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_782999",
   "koodiArvo" : "782999",
@@ -43704,7 +43704,7 @@
     "lyhytNimi" : "Other or Unknown Education in Services, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_791000",
   "koodiArvo" : "791000",
@@ -43721,7 +43721,7 @@
     "lyhytNimi" : "Other Polytechnic Master's Degree",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_791900",
   "koodiArvo" : "791900",
@@ -43738,7 +43738,7 @@
     "lyhytNimi" : "Other Polytechnic Master's Degree",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_791999",
   "koodiArvo" : "791999",
@@ -43755,7 +43755,7 @@
     "lyhytNimi" : "Other or Unknown Polytechnic Master's Degree",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_792000",
   "koodiArvo" : "792000",
@@ -43772,7 +43772,7 @@
     "lyhytNimi" : "Master of Arts, Other Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_792900",
   "koodiArvo" : "792900",
@@ -43789,7 +43789,7 @@
     "lyhytNimi" : "Master of Arts, Other Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_792999",
   "koodiArvo" : "792999",
@@ -43806,7 +43806,7 @@
     "lyhytNimi" : "Master of Philosophy, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_799000",
   "koodiArvo" : "799000",
@@ -43823,7 +43823,7 @@
     "lyhytNimi" : "Other Education, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_799900",
   "koodiArvo" : "799900",
@@ -43840,7 +43840,7 @@
     "lyhytNimi" : "Other Education, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_799999",
   "koodiArvo" : "799999",
@@ -43857,7 +43857,7 @@
     "lyhytNimi" : "Other or Unknown Education, Higher-Degree Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_812000",
   "koodiArvo" : "812000",
@@ -43874,7 +43874,7 @@
     "lyhytNimi" : "Licentiate of Philosophy (Education)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_812100",
   "koodiArvo" : "812100",
@@ -43891,7 +43891,7 @@
     "lyhytNimi" : "Licentiate of Philosophy (Education)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_812101",
   "koodiArvo" : "812101",
@@ -43908,7 +43908,7 @@
     "lyhytNimi" : "Licentiate of Philosophy (Education), Educational Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_812102",
   "koodiArvo" : "812102",
@@ -43925,7 +43925,7 @@
     "lyhytNimi" : "Licentiate of Philosophy (Education), Adult Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_812103",
   "koodiArvo" : "812103",
@@ -43942,7 +43942,7 @@
     "lyhytNimi" : "Licentiate of Philosophy (Education), Special Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_812105",
   "koodiArvo" : "812105",
@@ -43959,7 +43959,7 @@
     "lyhytNimi" : "Licentiate of Philosophy (Education), Textiles and Related Crafts, Technical Handicraft and Home Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_812199",
   "koodiArvo" : "812199",
@@ -43976,7 +43976,7 @@
     "lyhytNimi" : "Licentiate of Philosophy (Education), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_812201",
   "koodiArvo" : "812201",
@@ -43993,7 +43993,7 @@
     "lyhytNimi" : "",
     "kieli" : "EN"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_815000",
   "koodiArvo" : "815000",
@@ -44010,7 +44010,7 @@
     "lyhytNimi" : "Doctor of Philosophy (Education)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_815100",
   "koodiArvo" : "815100",
@@ -44027,7 +44027,7 @@
     "lyhytNimi" : "Doctor of Philosophy (Education)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_815101",
   "koodiArvo" : "815101",
@@ -44044,7 +44044,7 @@
     "lyhytNimi" : "Doctor of Philosophy (Education), Educational Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_815102",
   "koodiArvo" : "815102",
@@ -44061,7 +44061,7 @@
     "lyhytNimi" : "Doctor of Philosophy (Education), Adult Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_815103",
   "koodiArvo" : "815103",
@@ -44078,7 +44078,7 @@
     "lyhytNimi" : "Doctor of Philosophy (Education), Special Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_815105",
   "koodiArvo" : "815105",
@@ -44095,7 +44095,7 @@
     "lyhytNimi" : "Doctor of Philosophy (Education), Textiles and Related Crafts, Technical Handicraft and Home Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_815199",
   "koodiArvo" : "815199",
@@ -44112,7 +44112,7 @@
     "lyhytNimi" : "Doctor of Philosophy (Education), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_815200",
   "koodiArvo" : "815200",
@@ -44129,7 +44129,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_815201",
   "koodiArvo" : "815201",
@@ -44146,7 +44146,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Educational Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_819000",
   "koodiArvo" : "819000",
@@ -44163,7 +44163,7 @@
     "lyhytNimi" : "Other Education in Educational Science, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_819900",
   "koodiArvo" : "819900",
@@ -44180,7 +44180,7 @@
     "lyhytNimi" : "Other Education in Educational Science, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_819999",
   "koodiArvo" : "819999",
@@ -44197,7 +44197,7 @@
     "lyhytNimi" : "Other or Unknown Education in Educational Science, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_822000",
   "koodiArvo" : "822000",
@@ -44214,7 +44214,7 @@
     "lyhytNimi" : "Licentiate of Arts (Art and Design)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_822100",
   "koodiArvo" : "822100",
@@ -44231,7 +44231,7 @@
     "lyhytNimi" : "Licentiate of Arts (Art and Design)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_822101",
   "koodiArvo" : "822101",
@@ -44248,7 +44248,7 @@
     "lyhytNimi" : "Licentiate of Arts (Art and Design)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_822200",
   "koodiArvo" : "822200",
@@ -44265,7 +44265,7 @@
     "lyhytNimi" : "Licentiate of Music",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_822201",
   "koodiArvo" : "822201",
@@ -44276,7 +44276,7 @@
     "nimi" : "Mus. lis., taiteilijakoulutus",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_822202",
   "koodiArvo" : "822202",
@@ -44287,7 +44287,7 @@
     "nimi" : "Mus. lis., tutkijakoulutus",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_822203",
   "koodiArvo" : "822203",
@@ -44298,7 +44298,7 @@
     "nimi" : "Mus. lis., kehittäjäkoulutus",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_822211",
   "koodiArvo" : "822211",
@@ -44315,7 +44315,7 @@
     "lyhytNimi" : "Licentiate of Music",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_822299",
   "koodiArvo" : "822299",
@@ -44326,7 +44326,7 @@
     "nimi" : "Mus. lis., muu tai tuntematon linja",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_822400",
   "koodiArvo" : "822400",
@@ -44343,7 +44343,7 @@
     "lyhytNimi" : "Licentiate of Arts (Theatre and Drama)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_822401",
   "koodiArvo" : "822401",
@@ -44360,7 +44360,7 @@
     "lyhytNimi" : "Licentiate of Arts (Theatre and Drama)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_822500",
   "koodiArvo" : "822500",
@@ -44377,7 +44377,7 @@
     "lyhytNimi" : "Licentiate of Arts (Dance)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_822501",
   "koodiArvo" : "822501",
@@ -44394,7 +44394,7 @@
     "lyhytNimi" : "Licentiate of Arts (Dance)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_822900",
   "koodiArvo" : "822900",
@@ -44411,7 +44411,7 @@
     "lyhytNimi" : "Other Licentiate Programme in Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_822999",
   "koodiArvo" : "822999",
@@ -44428,7 +44428,7 @@
     "lyhytNimi" : "Other or Unknown Licentiate Programme in Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823000",
   "koodiArvo" : "823000",
@@ -44445,7 +44445,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Humanities",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823100",
   "koodiArvo" : "823100",
@@ -44462,7 +44462,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Linguistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823101",
   "koodiArvo" : "823101",
@@ -44479,7 +44479,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Finnish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823102",
   "koodiArvo" : "823102",
@@ -44496,7 +44496,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Swedish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823103",
   "koodiArvo" : "823103",
@@ -44513,7 +44513,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, English Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823104",
   "koodiArvo" : "823104",
@@ -44530,7 +44530,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, German Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823105",
   "koodiArvo" : "823105",
@@ -44547,7 +44547,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, French Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823106",
   "koodiArvo" : "823106",
@@ -44564,7 +44564,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Russian Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823107",
   "koodiArvo" : "823107",
@@ -44581,7 +44581,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Spanish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823108",
   "koodiArvo" : "823108",
@@ -44598,7 +44598,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Italian Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823109",
   "koodiArvo" : "823109",
@@ -44615,7 +44615,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Sami Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823110",
   "koodiArvo" : "823110",
@@ -44632,7 +44632,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Finno-Ugrian Languages",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823111",
   "koodiArvo" : "823111",
@@ -44649,7 +44649,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Hungarian Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823112",
   "koodiArvo" : "823112",
@@ -44666,7 +44666,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Baltic Languages",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823113",
   "koodiArvo" : "823113",
@@ -44683,7 +44683,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Classical Languages",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823114",
   "koodiArvo" : "823114",
@@ -44700,7 +44700,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Slavonic Languages",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823115",
   "koodiArvo" : "823115",
@@ -44717,7 +44717,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Sign Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823199",
   "koodiArvo" : "823199",
@@ -44734,7 +44734,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Other or Unknown Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823200",
   "koodiArvo" : "823200",
@@ -44751,7 +44751,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Translation and Interpretation",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823201",
   "koodiArvo" : "823201",
@@ -44768,7 +44768,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Translation and Interpretation, Finnish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823202",
   "koodiArvo" : "823202",
@@ -44785,7 +44785,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Translation and Interpretation, Swedish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823203",
   "koodiArvo" : "823203",
@@ -44802,7 +44802,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Translation and Interpretation, English Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823204",
   "koodiArvo" : "823204",
@@ -44819,7 +44819,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Translation and Interpretation, German Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823205",
   "koodiArvo" : "823205",
@@ -44836,7 +44836,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Translation and Interpretation, French Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823206",
   "koodiArvo" : "823206",
@@ -44853,7 +44853,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Translation and Interpretation, Russian Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823207",
   "koodiArvo" : "823207",
@@ -44870,7 +44870,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Translation and Interpretation, Spanish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823208",
   "koodiArvo" : "823208",
@@ -44887,7 +44887,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Translation and Interpretation, Italian Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823299",
   "koodiArvo" : "823299",
@@ -44904,7 +44904,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Other or Unknown Translation and Interpretation",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823300",
   "koodiArvo" : "823300",
@@ -44921,7 +44921,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, History and Archeology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823301",
   "koodiArvo" : "823301",
@@ -44938,7 +44938,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, History",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823302",
   "koodiArvo" : "823302",
@@ -44955,7 +44955,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Archeology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823400",
   "koodiArvo" : "823400",
@@ -44972,7 +44972,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Literature, Cultural Research and Linguistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823401",
   "koodiArvo" : "823401",
@@ -44989,7 +44989,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Literature",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823402",
   "koodiArvo" : "823402",
@@ -45006,7 +45006,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Cultural Research",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823403",
   "koodiArvo" : "823403",
@@ -45023,7 +45023,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Linguistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823404",
   "koodiArvo" : "823404",
@@ -45040,7 +45040,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Speech Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823500",
   "koodiArvo" : "823500",
@@ -45057,7 +45057,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Arts Research",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823501",
   "koodiArvo" : "823501",
@@ -45074,7 +45074,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Art History and Art Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823502",
   "koodiArvo" : "823502",
@@ -45091,7 +45091,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Musicology and Music Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823503",
   "koodiArvo" : "823503",
@@ -45108,7 +45108,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Theatre",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823599",
   "koodiArvo" : "823599",
@@ -45125,7 +45125,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Other or Unknown Arts Research Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823600",
   "koodiArvo" : "823600",
@@ -45142,7 +45142,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Communication and Information Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823601",
   "koodiArvo" : "823601",
@@ -45159,7 +45159,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Communication and Information Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823700",
   "koodiArvo" : "823700",
@@ -45176,7 +45176,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Philosophy (Humanities)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823701",
   "koodiArvo" : "823701",
@@ -45193,7 +45193,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Philosophy (Humanities)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823900",
   "koodiArvo" : "823900",
@@ -45210,7 +45210,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Other Field in Humanities",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_823999",
   "koodiArvo" : "823999",
@@ -45227,7 +45227,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Other or Unknown Field in Humanities",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_824000",
   "koodiArvo" : "824000",
@@ -45244,7 +45244,7 @@
     "lyhytNimi" : "Licentiate of Theology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_824100",
   "koodiArvo" : "824100",
@@ -45261,7 +45261,7 @@
     "lyhytNimi" : "Licentiate of Theology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_824101",
   "koodiArvo" : "824101",
@@ -45278,7 +45278,7 @@
     "lyhytNimi" : "Licentiate of Theology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_825000",
   "koodiArvo" : "825000",
@@ -45295,7 +45295,7 @@
     "lyhytNimi" : "Doctor of Arts (Art and Design)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_825100",
   "koodiArvo" : "825100",
@@ -45312,7 +45312,7 @@
     "lyhytNimi" : "Doctor of Arts (Art and Design)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_825101",
   "koodiArvo" : "825101",
@@ -45329,7 +45329,7 @@
     "lyhytNimi" : "Doctor of Arts (Art and Design)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_825200",
   "koodiArvo" : "825200",
@@ -45346,7 +45346,7 @@
     "lyhytNimi" : "Doctor of Music",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_825201",
   "koodiArvo" : "825201",
@@ -45357,7 +45357,7 @@
     "nimi" : "Mus. toht., taiteilijakoulutus",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_825202",
   "koodiArvo" : "825202",
@@ -45368,7 +45368,7 @@
     "nimi" : "Mus. toht., tutkijakoulutus",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_825203",
   "koodiArvo" : "825203",
@@ -45379,7 +45379,7 @@
     "nimi" : "Mus. toht., kehittäjäkoulutus",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_825211",
   "koodiArvo" : "825211",
@@ -45396,7 +45396,7 @@
     "lyhytNimi" : "Doctor of Music",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_825299",
   "koodiArvo" : "825299",
@@ -45407,7 +45407,7 @@
     "nimi" : "Mus. toht., muu tai tuntematon linja",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_825300",
   "koodiArvo" : "825300",
@@ -45424,7 +45424,7 @@
     "lyhytNimi" : "Doctor of Fine Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_825301",
   "koodiArvo" : "825301",
@@ -45441,7 +45441,7 @@
     "lyhytNimi" : "Doctor of Fine Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_825400",
   "koodiArvo" : "825400",
@@ -45458,7 +45458,7 @@
     "lyhytNimi" : "Doctor of Arts (Theatre and Drama)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_825401",
   "koodiArvo" : "825401",
@@ -45475,7 +45475,7 @@
     "lyhytNimi" : "Doctor of Arts (Theatre and Drama)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_825500",
   "koodiArvo" : "825500",
@@ -45492,7 +45492,7 @@
     "lyhytNimi" : "Doctor of Arts (Dance)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_825501",
   "koodiArvo" : "825501",
@@ -45509,7 +45509,7 @@
     "lyhytNimi" : "Doctor of Arts (Dance)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_825900",
   "koodiArvo" : "825900",
@@ -45526,7 +45526,7 @@
     "lyhytNimi" : "Other Doctoral Programme in Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_825901",
   "koodiArvo" : "825901",
@@ -45543,7 +45543,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Industrial Art",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_825999",
   "koodiArvo" : "825999",
@@ -45560,7 +45560,7 @@
     "lyhytNimi" : "Other or Unknown Doctoral Programme in Arts",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826000",
   "koodiArvo" : "826000",
@@ -45577,7 +45577,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Humanities",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826100",
   "koodiArvo" : "826100",
@@ -45594,7 +45594,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Linguistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826101",
   "koodiArvo" : "826101",
@@ -45611,7 +45611,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Finnish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826102",
   "koodiArvo" : "826102",
@@ -45628,7 +45628,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Swedish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826103",
   "koodiArvo" : "826103",
@@ -45645,7 +45645,7 @@
     "lyhytNimi" : "Doctor of Philosophy, English Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826104",
   "koodiArvo" : "826104",
@@ -45662,7 +45662,7 @@
     "lyhytNimi" : "Doctor of Philosophy, German Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826105",
   "koodiArvo" : "826105",
@@ -45679,7 +45679,7 @@
     "lyhytNimi" : "Doctor of Philosophy, French Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826106",
   "koodiArvo" : "826106",
@@ -45696,7 +45696,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Russian Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826107",
   "koodiArvo" : "826107",
@@ -45713,7 +45713,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Spanish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826108",
   "koodiArvo" : "826108",
@@ -45730,7 +45730,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Italian Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826109",
   "koodiArvo" : "826109",
@@ -45747,7 +45747,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Sami Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826110",
   "koodiArvo" : "826110",
@@ -45764,7 +45764,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Finno-Ugrian Languages",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826111",
   "koodiArvo" : "826111",
@@ -45781,7 +45781,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Hungarian Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826112",
   "koodiArvo" : "826112",
@@ -45798,7 +45798,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Baltic Languages",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826113",
   "koodiArvo" : "826113",
@@ -45815,7 +45815,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Classical Languages",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826114",
   "koodiArvo" : "826114",
@@ -45832,7 +45832,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Slavonic Languages",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826115",
   "koodiArvo" : "826115",
@@ -45849,7 +45849,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Sign Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826199",
   "koodiArvo" : "826199",
@@ -45866,7 +45866,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Other or Unknown Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826200",
   "koodiArvo" : "826200",
@@ -45883,7 +45883,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Translation and Interpretation",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826201",
   "koodiArvo" : "826201",
@@ -45900,7 +45900,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Translation and Interpretation, Finnish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826202",
   "koodiArvo" : "826202",
@@ -45917,7 +45917,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Translation and Interpretation, Swedish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826203",
   "koodiArvo" : "826203",
@@ -45934,7 +45934,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Translation and Interpretation, English Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826204",
   "koodiArvo" : "826204",
@@ -45951,7 +45951,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Translation and Interpretation, German Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826205",
   "koodiArvo" : "826205",
@@ -45968,7 +45968,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Translation and Interpretation, French Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826206",
   "koodiArvo" : "826206",
@@ -45985,7 +45985,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Translation and Interpretation, Russian Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826207",
   "koodiArvo" : "826207",
@@ -46002,7 +46002,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Translation and Interpretation, Spanish Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826208",
   "koodiArvo" : "826208",
@@ -46019,7 +46019,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Translation and Interpretation, Italian Language",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826299",
   "koodiArvo" : "826299",
@@ -46036,7 +46036,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Other or Unknown Translation and Interpretation",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826300",
   "koodiArvo" : "826300",
@@ -46053,7 +46053,7 @@
     "lyhytNimi" : "Doctor of Philosophy, History and Archeology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826301",
   "koodiArvo" : "826301",
@@ -46070,7 +46070,7 @@
     "lyhytNimi" : "Doctor of Philosophy, History",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826302",
   "koodiArvo" : "826302",
@@ -46087,7 +46087,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Archeology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826400",
   "koodiArvo" : "826400",
@@ -46104,7 +46104,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Literature, Cultural Research and Linguistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826401",
   "koodiArvo" : "826401",
@@ -46121,7 +46121,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Literature",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826402",
   "koodiArvo" : "826402",
@@ -46138,7 +46138,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Cultural Research",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826403",
   "koodiArvo" : "826403",
@@ -46155,7 +46155,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Linguistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826404",
   "koodiArvo" : "826404",
@@ -46172,7 +46172,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Speech Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826500",
   "koodiArvo" : "826500",
@@ -46189,7 +46189,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Arts Research",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826501",
   "koodiArvo" : "826501",
@@ -46206,7 +46206,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Art History and Art Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826502",
   "koodiArvo" : "826502",
@@ -46223,7 +46223,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Musicology and Music Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826503",
   "koodiArvo" : "826503",
@@ -46240,7 +46240,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Theatre",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826599",
   "koodiArvo" : "826599",
@@ -46257,7 +46257,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Other or Unknown Arts Research Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826600",
   "koodiArvo" : "826600",
@@ -46274,7 +46274,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Communication and Information Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826601",
   "koodiArvo" : "826601",
@@ -46291,7 +46291,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Communication and Information Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826700",
   "koodiArvo" : "826700",
@@ -46308,7 +46308,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Philosophy (Humanities)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826701",
   "koodiArvo" : "826701",
@@ -46325,7 +46325,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Philosophy (Humanities)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826900",
   "koodiArvo" : "826900",
@@ -46342,7 +46342,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Other Field in Humanities",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826901",
   "koodiArvo" : "826901",
@@ -46359,7 +46359,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Theology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_826999",
   "koodiArvo" : "826999",
@@ -46376,7 +46376,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Other or Unknown Field in Humanitites",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_827000",
   "koodiArvo" : "827000",
@@ -46393,7 +46393,7 @@
     "lyhytNimi" : "Doctor of Theology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_827100",
   "koodiArvo" : "827100",
@@ -46410,7 +46410,7 @@
     "lyhytNimi" : "Doctor of Theology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_827101",
   "koodiArvo" : "827101",
@@ -46427,7 +46427,7 @@
     "lyhytNimi" : "Doctor of Theology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_829000",
   "koodiArvo" : "829000",
@@ -46444,7 +46444,7 @@
     "lyhytNimi" : "Other Education in Humanities and Arts, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_829900",
   "koodiArvo" : "829900",
@@ -46461,7 +46461,7 @@
     "lyhytNimi" : "Other Education in Humanities and arts, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_829999",
   "koodiArvo" : "829999",
@@ -46478,7 +46478,7 @@
     "lyhytNimi" : "Education in Humanities and Arts, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_832000",
   "koodiArvo" : "832000",
@@ -46495,7 +46495,7 @@
     "lyhytNimi" : "Education in Business, Licentiate",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_832100",
   "koodiArvo" : "832100",
@@ -46512,7 +46512,7 @@
     "lyhytNimi" : "Licentiate of Science (Business and Administration)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_832101",
   "koodiArvo" : "832101",
@@ -46529,7 +46529,7 @@
     "lyhytNimi" : "Licentiate of Science (Economics and Business Administration), Business Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_832105",
   "koodiArvo" : "832105",
@@ -46546,7 +46546,7 @@
     "lyhytNimi" : "Licentiate of Science (Economics and Business Administration), Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_832114",
   "koodiArvo" : "832114",
@@ -46563,7 +46563,7 @@
     "lyhytNimi" : "Licentiate of Science (Economics and Business Administration), Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_832115",
   "koodiArvo" : "832115",
@@ -46580,7 +46580,7 @@
     "lyhytNimi" : "Licentiate of Science (Economics and Business Administration), Information Systems Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_832199",
   "koodiArvo" : "832199",
@@ -46597,7 +46597,7 @@
     "lyhytNimi" : "Licentiate of Science (Economics and Business Administration), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_832300",
   "koodiArvo" : "832300",
@@ -46614,7 +46614,7 @@
     "lyhytNimi" : "Licentiate of Economic Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_832351",
   "koodiArvo" : "832351",
@@ -46631,7 +46631,7 @@
     "lyhytNimi" : "Licentiate of Science (Economics and Business Administration), Business Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_832355",
   "koodiArvo" : "832355",
@@ -46648,7 +46648,7 @@
     "lyhytNimi" : "Licentiate of Science (Economics and Business Administration), Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_832364",
   "koodiArvo" : "832364",
@@ -46665,7 +46665,7 @@
     "lyhytNimi" : "Licentiate of Science (Economics and Business Administration), Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_832365",
   "koodiArvo" : "832365",
@@ -46682,7 +46682,7 @@
     "lyhytNimi" : "Licentiate of Science (Economics and Business Administration), Information Systems Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_832399",
   "koodiArvo" : "832399",
@@ -46699,7 +46699,7 @@
     "lyhytNimi" : "Licentiate of Science (Economics and Business Administration), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_832900",
   "koodiArvo" : "832900",
@@ -46716,7 +46716,7 @@
     "lyhytNimi" : "Other Licentiate Programme in Business",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_832999",
   "koodiArvo" : "832999",
@@ -46733,7 +46733,7 @@
     "lyhytNimi" : "Other or Unknown Licentiate Programme in Business",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833000",
   "koodiArvo" : "833000",
@@ -46750,7 +46750,7 @@
     "lyhytNimi" : "Education in Social Sciences, Licentiate",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833100",
   "koodiArvo" : "833100",
@@ -46767,7 +46767,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833101",
   "koodiArvo" : "833101",
@@ -46784,7 +46784,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences, Political Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833102",
   "koodiArvo" : "833102",
@@ -46801,7 +46801,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences, Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833103",
   "koodiArvo" : "833103",
@@ -46818,7 +46818,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences, Social Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833105",
   "koodiArvo" : "833105",
@@ -46835,7 +46835,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences, Psychology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833106",
   "koodiArvo" : "833106",
@@ -46852,7 +46852,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences, Communication Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833107",
   "koodiArvo" : "833107",
@@ -46869,7 +46869,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences, Philosophy",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833108",
   "koodiArvo" : "833108",
@@ -46886,7 +46886,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences, Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833110",
   "koodiArvo" : "833110",
@@ -46903,7 +46903,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences, Regional and Environmental Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833199",
   "koodiArvo" : "833199",
@@ -46920,7 +46920,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833200",
   "koodiArvo" : "833200",
@@ -46937,7 +46937,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833201",
   "koodiArvo" : "833201",
@@ -46954,7 +46954,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences, Political Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833202",
   "koodiArvo" : "833202",
@@ -46971,7 +46971,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences, Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833203",
   "koodiArvo" : "833203",
@@ -46988,7 +46988,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences, Social Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833205",
   "koodiArvo" : "833205",
@@ -47005,7 +47005,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences, Psychology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833206",
   "koodiArvo" : "833206",
@@ -47022,7 +47022,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences, Communication Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833207",
   "koodiArvo" : "833207",
@@ -47039,7 +47039,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences, Philosophy",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833208",
   "koodiArvo" : "833208",
@@ -47056,7 +47056,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences, Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833209",
   "koodiArvo" : "833209",
@@ -47073,7 +47073,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences, Computer Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833210",
   "koodiArvo" : "833210",
@@ -47090,7 +47090,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences, Regional and Environmental Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833211",
   "koodiArvo" : "833211",
@@ -47107,7 +47107,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences, Tourism",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833299",
   "koodiArvo" : "833299",
@@ -47124,7 +47124,7 @@
     "lyhytNimi" : "Licentiate of Social Sciences, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833300",
   "koodiArvo" : "833300",
@@ -47141,7 +47141,7 @@
     "lyhytNimi" : "Licentiate of Administrative Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833301",
   "koodiArvo" : "833301",
@@ -47158,7 +47158,7 @@
     "lyhytNimi" : "Licentiate of Administrative Sciences, Administrative Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833310",
   "koodiArvo" : "833310",
@@ -47175,7 +47175,7 @@
     "lyhytNimi" : "Licentiate of Administrative Sciences, Regional and Environmental Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833399",
   "koodiArvo" : "833399",
@@ -47192,7 +47192,7 @@
     "lyhytNimi" : "Licentiate of Administrative Sciences, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833400",
   "koodiArvo" : "833400",
@@ -47209,7 +47209,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833401",
   "koodiArvo" : "833401",
@@ -47226,7 +47226,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Political Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833402",
   "koodiArvo" : "833402",
@@ -47243,7 +47243,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833403",
   "koodiArvo" : "833403",
@@ -47260,7 +47260,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Social Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833404",
   "koodiArvo" : "833404",
@@ -47277,7 +47277,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833405",
   "koodiArvo" : "833405",
@@ -47294,7 +47294,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Psychology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833407",
   "koodiArvo" : "833407",
@@ -47311,7 +47311,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Philosophy (Social Sciences)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833408",
   "koodiArvo" : "833408",
@@ -47328,7 +47328,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Statistics (Social Sciences)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833499",
   "koodiArvo" : "833499",
@@ -47345,7 +47345,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Social Sciences, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833500",
   "koodiArvo" : "833500",
@@ -47362,7 +47362,7 @@
     "lyhytNimi" : "Licentiate of Arts (Psychology)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833501",
   "koodiArvo" : "833501",
@@ -47379,7 +47379,7 @@
     "lyhytNimi" : "Licentiate of Arts (Psychology)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833900",
   "koodiArvo" : "833900",
@@ -47396,7 +47396,7 @@
     "lyhytNimi" : "Other Licentiate Programme in Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_833999",
   "koodiArvo" : "833999",
@@ -47413,7 +47413,7 @@
     "lyhytNimi" : "Other or Unknown Licentiate Programme in Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_834000",
   "koodiArvo" : "834000",
@@ -47430,7 +47430,7 @@
     "lyhytNimi" : "Licentiate of Laws",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_834100",
   "koodiArvo" : "834100",
@@ -47447,7 +47447,7 @@
     "lyhytNimi" : "Licentiate of Laws",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_834101",
   "koodiArvo" : "834101",
@@ -47464,7 +47464,7 @@
     "lyhytNimi" : "Licentiate of Laws",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_835000",
   "koodiArvo" : "835000",
@@ -47481,7 +47481,7 @@
     "lyhytNimi" : "Education in Business, Doctor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_835100",
   "koodiArvo" : "835100",
@@ -47498,7 +47498,7 @@
     "lyhytNimi" : "Doctor of Science (Economics and Business Administration)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_835101",
   "koodiArvo" : "835101",
@@ -47515,7 +47515,7 @@
     "lyhytNimi" : "Doctor of Science (Economics and Business Administration), Business Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_835105",
   "koodiArvo" : "835105",
@@ -47532,7 +47532,7 @@
     "lyhytNimi" : "Doctor of Science (Economics and Business Administration), Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_835114",
   "koodiArvo" : "835114",
@@ -47549,7 +47549,7 @@
     "lyhytNimi" : "Doctor of Science (Economics and Business Administration), Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_835115",
   "koodiArvo" : "835115",
@@ -47566,7 +47566,7 @@
     "lyhytNimi" : "Doctor of Science (Economics and Business Administration), Information Systems Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_835199",
   "koodiArvo" : "835199",
@@ -47583,7 +47583,7 @@
     "lyhytNimi" : "Doctor of Science (Economics and Business Administration), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_835300",
   "koodiArvo" : "835300",
@@ -47600,7 +47600,7 @@
     "lyhytNimi" : "Doctor of Science (Economics and Business Administration)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_835351",
   "koodiArvo" : "835351",
@@ -47617,7 +47617,7 @@
     "lyhytNimi" : "Doctor of Science (Economics and Business Administration), Business Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_835355",
   "koodiArvo" : "835355",
@@ -47634,7 +47634,7 @@
     "lyhytNimi" : "Doctor of Science (Economics and Business Administration), Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_835365",
   "koodiArvo" : "835365",
@@ -47651,7 +47651,7 @@
     "lyhytNimi" : "Doctor of Science (Economics and Business Administration), Information Systems Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_835399",
   "koodiArvo" : "835399",
@@ -47668,7 +47668,7 @@
     "lyhytNimi" : "Doctor of Science (Economics and Business Administration), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_835900",
   "koodiArvo" : "835900",
@@ -47685,7 +47685,7 @@
     "lyhytNimi" : "Other Doctoral Programme in Business",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_835999",
   "koodiArvo" : "835999",
@@ -47702,7 +47702,7 @@
     "lyhytNimi" : "Other or Unknown Doctoral Programme in Business",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836000",
   "koodiArvo" : "836000",
@@ -47719,7 +47719,7 @@
     "lyhytNimi" : "Education in Social Sciences, Doctor",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836100",
   "koodiArvo" : "836100",
@@ -47736,7 +47736,7 @@
     "lyhytNimi" : "Doctor of Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836101",
   "koodiArvo" : "836101",
@@ -47753,7 +47753,7 @@
     "lyhytNimi" : "Doctor of Social Sciences, Political Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836102",
   "koodiArvo" : "836102",
@@ -47770,7 +47770,7 @@
     "lyhytNimi" : "Doctor of Social Sciences, Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836103",
   "koodiArvo" : "836103",
@@ -47787,7 +47787,7 @@
     "lyhytNimi" : "Doctor of Social Sciences, Social Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836105",
   "koodiArvo" : "836105",
@@ -47804,7 +47804,7 @@
     "lyhytNimi" : "Doctor of Social Sciences, Psychology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836106",
   "koodiArvo" : "836106",
@@ -47821,7 +47821,7 @@
     "lyhytNimi" : "Doctor of Social Sciences, Communication Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836107",
   "koodiArvo" : "836107",
@@ -47838,7 +47838,7 @@
     "lyhytNimi" : "Doctor of Social Sciences, Philosophy",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836108",
   "koodiArvo" : "836108",
@@ -47855,7 +47855,7 @@
     "lyhytNimi" : "Doctor of Social Sciences, Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836110",
   "koodiArvo" : "836110",
@@ -47872,7 +47872,7 @@
     "lyhytNimi" : "Doctor of Social Sciences, Regional and Environmental Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836199",
   "koodiArvo" : "836199",
@@ -47889,7 +47889,7 @@
     "lyhytNimi" : "Doctor of Social Sciences, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836200",
   "koodiArvo" : "836200",
@@ -47906,7 +47906,7 @@
     "lyhytNimi" : "Doctor of Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836201",
   "koodiArvo" : "836201",
@@ -47923,7 +47923,7 @@
     "lyhytNimi" : "Doctor of Social Sciences, Political Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836202",
   "koodiArvo" : "836202",
@@ -47940,7 +47940,7 @@
     "lyhytNimi" : "Doctor of Social Sciences, Economics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836203",
   "koodiArvo" : "836203",
@@ -47957,7 +47957,7 @@
     "lyhytNimi" : "Doctor of Social Sciences, Social Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836205",
   "koodiArvo" : "836205",
@@ -47974,7 +47974,7 @@
     "lyhytNimi" : "Doctor of Social Sciences, Psychology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836206",
   "koodiArvo" : "836206",
@@ -47991,7 +47991,7 @@
     "lyhytNimi" : "Doctor of Social Sciences, Communication Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836207",
   "koodiArvo" : "836207",
@@ -48008,7 +48008,7 @@
     "lyhytNimi" : "Doctor of Social Sciences, Philosophy",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836208",
   "koodiArvo" : "836208",
@@ -48025,7 +48025,7 @@
     "lyhytNimi" : "Doctor of Social Sciences, Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836209",
   "koodiArvo" : "836209",
@@ -48042,7 +48042,7 @@
     "lyhytNimi" : "Doctor of Social Sciences, Computer Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836210",
   "koodiArvo" : "836210",
@@ -48059,7 +48059,7 @@
     "lyhytNimi" : "Doctor of Social Sciences, Regional and Environmental Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836211",
   "koodiArvo" : "836211",
@@ -48076,7 +48076,7 @@
     "lyhytNimi" : "Doctor of Social Sciences, Tourism",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836299",
   "koodiArvo" : "836299",
@@ -48093,7 +48093,7 @@
     "lyhytNimi" : "Doctor of Social Sciences, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836300",
   "koodiArvo" : "836300",
@@ -48110,7 +48110,7 @@
     "lyhytNimi" : "Doctor of Administrative Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836301",
   "koodiArvo" : "836301",
@@ -48127,7 +48127,7 @@
     "lyhytNimi" : "Doctor of Administrative Sciences, Administrative Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836310",
   "koodiArvo" : "836310",
@@ -48144,7 +48144,7 @@
     "lyhytNimi" : "Doctor of Administrative Sciences, Regional and Environmental Studies",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836399",
   "koodiArvo" : "836399",
@@ -48161,7 +48161,7 @@
     "lyhytNimi" : "Doctor of Administrative Sciences, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836500",
   "koodiArvo" : "836500",
@@ -48178,7 +48178,7 @@
     "lyhytNimi" : "Doctor of Philosophy (Psychology)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836501",
   "koodiArvo" : "836501",
@@ -48195,7 +48195,7 @@
     "lyhytNimi" : "Doctor of Philosophy (Psychology)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836900",
   "koodiArvo" : "836900",
@@ -48212,7 +48212,7 @@
     "lyhytNimi" : "Other Doctoral Programme in Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_836999",
   "koodiArvo" : "836999",
@@ -48229,7 +48229,7 @@
     "lyhytNimi" : "Other or Unknown Doctoral Programme in Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_837000",
   "koodiArvo" : "837000",
@@ -48246,7 +48246,7 @@
     "lyhytNimi" : "Doctor of Laws",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_837300",
   "koodiArvo" : "837300",
@@ -48263,7 +48263,7 @@
     "lyhytNimi" : "Doctor of Laws",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_837301",
   "koodiArvo" : "837301",
@@ -48280,7 +48280,7 @@
     "lyhytNimi" : "Doctor of Laws",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_839000",
   "koodiArvo" : "839000",
@@ -48297,7 +48297,7 @@
     "lyhytNimi" : "Other Education in Social Sciences and Business, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_839100",
   "koodiArvo" : "839100",
@@ -48314,7 +48314,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Economics and Social Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_839101",
   "koodiArvo" : "839101",
@@ -48331,7 +48331,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Economics Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_839102",
   "koodiArvo" : "839102",
@@ -48348,7 +48348,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Social Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_839103",
   "koodiArvo" : "839103",
@@ -48365,7 +48365,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Psychology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_839104",
   "koodiArvo" : "839104",
@@ -48382,7 +48382,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Laws",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_839199",
   "koodiArvo" : "839199",
@@ -48399,7 +48399,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Other or Unknown Field in Social Sciences or Business",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_839900",
   "koodiArvo" : "839900",
@@ -48416,7 +48416,7 @@
     "lyhytNimi" : "Other Education in Social Sciences and Business, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_839999",
   "koodiArvo" : "839999",
@@ -48433,7 +48433,7 @@
     "lyhytNimi" : "Other or Unknown Education in Social Sciences and Business, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842000",
   "koodiArvo" : "842000",
@@ -48450,7 +48450,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Natural Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842100",
   "koodiArvo" : "842100",
@@ -48467,7 +48467,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Mathematics and Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842101",
   "koodiArvo" : "842101",
@@ -48484,7 +48484,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Mathematics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842102",
   "koodiArvo" : "842102",
@@ -48501,7 +48501,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Statistics (Natural Sciences)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842200",
   "koodiArvo" : "842200",
@@ -48518,7 +48518,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Computer Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842201",
   "koodiArvo" : "842201",
@@ -48535,7 +48535,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Computer Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842300",
   "koodiArvo" : "842300",
@@ -48552,7 +48552,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Physical Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842301",
   "koodiArvo" : "842301",
@@ -48569,7 +48569,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Physics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842302",
   "koodiArvo" : "842302",
@@ -48586,7 +48586,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Geophysics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842303",
   "koodiArvo" : "842303",
@@ -48603,7 +48603,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Meteorology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842304",
   "koodiArvo" : "842304",
@@ -48620,7 +48620,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Astronomy",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842400",
   "koodiArvo" : "842400",
@@ -48637,7 +48637,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Chemistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842401",
   "koodiArvo" : "842401",
@@ -48654,7 +48654,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Chemistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842500",
   "koodiArvo" : "842500",
@@ -48671,7 +48671,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Geology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842501",
   "koodiArvo" : "842501",
@@ -48688,7 +48688,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Geology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842600",
   "koodiArvo" : "842600",
@@ -48705,7 +48705,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Geography",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842601",
   "koodiArvo" : "842601",
@@ -48722,7 +48722,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Geography",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842700",
   "koodiArvo" : "842700",
@@ -48739,7 +48739,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Biology, Biosciences, Biochemistry and Ecology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842701",
   "koodiArvo" : "842701",
@@ -48756,7 +48756,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Biology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842702",
   "koodiArvo" : "842702",
@@ -48773,7 +48773,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Biosciences, Biochemistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842703",
   "koodiArvo" : "842703",
@@ -48790,7 +48790,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Environmental Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842704",
   "koodiArvo" : "842704",
@@ -48801,7 +48801,7 @@
     "nimi" : "Fil. lis., biotiede",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_842900",
   "koodiArvo" : "842900",
@@ -48818,7 +48818,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Other Field in Natural Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842901",
   "koodiArvo" : "842901",
@@ -48835,7 +48835,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Philosophy (Natural Sciences)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_842999",
   "koodiArvo" : "842999",
@@ -48852,7 +48852,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Other or Unknown Field in Natural Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845000",
   "koodiArvo" : "845000",
@@ -48869,7 +48869,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Natural Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845100",
   "koodiArvo" : "845100",
@@ -48886,7 +48886,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Mathematics and Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845101",
   "koodiArvo" : "845101",
@@ -48903,7 +48903,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Mathematics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845102",
   "koodiArvo" : "845102",
@@ -48920,7 +48920,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Statistics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845200",
   "koodiArvo" : "845200",
@@ -48937,7 +48937,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Computer Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845201",
   "koodiArvo" : "845201",
@@ -48954,7 +48954,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Computer Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845300",
   "koodiArvo" : "845300",
@@ -48971,7 +48971,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Physical Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845301",
   "koodiArvo" : "845301",
@@ -48988,7 +48988,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Physics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845302",
   "koodiArvo" : "845302",
@@ -49005,7 +49005,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Geophysics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845303",
   "koodiArvo" : "845303",
@@ -49022,7 +49022,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Meteorology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845304",
   "koodiArvo" : "845304",
@@ -49039,7 +49039,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Astronomy",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845400",
   "koodiArvo" : "845400",
@@ -49056,7 +49056,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Chemistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845401",
   "koodiArvo" : "845401",
@@ -49073,7 +49073,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Chemistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845500",
   "koodiArvo" : "845500",
@@ -49090,7 +49090,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Geology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845501",
   "koodiArvo" : "845501",
@@ -49107,7 +49107,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Geology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845600",
   "koodiArvo" : "845600",
@@ -49124,7 +49124,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Geography",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845601",
   "koodiArvo" : "845601",
@@ -49141,7 +49141,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Geography",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845700",
   "koodiArvo" : "845700",
@@ -49158,7 +49158,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Biology, Biosciences, Biochemistry and Ecology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845701",
   "koodiArvo" : "845701",
@@ -49175,7 +49175,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Biology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845702",
   "koodiArvo" : "845702",
@@ -49192,7 +49192,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Biosciences, Biochemistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845703",
   "koodiArvo" : "845703",
@@ -49209,7 +49209,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Environmental Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845704",
   "koodiArvo" : "845704",
@@ -49220,7 +49220,7 @@
     "nimi" : "Fil. toht., biotiede",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_845900",
   "koodiArvo" : "845900",
@@ -49237,7 +49237,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Other Field in Natural Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845901",
   "koodiArvo" : "845901",
@@ -49254,7 +49254,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Philosophy (Natural Sciences)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_845999",
   "koodiArvo" : "845999",
@@ -49271,7 +49271,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Other or Unknown Field in Natural Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_849000",
   "koodiArvo" : "849000",
@@ -49288,7 +49288,7 @@
     "lyhytNimi" : "Other Education in Natural Sciences, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_849900",
   "koodiArvo" : "849900",
@@ -49305,7 +49305,7 @@
     "lyhytNimi" : "Other Education in Natural Sciences, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_849999",
   "koodiArvo" : "849999",
@@ -49322,7 +49322,7 @@
     "lyhytNimi" : "Other or Unknown Education in Natural Sciences, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851000",
   "koodiArvo" : "851000",
@@ -49339,7 +49339,7 @@
     "lyhytNimi" : "Licentiate of Science in Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851100",
   "koodiArvo" : "851100",
@@ -49356,7 +49356,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Mechanical Engineering and Energy Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851101",
   "koodiArvo" : "851101",
@@ -49373,7 +49373,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Mechanical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851102",
   "koodiArvo" : "851102",
@@ -49390,7 +49390,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Energy Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851200",
   "koodiArvo" : "851200",
@@ -49407,7 +49407,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Electrical Engineering and Automation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851201",
   "koodiArvo" : "851201",
@@ -49424,7 +49424,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Electrical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851202",
   "koodiArvo" : "851202",
@@ -49441,7 +49441,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Automation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851203",
   "koodiArvo" : "851203",
@@ -49458,7 +49458,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Engineering Physics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851204",
   "koodiArvo" : "851204",
@@ -49475,7 +49475,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Science and Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851300",
   "koodiArvo" : "851300",
@@ -49492,7 +49492,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Information Technology and Telecommunications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851301",
   "koodiArvo" : "851301",
@@ -49509,7 +49509,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Information Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851302",
   "koodiArvo" : "851302",
@@ -49526,7 +49526,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Telecommunications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851400",
   "koodiArvo" : "851400",
@@ -49543,7 +49543,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Process Engineering and Materials Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851401",
   "koodiArvo" : "851401",
@@ -49560,7 +49560,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Chemical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851402",
   "koodiArvo" : "851402",
@@ -49577,7 +49577,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Process Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851403",
   "koodiArvo" : "851403",
@@ -49594,7 +49594,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Environmental Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851404",
   "koodiArvo" : "851404",
@@ -49611,7 +49611,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Wood Processing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851408",
   "koodiArvo" : "851408",
@@ -49628,7 +49628,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Materials Technology, Rock Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851409",
   "koodiArvo" : "851409",
@@ -49645,7 +49645,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Biotehcnology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851410",
   "koodiArvo" : "851410",
@@ -49675,7 +49675,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Building Construction and Surveying Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851501",
   "koodiArvo" : "851501",
@@ -49692,7 +49692,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Building Construction, Community Development",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851502",
   "koodiArvo" : "851502",
@@ -49709,7 +49709,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Surveying Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851600",
   "koodiArvo" : "851600",
@@ -49726,7 +49726,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Industrial Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851601",
   "koodiArvo" : "851601",
@@ -49743,7 +49743,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Industrial Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851800",
   "koodiArvo" : "851800",
@@ -49760,7 +49760,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Architecture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851801",
   "koodiArvo" : "851801",
@@ -49777,7 +49777,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Architecture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851900",
   "koodiArvo" : "851900",
@@ -49794,7 +49794,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Other Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851901",
   "koodiArvo" : "851901",
@@ -49811,7 +49811,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Textiles and Clothing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_851999",
   "koodiArvo" : "851999",
@@ -49828,7 +49828,7 @@
     "lyhytNimi" : "Licentiate of Science (Technology), Other or Unknown Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855000",
   "koodiArvo" : "855000",
@@ -49845,7 +49845,7 @@
     "lyhytNimi" : "Doctor of Science in Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855100",
   "koodiArvo" : "855100",
@@ -49862,7 +49862,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Mechanical Engineering and Energy Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855101",
   "koodiArvo" : "855101",
@@ -49879,7 +49879,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Mechanical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855102",
   "koodiArvo" : "855102",
@@ -49896,7 +49896,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Energy Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855200",
   "koodiArvo" : "855200",
@@ -49913,7 +49913,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Electrical Engineering and Automation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855201",
   "koodiArvo" : "855201",
@@ -49930,7 +49930,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Electrical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855202",
   "koodiArvo" : "855202",
@@ -49947,7 +49947,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Automation Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855203",
   "koodiArvo" : "855203",
@@ -49964,7 +49964,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Engineering Physics",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855204",
   "koodiArvo" : "855204",
@@ -49981,7 +49981,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Science and Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855300",
   "koodiArvo" : "855300",
@@ -49998,7 +49998,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Information Technology and Telecommunications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855301",
   "koodiArvo" : "855301",
@@ -50015,7 +50015,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Information Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855302",
   "koodiArvo" : "855302",
@@ -50032,7 +50032,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Telecommunications Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855400",
   "koodiArvo" : "855400",
@@ -50049,7 +50049,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Process Engineering and Materials Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855401",
   "koodiArvo" : "855401",
@@ -50066,7 +50066,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Chemical Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855402",
   "koodiArvo" : "855402",
@@ -50083,7 +50083,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Process Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855403",
   "koodiArvo" : "855403",
@@ -50100,7 +50100,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Environmental Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855404",
   "koodiArvo" : "855404",
@@ -50117,7 +50117,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Wood Processing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855408",
   "koodiArvo" : "855408",
@@ -50134,7 +50134,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Materials Technology, Rock Engineering",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855409",
   "koodiArvo" : "855409",
@@ -50151,7 +50151,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Biotechnology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855410",
   "koodiArvo" : "855410",
@@ -50181,7 +50181,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Building Construction and Surveying Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855501",
   "koodiArvo" : "855501",
@@ -50198,7 +50198,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Building Construction, Community Development",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855502",
   "koodiArvo" : "855502",
@@ -50215,7 +50215,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Surveying Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855600",
   "koodiArvo" : "855600",
@@ -50232,7 +50232,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Industrial Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855601",
   "koodiArvo" : "855601",
@@ -50249,7 +50249,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Industrial Management",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855800",
   "koodiArvo" : "855800",
@@ -50266,7 +50266,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Architecture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855801",
   "koodiArvo" : "855801",
@@ -50283,7 +50283,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Architecture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855900",
   "koodiArvo" : "855900",
@@ -50300,7 +50300,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Other Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855901",
   "koodiArvo" : "855901",
@@ -50317,7 +50317,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Textiles and Clothing Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_855999",
   "koodiArvo" : "855999",
@@ -50334,7 +50334,7 @@
     "lyhytNimi" : "Doctor of Science (Technology), Other or Unknown Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_856000",
   "koodiArvo" : "856000",
@@ -50351,7 +50351,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_856100",
   "koodiArvo" : "856100",
@@ -50368,7 +50368,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_856101",
   "koodiArvo" : "856101",
@@ -50385,7 +50385,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Technology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_859000",
   "koodiArvo" : "859000",
@@ -50402,7 +50402,7 @@
     "lyhytNimi" : "Other Education in Technology, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_859900",
   "koodiArvo" : "859900",
@@ -50419,7 +50419,7 @@
     "lyhytNimi" : "Other Education in Technology, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_859999",
   "koodiArvo" : "859999",
@@ -50436,7 +50436,7 @@
     "lyhytNimi" : "Other or Unknown Education in Technology, Second Stage of Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_862000",
   "koodiArvo" : "862000",
@@ -50453,7 +50453,7 @@
     "lyhytNimi" : "Licentiate of Science (Agriculture and Forestry)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_862200",
   "koodiArvo" : "862200",
@@ -50470,7 +50470,7 @@
     "lyhytNimi" : "Licentiate of Science (Agriculture and Forestry)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_862201",
   "koodiArvo" : "862201",
@@ -50487,7 +50487,7 @@
     "lyhytNimi" : "Licentiate of Science (Agriculture and Forestry), Agriculture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_862202",
   "koodiArvo" : "862202",
@@ -50504,7 +50504,7 @@
     "lyhytNimi" : "Licentiate of Science (Agriculture and Forestry), Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_862203",
   "koodiArvo" : "862203",
@@ -50521,7 +50521,7 @@
     "lyhytNimi" : "Licentiate of Science (Agriculture and Forestry), Environmental Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_862204",
   "koodiArvo" : "862204",
@@ -50538,7 +50538,7 @@
     "lyhytNimi" : "Licentiate of Science (Agriculture and Forestry), Household Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_862205",
   "koodiArvo" : "862205",
@@ -50555,7 +50555,7 @@
     "lyhytNimi" : "Licentiate of Science (Agriculture and Forestry), Biotechnology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_862251",
   "koodiArvo" : "862251",
@@ -50572,7 +50572,7 @@
     "lyhytNimi" : "Licentiate of Science (Agriculture and Forestry), Food Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_862299",
   "koodiArvo" : "862299",
@@ -50589,7 +50589,7 @@
     "lyhytNimi" : "Licentiate of Science (Agriculture and Forestry), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_862300",
   "koodiArvo" : "862300",
@@ -50606,7 +50606,7 @@
     "lyhytNimi" : "Licentiate of Food Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_862301",
   "koodiArvo" : "862301",
@@ -50623,7 +50623,7 @@
     "lyhytNimi" : "Licentiate of Food Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_862900",
   "koodiArvo" : "862900",
@@ -50640,7 +50640,7 @@
     "lyhytNimi" : "Other Licentiate Programme in Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_862999",
   "koodiArvo" : "862999",
@@ -50657,7 +50657,7 @@
     "lyhytNimi" : "Other or Unknown Licentiate Programme in Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_865000",
   "koodiArvo" : "865000",
@@ -50674,7 +50674,7 @@
     "lyhytNimi" : "Doctor of Science (Agriculture and Forestry)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_865200",
   "koodiArvo" : "865200",
@@ -50691,7 +50691,7 @@
     "lyhytNimi" : "Doctor of Science (Agriculture and Forestry)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_865201",
   "koodiArvo" : "865201",
@@ -50708,7 +50708,7 @@
     "lyhytNimi" : "Doctor of Science (Agriculture and Forestry), Agriculture",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_865202",
   "koodiArvo" : "865202",
@@ -50725,7 +50725,7 @@
     "lyhytNimi" : "Doctor of Science (Agriculture and Forestry), Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_865203",
   "koodiArvo" : "865203",
@@ -50742,7 +50742,7 @@
     "lyhytNimi" : "Doctor of Science (Agriculture and Forestry), Environmental Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_865204",
   "koodiArvo" : "865204",
@@ -50759,7 +50759,7 @@
     "lyhytNimi" : "Doctor of Science (Agriculture and Forestry), Household Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_865205",
   "koodiArvo" : "865205",
@@ -50776,7 +50776,7 @@
     "lyhytNimi" : "Doctor of Science (Agriculture and Forestry), Biotechnology",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_865251",
   "koodiArvo" : "865251",
@@ -50793,7 +50793,7 @@
     "lyhytNimi" : "Doctor of Science (Agriculture and Forestry), Food Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_865299",
   "koodiArvo" : "865299",
@@ -50810,7 +50810,7 @@
     "lyhytNimi" : "Doctor of Science (Agriculture and Forestry), Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_865300",
   "koodiArvo" : "865300",
@@ -50827,7 +50827,7 @@
     "lyhytNimi" : "Doctor of Food Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_865301",
   "koodiArvo" : "865301",
@@ -50844,7 +50844,7 @@
     "lyhytNimi" : "Doctor of Food Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_865500",
   "koodiArvo" : "865500",
@@ -50861,7 +50861,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_865501",
   "koodiArvo" : "865501",
@@ -50878,7 +50878,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_865900",
   "koodiArvo" : "865900",
@@ -50895,7 +50895,7 @@
     "lyhytNimi" : "Other Doctoral Programme in Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_865999",
   "koodiArvo" : "865999",
@@ -50912,7 +50912,7 @@
     "lyhytNimi" : "Other or Unknown Doctoral Programme in Agriculture and Forestry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_869000",
   "koodiArvo" : "869000",
@@ -50929,7 +50929,7 @@
     "lyhytNimi" : "Other Education in Agriculture and Forestry, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_869900",
   "koodiArvo" : "869900",
@@ -50946,7 +50946,7 @@
     "lyhytNimi" : "Other Education in Agriculture and Forestry, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_869999",
   "koodiArvo" : "869999",
@@ -50963,7 +50963,7 @@
     "lyhytNimi" : "Other or Unknown Education in Agriculture and Forestry, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_872000",
   "koodiArvo" : "872000",
@@ -50980,7 +50980,7 @@
     "lyhytNimi" : "Licentiate of Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_872400",
   "koodiArvo" : "872400",
@@ -50997,7 +50997,7 @@
     "lyhytNimi" : "Licentiate of Science (Pharmacy)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_872401",
   "koodiArvo" : "872401",
@@ -51014,7 +51014,7 @@
     "lyhytNimi" : "Licentiate of Science (Pharmacy)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_872500",
   "koodiArvo" : "872500",
@@ -51031,7 +51031,7 @@
     "lyhytNimi" : "Licentiate of Health Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_872501",
   "koodiArvo" : "872501",
@@ -51048,7 +51048,7 @@
     "lyhytNimi" : "Licentiate of Health Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_872900",
   "koodiArvo" : "872900",
@@ -51065,7 +51065,7 @@
     "lyhytNimi" : "Other Licentiate Programme in Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_872999",
   "koodiArvo" : "872999",
@@ -51082,7 +51082,7 @@
     "lyhytNimi" : "Other or Unknown Licentiate Programme in Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_875000",
   "koodiArvo" : "875000",
@@ -51099,7 +51099,7 @@
     "lyhytNimi" : "Doctor of Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_875100",
   "koodiArvo" : "875100",
@@ -51116,7 +51116,7 @@
     "lyhytNimi" : "Doctor of Medical Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_875101",
   "koodiArvo" : "875101",
@@ -51133,7 +51133,7 @@
     "lyhytNimi" : "Doctor of Medicinal Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_875200",
   "koodiArvo" : "875200",
@@ -51150,7 +51150,7 @@
     "lyhytNimi" : "Doctor of Dental Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_875201",
   "koodiArvo" : "875201",
@@ -51167,7 +51167,7 @@
     "lyhytNimi" : "Doctor of Dental Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_875300",
   "koodiArvo" : "875300",
@@ -51184,7 +51184,7 @@
     "lyhytNimi" : "Doctor of Veterinary Medicine",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_875301",
   "koodiArvo" : "875301",
@@ -51201,7 +51201,7 @@
     "lyhytNimi" : "Doctor of Veterinary Medicine",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_875400",
   "koodiArvo" : "875400",
@@ -51218,7 +51218,7 @@
     "lyhytNimi" : "Doctor of Science (Pharmacy)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_875401",
   "koodiArvo" : "875401",
@@ -51235,7 +51235,7 @@
     "lyhytNimi" : "Doctor of Science (Pharmacy)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_875500",
   "koodiArvo" : "875500",
@@ -51252,7 +51252,7 @@
     "lyhytNimi" : "Doctor of Health Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_875501",
   "koodiArvo" : "875501",
@@ -51269,7 +51269,7 @@
     "lyhytNimi" : "Doctor of Health Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_875600",
   "koodiArvo" : "875600",
@@ -51286,7 +51286,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_875601",
   "koodiArvo" : "875601",
@@ -51303,7 +51303,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Medicine",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_875602",
   "koodiArvo" : "875602",
@@ -51320,7 +51320,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Dentistry",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_875603",
   "koodiArvo" : "875603",
@@ -51337,7 +51337,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Veterinary Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_875604",
   "koodiArvo" : "875604",
@@ -51354,7 +51354,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Pharmacy",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_875605",
   "koodiArvo" : "875605",
@@ -51371,7 +51371,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Health Care",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_875699",
   "koodiArvo" : "875699",
@@ -51388,7 +51388,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Other or Unknown Field in Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_875900",
   "koodiArvo" : "875900",
@@ -51405,7 +51405,7 @@
     "lyhytNimi" : "Other Doctoral Programme in Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_875999",
   "koodiArvo" : "875999",
@@ -51422,7 +51422,7 @@
     "lyhytNimi" : "Other or Unknown Doctoral Programme in Health and Welfare",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_879000",
   "koodiArvo" : "879000",
@@ -51439,7 +51439,7 @@
     "lyhytNimi" : "Other Education in Health and Welfare, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_879900",
   "koodiArvo" : "879900",
@@ -51456,7 +51456,7 @@
     "lyhytNimi" : "Other Education in Health and Welfare, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_879999",
   "koodiArvo" : "879999",
@@ -51473,7 +51473,7 @@
     "lyhytNimi" : "Other or Unknown Education in Health and Welfare, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_882000",
   "koodiArvo" : "882000",
@@ -51490,7 +51490,7 @@
     "lyhytNimi" : "Licentiate Programme in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_882200",
   "koodiArvo" : "882200",
@@ -51507,7 +51507,7 @@
     "lyhytNimi" : "Licentiate of Philosophy (Sport and Health Sciences)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_882201",
   "koodiArvo" : "882201",
@@ -51524,7 +51524,7 @@
     "lyhytNimi" : "Licentiate of Philosophy (Sport and Health Sciences)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_882900",
   "koodiArvo" : "882900",
@@ -51541,7 +51541,7 @@
     "lyhytNimi" : "Other Licentiate Programme in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_882999",
   "koodiArvo" : "882999",
@@ -51558,7 +51558,7 @@
     "lyhytNimi" : "Other or Unknown Licentiate Programme in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_885000",
   "koodiArvo" : "885000",
@@ -51575,7 +51575,7 @@
     "lyhytNimi" : "Doctoral Programme in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_885200",
   "koodiArvo" : "885200",
@@ -51592,7 +51592,7 @@
     "lyhytNimi" : "Doctor of Philosophy (Sport and Health Sciences)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_885201",
   "koodiArvo" : "885201",
@@ -51609,7 +51609,7 @@
     "lyhytNimi" : "Doctor of Philosophy (Sport and Health Sciences)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_885300",
   "koodiArvo" : "885300",
@@ -51626,7 +51626,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Sport and Health Sciences",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_885301",
   "koodiArvo" : "885301",
@@ -51643,7 +51643,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Sport Science",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_885600",
   "koodiArvo" : "885600",
@@ -51660,7 +51660,7 @@
     "lyhytNimi" : "Education in Military Science, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_885601",
   "koodiArvo" : "885601",
@@ -51677,7 +51677,7 @@
     "lyhytNimi" : "Doctor of Arts (Military Science)",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_885900",
   "koodiArvo" : "885900",
@@ -51694,7 +51694,7 @@
     "lyhytNimi" : "Other Doctoral Programme in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_885999",
   "koodiArvo" : "885999",
@@ -51711,7 +51711,7 @@
     "lyhytNimi" : "Other or Unknown Doctoral Programme in Services",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_889000",
   "koodiArvo" : "889000",
@@ -51728,7 +51728,7 @@
     "lyhytNimi" : "Other Education in Services, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_889900",
   "koodiArvo" : "889900",
@@ -51745,7 +51745,7 @@
     "lyhytNimi" : "Other Education in Services, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_889999",
   "koodiArvo" : "889999",
@@ -51762,7 +51762,7 @@
     "lyhytNimi" : "Other or Unknown Education in Services, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_892000",
   "koodiArvo" : "892000",
@@ -51779,7 +51779,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Other Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_892900",
   "koodiArvo" : "892900",
@@ -51796,7 +51796,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Other Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_892999",
   "koodiArvo" : "892999",
@@ -51813,7 +51813,7 @@
     "lyhytNimi" : "Licentiate of Philosophy, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_895000",
   "koodiArvo" : "895000",
@@ -51830,7 +51830,7 @@
     "lyhytNimi" : "Doctor of Philosphy, Other Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_895900",
   "koodiArvo" : "895900",
@@ -51847,7 +51847,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Other Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_895999",
   "koodiArvo" : "895999",
@@ -51864,7 +51864,7 @@
     "lyhytNimi" : "Doctor of Philosophy, Other or Unknown Field",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_899000",
   "koodiArvo" : "899000",
@@ -51881,7 +51881,7 @@
     "lyhytNimi" : "Other Education, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_899900",
   "koodiArvo" : "899900",
@@ -51898,7 +51898,7 @@
     "lyhytNimi" : "Other Education, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_899999",
   "koodiArvo" : "899999",
@@ -51915,7 +51915,7 @@
     "lyhytNimi" : "Other or Unknown Education, Doctorate or Equivalent Level Tertiary Education",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_909000",
   "koodiArvo" : "909000",
@@ -51932,7 +51932,7 @@
     "lyhytNimi" : "General Education, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_909900",
   "koodiArvo" : "909900",
@@ -51949,7 +51949,7 @@
     "lyhytNimi" : "General Education, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_909999",
   "koodiArvo" : "909999",
@@ -51966,7 +51966,7 @@
     "lyhytNimi" : "General Education, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_919000",
   "koodiArvo" : "919000",
@@ -51983,7 +51983,7 @@
     "lyhytNimi" : "Teacher Education and Educational Science, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_919900",
   "koodiArvo" : "919900",
@@ -52000,7 +52000,7 @@
     "lyhytNimi" : "Teacher Education and Educational Science, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_919999",
   "koodiArvo" : "919999",
@@ -52017,7 +52017,7 @@
     "lyhytNimi" : "Teacher Education and Educational Science, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_929000",
   "koodiArvo" : "929000",
@@ -52034,7 +52034,7 @@
     "lyhytNimi" : "Education in Humanities and Arts, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_929900",
   "koodiArvo" : "929900",
@@ -52051,7 +52051,7 @@
     "lyhytNimi" : "Education in Humanities and Arts, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_929999",
   "koodiArvo" : "929999",
@@ -52068,7 +52068,7 @@
     "lyhytNimi" : "Education in Humanities and Arts, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_939000",
   "koodiArvo" : "939000",
@@ -52085,7 +52085,7 @@
     "lyhytNimi" : "Education in Social Sciences and Business, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_939900",
   "koodiArvo" : "939900",
@@ -52102,7 +52102,7 @@
     "lyhytNimi" : "Education in Social Sciences and Business, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_939999",
   "koodiArvo" : "939999",
@@ -52119,7 +52119,7 @@
     "lyhytNimi" : "Education in Social Sciences and Business, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_949000",
   "koodiArvo" : "949000",
@@ -52136,7 +52136,7 @@
     "lyhytNimi" : "Education in Natural Sciences, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_949900",
   "koodiArvo" : "949900",
@@ -52153,7 +52153,7 @@
     "lyhytNimi" : "Education in Natural Sciences, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_949999",
   "koodiArvo" : "949999",
@@ -52170,7 +52170,7 @@
     "lyhytNimi" : "Education in Natural Sciences, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_959000",
   "koodiArvo" : "959000",
@@ -52187,7 +52187,7 @@
     "lyhytNimi" : "Education in Technology, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_959900",
   "koodiArvo" : "959900",
@@ -52204,7 +52204,7 @@
     "lyhytNimi" : "Education in Technology, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_959999",
   "koodiArvo" : "959999",
@@ -52221,7 +52221,7 @@
     "lyhytNimi" : "Education in Technology, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_969000",
   "koodiArvo" : "969000",
@@ -52238,7 +52238,7 @@
     "lyhytNimi" : "Education in Agriculture and Forestry, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_969900",
   "koodiArvo" : "969900",
@@ -52255,7 +52255,7 @@
     "lyhytNimi" : "Education in Agriculture and Forestry, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_969999",
   "koodiArvo" : "969999",
@@ -52272,7 +52272,7 @@
     "lyhytNimi" : "Education in Agriculture and Forestry, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_979000",
   "koodiArvo" : "979000",
@@ -52289,7 +52289,7 @@
     "lyhytNimi" : "Education in Health and Welfare, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_979900",
   "koodiArvo" : "979900",
@@ -52306,7 +52306,7 @@
     "lyhytNimi" : "Education in Health and Welfare, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_979999",
   "koodiArvo" : "979999",
@@ -52323,7 +52323,7 @@
     "lyhytNimi" : "Education in Health and Welfare, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_989000",
   "koodiArvo" : "989000",
@@ -52340,7 +52340,7 @@
     "lyhytNimi" : "Education in Services, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_989900",
   "koodiArvo" : "989900",
@@ -52357,7 +52357,7 @@
     "lyhytNimi" : "Education in Services, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_989999",
   "koodiArvo" : "989999",
@@ -52374,7 +52374,7 @@
     "lyhytNimi" : "Education in Services, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_999000",
   "koodiArvo" : "999000",
@@ -52391,7 +52391,7 @@
     "lyhytNimi" : "Other Education, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_999900",
   "koodiArvo" : "999900",
@@ -52408,7 +52408,7 @@
     "lyhytNimi" : "Other Education, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 }, {
   "koodiUri" : "koulutus_999901",
   "koodiArvo" : "999901",
@@ -52458,7 +52458,7 @@
     "nimi" : "utbildning som förbereder för fristående examen",
     "kieli" : "SV"
   } ],
-  "versio" : 7
+  "versio" : 6
 }, {
   "koodiUri" : "koulutus_999905",
   "koodiArvo" : "999905",
@@ -52525,5 +52525,5 @@
     "lyhytNimi" : "Other or Unknown Education, Level of Education Unknown",
     "kieli" : "EN"
   } ],
-  "versio" : 12
+  "versio" : 11
 } ]

--- a/src/main/scala/fi/oph/koski/documentation/DocumentationApiServlet.scala
+++ b/src/main/scala/fi/oph/koski/documentation/DocumentationApiServlet.scala
@@ -81,7 +81,7 @@ class DocumentationApiServlet extends KoskiSpecificApiServlet with Unauthenticat
   }
 
   get("/koodistot.json") {
-    renderObject[List[String]](Koodistot.koodistot)
+    renderObject[List[String]](Koodistot.koodistoAsetukset.filter(_.koodistoVersio.isEmpty).map(_.toString))
   }
 
   override def toJsonString[T: ru.TypeTag](x: T): String = JsonSerializer.writeWithRoot(x)

--- a/src/main/scala/fi/oph/koski/koodisto/Koodisto.scala
+++ b/src/main/scala/fi/oph/koski/koodisto/Koodisto.scala
@@ -6,7 +6,17 @@ import fi.oph.koski.schema.LocalizedString
 import fi.oph.scalaschema.annotation.DefaultValue
 
 // Tätä oliota käytetään myös koodistojen luonnissa. Älä poista kenttiä!
-case class Koodisto(koodistoUri: String, versio: Int, metadata: List[KoodistoMetadata], codesGroupUri: String, voimassaAlkuPvm: LocalDate, organisaatioOid: String, withinCodes: Option[List[KoodistoRelationship]] = None, @DefaultValue("LUONNOS") tila: String = "LUONNOS", @DefaultValue(0) version: Int = 0) {
+case class Koodisto(
+  koodistoUri: String,
+  versio: Int,
+  metadata: List[KoodistoMetadata],
+  codesGroupUri: String,
+  voimassaAlkuPvm: LocalDate,
+  organisaatioOid: String,
+  withinCodes: Option[List[KoodistoRelationship]] = None,
+  @DefaultValue("LUONNOS") tila: String = "LUONNOS",
+  @DefaultValue(0) version: Int = 0
+) {
   def koodistoViite = KoodistoViite(koodistoUri, versio)
   def nimi = localizedStringFromMetadata { meta => meta.nimi.map(_.trim) }
   def kuvaus = localizedStringFromMetadata { meta => meta.kuvaus.map(_.trim) }

--- a/src/main/scala/fi/oph/koski/koodisto/KoodistoMockDataSorter.scala
+++ b/src/main/scala/fi/oph/koski/koodisto/KoodistoMockDataSorter.scala
@@ -11,18 +11,18 @@ object KoodistoMockDataSorter extends App with Logging {
   sortMockData()
 
   def sortMockData(): Unit = {
-    Koodistot.koodistot.foreach(sortMockDataForKoodisto)
+    Koodistot.koodistoAsetukset.foreach(sortMockDataForKoodisto)
     logger.info("Done")
   }
 
-  private def sortMockDataForKoodisto(koodistoUri: String): Unit = {
-    val koodistoFileName = MockKoodistoPalvelu.koodistoFileName(koodistoUri)
+  private def sortMockDataForKoodisto(koodistoAsetus: KoodistoAsetus): Unit = {
+    val koodistoFileName = MockKoodistoPalvelu.koodistoFileName(koodistoAsetus.koodisto, koodistoAsetus.koodistoVersio)
     logger.info(s"Sorting ${koodistoFileName}")
     val koodisto = JsonSerializer.extract[Koodisto](JsonFiles.readFile(koodistoFileName), ignoreExtras = true)
     val koodistoSorted = MockKoodistoPalvelu.sortKoodistoMetadata(koodisto)
     JsonFiles.writeFile(koodistoFileName, koodistoSorted)
 
-    val kooditFileName = MockKoodistoPalvelu.koodistoKooditFileName(koodistoUri)
+    val kooditFileName = MockKoodistoPalvelu.koodistoKooditFileName(koodistoAsetus.koodisto, koodistoAsetus.koodistoVersio)
     logger.info(s"Sorting ${kooditFileName}")
     val koodit = JsonSerializer.extract[List[KoodistoKoodi]](JsonFiles.readFile(kooditFileName), ignoreExtras = true)
     val kooditSorted = koodit.map(MockKoodistoPalvelu.sortKoodistoKoodiMetadata).sortBy(_.koodiArvo)

--- a/src/main/scala/fi/oph/koski/koodisto/KoodistoMockDataUpdater.scala
+++ b/src/main/scala/fi/oph/koski/koodisto/KoodistoMockDataUpdater.scala
@@ -22,12 +22,12 @@ object KoodistoMockDataUpdater extends App with Logging {
       case Some(versio) =>
         logger.info("Päivitetään testidata koodistolle " + koodistoUri + "/" + versio)
         JsonFiles.writeFile(
-          MockKoodistoPalvelu.koodistoFileName(koodistoUri),
+          MockKoodistoPalvelu.koodistoFileName(koodistoUri, None),
           kp.getKoodisto(versio).map(sortKoodistoMetadata)
         )
         val koodit: List[KoodistoKoodi] = kp.getKoodistoKoodit(versio).map(sortKoodistoKoodiMetadata).sortBy(_.koodiArvo)
         JsonFiles.writeFile(
-          MockKoodistoPalvelu.koodistoKooditFileName(koodistoUri),
+          MockKoodistoPalvelu.koodistoKooditFileName(koodistoUri, None),
           koodit
         )
       case None =>

--- a/src/main/scala/fi/oph/koski/koodisto/Koodistot.scala
+++ b/src/main/scala/fi/oph/koski/koodisto/Koodistot.scala
@@ -1,10 +1,17 @@
 package fi.oph.koski.koodisto
 
-case class KoodistoAsetus(koodisto: String, vaadiSuomenkielinenNimi: Boolean = true, vaadiRuotsinkielinenNimi: Boolean = true)
+case class KoodistoAsetus(
+  koodisto: String,
+  vaadiSuomenkielinenNimi: Boolean = true,
+  vaadiRuotsinkielinenNimi: Boolean = true,
+  koodistoVersio: Option[Int] = None
+) {
+  override def toString: String = koodisto + koodistoVersio.map(v => s"_$v").getOrElse("")
+}
 
 object Koodistot {
   // Koski-spesifiset koodistot.
-  private val koskiKoodistoAsetukset = List (
+  val koskiKoodistoAsetukset = List (
     KoodistoAsetus("aikuistenperusopetuksenkurssit2015"),
     KoodistoAsetus("aikuistenperusopetuksenalkuvaiheenkurssit2017"),
     KoodistoAsetus("aikuistenperusopetuksenalkuvaiheenoppiaineet"),
@@ -90,10 +97,10 @@ object Koodistot {
     KoodistoAsetus("valpasvastaanottotieto"),
     KoodistoAsetus("tuvajarjestamislupa"),
   )
-  val koskiKoodistot = koskiKoodistoAsetukset.map(_.koodisto)
+  val koskiKoodistot = koskiKoodistoAsetukset.map(_.toString)
 
   // Muut koodistot, joita Koski käyttää
-  private val muutKoodistoAsetukset = List (
+  val muutKoodistoAsetukset = List (
     KoodistoAsetus("ammatillisenoppiaineet"),
     KoodistoAsetus("ammatilliseentehtavaanvalmistavakoulutus"),
     KoodistoAsetus("hakutapa"),
@@ -102,6 +109,7 @@ object Koodistot {
     KoodistoAsetus("kieli"),
     KoodistoAsetus("kielivalikoima"),
     KoodistoAsetus("koulutus"),
+    KoodistoAsetus("koulutus", koodistoVersio = Some(11)),
     KoodistoAsetus("koulutustyyppi"),
     KoodistoAsetus("kunta"),
     KoodistoAsetus("lukionkurssit"),
@@ -125,7 +133,7 @@ object Koodistot {
     KoodistoAsetus("yhteystietotyypit"),
     KoodistoAsetus("opintokokonaisuudet")
   )
-  val muutKoodistot = muutKoodistoAsetukset.map(_.koodisto)
+  val muutKoodistot = muutKoodistoAsetukset.map(_.toString)
 
   val koodistoAsetukset = (koskiKoodistoAsetukset ++ muutKoodistoAsetukset).sortBy(_.koodisto)
   val koodistot = (koskiKoodistot ++ muutKoodistot).sorted
@@ -141,6 +149,8 @@ object Koodistot {
         mvn exec:java -Dexec.mainClass=fi.oph.koski.koodisto.KoodistoMockDataUpdater -Dopintopolku.virkailija.url=https://virkailija.opintopolku.fi -DkoskiKoodistot=false -DmuutKoodistot=true
     1c) Uusi Koski-spesifinen koodisto: Tee käsin koodistofileet src/main/resources/koodisto
         Lisää koodiston nimi yllä olevaan koskiKoodistot-listaan
+    1d) Koodiston versiointi: Jos haluat lisätä jostain koodistosta kokonaan eri version, niin lisää koodisto ja koodit json-tiedostojen loppuun koodiston versio alaviivalla erotettuna.
+        Esim: koulutus_11.json. Koodisto ilman määriteltyä versiota tulkitaan aina uusimmaksi versioksi.
 
     2) Kommitoi uudet json-fileet. Muutoksia olemassa oleviin fileisiin ei kannattane tässä yhteydessä kommitoida.
     3) Aja koski-applikaatio -Dconfig.resource=koskidev.conf -Dkoodisto.create=true, jolloin uusi koodisto kopioituu myös koskidev-ympäristöön.

--- a/src/test/scala/fi/oph/koski/localization/KoodistotLocalizationTest.scala
+++ b/src/test/scala/fi/oph/koski/localization/KoodistotLocalizationTest.scala
@@ -15,7 +15,7 @@ class KoodistotLocalizationTest extends AnyFreeSpec with TestEnvironment with Ma
     lazy val root = sys.env.getOrElse("VIRKAILIJA_ROOT", throw new RuntimeException("Environment variable VIRKAILIJA_ROOT missing"))
     lazy val koodistoPalvelu = new RemoteKoodistoPalvelu(root)
 
-    Koodistot.koodistoAsetukset.foreach { koodistoAsetus =>
+    Koodistot.koodistoAsetukset.filter(_.koodistoVersio.isEmpty).foreach { koodistoAsetus =>
       s"${koodistoAsetus.koodisto}" taggedAs (LocalizationTestTag) in {
         val koodistoViite = koodistoPalvelu.getLatestVersionRequired(koodistoAsetus.koodisto)
         val koodit = koodistoPalvelu.getKoodistoKoodit(koodistoViite)

--- a/src/test/scala/fi/oph/koski/tools/CsvToKoodisto.scala
+++ b/src/test/scala/fi/oph/koski/tools/CsvToKoodisto.scala
@@ -22,12 +22,12 @@ object CsvToKoodisto extends App {
       case List(nimi: String, koodi: String) => KoodistoKoodi(KoodistoKoodi.koodiUri(koodistoUri, koodi), koodi, List(KoodistoKoodiMetadata(kieli = Some("FI"), nimi = Some(nimi))), 1, None, None)
     }
   JsonFiles.writeFile(
-    MockKoodistoPalvelu.koodistoKooditFileName(koodistoUri),
+    MockKoodistoPalvelu.koodistoKooditFileName(koodistoUri, None),
     koodit
   )
   val koodisto = Koodisto(koodistoUri, 1, List(KoodistoMetadata("FI", Some(koodistoNimi), None)), "http://koski", LocalDate.now, "1.2.246.562.10.00000000001")
   JsonFiles.writeFile(
-    MockKoodistoPalvelu.koodistoFileName(koodistoUri),
+    MockKoodistoPalvelu.koodistoFileName(koodistoUri, None),
     koodisto
   )
 }

--- a/src/test/scala/fi/oph/koski/tools/TxtToKoodisto.scala
+++ b/src/test/scala/fi/oph/koski/tools/TxtToKoodisto.scala
@@ -28,12 +28,12 @@ object TxtToKoodisto extends App {
       case _ => ???
     }
   JsonFiles.writeFile(
-    MockKoodistoPalvelu.koodistoKooditFileName(koodistoUri),
+    MockKoodistoPalvelu.koodistoKooditFileName(koodistoUri, None),
     koodit
   )
   val koodisto = Koodisto(koodistoUri, 1, List(KoodistoMetadata("FI", Some(koodistoNimi), None)), "http://koski", LocalDate.now, "1.2.246.562.10.00000000001")
   JsonFiles.writeFile(
-    MockKoodistoPalvelu.koodistoFileName(koodistoUri),
+    MockKoodistoPalvelu.koodistoFileName(koodistoUri, None),
     koodisto
   )
 }

--- a/web/app/uusisuoritus/UusiAmmatillisenTutkinnonSuoritus.jsx
+++ b/web/app/uusisuoritus/UusiAmmatillisenTutkinnonSuoritus.jsx
@@ -104,7 +104,7 @@ const Popup = (isValmistava) => ({opiskeluoikeus, resultCallback}) => {
                   return <TutkintoAutocomplete tutkintoAtom={tutkintoAtom} oppilaitosP={Bacon.constant(modelData(opiskeluoikeus, 'oppilaitos'))}/>
                 case 'suoritustapa':
                   let tutkinto = modelData(oppiaineenSuoritus, 'koulutusmoduuli')
-                  return<SuoritustapaDropdown diaarinumero={tutkinto.perusteenDiaarinumero} suoritustapaAtom={suoritustapaAtom}/>
+                  return <SuoritustapaDropdown diaarinumero={tutkinto.perusteenDiaarinumero} suoritustapaAtom={suoritustapaAtom}/>
                 default: return getDefault()
               }
             }}

--- a/web/test/page/opinnotPage.js
+++ b/web/test/page/opinnotPage.js
@@ -49,6 +49,10 @@ function OpinnotPage() {
       var opiskeluoikeus = resolveOpiskeluoikeus(indexOrName)
       return opiskeluoikeus.find('.suoritus .property.koulutusmoduuli .koulutusmoduuli .tunniste').text()
     },
+    getSuoritustapa: function(indexOrName) {
+      var opiskeluoikeus = resolveOpiskeluoikeus(indexOrName)
+      return opiskeluoikeus.find('.suoritus .property.suoritustapa .value').text()
+    },
     getKoulutusModuuli: function(indexOrName) {
       var opiskeluoikeus = resolveOpiskeluoikeus(indexOrName)
       return {
@@ -692,7 +696,7 @@ function VSTSuoritukset(prev) {
         }
         return VSTSuoritukset(found)
       }
-    }  
+    }
   }
   return _.merge(api, Editor(S(selectedOsasuoritus)), Property(function () { return S(selectedOsasuoritus) }))
 }

--- a/web/test/spec/ammatillinenSpec.js
+++ b/web/test/spec/ammatillinenSpec.js
@@ -358,7 +358,11 @@ describe('Ammatillinen koulutus', function() {
       describe('Uutena opiskeluoikeutena', function() {
         before(
           prepareForNewOppija('kalle', '230872-7258'),
-          addOppija.enterValidDataAmmatillinen({suorituskieli: 'ruotsi'}),
+          addOppija.enterValidDataAmmatillinen({
+            suorituskieli: 'ruotsi',
+            tutkinto: 'Autoalan työnjoh',
+            suoritustapa: ''
+          }),
           addOppija.selectOppimäärä('Näyttötutkintoon valmistava koulutus'),
           addOppija.submitAndExpectSuccess('Tyhjä, Tero (230872-7258)', 'Näyttötutkintoon valmistava koulutus')
         )
@@ -379,18 +383,18 @@ describe('Ammatillinen koulutus', function() {
           )
           describe('Ennen lisäystä', function() {
             it('Esitäyttää tutkinnon näyttötutkintoon valmistavasta koulutuksesta', function() {
-              expect(lisääSuoritus.tutkinto()).to.equal('Autoalan perustutkinto 39/011/2014')
+              expect(lisääSuoritus.tutkinto()).to.equal('Autoalan työnjohdon erikoisammattitutkinto 40/011/2001')
             })
           })
           describe('Lisäyksen jälkeen', function() {
             before(
-              lisääSuoritus.selectTutkinto('Autoalan perustutkinto'),
-              lisääSuoritus.selectSuoritustapa('Näyttötutkinto'),
+              lisääSuoritus.selectTutkinto('Autoalan työnjohdon erikoisammattitutkinto'),
               lisääSuoritus.lisääSuoritus,
               editor.saveChanges
             )
-            it('Tutkinnon suoritus näytetään', function() {
-              expect(opinnot.getTutkinto()).to.equal('Autoalan perustutkinto')
+            it('Tutkinnon suoritus ja suoritustapa näytetään', function() {
+              expect(opinnot.getTutkinto()).to.equal('Autoalan työnjohdon erikoisammattitutkinto')
+              expect(opinnot.getSuoritustapa()).to.equal('Näyttötutkinto')
             })
           })
         })
@@ -399,8 +403,8 @@ describe('Ammatillinen koulutus', function() {
         var lisääSuoritus = opinnot.lisääSuoritusDialog
         before(
           prepareForNewOppija('kalle', '230872-7258'),
-          addOppija.enterValidDataAmmatillinen({suorituskieli: 'ruotsi', suoritustapa: 'Näyttö'}),
-          addOppija.submitAndExpectSuccess('Tyhjä, Tero (230872-7258)', 'Autoalan perustutkinto'),
+          addOppija.enterValidDataAmmatillinen({suorituskieli: 'ruotsi', suoritustapa: '', tutkinto: 'Autoalan työnjohd'}),
+          addOppija.submitAndExpectSuccess('Tyhjä, Tero (230872-7258)', 'Autoalan työnjohdon erikoisammattitutkinto'),
           editor.edit,
           lisääSuoritus.open('lisää näyttötutkintoon valmistavan koulutuksen suoritus')
         )
@@ -414,7 +418,7 @@ describe('Ammatillinen koulutus', function() {
           })
 
           it('Esitäyttää tutkinnon tutkintokoulutuksen suorituksesta', function() {
-            expect(lisääSuoritus.tutkinto()).to.equal('Autoalan perustutkinto 39/011/2014')
+            expect(lisääSuoritus.tutkinto()).to.equal('Autoalan työnjohdon erikoisammattitutkinto 40/011/2001')
           })
         })
         describe('Lisäyksen jälkeen', function() {

--- a/web/test/spec/muuAmmatillinenSpec.js
+++ b/web/test/spec/muuAmmatillinenSpec.js
@@ -95,17 +95,17 @@ describe('Muu ammatillinen koulutus', function() {
 
     describe('Tietojen muuttaminen', function() {
       before(page.openPage, page.oppijaHaku.searchAndSelect('130320-899Y'))
-      
+
       describe('Täydentää tutkintoa', function() {
         before(
           editor.edit,
           editor.property('täydentääTutkintoa').addValue,
-          opinnot.tutkinto('.täydentääTutkintoa').select('autoalan perustutkinto'),
+          opinnot.tutkinto('.täydentääTutkintoa').select('autoalan työnjohdon'),
           editor.saveChangesAndWaitForSuccess
         )
 
         it('tutkinnon voi valita', function() {
-          expect(editor.property('täydentääTutkintoa').getText()).to.equal('Täydentää tutkintoa Autoalan perustutkinto 351301 39/011/2014')
+          expect(editor.property('täydentääTutkintoa').getText()).to.equal('Täydentää tutkintoa Autoalan työnjohdon erikoisammattitutkinto 357305 40/011/2001')
         })
       })
 


### PR DESCRIPTION
Vanhemmat versiot koodistoista lisätään mock-dataan siten, että versio erotetaan alaviivalla json-tiedostojen nimiin ja versio lisätään myös listaukseen Koodistot.scalaan.

Koodistot ilman eksplisiittistä versiota tulkitaan "uusimmaksi".