### PR TITLE
Varmista uniikki id kaikille tiedonsiirtolokin dokumenteille

### DIFF
--- a/.github/workflows/run_koski_tests_continuously_on_master.yml
+++ b/.github/workflows/run_koski_tests_continuously_on_master.yml
@@ -222,7 +222,7 @@ jobs:
           fi.oph.koski.userdirectory,fi.oph.koski.util,fi.oph.koski.valpas, \
           fi.oph.koski.valvira,fi.oph.koski.versioning,fi.oph.koski.virta, \
           fi.oph.koski.ytl,fi.oph.koski.ytr, fi.oph.koski.ytl,fi.oph.koski.meta, \
-          fi.oph.koski.frontendvalvonta"
+          fi.oph.koski.frontendvalvonta, fi.oph.koski.tiedonsiirto"
 
   run_frontend_tests_0:
     name: Run Koski frontend tests runner 0

--- a/.github/workflows/run_koski_tests_on_branches.yml
+++ b/.github/workflows/run_koski_tests_on_branches.yml
@@ -225,7 +225,7 @@ jobs:
           fi.oph.koski.userdirectory,fi.oph.koski.util,fi.oph.koski.valpas, \
           fi.oph.koski.valvira,fi.oph.koski.versioning,fi.oph.koski.virta, \
           fi.oph.koski.ytl,fi.oph.koski.ytr, fi.oph.koski.ytl,fi.oph.koski.meta, \
-          fi.oph.koski.frontendvalvonta"
+          fi.oph.koski.frontendvalvonta, fi.oph.koski.tiedonsiirto"
 
   run_frontend_tests_0:
     name: Run Koski frontend tests runner 0

--- a/.github/workflows/test_build_deploy_master.yml
+++ b/.github/workflows/test_build_deploy_master.yml
@@ -202,7 +202,7 @@ jobs:
           fi.oph.koski.userdirectory,fi.oph.koski.util,fi.oph.koski.valpas, \
           fi.oph.koski.valvira,fi.oph.koski.versioning,fi.oph.koski.virta, \
           fi.oph.koski.ytl,fi.oph.koski.ytr, fi.oph.koski.ytl,fi.oph.koski.meta, \
-          fi.oph.koski.frontendvalvonta"
+          fi.oph.koski.frontendvalvonta, fi.oph.koski.tiedonsiirto"
 
   run_frontend_tests_0:
     name: Run Koski frontend tests runner 0

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ backtest:
 	fi.oph.koski.userdirectory,fi.oph.koski.util,fi.oph.koski.valpas,\
 	fi.oph.koski.valvira,fi.oph.koski.versioning,fi.oph.koski.virta,\
 	fi.oph.koski.ytl,fi.oph.koski.ytr,fi.oph.koski.ytl,fi.oph.koski.meta,\
-	fi.oph.koski.ytl,fi.oph.koski.api,fi.oph.koski.frontendvalvonta"
+	fi.oph.koski.ytl,fi.oph.koski.api,fi.oph.koski.frontendvalvonta,fi.oph.koski.tiedonsiirto"
 
 .PHONY: backtestnonmock
 backtestnonmock:

--- a/src/main/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoService.scala
+++ b/src/main/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoService.scala
@@ -24,6 +24,8 @@ import org.json4s.JsonAST.{JArray, JString}
 import org.json4s.jackson.JsonMethods
 import org.json4s.{JValue, _}
 
+import scala.util.Random
+
 object TiedonsiirtoService {
   private val settings = Map(
     "analysis" -> Map(
@@ -532,20 +534,24 @@ case class TiedonsiirtoQuery(oppilaitos: Option[String],
 case class TiedonsiirtoKäyttäjä(oid: String, käyttäjätunnus: Option[String])
 case class TiedonsiirtoError(data: JValue, virheet: List[ErrorDetail])
 
-case class TiedonsiirtoDocument(tallentajaKäyttäjäOid: String,
-                                tallentajaKäyttäjätunnus: Option[String],
-                                tallentajaOrganisaatioOid: String,
-                                oppija: Option[TiedonsiirtoOppija],
-                                oppilaitokset: Option[List[OidOrganisaatio]],
-                                koulutusmuoto: Option[String],
-                                suoritustiedot: Option[List[TiedonsiirtoSuoritusTiedot]],
-                                data: Option[JValue],
-                                success: Boolean,
-                                virheet: List[ErrorDetail],
-                                lähdejärjestelmä: Option[String],
-                                aikaleima: Timestamp) {
+case class TiedonsiirtoDocument(
+  tallentajaKäyttäjäOid: String,
+  tallentajaKäyttäjätunnus: Option[String],
+  tallentajaOrganisaatioOid: String,
+  oppija: Option[TiedonsiirtoOppija],
+  oppilaitokset: Option[List[OidOrganisaatio]],
+  koulutusmuoto: Option[String],
+  suoritustiedot: Option[List[TiedonsiirtoSuoritusTiedot]],
+  data: Option[JValue],
+  success: Boolean,
+  virheet: List[ErrorDetail],
+  lähdejärjestelmä: Option[String],
+  aikaleima: Timestamp,
+  requestId: String = Random.alphanumeric.take(6).mkString
+) {
   def id: String = tallentajaOrganisaatioOid + "_" + oppijaId
-  private def oppijaId: String = oppija.flatMap(h => h.hetu.orElse(h.oid)).getOrElse("")
+
+  private def oppijaId: String = oppija.flatMap(h => h.hetu.orElse(h.oid)).getOrElse(requestId)
 }
 
 case class TiedonsiirtoSuoritusTiedot(

--- a/src/test/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoServiceSpec.scala
+++ b/src/test/scala/fi/oph/koski/tiedonsiirto/TiedonsiirtoServiceSpec.scala
@@ -1,0 +1,36 @@
+package fi.oph.koski.tiedonsiirto
+
+import fi.oph.koski.log.Logging
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.sql.Timestamp
+import java.time.Instant
+
+class TiedonsiirtoServiceSpec extends AnyFreeSpec with Matchers with Logging {
+
+  "TiedonsiirtoDocument generoi stabiilin id:n dokumentille jos oppijan tiedot puuttuvat" in {
+    val aikaleima = Timestamp.from(Instant.now())
+    def doc = TiedonsiirtoDocument(
+      tallentajaKäyttäjäOid = "tallentaja",
+      tallentajaKäyttäjätunnus = None,
+      tallentajaOrganisaatioOid = "tallentajaOrganisaatio",
+      oppija = None,
+      oppilaitokset = None,
+      koulutusmuoto = None,
+      suoritustiedot = None,
+      data = None,
+      success = true,
+      virheet = List.empty,
+      lähdejärjestelmä = None,
+      aikaleima = aikaleima
+    )
+
+    val doc1 = doc
+    val doc2 = doc
+
+    doc1.id shouldBe doc1.id
+    doc1.id should not be doc2.id
+    doc2.id shouldBe doc2.id
+  }
+}

--- a/web/test/page/tiedonsiirrotPage.js
+++ b/web/test/page/tiedonsiirrotPage.js
@@ -30,6 +30,9 @@ function TiedonsiirrotPage() {
     setValinta: function(id, selected) {
       return Page().setInputValue('#' + id.replace( /(\.)/g, '\\$1' ) + ' input', selected)
     },
+    setValintaViimeiseen: function(selected) {
+      return Page().setInputValue('.tiedonsiirrot tbody:last-child input', selected)
+    },
     openVirhesivu: seq(
       click('.virheet-link'),
       wait.untilVisible('#content .tiedonsiirto-virheet')

--- a/web/test/spec/tiedonsiirrotSpec.js
+++ b/web/test/spec/tiedonsiirrotSpec.js
@@ -28,6 +28,7 @@ describe('Tiedonsiirrot', function() {
         ['280618-402H', 'Ammattilainen, Aarne', 'Aalto-yliopisto', '', 'virhe', 'tiedot'],
         ['24.2.1977', 'Hetuton, Heikki', 'Stadin ammatti- ja aikuisopisto', 'Autoalan perustutkinto', '', ''],
         ['270303-281N', 'Tiedonsiirto, Tiina', 'Stadin ammatti- ja aikuisopisto', 'Autoalan perustutkinto', '', ''],
+        ['', '', '', '', 'virhe', 'tiedot'],
         ['', '', '', '', 'virhe', 'tiedot']
       ].sort(sortByName))
     })
@@ -48,7 +49,8 @@ describe('Tiedonsiirrot', function() {
       expect(tiedonsiirrot.tiedot()).to.deep.equal([
         ['epävalidiHetu', 'Tiedonsiirto, Tiina', 'Stadin ammatti- ja aikuisopisto', 'Luonto- ja ympäristöalan perustutkintoAutokorinkorjauksen osaamisalaAutokorinkorjaaja', 'Virheellinen muoto hetulla: epävalidiHetuvirhe', 'tiedot'],
         ['280618-402H', 'Ammattilainen, Aarne', 'Aalto-yliopisto', '', 'Ei oikeuksia organisatioon 1.2.246.562.10.56753942459virhe', 'tiedot'],
-        ['', '', '', '', 'Viesti ei ole skeeman mukainen (notAnyOf henkilö)virhe', 'tiedot']
+        ['', '', '', '', 'Viesti ei ole skeeman mukainen (notAnyOf henkilö)virhe', 'tiedot'],
+        [ '', '', '', '', 'Epäkelpo JSON-dokumenttivirhe', 'tiedot' ]
       ])
     })
 
@@ -61,7 +63,7 @@ describe('Tiedonsiirrot', function() {
         })
       })
       describe('Kun valitaan rivi', function() {
-        before(tiedonsiirrot.setValinta('tiedonsiirto-1.2.246.562.10.346830761110_', true))
+        before(tiedonsiirrot.setValintaViimeiseen(true))
 
         it('Poista valitut nappi enabloituu', function() {
           expect(tiedonsiirrot.poistaNappiEnabloitu()).to.equal(true)
@@ -82,7 +84,7 @@ describe('Tiedonsiirrot', function() {
             })
 
             describe('Kun poistetaan viimeinen rivi', function() {
-              before(tiedonsiirrot.setValinta('tiedonsiirto-1.2.246.562.10.346830761110_', false))
+              before(tiedonsiirrot.setValintaViimeiseen(false))
 
               it('Poista valitut nappi on disabloitu', function() {
                 expect(tiedonsiirrot.poistaNappiEnabloitu()).to.equal(false)
@@ -93,7 +95,7 @@ describe('Tiedonsiirrot', function() {
       })
       describe('Kun poistetaan valittu rivi', function() {
         before(
-          tiedonsiirrot.setValinta('tiedonsiirto-1.2.246.562.10.346830761110_', true),
+          tiedonsiirrot.setValintaViimeiseen(true),
           // tiedonsiirrot.poista does page reload, so wait.forAjax is not enough
           wait.prepareForNavigation,
           tiedonsiirrot.poista,
@@ -103,7 +105,8 @@ describe('Tiedonsiirrot', function() {
         it('Se poistuu listauksesta', function() {
           expect(tiedonsiirrot.tiedot()).to.deep.equal([
             ['epävalidiHetu', 'Tiedonsiirto, Tiina', 'Stadin ammatti- ja aikuisopisto', 'Luonto- ja ympäristöalan perustutkintoAutokorinkorjauksen osaamisalaAutokorinkorjaaja', 'Virheellinen muoto hetulla: epävalidiHetuvirhe', 'tiedot'],
-            ['280618-402H', 'Ammattilainen, Aarne', 'Aalto-yliopisto', '', 'Ei oikeuksia organisatioon 1.2.246.562.10.56753942459virhe', 'tiedot']
+            ['280618-402H', 'Ammattilainen, Aarne', 'Aalto-yliopisto', '', 'Ei oikeuksia organisatioon 1.2.246.562.10.56753942459virhe', 'tiedot'],
+            [ '', '', '', '', 'Viesti ei ole skeeman mukainen (notAnyOf henkilö)virhe', 'tiedot' ]
           ])
         })
         it('Poista valitut nappi on disabloitu', function () {


### PR DESCRIPTION
Korjaa duplikaatti id:t dokumenteille, joille ei ole henkilötietoja tai niitä ei voida parsia syötteestä.