### PR TITLE
Korjaus ammatillisen suorituksen keskiarvon validaatioon

### DIFF
--- a/src/test/scala/fi/oph/koski/api/OppijaValidationAmmatillinenSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationAmmatillinenSpec.scala
@@ -727,6 +727,16 @@ class OppijaValidationAmmatillinenSpec extends TutkinnonPerusteetTest[Ammatillin
           "palautetaan HTTP 400" in (putTutkintoSuoritus(valmisSuoritusIlmanKeskiarvoa)(
             verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.ammatillinen.valmiillaSuorituksellaPitääOllaKeskiarvo("Suorituksella pitää olla keskiarvo kun suoritus on valmis"))))
         }
+        val osasuoritusJaKeskiarvo = autoalanPerustutkinnonSuoritus().copy(
+          vahvistus = None,
+          keskiarvo = Some(4.0),
+          osasuoritukset = Some(List(tutkinnonOsaSuoritus)))
+        val opiskeluoikeus = lisääTila(defaultOpiskeluoikeus.copy(suoritukset = List(osasuoritusJaKeskiarvo)), LocalDate.now().minusYears(1), opiskeluoikeusKatsotaanEronneeksi)
+        "sallitaan jos tila on katsotaan eronneeksi mutta tutkinnon osa löytyy" - {
+          "palautetaan HTTP 200" in (putOpiskeluoikeus(opiskeluoikeus)(
+            verifyResponseStatusOk()
+          ))
+        }
       }
     }
 

--- a/validaation_muutoshistoria.md
+++ b/validaation_muutoshistoria.md
@@ -1,7 +1,7 @@
 
 # Koskeen tallennettavien tietojen validaatiosäännöt
 
-## 27.9.2022
+## 29.9.2022
 - Ammatillisen suoritukselle pitää lisätä keskiarvo kun suoritus on valmis
 - Ammatillisen suoritukselle sallitaan keskiarvo, kun opiskeluoikeuden tilana on "katsotaan eronneeksi" ja suorituksissa on vähintään yksi tutkinnon osa
 


### PR DESCRIPTION
Sallitaan keskiarvo kun _opiskeluoikeuden_ tila on "katsotaan eronneeksi". Aiemmin yritettiin katsoa suorituksen tilaa. 