### PR TITLE
TOR-XXXX: Korjaa tiedonsiirtovirheiden näkymässä pre-elementin tekstin ylivuoto

### DIFF
--- a/web/app/style/tiedonsiirrot.less
+++ b/web/app/style/tiedonsiirrot.less
@@ -125,5 +125,9 @@
       text-align: right;
       margin-bottom: 10px;
     }
+
+    pre {
+      white-space: pre-wrap;
+    }
   }
 }


### PR DESCRIPTION
Ennen:
![Screenshot 2022-10-03 at 13 46 02](https://user-images.githubusercontent.com/7612995/193559725-16f665ec-b006-4465-b855-241efcb5d0b3.png)

Jälkeen:

![Screenshot 2022-10-03 at 13 46 12](https://user-images.githubusercontent.com/7612995/193559781-35aa0917-232d-4b83-82c0-98c48f2ecd73.png)
