### PR TITLE
TOR-1790 älä päivitä haluttuja mock-koodistoja koskaan ympäristöihin

### DIFF
--- a/src/main/scala/fi/oph/koski/koodisto/KoodistoCreator.scala
+++ b/src/main/scala/fi/oph/koski/koodisto/KoodistoCreator.scala
@@ -20,17 +20,17 @@ case class KoodistoCreator(application: KoskiApplication) extends Logging {
   private val updateable = Koodistot.koodistot.filter { koodistoUri =>
     updateExistingStr match {
       case "all" => true
-      case "koskiKoodistot" => Koodistot.koskiKoodistot.contains(koodistoUri)
-      case "muutKoodistot" => Koodistot.muutKoodistot.contains(koodistoUri)
+      case "koskiKoodistot" => Koodistot.ympäristöihinPäivitettävätKoskiKoodistot.contains(koodistoUri)
+      case "muutKoodistot" => Koodistot.ympäristöihinPäivitettävätMuutKoodistot.contains(koodistoUri)
       case _ => updateExistingStr.split(",").contains(koodistoUri)
     }
   }
   private val createable = Koodistot.koodistot.filter { koodistoUri =>
     createMissingStr match {
       case "all" => true
-      case "koskiKoodistot" => Koodistot.koskiKoodistot.contains(koodistoUri)
-      case "muutKoodistot" => Koodistot.muutKoodistot.contains(koodistoUri)
-      case "true" => Koodistot.koskiKoodistot.contains(koodistoUri) // the former default case
+      case "koskiKoodistot" => Koodistot.ympäristöihinPäivitettävätKoskiKoodistot.contains(koodistoUri)
+      case "muutKoodistot" => Koodistot.ympäristöihinPäivitettävätMuutKoodistot.contains(koodistoUri)
+      case "true" => Koodistot.ympäristöihinPäivitettävätKoskiKoodistot.contains(koodistoUri) // the former default case
       case _ => createMissingStr.split(",").contains(koodistoUri)
     }
   }

--- a/src/main/scala/fi/oph/koski/koodisto/Koodistot.scala
+++ b/src/main/scala/fi/oph/koski/koodisto/Koodistot.scala
@@ -4,7 +4,8 @@ case class KoodistoAsetus(
   koodisto: String,
   vaadiSuomenkielinenNimi: Boolean = true,
   vaadiRuotsinkielinenNimi: Boolean = true,
-  koodistoVersio: Option[Int] = None
+  koodistoVersio: Option[Int] = None,
+  päivitäMockDataYmpäristöihin: Boolean = true
 ) {
   override def toString: String = koodisto + koodistoVersio.map(v => s"_$v").getOrElse("")
 }
@@ -48,6 +49,7 @@ object Koodistot {
     KoodistoAsetus("erityisopetuksentoteutuspaikka"),
     KoodistoAsetus("internationalschooldiplomatype", vaadiSuomenkielinenNimi = false, vaadiRuotsinkielinenNimi = false),
     KoodistoAsetus("internationalschoolluokkaaste", vaadiSuomenkielinenNimi = false, vaadiRuotsinkielinenNimi = false),
+    KoodistoAsetus("koskikoulutustendiaarinumerot", päivitäMockDataYmpäristöihin = false),
     KoodistoAsetus("koskiopiskeluoikeudentila"),
     KoodistoAsetus("koskioppiaineetyleissivistava"),
     KoodistoAsetus("koskiyoarvosanat", vaadiRuotsinkielinenNimi = false),
@@ -97,6 +99,7 @@ object Koodistot {
     KoodistoAsetus("tuvajarjestamislupa"),
   )
   val koskiKoodistot = koskiKoodistoAsetukset.map(_.toString)
+  val ympäristöihinPäivitettävätKoskiKoodistot = koskiKoodistoAsetukset.filter(_.päivitäMockDataYmpäristöihin).map(_.toString)
 
   // Muut koodistot, joita Koski käyttää
   val muutKoodistoAsetukset = List (
@@ -107,7 +110,6 @@ object Koodistot {
     KoodistoAsetus("jarjestamismuoto"),
     KoodistoAsetus("kieli"),
     KoodistoAsetus("kielivalikoima"),
-    KoodistoAsetus("koskikoulutustendiaarinumerot"),
     KoodistoAsetus("koulutus"),
     KoodistoAsetus("koulutus", koodistoVersio = Some(11)),
     KoodistoAsetus("koulutustyyppi"),
@@ -134,6 +136,7 @@ object Koodistot {
     KoodistoAsetus("opintokokonaisuudet")
   )
   val muutKoodistot = muutKoodistoAsetukset.map(_.toString)
+  val ympäristöihinPäivitettävätMuutKoodistot = muutKoodistoAsetukset.filter(_.päivitäMockDataYmpäristöihin).map(_.toString)
 
   val koodistoAsetukset = (koskiKoodistoAsetukset ++ muutKoodistoAsetukset).sortBy(_.koodisto)
   val koodistot = (koskiKoodistot ++ muutKoodistot).sorted

--- a/src/test/scala/fi/oph/koski/koodisto/KoodistotTest.scala
+++ b/src/test/scala/fi/oph/koski/koodisto/KoodistotTest.scala
@@ -75,6 +75,11 @@ class KoodistotTest extends AnyFreeSpec with TestEnvironment with Matchers {
     }
   }
 
+  "Päivitetään vain halutut koodistot KoodistoCreatorilla ympäristöihin" in {
+    Koodistot.koskiKoodistot should contain("koskikoulutustendiaarinumerot")
+    Koodistot.ympäristöihinPäivitettävätKoskiKoodistot should not contain("koskikoulutustendiaarinumerot")
+  }
+
   private def getKoodisto(koodistoUri: String, koodistoVersio: Option[Int]) = {
     val versio = koodistoVersio.map(v => KoodistoViite(koodistoUri, v))
       .getOrElse(MockKoodistoPalvelu().getLatestVersionRequired(koodistoUri))


### PR DESCRIPTION
Lisää kenttä jonka perusteella rajataan mock-koodistoista ulos sellaiset, joita ei haluta päivittää ympäristöjen koodisto-palveluun.