### PR TITLE
TOR-1822 Lisää Kelan malliin tieto oppisopimuksen purkamisesta

### DIFF
--- a/src/main/scala/fi/oph/koski/kela/KelaAmmatillinenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaAmmatillinenSchema.scala
@@ -2,6 +2,7 @@ package fi.oph.koski.kela
 
 import fi.oph.koski.koskiuser.Rooli
 import fi.oph.koski.schema
+import fi.oph.koski.schema.OppisopimuksenPurkaminen
 import fi.oph.koski.schema.annotation.{Deprecated, KoodistoKoodiarvo, SensitiveData}
 import fi.oph.scalaschema.annotation.{DefaultValue, Description, Title}
 
@@ -245,7 +246,8 @@ case class Järjestämismuotojakso(
 )
 
 case class Oppisopimus(
-  työnantaja: Yritys
+  työnantaja: Yritys,
+  oppisopimuksenPurkaminen: Option[OppisopimuksenPurkaminen]
 )
 
 case class Yritys(

--- a/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
+++ b/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
@@ -64,6 +64,20 @@ class KelaSpec
         tuvaOpiskeluoikeus.suoritukset.head.osasuoritukset.get.length shouldBe 7
       }
     }
+
+    "Palauttaa tiedon oppisopimuksen purkamisesta" in {
+      postHetu(KoskiSpecificMockOppijat.reformitutkinto.hetu.get, user = MockUsers.kelaLaajatOikeudet) {
+        verifyResponseStatusOk()
+        val oppija = JsonSerializer.parse[KelaOppija](body)
+        oppija.opiskeluoikeudet.length.shouldBe(1)
+        oppija.opiskeluoikeudet.head.suoritukset.length.shouldBe(1)
+        val suoritus = oppija.opiskeluoikeudet.head.suoritukset.head.asInstanceOf[KelaAmmatillinenPäätasonSuoritus]
+        suoritus.osaamisenHankkimistavat.map(oht => oht.length).shouldBe(Some(2))
+        suoritus.osaamisenHankkimistavat.map(oht => oht.last.osaamisenHankkimistapa.isInstanceOf[OppisopimuksellinenOsaamisenHankkimistapa]).shouldBe(Some(true))
+        val hankkimistapa = suoritus.osaamisenHankkimistavat.map(oht => oht.last.osaamisenHankkimistapa.asInstanceOf[OppisopimuksellinenOsaamisenHankkimistapa])
+        hankkimistapa.get.oppisopimus.oppisopimuksenPurkaminen.exists(_.päivä.equals(LocalDate.of(2013,3,20))).shouldBe(true)
+      }
+    }
     "Ei palauta mitätöityä opiskeluoikeutta" in {
       postHetu(KoskiSpecificMockOppijat.lukiolainen.hetu.get, user = MockUsers.kelaLaajatOikeudet) {
         verifyResponseStatusOk()


### PR DESCRIPTION
Lisätty Kelan tietomalliin tiedot oppisopimuksen purkamisesta. Tiketissä mainittu dokumentaation päivitys puuttuu tästä pullarista - tehdään erikseen.