### PR TITLE
TOR-1840 lisää puuttuvat koulutukset perusteen rakennevalidaatioon

### DIFF
--- a/src/main/scala/fi/oph/koski/eperusteetvalidation/TutkintoRakenneValidator.scala
+++ b/src/main/scala/fi/oph/koski/eperusteetvalidation/TutkintoRakenneValidator.scala
@@ -118,6 +118,16 @@ case class TutkintoRakenneValidator(tutkintoRepository: TutkintoRepository, kood
           HttpStatus.justStatus(validateKoulutustyypitJaHaeRakenteet(d, Some(List(telma)), Some(vaadittuPerusteenVoimassaolopäivä)))
         case d: LukionOppiaine =>
           HttpStatus.justStatus(validateKoulutustyypitJaHaeRakenteet(d, Some(lukionKoulutustyypit), Some(vaadittuPerusteenVoimassaolopäivä))).onSuccess(validateLukio2015Diaarinumero(d))
+        case d: TutkintokoulutukseenValmentavanKoulutus =>
+          HttpStatus.justStatus(validateKoulutustyypitJaHaeRakenteet(d, Some(List(tuva)), Some(vaadittuPerusteenVoimassaolopäivä)))
+        case d: OppivelvollisilleSuunnattuVapaanSivistystyönKoulutus =>
+          HttpStatus.justStatus(validateKoulutustyypitJaHaeRakenteet(d, Some(List(vapaanSivistystyönVapaatavoitteinenKoulutus)), Some(vaadittuPerusteenVoimassaolopäivä)))
+        case d: VapaanSivistystyönLukutaitokoulutus =>
+          HttpStatus.justStatus(validateKoulutustyypitJaHaeRakenteet(d, Some(List(vstlukutaitokoulutus)), Some(vaadittuPerusteenVoimassaolopäivä)))
+        case d: VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutus =>
+          HttpStatus.justStatus(validateKoulutustyypitJaHaeRakenteet(d, Some(List(vapaanSivistystyönMaahanmuuttajienKotoutumisKoulutus)), Some(vaadittuPerusteenVoimassaolopäivä)))
+        case d: VSTKotoutumiskoulutus2022 =>
+          HttpStatus.justStatus(validateKoulutustyypitJaHaeRakenteet(d, Some(List(vapaanSivistystyönMaahanmuuttajienKotoutumisKoulutus)), Some(vaadittuPerusteenVoimassaolopäivä)))
         case d: Diaarinumerollinen =>
           HttpStatus.justStatus(validateKoulutustyypitJaHaeRakenteet(d, None, Some(vaadittuPerusteenVoimassaolopäivä)))
         case _ => HttpStatus.ok

--- a/src/test/scala/fi/oph/koski/api/OppijaValidationVapaaSivistystyöKOPSSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationVapaaSivistystyöKOPSSpec.scala
@@ -1,0 +1,156 @@
+package fi.oph.koski.api
+
+import fi.oph.koski.KoskiHttpSpec
+import fi.oph.koski.documentation.ExampleData.{opiskeluoikeusKatsotaanEronneeksi, opiskeluoikeusLäsnä}
+import fi.oph.koski.documentation.VapaaSivistystyöExample._
+import fi.oph.koski.documentation.VapaaSivistystyöExampleData._
+import fi.oph.koski.http.KoskiErrorCategory
+import fi.oph.koski.schema._
+
+import java.time.LocalDate.{of => date}
+
+class OppijaValidationVapaaSivistystyöKOPSSpec extends TutkinnonPerusteetTest[VapaanSivistystyönOpiskeluoikeus] with KoskiHttpSpec {
+  def tag = implicitly[reflect.runtime.universe.TypeTag[VapaanSivistystyönOpiskeluoikeus]]
+
+  "KOPS" - {
+    "Laajuudet" - {
+      "Osaamiskokonaisuuden laajuus" - {
+        "Osaamiskokonaisuuden laajuus lasketaan opintokokonaisuuksien laajuuksista" in {
+          val oo = defaultOpiskeluoikeus.copy(suoritukset = List(suoritusKOPS.copy(
+            osasuoritukset = Some(List(
+              osaamiskokonaisuudenSuoritus("1002", List(
+                opintokokonaisuudenSuoritus(
+                  opintokokonaisuus("A01", "Arjen rahankäyttö", "Arjen rahankäyttö", 2.0)
+                ),
+                opintokokonaisuudenSuoritus(
+                  opintokokonaisuus("M01", "Mielen liikkeet", "Mielen liikkeet ja niiden havaitseminen", 51),
+                  vstArviointi("Hyväksytty", date(2021, 11, 2))
+                )
+              ))
+            ))
+          )))
+
+          val opiskeluoikeus: Opiskeluoikeus = putAndGetOpiskeluoikeus(oo)
+          opiskeluoikeus.suoritukset.head.osasuoritusLista.head.koulutusmoduuli.laajuusArvo(0) should equal(53.0)
+        }
+
+        "Valinnaisten suuntautumisopintojen laajuus lasketaan opintokokonaisuuksien laajuuksista" in {
+          val oo = defaultOpiskeluoikeus.copy(suoritukset = List(suoritusKOPS.copy(
+            osasuoritukset = Some(List(
+              suuntautumisopintojenSuoritus(List(
+                opintokokonaisuudenSuoritus(
+                  opintokokonaisuus("ATX01", "Tietokoneen huolto", "Nykyaikaisen tietokoneen tyypilliset huoltotoimenpiteet", 3.0),
+                  vstArviointi("Hyväksytty", date(2021, 11, 12))
+                ),
+                opintokokonaisuudenSuoritus(
+                  opintokokonaisuus("VT02", "Valaisintekniikka", "Valaisinlähteet ja niiden toiminta", 10.0)
+                ),
+                opintokokonaisuudenSuoritus(
+                  opintokokonaisuus("TAI01", "Taide työkaluna", "Taiteen käyttö työkaluna", 40.0)
+                )
+              ))
+            ))
+          )))
+
+          val opiskeluoikeus: Opiskeluoikeus = putAndGetOpiskeluoikeus(oo)
+          opiskeluoikeus.suoritukset.head.osasuoritusLista.head.koulutusmoduuli.laajuusArvo(0) should equal(53.0)
+        }
+
+        "Jos osaamiskokonaisuudella ei ole opintokokonaisuuksia, sille asetettu laajuus poistetaan" in {
+          val oo = defaultOpiskeluoikeus.copy(
+            suoritukset = List(suoritusKOPS.copy(
+              vahvistus = None,
+              osasuoritukset = Some(List(tyhjäOsaamiskokonaisuudenSuoritus("1003", Some(laajuus(5.0)))))
+            )))
+
+          val opiskeluoikeus: Opiskeluoikeus = putAndGetOpiskeluoikeus(oo)
+          opiskeluoikeus.suoritukset.head.osasuoritusLista.head.koulutusmoduuli.getLaajuus should equal(None)
+        }
+
+        "Jos valinnaisilla suuntautumisopinnoilla ei ole opintokokonaisuuksia, sille asetettu laajuus poistetaan" in {
+          val oo = defaultOpiskeluoikeus.copy(suoritukset = List(suoritusKOPS.copy(
+            vahvistus = None,
+            osasuoritukset = Some(List(tyhjäSuuntautumisopintojenSuoritus(Some(laajuus(5.0)))))
+          )))
+
+          val opiskeluoikeus: Opiskeluoikeus = putAndGetOpiskeluoikeus(oo)
+          opiskeluoikeus.suoritukset.head.osasuoritusLista.head.koulutusmoduuli.getLaajuus should equal(None)
+        }
+
+        "Jos päätason suorituksella on osaamiskokonaisuuksia, joiden laajuus on alle 4, päätason suoritusta ei voida merkitä valmiiksi" in {
+          val oo = defaultOpiskeluoikeus.copy(suoritukset = List(suoritusKOPS.copy(
+            osasuoritukset = Some(List(
+              osaamiskokonaisuudenSuoritus("1002", List(
+                opintokokonaisuudenSuoritus(
+                  opintokokonaisuus("M01", "Mielen liikkeet", "Mielen liikkeet ja niiden havaitseminen", 51),
+                  vstArviointi("Hyväksytty", date(2021, 11, 2))
+                )
+              )),
+              osaamiskokonaisuudenSuoritus("1003", List(
+                opintokokonaisuudenSuoritus(
+                  opintokokonaisuus("A01", "Arjen rahankäyttö", "Arjen rahankäyttö", 2.0),
+                  vstArviointi("Hyväksytty", date(2021, 11, 2))
+                )
+              ))
+            ))
+          )))
+
+          putOpiskeluoikeus(oo) {
+            verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.tila.vapaanSivistystyönVahvistetunPäätasonSuorituksenLaajuus("Päätason suoritus koulutus/999909 on vahvistettu, mutta sillä on hyväksytyksi arvioituja osaamiskokonaisuuksia, joiden laajuus on alle 4 opintopistettä"))
+          }
+        }
+      }
+    }
+    "Katsotaan eronneeksi tilaan päättyneellä opiskeluoikeudella ei saa olla arvioimattomia osasuorituksia" in {
+      val oo = defaultOpiskeluoikeus.copy(
+        tila = VapaanSivistystyönOpiskeluoikeudenTila(List(
+          VapaanSivistystyönOpiskeluoikeusjakso(date(2021, 9, 1), opiskeluoikeusLäsnä),
+          VapaanSivistystyönOpiskeluoikeusjakso(date(2022, 6, 1), opiskeluoikeusKatsotaanEronneeksi)
+        )),
+        suoritukset = List(suoritusKOPS.copy(
+        osasuoritukset = Some(List(
+          osaamiskokonaisuudenSuoritus("1002", List(
+            opintokokonaisuudenSuoritus(
+              opintokokonaisuus("A01", "Arjen rahankäyttö", "Arjen rahankäyttö", 2.0)
+            ),
+            opintokokonaisuudenSuoritus(
+              opintokokonaisuus("M01", "Mielen liikkeet", "Mielen liikkeet ja niiden havaitseminen", 51)
+            ).copy(arviointi = None)
+          ))
+        ))
+      )))
+
+      putOpiskeluoikeus(oo) {
+        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.tila.eronneeksiKatsotunOpiskeluoikeudenArvioinnit("Katsotaan eronneeksi -tilaan päättyvällä opiskeluoikeudella ei saa olla osasuorituksia, joista puuttuu arviointi"))
+      }
+    }
+    "Ei voi tallentaa väärällä perusteen diaarinumerolla" in {
+      val oo = defaultOpiskeluoikeus.copy(suoritukset = List(suoritusKOPS.copy(
+        koulutusmoduuli = OppivelvollisilleSuunnattuVapaanSivistystyönKoulutus(perusteenDiaarinumero = Some("OPH-5410-2021")) // ajoneuvoalan perustutkinto
+      )))
+      putOpiskeluoikeus(oo) {
+        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.rakenne.vääräKoulutustyyppi("Suoritukselle OppivelvollisilleSuunnattuVapaanSivistystyönKoulutus ei voi käyttää opiskeluoikeuden voimassaoloaikana voimassaollutta perustetta OPH-5410-2021 (7614470), jonka koulutustyyppi on 1(Ammatillinen perustutkinto). Tälle suoritukselle hyväksytyt perusteen koulutustyypit ovat 10(Vapaan sivistystyön koulutus)."))
+      }
+    }
+  }
+
+
+  private def putAndGetOpiskeluoikeus(oo: KoskeenTallennettavaOpiskeluoikeus): Opiskeluoikeus = putOpiskeluoikeus(oo) {
+    verifyResponseStatusOk()
+    getOpiskeluoikeus(readPutOppijaResponse.opiskeluoikeudet.head.oid)
+  }
+
+  override def defaultOpiskeluoikeus: VapaanSivistystyönOpiskeluoikeus = opiskeluoikeusKOPS
+
+  override def opiskeluoikeusWithPerusteenDiaarinumero(diaari: Option[String]): VapaanSivistystyönOpiskeluoikeus = {
+    opiskeluoikeusKOPS.withSuoritukset(
+      List(
+        suoritusKOPS.withKoulutusmoduuli(OppivelvollisilleSuunnattuVapaanSivistystyönKoulutus(perusteenDiaarinumero = diaari))
+      )
+    ) match {
+      case v: VapaanSivistystyönOpiskeluoikeus => v
+    }
+  }
+
+  override def eperusteistaLöytymätönValidiDiaarinumero: String = "6/011/2015"
+}

--- a/src/test/scala/fi/oph/koski/api/OppijaValidationVapaaSivistystyöKOTOSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationVapaaSivistystyöKOTOSpec.scala
@@ -1,134 +1,19 @@
 package fi.oph.koski.api
 
 import fi.oph.koski.KoskiHttpSpec
-import fi.oph.koski.documentation.ExampleData.{opiskeluoikeusKatsotaanEronneeksi, opiskeluoikeusLäsnä}
+import fi.oph.koski.documentation.ExampleData.opiskeluoikeusLäsnä
 import fi.oph.koski.documentation.VapaaSivistystyöExample._
 import fi.oph.koski.documentation.VapaaSivistystyöExampleData._
 import fi.oph.koski.documentation.{ExamplesVapaaSivistystyöKotoutuskoulutus2022 => Koto2022}
-import fi.oph.koski.http.{HttpStatus, KoskiErrorCategory}
+import fi.oph.koski.http.{ErrorMatcher, HttpStatus, KoskiErrorCategory}
 import fi.oph.koski.schema._
 import fi.oph.koski.validation.VSTKotoutumiskoulutus2022Validation
 import org.scalatest.freespec.AnyFreeSpec
 
 import java.time.LocalDate
-import java.time.LocalDate.{of => date}
 
-class OppijaValidationVapaaSivistystyöMuutSpec extends AnyFreeSpec with PutOpiskeluoikeusTestMethods[VapaanSivistystyönOpiskeluoikeus] with KoskiHttpSpec {
+class OppijaValidationVapaaSivistystyöKOTOSpec extends AnyFreeSpec with PutOpiskeluoikeusTestMethods[VapaanSivistystyönOpiskeluoikeus] with KoskiHttpSpec {
   def tag = implicitly[reflect.runtime.universe.TypeTag[VapaanSivistystyönOpiskeluoikeus]]
-
-  "KOPS" - {
-    "Laajuudet" - {
-      "Osaamiskokonaisuuden laajuus" - {
-        "Osaamiskokonaisuuden laajuus lasketaan opintokokonaisuuksien laajuuksista" in {
-          val oo = defaultOpiskeluoikeus.copy(suoritukset = List(suoritusKOPS.copy(
-            osasuoritukset = Some(List(
-              osaamiskokonaisuudenSuoritus("1002", List(
-                opintokokonaisuudenSuoritus(
-                  opintokokonaisuus("A01", "Arjen rahankäyttö", "Arjen rahankäyttö", 2.0)
-                ),
-                opintokokonaisuudenSuoritus(
-                  opintokokonaisuus("M01", "Mielen liikkeet", "Mielen liikkeet ja niiden havaitseminen", 51),
-                  vstArviointi("Hyväksytty", date(2021, 11, 2))
-                )
-              ))
-            ))
-          )))
-
-          val opiskeluoikeus: Opiskeluoikeus = putAndGetOpiskeluoikeus(oo)
-          opiskeluoikeus.suoritukset.head.osasuoritusLista.head.koulutusmoduuli.laajuusArvo(0) should equal(53.0)
-        }
-
-        "Valinnaisten suuntautumisopintojen laajuus lasketaan opintokokonaisuuksien laajuuksista" in {
-          val oo = defaultOpiskeluoikeus.copy(suoritukset = List(suoritusKOPS.copy(
-            osasuoritukset = Some(List(
-              suuntautumisopintojenSuoritus(List(
-                opintokokonaisuudenSuoritus(
-                  opintokokonaisuus("ATX01", "Tietokoneen huolto", "Nykyaikaisen tietokoneen tyypilliset huoltotoimenpiteet", 3.0),
-                  vstArviointi("Hyväksytty", date(2021, 11, 12))
-                ),
-                opintokokonaisuudenSuoritus(
-                  opintokokonaisuus("VT02", "Valaisintekniikka", "Valaisinlähteet ja niiden toiminta", 10.0)
-                ),
-                opintokokonaisuudenSuoritus(
-                  opintokokonaisuus("TAI01", "Taide työkaluna", "Taiteen käyttö työkaluna", 40.0)
-                )
-              ))
-            ))
-          )))
-
-          val opiskeluoikeus: Opiskeluoikeus = putAndGetOpiskeluoikeus(oo)
-          opiskeluoikeus.suoritukset.head.osasuoritusLista.head.koulutusmoduuli.laajuusArvo(0) should equal(53.0)
-        }
-
-        "Jos osaamiskokonaisuudella ei ole opintokokonaisuuksia, sille asetettu laajuus poistetaan" in {
-          val oo = defaultOpiskeluoikeus.copy(
-            suoritukset = List(suoritusKOPS.copy(
-              vahvistus = None,
-              osasuoritukset = Some(List(tyhjäOsaamiskokonaisuudenSuoritus("1003", Some(laajuus(5.0)))))
-            )))
-
-          val opiskeluoikeus: Opiskeluoikeus = putAndGetOpiskeluoikeus(oo)
-          opiskeluoikeus.suoritukset.head.osasuoritusLista.head.koulutusmoduuli.getLaajuus should equal(None)
-        }
-
-        "Jos valinnaisilla suuntautumisopinnoilla ei ole opintokokonaisuuksia, sille asetettu laajuus poistetaan" in {
-          val oo = defaultOpiskeluoikeus.copy(suoritukset = List(suoritusKOPS.copy(
-            vahvistus = None,
-            osasuoritukset = Some(List(tyhjäSuuntautumisopintojenSuoritus(Some(laajuus(5.0)))))
-          )))
-
-          val opiskeluoikeus: Opiskeluoikeus = putAndGetOpiskeluoikeus(oo)
-          opiskeluoikeus.suoritukset.head.osasuoritusLista.head.koulutusmoduuli.getLaajuus should equal(None)
-        }
-
-        "Jos päätason suorituksella on osaamiskokonaisuuksia, joiden laajuus on alle 4, päätason suoritusta ei voida merkitä valmiiksi" in {
-          val oo = defaultOpiskeluoikeus.copy(suoritukset = List(suoritusKOPS.copy(
-            osasuoritukset = Some(List(
-              osaamiskokonaisuudenSuoritus("1002", List(
-                opintokokonaisuudenSuoritus(
-                  opintokokonaisuus("M01", "Mielen liikkeet", "Mielen liikkeet ja niiden havaitseminen", 51),
-                  vstArviointi("Hyväksytty", date(2021, 11, 2))
-                )
-              )),
-              osaamiskokonaisuudenSuoritus("1003", List(
-                opintokokonaisuudenSuoritus(
-                  opintokokonaisuus("A01", "Arjen rahankäyttö", "Arjen rahankäyttö", 2.0),
-                  vstArviointi("Hyväksytty", date(2021, 11, 2))
-                )
-              ))
-            ))
-          )))
-
-          putOpiskeluoikeus(oo) {
-            verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.tila.vapaanSivistystyönVahvistetunPäätasonSuorituksenLaajuus("Päätason suoritus koulutus/999909 on vahvistettu, mutta sillä on hyväksytyksi arvioituja osaamiskokonaisuuksia, joiden laajuus on alle 4 opintopistettä"))
-          }
-        }
-      }
-    }
-    "Katsotaan eronneeksi tilaan päättyneellä opiskeluoikeudella ei saa olla arvioimattomia osasuorituksia" in {
-      val oo = defaultOpiskeluoikeus.copy(
-        tila = VapaanSivistystyönOpiskeluoikeudenTila(List(
-          VapaanSivistystyönOpiskeluoikeusjakso(date(2021, 9, 1), opiskeluoikeusLäsnä),
-          VapaanSivistystyönOpiskeluoikeusjakso(date(2022, 6, 1), opiskeluoikeusKatsotaanEronneeksi)
-        )),
-        suoritukset = List(suoritusKOPS.copy(
-        osasuoritukset = Some(List(
-          osaamiskokonaisuudenSuoritus("1002", List(
-            opintokokonaisuudenSuoritus(
-              opintokokonaisuus("A01", "Arjen rahankäyttö", "Arjen rahankäyttö", 2.0)
-            ),
-            opintokokonaisuudenSuoritus(
-              opintokokonaisuus("M01", "Mielen liikkeet", "Mielen liikkeet ja niiden havaitseminen", 51)
-            ).copy(arviointi = None)
-          ))
-        ))
-      )))
-
-      putOpiskeluoikeus(oo) {
-        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.tila.eronneeksiKatsotunOpiskeluoikeudenArvioinnit("Katsotaan eronneeksi -tilaan päättyvällä opiskeluoikeudella ei saa olla osasuorituksia, joista puuttuu arviointi"))
-      }
-    }
-  }
 
   "KOTO" - {
     "Päätason suorituksen laajuus lasketaan automaattisesti osasuoritusten laajuuksista" in {
@@ -142,6 +27,17 @@ class OppijaValidationVapaaSivistystyöMuutSpec extends AnyFreeSpec with PutOpis
       )))
       val result = putAndGetOpiskeluoikeus(opiskeluoikeus)
       result.suoritukset.head.koulutusmoduuli.laajuusArvo(0) shouldBe(69)
+    }
+
+    "Ei voi tallentaa väärällä perusteen diaarinumerolla" in {
+      val oo = opiskeluoikeusKOTO.withSuoritukset(List(
+        suoritusKOTO.copy(
+          koulutusmoduuli = VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutus(perusteenDiaarinumero = Some("OPH-5410-2021")) // ajoneuvoalan perustutkinto
+        )
+      ))
+      putOpiskeluoikeus(oo) {
+        verifyResponseStatus(400, ErrorMatcher.regex(KoskiErrorCategory.badRequest.validation.jsonSchema, ".*notAnyOf.*".r))
+      }
     }
   }
 
@@ -333,55 +229,17 @@ class OppijaValidationVapaaSivistystyöMuutSpec extends AnyFreeSpec with PutOpis
         }
       }
     }
-  }
 
-  "Lukutaitokoulutus" - {
-    "Päätason suorituksen laajuus lasketaan automaattisesti osasuoritusten laajuuksista" in {
-      val opiskeluoikeus = opiskeluoikeusLukutaito.withSuoritukset(List(
-        suoritusLukutaito.withOsasuoritukset(Some(List(
-          vapaanSivistystyönLukutaitokoulutuksenVuorovaikutustilanteissaToimimisenSuoritus(laajuus = LaajuusOpintopisteissä(60)),
-          vapaanSivistystyönLukutaitokoulutuksenTekstienLukeminenJaTulkitseminenSuoritus(laajuus = LaajuusOpintopisteissä(9))
-        )))
+    "Ei voi tallentaa väärällä perusteen diaarinumerolla" in {
+      val oo = Koto2022.Opiskeluoikeus.suoritettu.copy(
+        suoritukset = List(
+          Koto2022.PäätasonSuoritus.suoritettu.copy(
+            koulutusmoduuli = VSTKotoutumiskoulutus2022(perusteenDiaarinumero = Some("OPH-5410-2021")) // ajoneuvoalan perustutkinto
+          )
       ))
-      val result = putAndGetOpiskeluoikeus(opiskeluoikeus)
-      result.suoritukset.head.koulutusmoduuli.laajuusArvo(0) shouldBe(69)
-    }
 
-    "Opiskeluoikeus ei voi käyttää tilaa 'hyvaksytystisuoritettu'" in {
-      val opiskeluoikeus = opiskeluoikeusLukutaito.withSuoritukset(List(
-        suoritusLukutaito.withOsasuoritukset(Some(List(
-          vapaanSivistystyönLukutaitokoulutuksenVuorovaikutustilanteissaToimimisenSuoritus(laajuus = LaajuusOpintopisteissä(60)),
-          vapaanSivistystyönLukutaitokoulutuksenTekstienLukeminenJaTulkitseminenSuoritus(laajuus = LaajuusOpintopisteissä(9))
-        )))
-      )).withTila(
-        VapaanSivistystyönOpiskeluoikeudenTila(
-          List(
-            VapaanSivistystyönOpiskeluoikeusjakso(date(2022, 5, 31), opiskeluoikeusHyväksytystiSuoritettu)
-          )
-        )
-      )
-
-      putOpiskeluoikeus(opiskeluoikeus) {
-        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.tila.vapaanSivistystyönOpiskeluoikeudellaVääräTila())
-      }
-    }
-
-    "Opiskeluoikeus ei voi käyttää tilaa 'keskeytynyt'" in {
-      val opiskeluoikeus = opiskeluoikeusLukutaito.withSuoritukset(List(
-        suoritusLukutaito.withOsasuoritukset(Some(List(
-          vapaanSivistystyönLukutaitokoulutuksenVuorovaikutustilanteissaToimimisenSuoritus(laajuus = LaajuusOpintopisteissä(60)),
-          vapaanSivistystyönLukutaitokoulutuksenTekstienLukeminenJaTulkitseminenSuoritus(laajuus = LaajuusOpintopisteissä(9))
-        )))
-      )).withTila(
-        VapaanSivistystyönOpiskeluoikeudenTila(
-          List(
-            VapaanSivistystyönOpiskeluoikeusjakso(date(2022, 5, 31), opiskeluoikeusKeskeytynyt)
-          )
-        )
-      )
-
-      putOpiskeluoikeus(opiskeluoikeus) {
-        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.tila.vapaanSivistystyönOpiskeluoikeudellaVääräTila())
+      putOpiskeluoikeus(oo) {
+        verifyResponseStatus(400, ErrorMatcher.regex(KoskiErrorCategory.badRequest.validation.jsonSchema, ".*notAnyOf.*".r))
       }
     }
   }
@@ -391,7 +249,5 @@ class OppijaValidationVapaaSivistystyöMuutSpec extends AnyFreeSpec with PutOpis
     getOpiskeluoikeus(readPutOppijaResponse.opiskeluoikeudet.head.oid)
   }
 
-  override def defaultOpiskeluoikeus: VapaanSivistystyönOpiskeluoikeus = opiskeluoikeusKOPS
-  def KOTOOPiskeluoikeus: VapaanSivistystyönOpiskeluoikeus = opiskeluoikeusKOTO
-  def VapaatavoitteinenOpiskeluoikeus: VapaanSivistystyönOpiskeluoikeus = opiskeluoikeusVapaatavoitteinen
+  override def defaultOpiskeluoikeus: VapaanSivistystyönOpiskeluoikeus = opiskeluoikeusKOTO
 }

--- a/src/test/scala/fi/oph/koski/api/OppijaValidationVapaaSivistystyöLukutaitoSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationVapaaSivistystyöLukutaitoSpec.scala
@@ -1,0 +1,96 @@
+package fi.oph.koski.api
+
+import fi.oph.koski.KoskiHttpSpec
+import fi.oph.koski.documentation.VapaaSivistystyöExample._
+import fi.oph.koski.documentation.VapaaSivistystyöExampleData._
+import fi.oph.koski.http.KoskiErrorCategory
+import fi.oph.koski.schema._
+
+import java.time.LocalDate.{of => date}
+
+class OppijaValidationVapaaSivistystyöLukutaitoSpec extends TutkinnonPerusteetTest[VapaanSivistystyönOpiskeluoikeus] with KoskiHttpSpec {
+  def tag = implicitly[reflect.runtime.universe.TypeTag[VapaanSivistystyönOpiskeluoikeus]]
+
+  "Lukutaitokoulutus" - {
+    "Päätason suorituksen laajuus lasketaan automaattisesti osasuoritusten laajuuksista" in {
+      val opiskeluoikeus = opiskeluoikeusLukutaito.withSuoritukset(List(
+        suoritusLukutaito.withOsasuoritukset(Some(List(
+          vapaanSivistystyönLukutaitokoulutuksenVuorovaikutustilanteissaToimimisenSuoritus(laajuus = LaajuusOpintopisteissä(60)),
+          vapaanSivistystyönLukutaitokoulutuksenTekstienLukeminenJaTulkitseminenSuoritus(laajuus = LaajuusOpintopisteissä(9))
+        )))
+      ))
+      val result = putAndGetOpiskeluoikeus(opiskeluoikeus)
+      result.suoritukset.head.koulutusmoduuli.laajuusArvo(0) shouldBe(69)
+    }
+
+    "Opiskeluoikeus ei voi käyttää tilaa 'hyvaksytystisuoritettu'" in {
+      val opiskeluoikeus = opiskeluoikeusLukutaito.withSuoritukset(List(
+        suoritusLukutaito.withOsasuoritukset(Some(List(
+          vapaanSivistystyönLukutaitokoulutuksenVuorovaikutustilanteissaToimimisenSuoritus(laajuus = LaajuusOpintopisteissä(60)),
+          vapaanSivistystyönLukutaitokoulutuksenTekstienLukeminenJaTulkitseminenSuoritus(laajuus = LaajuusOpintopisteissä(9))
+        )))
+      )).withTila(
+        VapaanSivistystyönOpiskeluoikeudenTila(
+          List(
+            VapaanSivistystyönOpiskeluoikeusjakso(date(2022, 5, 31), opiskeluoikeusHyväksytystiSuoritettu)
+          )
+        )
+      )
+
+      putOpiskeluoikeus(opiskeluoikeus) {
+        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.tila.vapaanSivistystyönOpiskeluoikeudellaVääräTila())
+      }
+    }
+
+    "Opiskeluoikeus ei voi käyttää tilaa 'keskeytynyt'" in {
+      val opiskeluoikeus = opiskeluoikeusLukutaito.withSuoritukset(List(
+        suoritusLukutaito.withOsasuoritukset(Some(List(
+          vapaanSivistystyönLukutaitokoulutuksenVuorovaikutustilanteissaToimimisenSuoritus(laajuus = LaajuusOpintopisteissä(60)),
+          vapaanSivistystyönLukutaitokoulutuksenTekstienLukeminenJaTulkitseminenSuoritus(laajuus = LaajuusOpintopisteissä(9))
+        )))
+      )).withTila(
+        VapaanSivistystyönOpiskeluoikeudenTila(
+          List(
+            VapaanSivistystyönOpiskeluoikeusjakso(date(2022, 5, 31), opiskeluoikeusKeskeytynyt)
+          )
+        )
+      )
+
+      putOpiskeluoikeus(opiskeluoikeus) {
+        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.tila.vapaanSivistystyönOpiskeluoikeudellaVääräTila())
+      }
+    }
+
+    "Ei voi tallentaa väärällä perusteen diaarinumerolla" in {
+      val oo = opiskeluoikeusLukutaito.withSuoritukset(
+        List(
+          suoritusLukutaito.withKoulutusmoduuli(
+            VapaanSivistystyönLukutaitokoulutus(perusteenDiaarinumero = Some("OPH-5410-2021")) // ajoneuvoalan perustutkinto
+          )
+      ))
+
+      putOpiskeluoikeus(oo) {
+        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.rakenne.vääräKoulutustyyppi("Suoritukselle VapaanSivistystyönLukutaitokoulutus ei voi käyttää opiskeluoikeuden voimassaoloaikana voimassaollutta perustetta OPH-5410-2021 (7614470), jonka koulutustyyppi on 1(Ammatillinen perustutkinto). Tälle suoritukselle hyväksytyt perusteen koulutustyypit ovat 35(Vapaan sivistystyön lukutaitokoulutus)."))
+      }
+    }
+  }
+
+  private def putAndGetOpiskeluoikeus(oo: KoskeenTallennettavaOpiskeluoikeus): Opiskeluoikeus = putOpiskeluoikeus(oo) {
+    verifyResponseStatusOk()
+    getOpiskeluoikeus(readPutOppijaResponse.opiskeluoikeudet.head.oid)
+  }
+
+  override def defaultOpiskeluoikeus: VapaanSivistystyönOpiskeluoikeus = opiskeluoikeusLukutaito
+
+  override def opiskeluoikeusWithPerusteenDiaarinumero(diaari: Option[String]): VapaanSivistystyönOpiskeluoikeus = {
+    opiskeluoikeusLukutaito.withSuoritukset(
+      List(
+        suoritusLukutaito.withKoulutusmoduuli(VapaanSivistystyönLukutaitokoulutus(perusteenDiaarinumero = diaari))
+      )
+    ) match {
+      case v: VapaanSivistystyönOpiskeluoikeus => v
+    }
+  }
+
+  override def eperusteistaLöytymätönValidiDiaarinumero: String = "6/011/2015"
+}

--- a/validaation_muutoshistoria.md
+++ b/validaation_muutoshistoria.md
@@ -3,6 +3,7 @@
 
 ## 24.10.2022
 - Sallittu väliaikaisesti oppilaitoksen vaihto tilanteessa, jossa vaihdetaan oppilaitoksesta 1.2.246.562.10.93428463247 oppilaitokseen 1.2.246.562.10.77609835432
+- Lisätty TUVA- ja VST-suorituksille perusteiden koulutustyypin validaatio. Estetään näin koulutuksien syöttäminen väärällä diaarinumerolla.
 
 ## 19.10.2022
 - Sallitaan uudet JOTPA-rahoitusmuodot ainoastaan ammatillisen koulutuksen opiskeluoikeuksille.


### PR DESCRIPTION
estetään näin opiskeluoikeuksien siirtäminen perusteella jossa on väärä koulutustyyppi.