### PR TITLE
TOR-1754 salli vahvistaa vuosiluokan suoritus ilman osasuorituksia vuosiluokkiin sitomattomassa opetuksessa

### DIFF
--- a/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
+++ b/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
@@ -1037,6 +1037,8 @@ class KoskiValidator(
            _: NäyttötutkintoonValmistavanKoulutuksenSuoritus
       => true
       case s: PerusopetuksenVuosiluokanSuoritus if s.koulutusmoduuli.tunniste.koodiarvo == "9" || s.jääLuokalle => true
+      case _: PerusopetuksenVuosiluokanSuoritus
+        if PerusopetuksenOpiskeluoikeusValidation.onVuosiluokkiinSitoutumatonOpetus(opiskeluoikeus) => true
       case s: LukionOppimääränSuoritus2019
       => osasuorituksetKunnossaLukio2019(s)
       case s: LukionOppiaineidenOppimäärienSuoritus2019 if opiskeluoikeus.asInstanceOf[LukionOpiskeluoikeus].oppimääräSuoritettu.getOrElse(false)
@@ -1087,6 +1089,8 @@ class KoskiValidator(
       KoskiErrorCategory.badRequest.validation.tila.valmiiksiMerkityltäPuuttuuOsasuorituksia(s"Suoritus ${suorituksenTunniste(suoritus)} on merkitty valmiiksi, mutta sillä ei ole ammatillisen tutkinnon osan suoritusta tai opiskeluoikeudelta puuttuu linkitys")
     case s: PerusopetuksenOppimääränSuoritus =>
       KoskiErrorCategory.badRequest.validation.tila.oppiaineetPuuttuvat("Suorituksella ei ole osasuorituksena yhtään oppiainetta, vaikka sillä on vahvistus")
+    case s: PerusopetuksenVuosiluokanSuoritus =>
+      KoskiErrorCategory.badRequest.validation.tila.oppiaineetPuuttuvat("Suorituksella ei ole osasuorituksena yhtään oppiainetta, vaikka sillä on vahvistus, eikä oppija ole vuosiluokkiin sitomattomassa opetuksessa.")
     case s: LukionOppimääränSuoritus2019 if s.oppimäärä.koodiarvo == "nuortenops" =>
       KoskiErrorCategory.badRequest.validation.tila.valmiiksiMerkityltäPuuttuuOsasuorituksia(s"Suoritus ${suorituksenTunniste(suoritus)} on merkitty valmiiksi tai opiskeluoikeuden tiedoissa oppimäärä on merkitty suoritetuksi, mutta sillä ei ole 150 op osasuorituksia, joista vähintään 20 op valinnaisia, tai opiskeluoikeudelta puuttuu linkitys")
     case s: LukionOppimääränSuoritus2019 if s.oppimäärä.koodiarvo == "aikuistenops" =>

--- a/src/main/scala/fi/oph/koski/validation/PerusopetuksenOpiskeluoikeudenValidation.scala
+++ b/src/main/scala/fi/oph/koski/validation/PerusopetuksenOpiskeluoikeudenValidation.scala
@@ -67,7 +67,7 @@ object PerusopetuksenOpiskeluoikeusValidation {
       case _: Any => false
     }
 
-    val vuosiluokkiinSitoutumatonOpetus = oo.lisätiedot.exists(_.vuosiluokkiinSitoutumatonOpetus)
+    val vuosiluokkiinSitoutumatonOpetus = onVuosiluokkiinSitoutumatonOpetus(oo)
 
     val kotiopetusVoimassaPäättötodistuksenVahvistuspäivänä = oo.suoritukset.exists {
       case päättö: NuortenPerusopetuksenOppimääränSuoritus => päättö.vahvistus.exists(vahvistus => {
@@ -86,6 +86,10 @@ object PerusopetuksenOpiskeluoikeusValidation {
     } else {
       KoskiErrorCategory.badRequest.validation.tila.nuortenPerusopetuksenValmistunutTilaIlmanYsiluokanSuoritusta()
     }
+  }
+
+  def onVuosiluokkiinSitoutumatonOpetus(oo: KoskeenTallennettavaOpiskeluoikeus): Boolean = oo match {
+    case p: PerusopetuksenOpiskeluoikeus => p.lisätiedot.exists(_.vuosiluokkiinSitoutumatonOpetus)
   }
 
   def filterDeprekoidutKentät(oo: KoskeenTallennettavaOpiskeluoikeus): KoskeenTallennettavaOpiskeluoikeus = {

--- a/src/test/scala/fi/oph/koski/api/OppijaValidationPerusopetuksenVuosiluokkaSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/OppijaValidationPerusopetuksenVuosiluokkaSpec.scala
@@ -43,4 +43,26 @@ class OppijaValidationPerusopetuksenVuosiluokkaSpec extends TutkinnonPerusteetTe
       verifyResponseStatusOk()
     }
   }
+
+  "Jos oppilaalle on merkitty vuosiluokkiin sitomaton opetus, vahvistetulta vuosiluokan suoritukselta ei vaadita osasuorituksia" in {
+    putOpiskeluoikeus(defaultOpiskeluoikeus.copy(
+      suoritukset = List(PerusopetusExampleData.seitsemännenLuokanSuoritus.copy(osasuoritukset = None)),
+      lisätiedot = Some(PerusopetuksenOpiskeluoikeudenLisätiedot(
+        vuosiluokkiinSitoutumatonOpetus = true
+      ))
+    )) {
+      verifyResponseStatusOk()
+    }
+  }
+
+  "Jos oppilaalle ei ole merkitty vuosiluokkiin sitomatonta opetusta, vahvistetulta vuosiluokan suoritukselta vaaditaan osasuorituksia" in {
+    putOpiskeluoikeus(defaultOpiskeluoikeus.copy(
+      suoritukset = List(PerusopetusExampleData.seitsemännenLuokanSuoritus.copy(osasuoritukset = None)),
+      lisätiedot = Some(PerusopetuksenOpiskeluoikeudenLisätiedot(
+        vuosiluokkiinSitoutumatonOpetus = false
+      ))
+    )) {
+      verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.tila.oppiaineetPuuttuvat("Suorituksella ei ole osasuorituksena yhtään oppiainetta, vaikka sillä on vahvistus, eikä oppija ole vuosiluokkiin sitomattomassa opetuksessa."))
+    }
+  }
 }

--- a/validaation_muutoshistoria.md
+++ b/validaation_muutoshistoria.md
@@ -1,5 +1,9 @@
 # Koskeen tallennettavien tietojen validaatiosäännöt
 
+## 21.11.2022
+- Nuorten perusopetuksen vuosiluokan päätason suoritus sallitaan vahvistaa ilman osasuorituksia,
+  kun oppija on vuosiluokkiin sitomattomassa opetuksessa.
+
 ## 15.11.2022
 - Ammatillisen perustutkinnon osatutkinnosta valmistuneilta vaaditaan keskiarvo, kun valmistumispäivä on 1.1.2022 tai sen jälkeen.
 


### PR DESCRIPTION
Nuorten perusopetuksen vuosiluokan päätason suoritus sallitaan vahvistaa ilman osasuorituksia, kun oppija on vuosiluokkiin sitomattomassa opetuksessa.