### PR TITLE
TOR-1876: Korjaa eqeqeq-säännön varoitukset Kosken ja Valppaan koodista

### DIFF
--- a/.github/workflows/all_tests.yml
+++ b/.github/workflows/all_tests.yml
@@ -208,7 +208,7 @@ jobs:
     name: Frontend 6/6
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/koski_frontend_playwright_test
 
   valpas_integration_tests_1:

--- a/src/main/resources/localization/koski-default-texts.json
+++ b/src/main/resources/localization/koski-default-texts.json
@@ -192,6 +192,7 @@
   "Lisää valinnainen oppiaine": "Lisää valinnainen oppiaine",
   "Lisää toiminta-alue": "Lisää toiminta-alue",
   "Lisää kurssi": "Lisää kurssi",
+  "Lisää alkuvaiheen kurssi": "Lisää alkuvaiheen kurssi",
   "Lisää paikallinen kurssi...": "Lisää paikallinen kurssi...",
   "Opiskeluoikeudet": "Opiskeluoikeudet",
   "Osasuoritukset": "Osasuoritukset",

--- a/valpas-web/.eslintrc
+++ b/valpas-web/.eslintrc
@@ -13,6 +13,7 @@
     "prettier"
   ],
   "rules": {
-    "prettier/prettier": ["error"]
+    "prettier/prettier": ["error"],
+    "eqeqeq": "warn"
   }
 }

--- a/valpas-web/src/components/shared/OrganisaatioValitsin.tsx
+++ b/valpas-web/src/components/shared/OrganisaatioValitsin.tsx
@@ -98,7 +98,7 @@ export const getOrganisaatiot = (
 ): OrganisaatioHierarkia[] => {
   const sallitutKäyttöoikeusroolit = käyttöoikeusroolit.filter(
     (kayttooikeusrooli) =>
-      kayttooikeusrooli.kayttooikeusrooli == käytettäväKäyttöoikeus
+      kayttooikeusrooli.kayttooikeusrooli === käytettäväKäyttöoikeus
   )
   const kaikki = pipe(
     sallitutKäyttöoikeusroolit,

--- a/valpas-web/src/components/tables/DataTable.tsx
+++ b/valpas-web/src/components/tables/DataTable.tsx
@@ -365,9 +365,9 @@ const compareDatum = (index: number) => (a: Datum, b: Datum) => {
     return string.Ord.compare(av, bv)
   } else if (typeof av === "number" && typeof bv === "number") {
     return number.Ord.compare(av, bv)
-  } else if (av == null && bv != null) {
+  } else if (av === null && bv !== null) {
     return 1
-  } else if (bv == null && av != null) {
+  } else if (bv === null && av !== null) {
     return -1
   } else {
     return 0

--- a/valpas-web/src/state/apitypes/opiskeluoikeus.ts
+++ b/valpas-web/src/state/apitypes/opiskeluoikeus.ts
@@ -87,12 +87,12 @@ export type PäätasonSuoritus = {
 
 export const isHakeutumisvalvottavaOpiskeluoikeus =
   (organisaatioOid: string | undefined) => (oo: OpiskeluoikeusSuppeatTiedot) =>
-    oo.onHakeutumisValvottava && oo.oppilaitos.oid == organisaatioOid
+    oo.onHakeutumisValvottava && oo.oppilaitos.oid === organisaatioOid
 
 export const isSuorittamisvalvottavaOpiskeluoikeus =
   (organisaatioOid: string | undefined) => (oo: OpiskeluoikeusSuppeatTiedot) =>
     oo.onSuorittamisValvottava &&
-    oo.oppilaitos.oid == organisaatioOid &&
+    oo.oppilaitos.oid === organisaatioOid &&
     // Redundantti tarkistus bugien varalta. Suorittamisvalvottavien pitäisi
     // kaikkien olla perusopetuksen jälkeisiä opintoja sisältäviä opiskeluoikeuksia:
     oo.perusopetuksenJälkeinenTiedot !== undefined

--- a/valpas-web/src/state/opiskeluoikeustiedot.tsx
+++ b/valpas-web/src/state/opiskeluoikeustiedot.tsx
@@ -83,7 +83,7 @@ export const perusopetuksenJälkeistäPreferoivatOpiskeluoikeustiedot = (
   const ooTiedots: Array<[OpiskeluoikeusSuppeatTiedot, OpintotasonTiedot]> =
     pipe(
       opiskeluoikeudet,
-      A.filter((oo) => oo.oid != käsiteltäväOpiskeluoikeus.oid),
+      A.filter((oo) => oo.oid !== käsiteltäväOpiskeluoikeus.oid),
       A.chain(perusopetuksenJälkeistäPreferoivaNäytettäväOpiskeluoikeusTieto)
     )
 

--- a/valpas-web/src/utils/conversions.ts
+++ b/valpas-web/src/utils/conversions.ts
@@ -2,7 +2,7 @@ export type FilterableNonNullValue = string | number | boolean
 export type FilterableValue = FilterableNonNullValue | null | undefined
 
 export const toFilterableString = (input: FilterableValue): string => {
-  if (input === null || input == undefined) {
+  if (input === null || input === undefined) {
     return ""
   }
   return input.toString()

--- a/valpas-web/src/utils/tableDataFormatters/hakemuksentila.tsx
+++ b/valpas-web/src/utils/tableDataFormatters/hakemuksentila.tsx
@@ -45,8 +45,8 @@ const hakemuksenTilaT = (
 ): Translation => {
   if (isLoadingHakutilanteet) return t("Ladataan")
   else if (hakutilanneError) return t("oppija__hakuhistoria_virhe")
-  else if (hakemusCount == 0) return t("hakemuksentila__ei_hakemusta")
-  else if (hakemusCount == 1) return t("hakemuksentila__hakenut")
+  else if (hakemusCount === 0) return t("hakemuksentila__ei_hakemusta")
+  else if (hakemusCount === 1) return t("hakemuksentila__hakenut")
   else return t("hakemuksentila__n_hakua", { lukumäärä: hakemusCount })
 }
 
@@ -59,7 +59,7 @@ const hakemuksenTilaDisplay = (
   pipe(
     A.head(hakutilanteet),
     O.map((hakutilanne) =>
-      hakutilanteet.length == 1 ? (
+      hakutilanteet.length === 1 ? (
         <ExternalLink to={hakutilanne.hakemusUrl}>
           {hakemuksenTilaValue}
         </ExternalLink>

--- a/valpas-web/src/views/HealthView.tsx
+++ b/valpas-web/src/views/HealthView.tsx
@@ -13,7 +13,7 @@ export default () => {
       <p id="health-status">
         {isInitial(res) || isLoading(res)
           ? "Checking..."
-          : isSuccess(res) && res.data == ""
+          : isSuccess(res) && res.data === ""
           ? "OK"
           : "Backend failure"}
       </p>

--- a/valpas-web/src/views/hakutilanne/HakutilanneTable.tsx
+++ b/valpas-web/src/views/hakutilanne/HakutilanneTable.tsx
@@ -231,7 +231,7 @@ const ryhmä = (oo: OpiskeluoikeusSuppeatTiedot): Value => {
   } else {
     if (
       oo.muuOpetusTiedot &&
-      oo.tyyppi.koodiarvo == "perusopetukseenvalmistavaopetus"
+      oo.tyyppi.koodiarvo === "perusopetukseenvalmistavaopetus"
     ) {
       const valo = t("hakutilanne__valo")
       return {

--- a/valpas-web/src/views/kunta/kuntailmoitus/KuntailmoitusView.tsx
+++ b/valpas-web/src/views/kunta/kuntailmoitus/KuntailmoitusView.tsx
@@ -157,7 +157,7 @@ export const KuntailmoitusView = withRequiresKuntavalvonta(
           </CardHeader>
           <CardBody>
             {isLoading(fetch) && <Spinner />}
-            {isSuccess(fetch) && fetch.data.length == 0 && (
+            {isSuccess(fetch) && fetch.data.length === 0 && (
               <NoDataMessage>
                 <T id="kuntailmoitusnäkymä__ei_ilmoituksia" />
               </NoDataMessage>

--- a/valpas-web/src/views/oppija/OppijanOpiskeluhistoria.tsx
+++ b/valpas-web/src/views/oppija/OppijanOpiskeluhistoria.tsx
@@ -448,7 +448,7 @@ const myöhempienOpintojenKoskiTilanAlkamispäivä = (
 
 const isValmistunutInternationalSchoolinPerusopetuksestaAiemminTaiLähitulevaisuudessa =
   (oo: MinimiOpiskeluoikeus) =>
-    oo.tyyppi?.koodiarvo == "internationalschool" &&
+    oo.tyyppi?.koodiarvo === "internationalschool" &&
     oo.perusopetusTiedot !== undefined &&
     oo.perusopetusTiedot.valmistunutAiemminTaiLähitulevaisuudessa &&
     oo.perusopetusTiedot.päättymispäivä !== undefined

--- a/valpas-web/src/views/oppija/OppijanOppivelvollisuustiedot.tsx
+++ b/valpas-web/src/views/oppija/OppijanOppivelvollisuustiedot.tsx
@@ -171,7 +171,7 @@ export const OppijanOppivelvollisuustiedot = (
                   <Error>
                     <T
                       id={
-                        pohjatiedot.status == 403
+                        pohjatiedot.status === 403
                           ? "oppija__ei_oikeuksia_tehdä_ilmoitusta"
                           : "oppija__pohjatietojen_haku_epäonnistui"
                       }

--- a/valpas-web/src/views/oppija/oppivelvollisuudenkeskeytys/OppivelvollisuudenKeskeytysForm.tsx
+++ b/valpas-web/src/views/oppija/oppivelvollisuudenkeskeytys/OppivelvollisuudenKeskeytysForm.tsx
@@ -73,7 +73,7 @@ export const OppivelvollisuudenKeskeytysForm = (
   const isOk =
     organisaatio !== undefined &&
     (määräaikainenSelected
-      ? dateRange.every((d) => d != null)
+      ? dateRange.every((d) => d !== null)
       : toistaiseksiVahvistettu)
 
   const submit = useCallback(() => {

--- a/valpas-web/src/views/suorittaminen/oppivelvolliset/SuorittaminenOppivelvollisetView.tsx
+++ b/valpas-web/src/views/suorittaminen/oppivelvolliset/SuorittaminenOppivelvollisetView.tsx
@@ -128,7 +128,7 @@ export const SuorittaminenOppivelvollisetView =
             </CardHeader>
             <ConstrainedCardBody>
               {isLoading(fetch) && <Spinner />}
-              {isSuccess(fetch) && fetch.data.length == 0 && (
+              {isSuccess(fetch) && fetch.data.length === 0 && (
                 <NoDataMessage>
                   <T id="suorittaminennäkymä__ei_oppivelvollisia" />
                 </NoDataMessage>

--- a/web/.eslintrc
+++ b/web/.eslintrc
@@ -50,7 +50,7 @@
     "array-callback-return": "off", // Bacon.js flatmap
     "react/no-render-return-value": "off", // Bacon.js React VDOM
     "prefer-regex-literals": "off", // Heitetään varoitus, TODO: Vaihda --> "warn"
-    "eqeqeq": "off" // Suosi triple-equalsin käyttöä, TODO: Vaihda --> "warn"
+    "eqeqeq": "warn"
   },
   "settings": {
     "react": {

--- a/web/app/ammatillinen/LisaaOsaToisestaTutkinnosta.jsx
+++ b/web/app/ammatillinen/LisaaOsaToisestaTutkinnosta.jsx
@@ -23,7 +23,7 @@ export const LisääOsaToisestaTutkinnosta = ({
           modelSetValues(koulutusmoduuliProto(), { tunniste: osa }),
           osa.title
         ),
-        tutkinto.diaarinumero != diaarinumero && tutkinto
+        tutkinto.diaarinumero !== diaarinumero && tutkinto
       )
     }
   }

--- a/web/app/ammatillinen/TutkinnonOsaToisestaTutkinnostaPicker.jsx
+++ b/web/app/ammatillinen/TutkinnonOsaToisestaTutkinnostaPicker.jsx
@@ -35,7 +35,7 @@ const TutkinnonOsaToisestaTutkinnostaPicker = ({
           placeholder={osatP
             .map('.length')
             .map((len) =>
-              len == 0 ? 'Valitse ensin tutkinto' : 'Valitse tutkinnon osa'
+              len === 0 ? 'Valitse ensin tutkinto' : 'Valitse tutkinnon osa'
             )
             .map(t)}
         />

--- a/web/app/components/Dropdown.jsx
+++ b/web/app/components/Dropdown.jsx
@@ -115,7 +115,7 @@ export default ({
     const matchingOptions = allOptions.filter(
       (o) =>
         inputElem.value &&
-        displayValue(o).toLowerCase() == inputElem.value.toLowerCase()
+        displayValue(o).toLowerCase() === inputElem.value.toLowerCase()
     )
     if (!R.isEmpty(matchingOptions) && !R.includes(s, matchingOptions)) {
       // if multiple options have the same display value (e.g. arviointiasteikkoammatillinent1k3 and ...15),
@@ -135,11 +135,11 @@ export default ({
   }
   const handleMouseOver = (allOptions, o) => {
     const index = allOptions.findIndex(
-      (option) => keyValue(option) == keyValue(o)
+      (option) => keyValue(option) === keyValue(o)
     )
     selectionIndexAtom.set(index)
   }
-  const isNewItem = (allOptions, o, i) => newItem && i == allOptions.length - 1
+  const isNewItem = (allOptions, o, i) => newItem && i === allOptions.length - 1
   const selectOption = (e, option) => {
     e.preventDefault()
     e.stopPropagation()
@@ -191,13 +191,13 @@ export default ({
                       handleInputBlur(allOptions, s)
                     )}
                     value={Bacon.combineWith(queryAtom, selectedP, (q, s) => {
-                      return q != undefined ? q : s ? displayValue(s) : ''
+                      return q !== undefined ? q : s ? displayValue(s) : ''
                     })}
                     aria-label={Bacon.combineWith(
                       queryAtom,
                       selectedP,
                       (q, s) => {
-                        return q != undefined
+                        return q !== undefined
                           ? q
                           : s
                           ? displayValue(s)
@@ -238,7 +238,7 @@ export default ({
                 >
                   {flatMapArray(allOptions, (o, i) => {
                     const isNew = isNewItem(allOptions, o, i)
-                    const isZeroValue = keyValue(o) == 'eivalintaa'
+                    const isZeroValue = keyValue(o) === 'eivalintaa'
                     const itemClassName = Bacon.combineWith(
                       (s, r, a) => s + r + a,
                       selectionIndexAtom.map((selectionIndex) =>
@@ -300,7 +300,7 @@ export default ({
                     )
                     const groupName =
                       grouped &&
-                      (i == 0 || allOptions[i - 1].groupName != o.groupName)
+                      (i === 0 || allOptions[i - 1].groupName !== o.groupName)
                         ? o.groupName
                         : ''
                     if (groupName) {

--- a/web/app/components/SortingTableHeader.jsx
+++ b/web/app/components/SortingTableHeader.jsx
@@ -12,10 +12,10 @@ export default class extends React.Component {
       ? [field, defaultSort]
       : []
 
-    const selected = sortBy == field
+    const selected = sortBy === field
 
     return (
-      <th className={sortBy == field ? field + ' sorted' : field}>
+      <th className={sortBy === field ? field + ' sorted' : field}>
         <div
           className="sorting"
           onClick={() =>
@@ -23,7 +23,7 @@ export default class extends React.Component {
               sort:
                 field +
                 ':' +
-                (selected ? (sortOrder == 'asc' ? 'desc' : 'asc') : 'asc')
+                (selected ? (sortOrder === 'asc' ? 'desc' : 'asc') : 'asc')
             })
           }
         >
@@ -33,12 +33,12 @@ export default class extends React.Component {
           <div className="sort-indicator">
             <div
               className={
-                selected && sortOrder == 'asc' ? 'asc selected' : 'asc'
+                selected && sortOrder === 'asc' ? 'asc selected' : 'asc'
               }
             ></div>
             <div
               className={
-                selected && sortOrder == 'desc' ? 'desc selected' : 'desc'
+                selected && sortOrder === 'desc' ? 'desc selected' : 'desc'
               }
             ></div>
           </div>

--- a/web/app/components/classnames.js
+++ b/web/app/components/classnames.js
@@ -31,7 +31,7 @@ export const removeClass = (x, name) => {
   if (isElement(x)) {
     x.className = removeClass(x.className, name)
   } else {
-    return buildClassNames(parseClassNames(x).filter((n) => n != name))
+    return buildClassNames(parseClassNames(x).filter((n) => n !== name))
   }
 }
 const isElement = (x) => x instanceof HTMLElement

--- a/web/app/dokumentaatio/DokumentaatioApiTester.jsx
+++ b/web/app/dokumentaatio/DokumentaatioApiTester.jsx
@@ -43,10 +43,10 @@ const makeApiUrl = (basePath, params) => {
 
 const curlCommand = (method, url) => {
   let curl = 'curl "' + url + '" --user kalle:kalle'
-  if (method != 'GET') {
+  if (method !== 'GET') {
     curl += ' -X ' + method
   }
-  if (method == 'POST' || method == 'PUT') {
+  if (method === 'POST' || method === 'PUT') {
     curl += ' -H "content-type: application/json" -d @curltestdata.json'
   }
   return curl
@@ -196,7 +196,7 @@ const ApiOperationTester = ({ operation }) => {
           .text()
           .then(function (text) {
             loadingA.set(false)
-            if (response.status == 401) {
+            if (response.status === 401) {
               resultA.set(
                 <div>
                   {response.status +
@@ -290,7 +290,7 @@ const ApiOperationStatusCodeRow = ({ errorCategory }) => {
   return (
     <tr>
       <td>{errorCategory.statusCode}</td>
-      <td>{errorCategory.statusCode != 200 ? errorCategory.key : ''}</td>
+      <td>{errorCategory.statusCode !== 200 ? errorCategory.key : ''}</td>
       <td>{errorCategory.message}</td>
       <td>
         <span

--- a/web/app/editor/Editor.jsx
+++ b/web/app/editor/Editor.jsx
@@ -70,7 +70,7 @@ Editor.shouldComponentUpdate = function (nextProps) {
   if (parseBool(nextProps.alwaysUpdate)) return true
   const next = nextProps.model
   const current = this.props.model
-  let result = next.modelId != current.modelId
+  let result = next.modelId !== current.modelId
   if (pathHash(next) !== pathHash(current)) {
     result = true
   }

--- a/web/app/editor/LocalizedStringEditor.jsx
+++ b/web/app/editor/LocalizedStringEditor.jsx
@@ -43,7 +43,7 @@ const localizedStringLens = (model) => {
     (m) => modelLookup(m, usedLanguage),
     (v, m) => {
       const protoForUsedLanguage = oneOfPrototypes(m).find(
-        (proto) => proto.value.properties[0].key == usedLanguage
+        (proto) => proto.value.properties[0].key === usedLanguage
       )
       const modelToPush = modelSetValue(
         protoForUsedLanguage,

--- a/web/app/editor/ModalDialog.jsx
+++ b/web/app/editor/ModalDialog.jsx
@@ -25,8 +25,8 @@ export default ({
     .map('.e')
 
   function handleKeys(e) {
-    if (e.keyCode == 27) onDismiss()
-    if (e.keyCode == 13 && submitOnEnterKey) onSubmit()
+    if (e.keyCode === 27) onDismiss()
+    if (e.keyCode === 13 && submitOnEnterKey) onSubmit()
   }
   const classNameP = submittedAtom.map(
     (submitted) =>

--- a/web/app/editor/NumberEditor.jsx
+++ b/web/app/editor/NumberEditor.jsx
@@ -57,7 +57,7 @@ NumberEditor.isEmpty = (m) =>
 NumberEditor.createEmpty = (m) => modelSetValue(m, undefined)
 NumberEditor.validateModel = (model) => {
   const value = modelData(model)
-  if (value == undefined) {
+  if (value === undefined) {
     if (!model.optional) return [{ key: 'missing' }]
   } else {
     if (

--- a/web/app/editor/TogglableEditor.jsx
+++ b/web/app/editor/TogglableEditor.jsx
@@ -12,7 +12,7 @@ export class TogglableEditor extends React.Component {
     const context = model.context
     const opiskeluoikeusOid = modelData(model.context.opiskeluoikeus, 'oid')
     const edit =
-      opiskeluoikeusOid && currentLocation().params.edit == opiskeluoikeusOid
+      opiskeluoikeusOid && currentLocation().params.edit === opiskeluoikeusOid
     const editingAny = !!currentLocation().params.edit
     const modifiedContext = R.mergeRight(context, { edit })
     const showEditLink = model.editable && !editingAny

--- a/web/app/editor/hashcode.js
+++ b/web/app/editor/hashcode.js
@@ -2,7 +2,7 @@ export const hashCode = (x) => {
   if (x === undefined || x === null) return 0
   let hash = 0
   if (typeof x === 'string') {
-    if (x.length == 0) return hash
+    if (x.length === 0) return hash
     for (let i = 0; i < x.length; i++) {
       const char = x.charCodeAt(i)
       hash = hashAdd(hash, char)

--- a/web/app/esh/europeanschoolofhelsinkiSuoritus.js
+++ b/web/app/esh/europeanschoolofhelsinkiSuoritus.js
@@ -72,7 +72,7 @@ export const suoritusTyyppi = (koulutusmoduulinTunniste) => {
   }
   if (
     koulutusmoduulinTunniste.koodistoUri === 'koulutus' &&
-    koulutusmoduulinTunniste.koodiarvo == '301104'
+    koulutusmoduulinTunniste.koodiarvo === '301104'
   ) {
     return eshSuorituksenTyyppi.ebtutkinto
   }

--- a/web/app/i18n/LocalizationEditBar.jsx
+++ b/web/app/i18n/LocalizationEditBar.jsx
@@ -42,7 +42,7 @@ export default ({ user }) => {
                 {languages.map((l) => (
                   <a
                     key={l}
-                    className={l + (l == lang ? ' selected' : '')}
+                    className={l + (l === lang ? ' selected' : '')}
                     onClick={() => {
                       localStorage.editLocalizations = true
                       setLang(l)
@@ -87,7 +87,7 @@ const EditAllTexts = () => {
                 <tr key={key}>
                   {languages.map((l) => (
                     <td>
-                      <Text key={l} name={key} lang={l} edit={l != 'fi'} />
+                      <Text key={l} name={key} lang={l} edit={l !== 'fi'} />
                     </td>
                   ))}
                 </tr>

--- a/web/app/i18n/Text.jsx
+++ b/web/app/i18n/Text.jsx
@@ -7,7 +7,7 @@ import Atom from 'bacon.atom'
 import { buildClassNames } from '../components/classnames'
 
 export default ({ name, ignoreMissing, lang, edit, className, ...rest }) => {
-  const editP = edit == undefined ? editAtom : Bacon.constant(parseBool(edit))
+  const editP = edit === undefined ? editAtom : Bacon.constant(parseBool(edit))
 
   if (name === null || name === undefined) {
     return null
@@ -41,7 +41,7 @@ const TextEditor = ({ name, lang }) => {
 
   const onInput = (event) => {
     const newValue = event.target.textContent
-    if (newValue != currentValue) {
+    if (newValue !== currentValue) {
       currentValue = newValue
       changed.set(true)
       changeText(name, newValue, lang)

--- a/web/app/i18n/i18n.js
+++ b/web/app/i18n/i18n.js
@@ -23,7 +23,7 @@ export const t = (s, ignoreMissing, languageOverride) => {
     if (!localizedString[usedLanguage]) {
       if (ignoreMissing === true) return null
       if (!missing[usedLanguage + '.' + s]) {
-        if (usedLanguage == 'fi')
+        if (usedLanguage === 'fi')
           console.error(`Localization missing for language ${usedLanguage}:`, s)
         missing[usedLanguage + '.' + s] = true
       }

--- a/web/app/kela/KeyValueTable.jsx
+++ b/web/app/kela/KeyValueTable.jsx
@@ -29,7 +29,7 @@ const rowInTable = ({ key, value, path }, index) => {
   )
 }
 
-export const NumberView = ({ value }) => <span>{value == 0 ? '' : value}</span>
+export const NumberView = ({ value }) => <span>{value === 0 ? '' : value}</span>
 export const BooleanView = ({ value }) => <Text name={value ? 'kyllä' : 'ei'} />
 export const DateView = ({ value }) => (
   <span>{(value && formatFinnishDate(parseISODate(value))) || ''}</span>

--- a/web/app/lukio/LuvaEditor.jsx
+++ b/web/app/lukio/LuvaEditor.jsx
@@ -52,12 +52,12 @@ export const LuvaEditor = ({ suorituksetModel }) => {
             ]}
             suoritusFilter={lukioonvalmistavankurssinsuorituksetFilter}
             forceLaajuusOpintopisteinä={
-              oppimaaraDiaarinumero == 'OPH-4958-2020'
+              oppimaaraDiaarinumero === 'OPH-4958-2020'
             }
           />
         </div>
       )}
-      {oppimaaraDiaarinumero == '56/011/2015' && (edit || hasLukionKursseja) && (
+      {oppimaaraDiaarinumero === '56/011/2015' && (edit || hasLukionKursseja) && (
         <div className="valinnaisena-suoritetut-lukiokurssit">
           <h5>
             <Text name="Valinnaisena suoritetut lukiokurssit" />
@@ -71,7 +71,7 @@ export const LuvaEditor = ({ suorituksetModel }) => {
           />
         </div>
       )}
-      {oppimaaraDiaarinumero == 'OPH-4958-2020' &&
+      {oppimaaraDiaarinumero === 'OPH-4958-2020' &&
         (edit || hasLukion2019Moduuleja) && (
           <div className="valinnaisena-suoritetut-lukiokurssit">
             <h5>

--- a/web/app/omattiedot/OmatTiedotOpiskeluoikeus.jsx
+++ b/web/app/omattiedot/OmatTiedotOpiskeluoikeus.jsx
@@ -262,7 +262,7 @@ class TabulatedSuoritukset extends React.Component {
 
 const SuoritusTabs = ({ selectedTabIndex, suoritukset, onChange }) => {
   const tabTitle = (suoritusModel) =>
-    suorituksenTyyppi(suoritusModel) == 'perusopetuksenoppimaara' ? (
+    suorituksenTyyppi(suoritusModel) === 'perusopetuksenoppimaara' ? (
       <Text name="Päättötodistus" />
     ) : (
       suoritusTitle(suoritusModel)

--- a/web/app/omattiedot/header/HuollettavaDropdown.jsx
+++ b/web/app/omattiedot/header/HuollettavaDropdown.jsx
@@ -12,7 +12,7 @@ export const HuollettavaDropdown = ({ oppija, oppijaSelectionBus }) => {
 
   const options = huollettavat
     .concat(kirjautunutHenkilo)
-    .filter((h) => h.oid != valittuHenkilo.oid)
+    .filter((h) => h.oid !== valittuHenkilo.oid)
     .sort(aakkosjarjestys)
 
   return (

--- a/web/app/opiskeluoikeus/OpiskeluoikeusEditor.jsx
+++ b/web/app/opiskeluoikeus/OpiskeluoikeusEditor.jsx
@@ -249,7 +249,7 @@ export const OpiskeluoikeudenVoimassaoloaika = ({ opiskeluoikeus }) => {
           path={päättymispäiväProperty}
         />
       </span>{' '}
-      {päättymispäiväProperty == 'arvioituPäättymispäivä' && (
+      {päättymispäiväProperty === 'arvioituPäättymispäivä' && (
         <Text name="(arvioitu)" />
       )}
     </div>

--- a/web/app/opiskeluoikeus/Versiohistoria.jsx
+++ b/web/app/opiskeluoikeus/Versiohistoria.jsx
@@ -23,7 +23,7 @@ export default class Versiohistoria extends BaconComponent {
         navigateTo(`/koski/oppija/${oppijaOid}`)
       }
     }
-    const selectedVersion = this.versionumero() || history.length
+    const selectedVersion = String(this.versionumero() || history.length)
     return opiskeluoikeusOid ? (
       <div className={'versiohistoria' + (showHistory ? ' open' : '')}>
         <a onClick={() => toggle()}>
@@ -37,7 +37,9 @@ export default class Versiohistoria extends BaconComponent {
                 <li
                   key={i}
                   className={
-                    version.versionumero == selectedVersion ? 'selected' : ''
+                    String(version.versionumero) === selectedVersion
+                      ? 'selected'
+                      : ''
                   }
                 >
                   <Link

--- a/web/app/oppija/OpiskeluoikeudetNavBar.jsx
+++ b/web/app/oppija/OpiskeluoikeudetNavBar.jsx
@@ -35,7 +35,7 @@ export default ({ oppijaOid, opiskeluoikeusTyypit, selectedIndex }) => {
   return (
     <ul className="opiskeluoikeustyypit-nav">
       {opiskeluoikeusTyypit.map((opiskeluoikeudenTyyppi, tyyppiIndex) => {
-        const selected = tyyppiIndex == selectedIndex
+        const selected = tyyppiIndex === selectedIndex
         const koodiarvo = modelData(opiskeluoikeudenTyyppi).tyyppi.koodiarvo
         const className = selected ? koodiarvo + ' selected' : koodiarvo
         const content = (

--- a/web/app/oppija/OppijaEditor.jsx
+++ b/web/app/oppija/OppijaEditor.jsx
@@ -13,7 +13,7 @@ export const OppijaEditor = ({ model }) => {
   const selectedIndex = selectedTyyppi
     ? opiskeluoikeusTyypit.findIndex(
         (opiskeluoikeudenTyyppi) =>
-          selectedTyyppi == modelData(opiskeluoikeudenTyyppi).tyyppi.koodiarvo
+          selectedTyyppi === modelData(opiskeluoikeudenTyyppi).tyyppi.koodiarvo
       )
     : 0
 

--- a/web/app/perusopetus/PerusopetuksenOppiaineetEditor.jsx
+++ b/web/app/perusopetus/PerusopetuksenOppiaineetEditor.jsx
@@ -340,11 +340,11 @@ class Oppiainetaulukko extends React.Component {
         ? uusiPerusopetukseenValmistavanOppiaineenSuoritus
         : uusiOppiaineenSuoritus
 
-    if (suoritukset.length == 0 && !model.context.edit) return null
+    if (suoritukset.length === 0 && !model.context.edit) return null
     const placeholder = t(
       isToimintaAlueittain(model)
         ? 'Lisää toiminta-alue'
-        : pakolliset == undefined
+        : pakolliset === undefined
         ? 'Lisää oppiaine'
         : pakolliset
         ? 'Lisää pakollinen oppiaine'

--- a/web/app/perusopetus/Perusopetus.js
+++ b/web/app/perusopetus/Perusopetus.js
@@ -15,7 +15,7 @@ export const isToimintaAlueittain = (suoritus) =>
       ).some((etp) => modelData(etp, 'opiskeleeToimintaAlueittain'))
     : false
 
-export const isYsiluokka = (suoritus) => luokkaAste(suoritus) == '9'
+export const isYsiluokka = (suoritus) => luokkaAste(suoritus) === '9'
 
 export const isPäättötodistus = (suoritus) => {
   const tunniste = modelData(suoritus, 'koulutusmoduuli.tunniste')
@@ -31,7 +31,7 @@ export const isPerusopetuksenOppimäärä = (suoritus) => {
 export const jääLuokalle = (suoritus) => modelData(suoritus, 'jääLuokalle')
 export const luokkaAste = (suoritus) => {
   const tunniste = modelData(suoritus, 'koulutusmoduuli.tunniste')
-  return tunniste.koodistoUri == 'perusopetuksenluokkaaste'
+  return tunniste.koodistoUri === 'perusopetuksenluokkaaste'
     ? tunniste.koodiarvo
     : undefined
 }

--- a/web/app/suoritus/JaaLuokalleTaiSiirretaanEditor.jsx
+++ b/web/app/suoritus/JaaLuokalleTaiSiirretaanEditor.jsx
@@ -17,7 +17,7 @@ export const JääLuokalleTaiSiirretäänEditor = ({ model }) => {
   const jääLuokalle = modelData(jääLuokalleModel)
   const luokka = modelData(model, 'koulutusmoduuli.tunniste.koodiarvo')
   if (luokka && suoritusValmis(model)) {
-    if (luokka == '9' || isEshS7(model)) {
+    if (luokka === '9' || isEshS7(model)) {
       if (!model.context.edit && jääLuokalle) {
         return (
           <div className="jaa-tai-siirretaan">

--- a/web/app/suoritus/LaajuusEditor.jsx
+++ b/web/app/suoritus/LaajuusEditor.jsx
@@ -63,7 +63,7 @@ const LaajuudenYksikköEditor = ({ model, compact, showReadonlyScope }) => {
   return model.context.edit ? (
     !yksikköModel ||
     !alternatives ||
-    (alternatives.length == 1 && parseBool(compact)) ? null : (
+    (alternatives.length === 1 && parseBool(compact)) ? null : (
       <span className="property laajuudenyksikko yksikko inline">
         <Editor
           model={yksikköModel}

--- a/web/app/suoritus/PerusteDropdown.jsx
+++ b/web/app/suoritus/PerusteDropdown.jsx
@@ -38,7 +38,7 @@ export const PerusteDropdown = ({ suoritusTyyppiP, perusteAtom }) => {
   const selectedOptionP = Bacon.combineWith(
     diaarinumerotP,
     perusteAtom,
-    (options, selected) => options.find((o) => o.koodiarvo == selected)
+    (options, selected) => options.find((o) => o.koodiarvo === selected)
   )
   const selectOption = (option) => {
     perusteAtom.set(option && option.koodiarvo)

--- a/web/app/suoritus/Suoritus.js
+++ b/web/app/suoritus/Suoritus.js
@@ -185,7 +185,7 @@ export const copyToimipiste = (from, to) =>
 
 export const opiskeluoikeudenSuoritusByTyyppi = (tyyppi) => (opiskeluoikeus) =>
   modelItems(opiskeluoikeus, 'suoritukset').find(
-    (suoritus) => suorituksenTyyppi(suoritus) == tyyppi
+    (suoritus) => suorituksenTyyppi(suoritus) === tyyppi
   )
 export const aikuistenPerusopetuksenOppimääränSuoritus =
   opiskeluoikeudenSuoritusByTyyppi('aikuistenperusopetuksenoppimaara')

--- a/web/app/tiedonsiirrot/Tiedonsiirtotaulukko.jsx
+++ b/web/app/tiedonsiirrot/Tiedonsiirtotaulukko.jsx
@@ -77,7 +77,7 @@ class Lokiriviryhmä extends React.Component {
     return (
       <tbody className="alternating">
         {flatMapArray(tiedonsiirtoRivit, (rivi, j) => {
-          const isParent = j == 0 && isGroup
+          const isParent = j === 0 && isGroup
           const isChild = j > 0 && isGroup
           const isHidden = isChild && !isExpanded
           return isHidden
@@ -89,7 +89,7 @@ class Lokiriviryhmä extends React.Component {
                   isParent={isParent}
                   isChild={isChild}
                   isExpanded={isExpanded}
-                  isEven={i % 2 == 1}
+                  isEven={i % 2 === 1}
                   showError={showError}
                   setExpanded={setExpanded}
                   selected={selected}

--- a/web/app/topbar/NavList.jsx
+++ b/web/app/topbar/NavList.jsx
@@ -14,7 +14,7 @@ export default ({ location, user }) => {
             'Opiskelijat',
             location.path,
             '',
-            (path, loc) => loc == path || loc.startsWith('/koski/oppija')
+            (path, loc) => loc === path || loc.startsWith('/koski/oppija')
           )}
         </li>
       )}

--- a/web/app/util/Error.jsx
+++ b/web/app/util/Error.jsx
@@ -40,7 +40,7 @@ export const handleError = (error) => {
 }
 
 export function requiresLogin(e) {
-  return e.httpStatus == 401 || e.httpStatus == 403
+  return e.httpStatus === 401 || e.httpStatus === 403
 }
 
 const extractValidationErrorText = (error) => {
@@ -54,7 +54,7 @@ const extractValidationErrorText = (error) => {
 const errorText = (error) => {
   if (error.text) return error.text
   else if (
-    error.httpStatus == 400 &&
+    error.httpStatus === 400 &&
     error.jsonMessage &&
     error.jsonMessage[0] &&
     error.jsonMessage[0].key.startsWith('badRequest.validation')

--- a/web/app/util/format.js
+++ b/web/app/util/format.js
@@ -1,6 +1,6 @@
 const numberToString = (s, scale) => {
-  if (s == undefined) return s
-  if (scale == undefined || typeof scale !== 'number') {
+  if (s === undefined) return s
+  if (scale === undefined || typeof scale !== 'number') {
     return (Math.round(s * 100) / 100).toString().replace('.', ',')
   } else {
     return (Math.round(s * 100) / 100).toFixed(scale).replace('.', ',')

--- a/web/app/util/location.js
+++ b/web/app/util/location.js
@@ -110,7 +110,7 @@ export function currentLocation() {
 }
 
 export function parseQuery(qstr) {
-  if (qstr == '') return {}
+  if (qstr === '') return {}
   const query = {}
   const a = qstr.substr(1).split('&')
   for (let i = 0; i < a.length; i++) {

--- a/web/app/uusioppija/SuoritustapaDropdown.jsx
+++ b/web/app/uusioppija/SuoritustapaDropdown.jsx
@@ -34,7 +34,7 @@ export default ({ diaarinumero, suoritustapaAtom, title }) => {
                     .map((k) => k.koodiarvo)
                     .includes(suoritustapa.koodiarvo)
                 if (!currentOneFound) {
-                  if (suoritustavat.length == 1) {
+                  if (suoritustavat.length === 1) {
                     suoritustapaAtom.set(suoritustavat[0])
                   } else if (suoritustapa) {
                     suoritustapaAtom.set(undefined)

--- a/web/app/uusioppija/UusiAikuistenPerusopetuksenSuoritus.jsx
+++ b/web/app/uusioppija/UusiAikuistenPerusopetuksenSuoritus.jsx
@@ -24,7 +24,7 @@ export default ({ suoritusAtom, oppilaitosAtom, suorituskieliAtom }) => {
   const suoritusPrototypeP = suoritustyyppiAtom
     .map('.koodiarvo')
     .flatMap((suorituksenTyyppi) => {
-      if (suorituksenTyyppi == 'perusopetuksenoppiaineenoppimaara') {
+      if (suorituksenTyyppi === 'perusopetuksenoppiaineenoppimaara') {
         return Http.cachedGet(
           '/koski/api/editor/prototype/fi.oph.koski.schema.PerusopetuksenOppiaineenOppimääränSuoritus'
         )

--- a/web/app/uusioppija/UusiLukionSuoritus.jsx
+++ b/web/app/uusioppija/UusiLukionSuoritus.jsx
@@ -23,7 +23,7 @@ export default ({ suoritusAtom, oppilaitosAtom, suorituskieliAtom }) => {
   const suoritusPrototypeP = suoritustyyppiAtom
     .map('.koodiarvo')
     .flatMap((suorituksenTyyppi) => {
-      if (suorituksenTyyppi == 'lukionoppiaineenoppimaara') {
+      if (suorituksenTyyppi === 'lukionoppiaineenoppimaara') {
         return Http.cachedGet(
           '/koski/api/editor/prototype/fi.oph.koski.schema.LukionOppiaineenOppimääränSuoritus2015'
         )

--- a/web/app/uusioppija/UusiNuortenPerusopetuksenSuoritus.jsx
+++ b/web/app/uusioppija/UusiNuortenPerusopetuksenSuoritus.jsx
@@ -24,7 +24,7 @@ export default ({ suoritusAtom, oppilaitosAtom, suorituskieliAtom }) => {
   const suoritusPrototypeP = suoritustyyppiAtom
     .map('.koodiarvo')
     .flatMap((suorituksenTyyppi) => {
-      if (suorituksenTyyppi == 'nuortenperusopetuksenoppiaineenoppimaara') {
+      if (suorituksenTyyppi === 'nuortenperusopetuksenoppiaineenoppimaara') {
         return Http.cachedGet(
           '/koski/api/editor/prototype/fi.oph.koski.schema.NuortenPerusopetuksenOppiaineenOppimääränSuoritus'
         )

--- a/web/app/uusioppija/UusiOppija.jsx
+++ b/web/app/uusioppija/UusiOppija.jsx
@@ -73,7 +73,7 @@ const toCreateOppija = (henkilö, opiskeluoikeus) => {
 export const postNewOppija = (oppija) =>
   Http.post('/koski/api/v2/oppija', oppija, {
     errorHandler: (e) => {
-      if (e.httpStatus == 409) {
+      if (e.httpStatus === 409) {
         e.text = (
           <Text name="Opiskeluoikeutta ei voida lisätä, koska oppijalla on jo vastaava opiskeluoikeus." />
         )

--- a/web/app/uusisuoritus/UusiAikuistenPerusopetuksenAlkuvaiheenSuoritus.jsx
+++ b/web/app/uusisuoritus/UusiAikuistenPerusopetuksenAlkuvaiheenSuoritus.jsx
@@ -24,7 +24,8 @@ export default {
   },
   canAddSuoritus: (opiskeluoikeus) => {
     return (
-      modelData(opiskeluoikeus, 'tyyppi.koodiarvo') == 'aikuistenperusopetus' &&
+      modelData(opiskeluoikeus, 'tyyppi.koodiarvo') ===
+        'aikuistenperusopetus' &&
       !!aikuistenPerusopetuksenOppimääränSuoritus(opiskeluoikeus) &&
       !aikuistenPerusopetuksenAlkuvaiheenSuoritus(opiskeluoikeus)
     )

--- a/web/app/uusisuoritus/UusiAikuistenPerusopetuksenOppimaaranSuoritus.jsx
+++ b/web/app/uusisuoritus/UusiAikuistenPerusopetuksenOppimaaranSuoritus.jsx
@@ -26,7 +26,8 @@ export default {
   },
   canAddSuoritus: (opiskeluoikeus) => {
     return (
-      modelData(opiskeluoikeus, 'tyyppi.koodiarvo') == 'aikuistenperusopetus' &&
+      modelData(opiskeluoikeus, 'tyyppi.koodiarvo') ===
+        'aikuistenperusopetus' &&
       !!aikuistenPerusopetuksenAlkuvaiheenSuoritus(opiskeluoikeus) &&
       !aikuistenPerusopetuksenOppimääränSuoritus(opiskeluoikeus)
     )

--- a/web/app/uusisuoritus/UusiAmmatillisenTutkinnonSuoritus.jsx
+++ b/web/app/uusisuoritus/UusiAmmatillisenTutkinnonSuoritus.jsx
@@ -60,11 +60,11 @@ const tutkintoLens = L.lens(
 const hasValmistavaTutkinto = (opiskeluoikeus) =>
   modelItems(opiskeluoikeus, 'suoritukset').find(
     (suoritus) =>
-      suorituksenTyyppi(suoritus) == 'nayttotutkintoonvalmistavakoulutus'
+      suorituksenTyyppi(suoritus) === 'nayttotutkintoonvalmistavakoulutus'
   )
 const hasAmmatillinenTutkinto = (opiskeluoikeus) =>
   modelItems(opiskeluoikeus, 'suoritukset').find(
-    (suoritus) => suorituksenTyyppi(suoritus) == 'ammatillinentutkinto'
+    (suoritus) => suorituksenTyyppi(suoritus) === 'ammatillinentutkinto'
   )
 const hasContradictingSuoritus = (opiskeluoikeus) => {
   const disallowedSuoritustyypit = [
@@ -229,7 +229,7 @@ const Popup =
 export const UusiAmmatillisenTutkinnonSuoritus = Popup(false)
 UusiAmmatillisenTutkinnonSuoritus.canAddSuoritus = (opiskeluoikeus) => {
   return (
-    modelData(opiskeluoikeus, 'tyyppi.koodiarvo') == 'ammatillinenkoulutus' &&
+    modelData(opiskeluoikeus, 'tyyppi.koodiarvo') === 'ammatillinenkoulutus' &&
     !hasAmmatillinenTutkinto(opiskeluoikeus) &&
     !hasContradictingSuoritus(opiskeluoikeus)
   )
@@ -246,7 +246,7 @@ UusiNäyttötutkintoonValmistavanKoulutuksenSuoritus.canAddSuoritus = (
   opiskeluoikeus
 ) => {
   return (
-    modelData(opiskeluoikeus, 'tyyppi.koodiarvo') == 'ammatillinenkoulutus' &&
+    modelData(opiskeluoikeus, 'tyyppi.koodiarvo') === 'ammatillinenkoulutus' &&
     !hasValmistavaTutkinto(opiskeluoikeus) &&
     !hasContradictingSuoritus(opiskeluoikeus)
   )

--- a/web/app/uusisuoritus/UusiPerusopetuksenOppiaineenOppimaaranSuoritus.jsx
+++ b/web/app/uusisuoritus/UusiPerusopetuksenOppiaineenOppimaaranSuoritus.jsx
@@ -70,7 +70,7 @@ const UusiPerusopetuksenOppiaineenSuoritusPopup = ({
                 'toimipiste'
               ])}
               getValueEditor={(p, getDefault) => {
-                return p.key == 'tunniste' ? (
+                return p.key === 'tunniste' ? (
                   <UusiPerusopetuksenOppiaineDropdown
                     organisaatioOid={modelData(
                       oppiaineenSuoritus,

--- a/web/app/uusisuoritus/UusiPerusopetuksenVuosiluokanSuoritus.jsx
+++ b/web/app/uusisuoritus/UusiPerusopetuksenVuosiluokanSuoritus.jsx
@@ -79,7 +79,7 @@ const UusiPerusopetuksenVuosiluokanSuoritusPopup = ({
           .map(modelP)
           .flatMapFirst((suoritus) => {
             const oppiaineidenSuoritukset =
-              luokkaAste(suoritus) == '9'
+              luokkaAste(suoritus) === '9'
                 ? Bacon.constant([])
                 : luokkaAsteenOsasuoritukset(
                     luokkaAste(suoritus),
@@ -130,7 +130,7 @@ UusiPerusopetuksenVuosiluokanSuoritusPopup.canAddSuoritus = (
   opiskeluoikeus
 ) => {
   return (
-    modelData(opiskeluoikeus, 'tyyppi.koodiarvo') == 'perusopetus' &&
+    modelData(opiskeluoikeus, 'tyyppi.koodiarvo') === 'perusopetus' &&
     puuttuvatLuokkaAsteet(opiskeluoikeus).length > 0 &&
     !nuortenPerusopetuksenOppiaineenOppimääränSuoritus(opiskeluoikeus)
   )
@@ -167,7 +167,7 @@ const siirretäänSeuraavalleLuokalle = (suoritus) =>
 const olemassaolevatLuokkaAsteenSuoritukset = (opiskeluoikeus) =>
   modelItems(opiskeluoikeus, 'suoritukset').filter(
     (suoritus) =>
-      modelData(suoritus, 'tyyppi.koodiarvo') == 'perusopetuksenvuosiluokka'
+      modelData(suoritus, 'tyyppi.koodiarvo') === 'perusopetuksenvuosiluokka'
   )
 
 const suorituksenLuokkaAste = (suoritus) =>

--- a/web/app/virkailija/OppijaHaku.jsx
+++ b/web/app/virkailija/OppijaHaku.jsx
@@ -85,7 +85,7 @@ export const OppijaHaku = () => {
             href,
             element: (
               <li
-                className={i == selectedIndex ? 'selected' : ''}
+                className={i === selectedIndex ? 'selected' : ''}
                 role="listitem"
                 aria-label={`${o.sukunimi}, ${o.etunimet}`}
                 key={i}
@@ -123,7 +123,7 @@ export const OppijaHaku = () => {
                 key={selectedIndexAtom.map((i) => i)}
                 baret-lift
                 className={selectedIndexAtom.map(
-                  (i) => 'lisaa-oppija' + (i == 0 ? ' selected' : '')
+                  (i) => 'lisaa-oppija' + (i === 0 ? ' selected' : '')
                 )}
                 href={href}
               >

--- a/web/app/virkailija/Oppijataulukko.jsx
+++ b/web/app/virkailija/Oppijataulukko.jsx
@@ -70,7 +70,7 @@ export class Oppijataulukko extends React.Component {
                       onChange={(e) => {
                         if (
                           e.target.value.length >= 3 ||
-                          e.target.value.length == 0
+                          e.target.value.length === 0
                         )
                           this.textFilterBus.push({ nimihaku: e.target.value })
                       }}
@@ -89,7 +89,7 @@ export class Oppijataulukko extends React.Component {
                         })
                       }
                       selected={opiskeluoikeudenTyypit.find(
-                        (o) => o.key == params.opiskeluoikeudenTyyppi
+                        (o) => o.key === params.opiskeluoikeudenTyyppi
                       )}
                     />
                   </th>
@@ -104,7 +104,7 @@ export class Oppijataulukko extends React.Component {
                         this.filterBus.push({ suorituksenTyyppi: option.key })
                       }
                       selected={koulutus.find(
-                        (o) => o.key == params.suorituksenTyyppi
+                        (o) => o.key === params.suorituksenTyyppi
                       )}
                     />
                   </th>
@@ -119,7 +119,7 @@ export class Oppijataulukko extends React.Component {
                       onChange={(e) => {
                         if (
                           e.target.value.length >= 3 ||
-                          e.target.value.length == 0
+                          e.target.value.length === 0
                         )
                           this.textFilterBus.push({
                             tutkintohaku: e.target.value
@@ -140,7 +140,7 @@ export class Oppijataulukko extends React.Component {
                         })
                       }
                       selected={opiskeluoikeudenTila.find(
-                        (o) => o.key == params.opiskeluoikeudenTila
+                        (o) => o.key === params.opiskeluoikeudenTila
                       )}
                     />
                   </th>
@@ -341,8 +341,8 @@ export class Oppijataulukko extends React.Component {
 
   UNSAFE_componentWillMount() {
     const koodistoMetadata = (k) =>
-      k.metadata.find((m) => m.kieli == lang.toUpperCase()) ||
-      k.metadata.find((m) => m.kieli == 'FI')
+      k.metadata.find((m) => m.kieli === lang.toUpperCase()) ||
+      k.metadata.find((m) => m.kieli === 'FI')
     const koodistoDropdownArvot = (koodit) =>
       koodit
         .filter((k) => k.koodiArvo !== 'mitatoity')

--- a/web/app/virkailija/OrganisaatioPicker.jsx
+++ b/web/app/virkailija/OrganisaatioPicker.jsx
@@ -20,7 +20,7 @@ const findSingleResult =
       return thisSelectable.concat(selectableChildren)
     }
     const selectables = flatMapArray(organisaatiot, selectableOrgs)
-    return selectables.length == 1 && selectables[0]
+    return selectables.length === 1 && selectables[0]
   }
 export default class OrganisaatioPicker extends BaconComponent {
   constructor(props) {
@@ -134,7 +134,7 @@ export default class OrganisaatioPicker extends BaconComponent {
               ref="hakuboksi"
               defaultValue={this.state.searchString}
               onChange={(e) => {
-                if (e.target.value.length >= 3 || e.target.value.length == 0)
+                if (e.target.value.length >= 3 || e.target.value.length === 0)
                   this.inputBus.push(e.target.value)
               }}
               data-testid="organisaatio-haku-input"
@@ -208,7 +208,7 @@ export default class OrganisaatioPicker extends BaconComponent {
     if (this.props.preselectSingleOption) {
       this.searchStringBus.push('')
       searchResult
-        .filter((r) => r.searchString == '')
+        .filter((r) => r.searchString === '')
         .take(1)
         .map('.organisaatiot')
         .map(findSingleResult(this.props.canSelectOrg))
@@ -232,8 +232,9 @@ export default class OrganisaatioPicker extends BaconComponent {
   }
 
   handleFocus(e) {
+    // TODO: Testaa, toimiiko oikein eqeqeq-säännön kanssa
     const focusInside =
-      e.target == window ? false : !!this.root.contains(e.target)
+      e.target === window ? false : !!this.root.contains(e.target)
     if (!focusInside) {
       this.setState({ open: false })
     }

--- a/web/app/virkailija/VirkailijaOppijaView.jsx
+++ b/web/app/virkailija/VirkailijaOppijaView.jsx
@@ -56,8 +56,8 @@ export const oppijaContentP = (oppijaOid) => {
   const version = currentLocation().params.versionumero
   if (
     !currentState ||
-    currentState.oppijaOid != oppijaOid ||
-    currentState.version != version
+    currentState.oppijaOid !== oppijaOid ||
+    currentState.version !== version
   ) {
     currentState = {
       oppijaOid,
@@ -156,10 +156,10 @@ const createState = (oppijaOid) => {
     const model = getModelFromChange(batch[0])
     const willThrottle =
       model &&
-      (model.type == 'string' ||
-        model.type == 'date' ||
-        model.type == 'number' ||
-        model.oneOfClass == 'localizedstring')
+      (model.type === 'string' ||
+        model.type === 'date' ||
+        model.type === 'number' ||
+        model.oneOfClass === 'localizedstring')
     return willThrottle
   }
 
@@ -209,7 +209,7 @@ const createState = (oppijaOid) => {
       (x) => x.opiskeluoikeudet
     )
     const opiskeluoikeus = opiskeluoikeudet.find(
-      (x) => x.oid == opiskeluoikeusOid
+      (x) => x.oid === opiskeluoikeusOid
     )
 
     const oppijaUpdate = {
@@ -434,7 +434,7 @@ export class Oppija extends React.Component {
         </div>
         <EditBar {...{ saveChangesBus, cancelChangesBus, stateP, oppija }} />
         {doActionWhileMounted(
-          globalSaveKeyEvent.filter(stateP.map((s) => s == 'dirty')),
+          globalSaveKeyEvent.filter(stateP.map((s) => s === 'dirty')),
           () => saveChangesBus.push()
         )}
       </div>
@@ -469,7 +469,7 @@ const globalSaveKeyEvent = Bacon.fromEvent(window, 'keydown')
   .filter(
     (e) =>
       (e.getModifierState('Meta') || e.getModifierState('Control')) &&
-      e.keyCode == 83
+      e.keyCode === 83
   )
   .doAction('.preventDefault')
 
@@ -479,7 +479,7 @@ const EditBar = ({ stateP, saveChangesBus, cancelChangesBus, oppija }) => {
     saveChangesBus.push()
   }
 
-  const dirtyP = stateP.map((state) => state == 'dirty')
+  const dirtyP = stateP.map((state) => state === 'dirty')
   const validationErrorP = dirtyP.map((dirty) => dirty && !modelValid(oppija))
   const canSaveP = dirtyP.and(validationErrorP.not())
   const messageMap = {


### PR DESCRIPTION
- `eqeqeq`-sääntö päälle Kosken ja Valppaan front-endissä
- `==` ja `!=` -vertailuoperaattorit muunnettu `===` ja `!==`:ksi Kosken ja Valppaan front-endissä
- Mochan testikoodiin ei ole koskettu.