### PR TITLE
Salli synteettiset hetut sen mukaan mitä appconfig sanoo

### DIFF
--- a/src/main/scala/fi/oph/koski/config/KoskiApplication.scala
+++ b/src/main/scala/fi/oph/koski/config/KoskiApplication.scala
@@ -117,8 +117,8 @@ class KoskiApplication(
     ePerusteetChangeValidator,
     config))
   lazy val ytr = TimedProxy[AuxiliaryOpiskeluoikeusRepository](YtrOpiskeluoikeusRepository(ytrRepository, organisaatioRepository, oppilaitosRepository, koodistoViitePalvelu, ytrAccessChecker, Some(validator), koskiLocalizationRepository))
-  lazy val opiskeluoikeusRepository = new CompositeOpiskeluoikeusRepository(possu, virta, ytr)
-  lazy val opiskeluoikeusRepositoryV2 = new CompositeOpiskeluoikeusRepository(possuV2, virta, ytr)
+  lazy val opiskeluoikeusRepository = new CompositeOpiskeluoikeusRepository(possu, virta, ytr, hetu)
+  lazy val opiskeluoikeusRepositoryV2 = new CompositeOpiskeluoikeusRepository(possuV2, virta, ytr, hetu)
   lazy val opiskeluoikeusQueryRepository = new OpiskeluoikeusQueryService(replicaDatabase.db)
   lazy val validator: KoskiValidator = new KoskiValidator(
     organisaatioRepository,

--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/CompositeOpiskeluoikeusRepository.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/CompositeOpiskeluoikeusRepository.scala
@@ -14,7 +14,7 @@ import fi.oph.koski.util.{Futures, WithWarnings}
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
-class CompositeOpiskeluoikeusRepository(main: KoskiOpiskeluoikeusRepository, virta: AuxiliaryOpiskeluoikeusRepository, ytr: AuxiliaryOpiskeluoikeusRepository) extends GlobalExecutionContext with Logging {
+class CompositeOpiskeluoikeusRepository(main: KoskiOpiskeluoikeusRepository, virta: AuxiliaryOpiskeluoikeusRepository, ytr: AuxiliaryOpiskeluoikeusRepository, hetu: Hetu) extends GlobalExecutionContext with Logging {
 
   private def withErrorLogging[T](fun: () => T)(implicit user: KoskiSpecificSession): T = {
     Try(fun()) match {
@@ -67,7 +67,7 @@ class CompositeOpiskeluoikeusRepository(main: KoskiOpiskeluoikeusRepository, vir
 
   def findByOppija(tunnisteet: HenkilönTunnisteet, useVirta: Boolean, useYtr: Boolean)(implicit user: KoskiSpecificSession): WithWarnings[Seq[Opiskeluoikeus]] = {
     val oid = tunnisteet.oid
-    val isValidHetu = Hetu.validate(tunnisteet.hetu.getOrElse(""), false) match {
+    val isValidHetu = hetu.validate(tunnisteet.hetu.getOrElse("")) match {
         case Right(_) => true
         case _ => false
     }


### PR DESCRIPTION
Käytetään olemassa olevaa Hetu-instanssia validoimiseen, jotta acceptSyntheticHetus -lippua ei tarvitse kovakoodata vaan se luetaan konfigista.