### PR TITLE
TOR-1691 lisää tunnustettu-rakenne taiteen perusopetukseen

### DIFF
--- a/src/main/resources/localization/koski-default-texts.json
+++ b/src/main/resources/localization/koski-default-texts.json
@@ -2435,6 +2435,7 @@
   "description:Taiteen perusopetuksen yleisen oppimäärän teemaopintojen..." : "Taiteen perusopetuksen yleisen oppimäärän teemaopintojen opintotason suoritus",
   "Taiteenala" : "Taiteenala",
   "description:Taiteen perusopetuksen opiskeluoikeuden oppimäärä" : "Taiteen perusopetuksen opiskeluoikeuden oppimäärä",
+  "description:Jos opintokokonaisuus on suoritettu osaamisen..." : "Jos opintokokonaisuus on suoritettu osaamisen tunnustamisena, syötetään tänne osaamisen tunnustamiseen liittyvät lisätiedot.",
   "Helsingin eurooppalaisen koulun opetussuunnitelmat": "Helsingin eurooppalaisen koulun opetussuunnitelmat",
   "Helsingin eurooppalaisen koulun opetussuunnitelmista ja arvosana-asteikoista on lisätietoja": "Helsingin eurooppalaisen koulun opetussuunnitelmista ja arvosana-asteikoista on lisätietoja",
   "Eurooppakoulujen sivulla": "Eurooppakoulujen sivulla",

--- a/src/main/scala/fi/oph/koski/documentation/ExamplesTaiteenPerusopetus.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesTaiteenPerusopetus.scala
@@ -55,6 +55,12 @@ object ExamplesTaiteenPerusopetus {
     )
   )
 
+  val tunnustus = Some(
+    TaiteenPerusopetuksenOsasuorituksenTunnustus(
+      selite = Finnish("Tunnustettu paikallinen opintokokonaisuus")
+    )
+  )
+
   object Opiskeluoikeus {
 
     def jaksoLäsnä(päivä: LocalDate = alkupäivä) = TaiteenPerusopetuksenOpiskeluoikeusjakso(
@@ -162,7 +168,7 @@ object ExamplesTaiteenPerusopetus {
       arviointi = Some(List(arviointiHyväksytty)),
       vahvistus = Some(vahvistus),
       osasuoritukset = Some(List(
-        Osasuoritus.osasuoritusMusiikki("musa1", 10.0),
+        Osasuoritus.tunnustettuOsasuoritusMusiikki("musa1", 10.0),
         Osasuoritus.osasuoritusMusiikki("musa2", 10.0),
         Osasuoritus.osasuoritusMusiikki("musa3", 9.6)
       ))
@@ -220,6 +226,13 @@ object ExamplesTaiteenPerusopetus {
     ) = TaiteenPerusopetuksenPaikallisenOpintokokonaisuudenSuoritus(
       koulutusmoduuli = Koulutusmoduuli.paikallinenOsasuoritus(tunniste, laajuus),
       arviointi = Some(List(arviointiHyväksytty))
+    )
+
+    def tunnustettuOsasuoritusMusiikki(
+      tunniste: String,
+      laajuus: Double
+    ): TaiteenPerusopetuksenPaikallisenOpintokokonaisuudenSuoritus = osasuoritusMusiikki(tunniste, laajuus).copy(
+      tunnustettu = tunnustus
     )
 
     object Koulutusmoduuli {

--- a/src/main/scala/fi/oph/koski/raportointikanta/OpiskeluoikeusLoader.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/OpiskeluoikeusLoader.scala
@@ -538,7 +538,7 @@ object OpiskeluoikeusLoader extends Logging {
         case _ => false
       },
       tunnustettuRahoituksenPiirissä = os match {
-        case m: MahdollisestiTunnustettu => m.tunnustettu.exists(_.rahoituksenPiirissä)
+        case m: MahdollisestiTunnustettu => m.tunnustettuRahoituksenPiirissä
         case _ => false
       },
       data = JsonManipulation.removeFields(data, fieldsToExcludeFromOsasuoritusJson),

--- a/src/main/scala/fi/oph/koski/schema/OsaamisenTunnustaminen.scala
+++ b/src/main/scala/fi/oph/koski/schema/OsaamisenTunnustaminen.scala
@@ -9,18 +9,27 @@ case class OsaamisenTunnustaminen(
   @Description("Aiemman, korvaavan suorituksen tiedot")
   @FlattenInUI
   osaaminen: Option[Suoritus],
-  @Description("Osaamisen tunnustamisen kautta saatavan tutkinnon osan suorituksen selite.")
-  @Tooltip("Kuvaus siitä, miten aikaisemmin hankittu osaaminen on tunnustettu.")
-  @OksaUri("tmpOKSAID629", "osaamisen tunnustaminen")
-  @Representative
-  @MultiLineString(5)
   selite: LocalizedString,
   @Description("Käytetään, mikäli tunnustettu osaaminen kuuluu rahoitukseen piiriin (esimerkiksi kaksoistutkintolaisilla ammatilliseen tutkintoon tunnustetut lukio-opinnot tai toiselta oppilaitokselta ostetut yksittäiset tutkinnon osat).")
   @Tooltip("Tunnustettu osaaminen kuuluu rahoitukseen piiriin (esimerkiksi kaksoistutkintolaisilla ammatilliseen tutkintoon tunnustetut lukio-opinnot tai toiselta oppilaitokselta ostetut yksittäiset tutkinnon osat).")
   @DefaultValue(false)
   rahoituksenPiirissä: Boolean = false
-)
+) extends SelitettyOsaamisenTunnustaminen
+
+trait SelitettyOsaamisenTunnustaminen {
+  @Description("Osaamisen tunnustamisen kautta saatavan tutkinnon osan suorituksen selite.")
+  @Tooltip("Kuvaus siitä, miten aikaisemmin hankittu osaaminen on tunnustettu.")
+  @OksaUri("tmpOKSAID629", "osaamisen tunnustaminen")
+  @Representative
+  @MultiLineString(5)
+  def selite: LocalizedString
+}
 
 trait MahdollisestiTunnustettu {
-  def tunnustettu: Option[OsaamisenTunnustaminen]
+  def tunnustettu: Option[SelitettyOsaamisenTunnustaminen]
+
+  def tunnustettuRahoituksenPiirissä: Boolean = tunnustettu.exists {
+    case o: OsaamisenTunnustaminen => o.rahoituksenPiirissä
+    case _ => false
+  }
 }

--- a/src/main/scala/fi/oph/koski/schema/TaiteenPerusopetus.scala
+++ b/src/main/scala/fi/oph/koski/schema/TaiteenPerusopetus.scala
@@ -247,8 +247,10 @@ case class TaiteenPerusopetuksenPaikallisenOpintokokonaisuudenSuoritus(
   koulutusmoduuli: TaiteenPerusopetuksenPaikallinenOpintokokonaisuus,
   arviointi: Option[List[TaiteenPerusopetuksenArviointi]],
   @KoodistoKoodiarvo("taiteenperusopetuksenpaikallinenopintokokonaisuus")
-  override val tyyppi: Koodistokoodiviite = Koodistokoodiviite("taiteenperusopetuksenpaikallinenopintokokonaisuus", "suorituksentyyppi")
-) extends Suoritus {
+  override val tyyppi: Koodistokoodiviite = Koodistokoodiviite("taiteenperusopetuksenpaikallinenopintokokonaisuus", "suorituksentyyppi"),
+  @Description("Jos opintokokonaisuus on suoritettu osaamisen tunnustamisena, syötetään tänne osaamisen tunnustamiseen liittyvät lisätiedot.")
+  tunnustettu: Option[TaiteenPerusopetuksenOsasuorituksenTunnustus] = None
+) extends Suoritus with MahdollisestiTunnustettu {
   override def vahvistus: Option[Vahvistus] = None
 }
 
@@ -262,3 +264,11 @@ case class TaiteenPerusopetuksenPaikallinenOpintokokonaisuus(
   tunniste: PaikallinenKoodi,
   laajuus: LaajuusOpintopisteissä
 ) extends PaikallinenKoulutusmoduuli with KoulutusmoduuliPakollinenLaajuus with StorablePreference
+
+/******************************************************************************
+ * OSASUORITUKSET - TUNNUSTAMINEN
+ *****************************************************************************/
+
+case class TaiteenPerusopetuksenOsasuorituksenTunnustus(
+  selite: LocalizedString
+) extends SelitettyOsaamisenTunnustaminen

--- a/src/test/resources/backwardcompatibility/taiteenperusopetus-hyvaksytystisuoritettu_2023-01-26.json
+++ b/src/test/resources/backwardcompatibility/taiteenperusopetus-hyvaksytystisuoritettu_2023-01-26.json
@@ -1,0 +1,436 @@
+{
+  "henkilö" : {
+    "hetu" : "010605A0734",
+    "etunimet" : "Pentti",
+    "kutsumanimi" : "Pentti",
+    "sukunimi" : "Taiteilija"
+  },
+  "opiskeluoikeudet" : [ {
+    "oppilaitos" : {
+      "oid" : "1.2.246.562.10.31915273374",
+      "oppilaitosnumero" : {
+        "koodiarvo" : "01694",
+        "koodistoUri" : "oppilaitosnumero"
+      },
+      "nimi" : {
+        "fi" : "Varsinais-Suomen kansanopisto"
+      }
+    },
+    "koulutustoimija" : {
+      "oid" : "1.2.246.562.10.44330177021",
+      "nimi" : {
+        "fi" : "Varsinais-Suomen Aikuiskoulutussäätiö sr"
+      },
+      "yTunnus" : "0136193-2",
+      "kotipaikka" : {
+        "koodiarvo" : "577",
+        "koodistoUri" : "kunta"
+      }
+    },
+    "tila" : {
+      "opiskeluoikeusjaksot" : [ {
+        "alku" : "2021-01-01",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "koodistoUri" : "koskiopiskeluoikeudentila"
+        }
+      }, {
+        "alku" : "2021-07-01",
+        "tila" : {
+          "koodiarvo" : "hyvaksytystisuoritettu",
+          "koodistoUri" : "koskiopiskeluoikeudentila"
+        }
+      } ]
+    },
+    "oppimäärä" : {
+      "koodiarvo" : "laajaoppimaara",
+      "koodistoUri" : "taiteenperusopetusoppimaara"
+    },
+    "suoritukset" : [ {
+      "koulutusmoduuli" : {
+        "tunniste" : {
+          "koodiarvo" : "999907",
+          "koodistoUri" : "koulutus"
+        },
+        "taiteenala" : {
+          "koodiarvo" : "musiikki",
+          "koodistoUri" : "taiteenperusopetustaiteenala"
+        },
+        "laajuus" : {
+          "arvo" : 29.6,
+          "yksikkö" : {
+            "koodiarvo" : "2",
+            "nimi" : {
+              "fi" : "opintopistettä",
+              "sv" : "studiepoäng",
+              "en" : "ECTS credits"
+            },
+            "lyhytNimi" : {
+              "fi" : "op",
+              "sv" : "sp",
+              "en" : "ECTS cr"
+            },
+            "koodistoUri" : "opintojenlaajuusyksikko"
+          }
+        },
+        "perusteenDiaarinumero" : "OPH-2068-2017"
+      },
+      "toimipiste" : {
+        "oid" : "1.2.246.562.10.78513447389"
+      },
+      "arviointi" : [ {
+        "arvosana" : {
+          "koodiarvo" : "hyvaksytty",
+          "koodistoUri" : "arviointiasteikkotaiteenperusopetus"
+        },
+        "päivä" : "2021-01-01",
+        "arvioitsijat" : [ {
+          "nimi" : "Musa Ope"
+        } ],
+        "hyväksytty" : true
+      } ],
+      "vahvistus" : {
+        "päivä" : "2021-01-01",
+        "paikkakunta" : {
+          "koodiarvo" : "091",
+          "nimi" : {
+            "fi" : "Helsinki"
+          },
+          "koodistoUri" : "kunta"
+        },
+        "myöntäjäOrganisaatio" : {
+          "oid" : "1.2.246.562.10.31915273374",
+          "oppilaitosnumero" : {
+            "koodiarvo" : "01694",
+            "koodistoUri" : "oppilaitosnumero"
+          },
+          "nimi" : {
+            "fi" : "Varsinais-Suomen kansanopisto"
+          }
+        },
+        "myöntäjäHenkilöt" : [ {
+          "nimi" : "Musa Ope",
+          "titteli" : {
+            "fi" : "Opettaja"
+          },
+          "organisaatio" : {
+            "oid" : "1.2.246.562.10.31915273374",
+            "oppilaitosnumero" : {
+              "koodiarvo" : "01694",
+              "koodistoUri" : "oppilaitosnumero"
+            },
+            "nimi" : {
+              "fi" : "Varsinais-Suomen kansanopisto"
+            }
+          }
+        } ]
+      },
+      "tyyppi" : {
+        "koodiarvo" : "taiteenperusopetuksenlaajanoppimaaranperusopinnot",
+        "koodistoUri" : "suorituksentyyppi"
+      },
+      "osasuoritukset" : [ {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "musa1",
+            "nimi" : {
+              "fi" : "Musiikin kurssi"
+            }
+          },
+          "laajuus" : {
+            "arvo" : 10.0,
+            "yksikkö" : {
+              "koodiarvo" : "2",
+              "nimi" : {
+                "fi" : "opintopistettä",
+                "sv" : "studiepoäng",
+                "en" : "ECTS credits"
+              },
+              "lyhytNimi" : {
+                "fi" : "op",
+                "sv" : "sp",
+                "en" : "ECTS cr"
+              },
+              "koodistoUri" : "opintojenlaajuusyksikko"
+            }
+          }
+        },
+        "arviointi" : [ {
+          "arvosana" : {
+            "koodiarvo" : "hyvaksytty",
+            "koodistoUri" : "arviointiasteikkotaiteenperusopetus"
+          },
+          "päivä" : "2021-01-01",
+          "arvioitsijat" : [ {
+            "nimi" : "Musa Ope"
+          } ],
+          "hyväksytty" : true
+        } ],
+        "tyyppi" : {
+          "koodiarvo" : "taiteenperusopetuksenpaikallinenopintokokonaisuus",
+          "koodistoUri" : "suorituksentyyppi"
+        },
+        "tunnustettu" : {
+          "selite" : {
+            "fi" : "Tunnustettu paikallinen opintokokonaisuus"
+          }
+        }
+      }, {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "musa2",
+            "nimi" : {
+              "fi" : "Musiikin kurssi"
+            }
+          },
+          "laajuus" : {
+            "arvo" : 10.0,
+            "yksikkö" : {
+              "koodiarvo" : "2",
+              "nimi" : {
+                "fi" : "opintopistettä",
+                "sv" : "studiepoäng",
+                "en" : "ECTS credits"
+              },
+              "lyhytNimi" : {
+                "fi" : "op",
+                "sv" : "sp",
+                "en" : "ECTS cr"
+              },
+              "koodistoUri" : "opintojenlaajuusyksikko"
+            }
+          }
+        },
+        "arviointi" : [ {
+          "arvosana" : {
+            "koodiarvo" : "hyvaksytty",
+            "koodistoUri" : "arviointiasteikkotaiteenperusopetus"
+          },
+          "päivä" : "2021-01-01",
+          "arvioitsijat" : [ {
+            "nimi" : "Musa Ope"
+          } ],
+          "hyväksytty" : true
+        } ],
+        "tyyppi" : {
+          "koodiarvo" : "taiteenperusopetuksenpaikallinenopintokokonaisuus",
+          "koodistoUri" : "suorituksentyyppi"
+        }
+      }, {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "musa3",
+            "nimi" : {
+              "fi" : "Musiikin kurssi"
+            }
+          },
+          "laajuus" : {
+            "arvo" : 9.6,
+            "yksikkö" : {
+              "koodiarvo" : "2",
+              "nimi" : {
+                "fi" : "opintopistettä",
+                "sv" : "studiepoäng",
+                "en" : "ECTS credits"
+              },
+              "lyhytNimi" : {
+                "fi" : "op",
+                "sv" : "sp",
+                "en" : "ECTS cr"
+              },
+              "koodistoUri" : "opintojenlaajuusyksikko"
+            }
+          }
+        },
+        "arviointi" : [ {
+          "arvosana" : {
+            "koodiarvo" : "hyvaksytty",
+            "koodistoUri" : "arviointiasteikkotaiteenperusopetus"
+          },
+          "päivä" : "2021-01-01",
+          "arvioitsijat" : [ {
+            "nimi" : "Musa Ope"
+          } ],
+          "hyväksytty" : true
+        } ],
+        "tyyppi" : {
+          "koodiarvo" : "taiteenperusopetuksenpaikallinenopintokokonaisuus",
+          "koodistoUri" : "suorituksentyyppi"
+        }
+      } ]
+    }, {
+      "koulutusmoduuli" : {
+        "tunniste" : {
+          "koodiarvo" : "999907",
+          "koodistoUri" : "koulutus"
+        },
+        "taiteenala" : {
+          "koodiarvo" : "musiikki",
+          "koodistoUri" : "taiteenperusopetustaiteenala"
+        },
+        "laajuus" : {
+          "arvo" : 18.5,
+          "yksikkö" : {
+            "koodiarvo" : "2",
+            "nimi" : {
+              "fi" : "opintopistettä",
+              "sv" : "studiepoäng",
+              "en" : "ECTS credits"
+            },
+            "lyhytNimi" : {
+              "fi" : "op",
+              "sv" : "sp",
+              "en" : "ECTS cr"
+            },
+            "koodistoUri" : "opintojenlaajuusyksikko"
+          }
+        },
+        "perusteenDiaarinumero" : "OPH-2068-2017"
+      },
+      "toimipiste" : {
+        "oid" : "1.2.246.562.10.78513447389"
+      },
+      "arviointi" : [ {
+        "arvosana" : {
+          "koodiarvo" : "hyvaksytty",
+          "koodistoUri" : "arviointiasteikkotaiteenperusopetus"
+        },
+        "päivä" : "2021-01-01",
+        "arvioitsijat" : [ {
+          "nimi" : "Musa Ope"
+        } ],
+        "hyväksytty" : true
+      } ],
+      "vahvistus" : {
+        "päivä" : "2021-01-01",
+        "paikkakunta" : {
+          "koodiarvo" : "091",
+          "nimi" : {
+            "fi" : "Helsinki"
+          },
+          "koodistoUri" : "kunta"
+        },
+        "myöntäjäOrganisaatio" : {
+          "oid" : "1.2.246.562.10.31915273374",
+          "oppilaitosnumero" : {
+            "koodiarvo" : "01694",
+            "koodistoUri" : "oppilaitosnumero"
+          },
+          "nimi" : {
+            "fi" : "Varsinais-Suomen kansanopisto"
+          }
+        },
+        "myöntäjäHenkilöt" : [ {
+          "nimi" : "Musa Ope",
+          "titteli" : {
+            "fi" : "Opettaja"
+          },
+          "organisaatio" : {
+            "oid" : "1.2.246.562.10.31915273374",
+            "oppilaitosnumero" : {
+              "koodiarvo" : "01694",
+              "koodistoUri" : "oppilaitosnumero"
+            },
+            "nimi" : {
+              "fi" : "Varsinais-Suomen kansanopisto"
+            }
+          }
+        } ]
+      },
+      "tyyppi" : {
+        "koodiarvo" : "taiteenperusopetuksenlaajanoppimaaransyventavatopinnot",
+        "koodistoUri" : "suorituksentyyppi"
+      },
+      "osasuoritukset" : [ {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "musa1",
+            "nimi" : {
+              "fi" : "Musiikin kurssi"
+            }
+          },
+          "laajuus" : {
+            "arvo" : 10.0,
+            "yksikkö" : {
+              "koodiarvo" : "2",
+              "nimi" : {
+                "fi" : "opintopistettä",
+                "sv" : "studiepoäng",
+                "en" : "ECTS credits"
+              },
+              "lyhytNimi" : {
+                "fi" : "op",
+                "sv" : "sp",
+                "en" : "ECTS cr"
+              },
+              "koodistoUri" : "opintojenlaajuusyksikko"
+            }
+          }
+        },
+        "arviointi" : [ {
+          "arvosana" : {
+            "koodiarvo" : "hyvaksytty",
+            "koodistoUri" : "arviointiasteikkotaiteenperusopetus"
+          },
+          "päivä" : "2021-01-01",
+          "arvioitsijat" : [ {
+            "nimi" : "Musa Ope"
+          } ],
+          "hyväksytty" : true
+        } ],
+        "tyyppi" : {
+          "koodiarvo" : "taiteenperusopetuksenpaikallinenopintokokonaisuus",
+          "koodistoUri" : "suorituksentyyppi"
+        }
+      }, {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "musa2",
+            "nimi" : {
+              "fi" : "Musiikin kurssi"
+            }
+          },
+          "laajuus" : {
+            "arvo" : 8.5,
+            "yksikkö" : {
+              "koodiarvo" : "2",
+              "nimi" : {
+                "fi" : "opintopistettä",
+                "sv" : "studiepoäng",
+                "en" : "ECTS credits"
+              },
+              "lyhytNimi" : {
+                "fi" : "op",
+                "sv" : "sp",
+                "en" : "ECTS cr"
+              },
+              "koodistoUri" : "opintojenlaajuusyksikko"
+            }
+          }
+        },
+        "arviointi" : [ {
+          "arvosana" : {
+            "koodiarvo" : "hyvaksytty",
+            "koodistoUri" : "arviointiasteikkotaiteenperusopetus"
+          },
+          "päivä" : "2021-01-01",
+          "arvioitsijat" : [ {
+            "nimi" : "Musa Ope"
+          } ],
+          "hyväksytty" : true
+        } ],
+        "tyyppi" : {
+          "koodiarvo" : "taiteenperusopetuksenpaikallinenopintokokonaisuus",
+          "koodistoUri" : "suorituksentyyppi"
+        }
+      } ]
+    } ],
+    "tyyppi" : {
+      "koodiarvo" : "taiteenperusopetus",
+      "koodistoUri" : "opiskeluoikeudentyyppi"
+    },
+    "arvioituPäättymispäivä" : "2022-01-01",
+    "alkamispäivä" : "2021-01-01",
+    "päättymispäivä" : "2021-07-01"
+  } ]
+}

--- a/src/test/scala/fi/oph/koski/migration/MigrationSpec.scala
+++ b/src/test/scala/fi/oph/koski/migration/MigrationSpec.scala
@@ -27,7 +27,7 @@ class MigrationSpec extends AnyFreeSpec with Matchers {
         "LoaderUtils.scala"                                         -> "38d31b4d1cfa5e3892083bb39f7f0047",
         "MuuAmmatillinenRaporttiRowBuilder.scala"                   -> "31774fb0fbd06a775a07325e867a951f",
         "OpiskeluoikeudenUlkopuolellaArvioidutOsasuoritukset.scala" -> "47d7ee909d283a47f9240d804d5ddde5",
-        "OpiskeluoikeusLoader.scala"                                -> "a630aebab0ef6194fa127aaf519659e6",
+        "OpiskeluoikeusLoader.scala"                                -> "2c8b66dcbc64d7666296b2bd21223b3f",
         "OppivelvollisuudenVapautusLoader.scala"                    -> "2870707413fff5719b7cb7063dd424c4",
         "OrganisaatioHistoriaRowBuilder.scala"                      -> "7e586d9e273a5a4ee7beae257f22c7f4",
         "OrganisaatioLoader.scala"                                  -> "9e2e45da33ed335af4a7b0a31b139a7",

--- a/tiedonsiirtoprotokollan_muutoshistoria.md
+++ b/tiedonsiirtoprotokollan_muutoshistoria.md
@@ -1,4 +1,7 @@
-# 19.1.2023
+## 26.1.2023
+- Taiteen perusopetuksen osasuorituksille lisätty valinnainen tunnustettu-rakenne.
+
+## 19.1.2023
 - Jatkuvaan oppimiseen suunnatun vapaan sivistystyön koulutuksen osasuoritusten ja aliosasuoritusten laajuus on muutettu valinnaiseksi kentäksi.
 
 ## 2.1.2023


### PR DESCRIPTION
Tunnustettu-rakenne on kevyempi kuin muissa opiskeluoikeuden tyypeissä ja sisältää ainoastaan selite-kentän.