### PR TITLE
TOR-1888 TUVA: rahoitusmuoto toimii käyttöliittymässä myös loma-tilaiselle

### DIFF
--- a/web/app/opiskeluoikeus/opintojenRahoitus.js
+++ b/web/app/opiskeluoikeus/opintojenRahoitus.js
@@ -52,13 +52,14 @@ export const opiskeluoikeudenTilaVaatiiRahoitusmuodon = (
       'luva',
       'ibtutkinto',
       'internationalschool',
-      'diatutkinto',
-      'tuva'
+      'diatutkinto'
     ].includes(opiskeluoikeudenTyyppiKoodiarvo)
   ) {
     return ['lasna', 'valmistunut'].includes(tila)
   }
-  if (opiskeluoikeudenTyyppiKoodiarvo === 'ammatillinenkoulutus') {
+  if (
+    ['ammatillinenkoulutus', 'tuva'].includes(opiskeluoikeudenTyyppiKoodiarvo)
+  ) {
     return ['lasna', 'valmistunut', 'loma'].includes(tila)
   }
   return false

--- a/web/test/page/addOppijaPage.js
+++ b/web/test/page/addOppijaPage.js
@@ -412,7 +412,7 @@ function AddOppijaPage() {
         järjestämislupa: 'Ammatillisen koulutuksen järjestämislupa (TUVA)',
         suorituskieli: 'suomi',
         alkamispäivä: '1.8.2021',
-        tila: 'Läsnä',
+        tila: 'Loma',
         opintojenRahoitus: 'Muuta kautta rahoitettu'
       })
       return function () {

--- a/web/test/spec/tuvaSpec.js
+++ b/web/test/spec/tuvaSpec.js
@@ -209,7 +209,7 @@ describe('TUVA', function () {
         ).to.equal('1.8.2021')
         expect(
           editor.propertyBySelector('.opiskeluoikeusjakso .tila').getText()
-        ).to.equal('Läsnä (muuta kautta rahoitettu)')
+        ).to.equal('Loma (muuta kautta rahoitettu)')
         expect(
           editor.propertyBySelector('.järjestämislupa').getValue()
         ).to.equal('Ammatillisen koulutuksen järjestämislupa (TUVA)')


### PR DESCRIPTION
Korjaus: rahoitusmuoto valittavaksi kälissä loma-tilaiselle TUVA-opiskeluoikeudelle