### PR TITLE
Poista synteettinen-annotaatio deprekoidulta suorituksen tilalta

### DIFF
--- a/src/main/scala/fi/oph/koski/schema/Suoritus.scala
+++ b/src/main/scala/fi/oph/koski/schema/Suoritus.scala
@@ -23,7 +23,6 @@ trait Suoritus {
   def alkamispäivä: Option[LocalDate] = None
   @Description("Suorituksen tila, ei käytössä.")
   @KoodistoUri("suorituksentila")
-  @SyntheticProperty
   @ReadOnly("Ei käytössä.")
   @Hidden
   @Deprecated("Ei käytössä.")


### PR DESCRIPTION
Annotaation poistaminen myös piilottaa kentän json-skeemasta kaikilta suorituksilta.