### PR TITLE
Pinnaa Kosken Dockerfilen image-versiot SHA256-hashiin

### DIFF
--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:alpine-slim
+FROM adoptopenjdk/openjdk11:alpine-slim@sha256:1ce1ecfc978acf836ff7a85beb4386ecdb2dd32898fa78847001ea83b4e9f8d4
 
 ARG KOSKI_VERSION
 ARG PROMETHEUS_JMX_EXPORTER_VERSION="0.17.2"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 services:
 
   postgres:
-    image: "postgres:12.11"
+    image: "postgres:12.11@sha256:15017a063c249afe1a87f6c6b163eddc3205601040b22c0f8b10625ae6c75402"
     command: "postgres -c max_connections=200 -c log_statement=all -c log_destination=stderr"
     environment:
     - "POSTGRES_USER=oph"
@@ -25,6 +25,6 @@ services:
     - "./opensearch/opensearch-docker.yml:/usr/share/opensearch/config/opensearch.yml:ro"
 
   dynamodb:
-    image: "amazon/dynamodb-local"
+    image: "amazon/dynamodb-local@sha256:f02384481c5133136cfd7edc82c6aed431e85a27bf5886fd637b889bdc0af6d5"
     ports:
     - "8000:8000"

--- a/opensearch/Dockerfile
+++ b/opensearch/Dockerfile
@@ -1,3 +1,3 @@
-FROM opensearchproject/opensearch:1.2.4
+FROM opensearchproject/opensearch:1.2.4@sha256:5fbe36f36c1e6f2bed51c98b7767b1d45b6264f48b666c1cac1a372d4bab8f55
 
 RUN bin/opensearch-plugin install --batch analysis-icu


### PR DESCRIPTION
Pinnataan Koskessa käytössä olevat Dockerfile-versiot hashiin.

SHA256-hashin etuja:

- Jos imagen ylläpitäjä julkaisee päivityksen ja se rikkoo asioita, niin menee myös Koski
- Ilman SHA256 hashia ei saada aikaan täysin deterministisiä buildeja Koskesta

Pinnaamalla Dockerfilet SHA256-hasheihin parannetaan myös turvallisuutta estämällä uusien image-muutosten tuominen automaattisesti ilman auditointia.