### PR TITLE
TOR-1933: Poista ytr-s3-certificates-credentials käytöstä

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -132,13 +132,6 @@ ytr.aws.accessKeyId = ""
 ytr.aws.externalId = ""
 ytr.aws.bucket = "mock"
 ytr.aws.roleArn = ""
-ytr.certificates.aws = {
-    secretAccessKey = ""
-    accessKeyId = ""
-    externalId = ""
-    bucket = "mock"
-    roleArn = ""
-}
 ytr.download.batchSize = 500
 ytr.download.extraSleepPerStudentInMs = 50
 ytr.download.maxAllowedLagInSeconds = 300

--- a/src/main/scala/fi/oph/koski/ytr/YoTodistusService.scala
+++ b/src/main/scala/fi/oph/koski/ytr/YoTodistusService.scala
@@ -13,7 +13,7 @@ import java.io.OutputStream
 
 object YoTodistusService {
   def apply(application: KoskiApplication): YoTodistusService = {
-    val s3config: YtrS3Config = YtrS3SignedCertificateConfig.getEnvironmentConfig(application)
+    val s3config: YtrS3Config = YtrS3Config.getEnvironmentConfig(application)
     if (s3config.bucket == "mock") {
       new MockYoTodistusService(application)
     } else {

--- a/src/main/scala/fi/oph/koski/ytr/YtrS3.scala
+++ b/src/main/scala/fi/oph/koski/ytr/YtrS3.scala
@@ -35,6 +35,10 @@ class YtrS3(config: YtrS3Config) {
 }
 
 object YtrS3Config {
+  def getEnvironmentConfig(application: KoskiApplication): YtrS3Config = {
+    if (Environment.usesAwsSecretsManager) this.fromSecretsManager else this.fromConfig(application.config)
+  }
+
   def fromConfig(config: Config): YtrS3Config = YtrS3Config(
     config.getString("ytr.aws.accessKeyId"),
     config.getString("ytr.aws.secretAccessKey"),
@@ -42,27 +46,10 @@ object YtrS3Config {
     config.getString("ytr.aws.externalId"),
     config.getString("ytr.aws.bucket")
   )
+
   def fromSecretsManager: YtrS3Config = {
     val cachedSecretsClient = new SecretsManager
     val secretId = cachedSecretsClient.getSecretId("YTR S3 secrets", "YTR_S3_SECRET_ID")
-    cachedSecretsClient.getStructuredSecret[YtrS3Config](secretId)
-  }
-}
-
-object YtrS3SignedCertificateConfig {
-  def getEnvironmentConfig(application: KoskiApplication): YtrS3Config =
-    if (Environment.usesAwsSecretsManager) YtrS3SignedCertificateConfig.fromSecretsManager else YtrS3SignedCertificateConfig.fromConfig(application.config)
-
-  def fromConfig(config: Config): YtrS3Config = YtrS3Config(
-    config.getString("ytr.certificates.aws.accessKeyId"),
-    config.getString("ytr.certificates.aws.secretAccessKey"),
-    config.getString("ytr.certificates.aws.roleArn"),
-    config.getString("ytr.certificates.aws.externalId"),
-    config.getString("ytr.certificates.aws.bucket")
-  )
-  def fromSecretsManager: YtrS3Config = {
-    val cachedSecretsClient = new SecretsManager
-    val secretId = cachedSecretsClient.getSecretId("YTR Certificates S3 secrets", "YTR_CERTIFICATES_S3_SECRET_ID")
     cachedSecretsClient.getStructuredSecret[YtrS3Config](secretId)
   }
 }


### PR DESCRIPTION
Yo-todistusta varten luotu s3-salaisuus on nykyisen toteutuksen myötä muuttunut turhaksi,
koska se on muilta osin sama kuin vanha ytr-s3-salaisuus paitsi bucketin, joka asetetaan
kutsujen yhteydessä joka tapauksessa dynaamisesti.
