### PR TITLE
TOR-1893 korjaa kurssien näkyminen raportin kurssien välilehdellä

### DIFF
--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabaseSchema.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointiDatabaseSchema.scala
@@ -6,7 +6,7 @@ import java.time.temporal.ChronoUnit
 import fi.oph.koski.db.PostgresDriverWithJsonSupport.api._
 import fi.oph.koski.json.JsonSerializer
 import fi.oph.koski.localization.LocalizationReader
-import fi.oph.koski.raportit.YleissivistäväRaporttiOppiaineTaiKurssi
+import fi.oph.koski.raportit.{YleissivistäväRaporttiKurssi, YleissivistäväRaporttiOppiaine, YleissivistäväRaporttiOppiaineTaiKurssi}
 import fi.oph.koski.schema.LocalizedString
 import org.json4s.JValue
 import shapeless.{Generic, HNil}
@@ -861,9 +861,14 @@ case class ROsasuoritusRow(
   sisältyyOpiskeluoikeuteenOid: Option[String]
 ) extends RSuoritusRow {
   override def matchesWith(x: YleissivistäväRaporttiOppiaineTaiKurssi, lang: String): Boolean = {
-    suorituksestaKäytettäväNimi(lang).contains(x.nimi) &&
-      koulutusmoduuliKoodiarvo == x.koulutusmoduuliKoodiarvo &&
-      koulutusmoduuliPaikallinen == x.koulutusmoduuliPaikallinen
+    x match {
+      case _: YleissivistäväRaporttiOppiaine => suorituksestaKäytettäväNimi(lang).contains(x.nimi) &&
+        koulutusmoduuliKoodiarvo == x.koulutusmoduuliKoodiarvo &&
+        koulutusmoduuliPaikallinen == x.koulutusmoduuliPaikallinen
+      case _: YleissivistäväRaporttiKurssi => koulutusModuulistaKäytettäväNimi(lang).contains(x.nimi) &&
+        koulutusmoduuliKoodiarvo == x.koulutusmoduuliKoodiarvo &&
+        koulutusmoduuliPaikallinen == x.koulutusmoduuliPaikallinen
+    }
   }
 
   def oppimääräKoodiarvo: Option[String] =

--- a/src/test/scala/fi/oph/koski/migration/MigrationSpec.scala
+++ b/src/test/scala/fi/oph/koski/migration/MigrationSpec.scala
@@ -34,7 +34,7 @@ class MigrationSpec extends AnyFreeSpec with Matchers {
         "PäivitettyOpiskeluoikeusLoader.scala"                      -> "500545bbe7ef47dedcfdc49580b536d2",
         "RaportointiDatabase.scala"                                 -> "2b7e37233ce8d107edb176224f4e2b2c",
         "RaportointiDatabaseCustomFunctions.scala"                  -> "956f101d1219c49ac9134b72a30caf3a",
-        "RaportointiDatabaseSchema.scala"                           -> "72059850ce1d8d1b7453507c134e94a2",
+        "RaportointiDatabaseSchema.scala"                           -> "a5d1771eab880a6241b4a556bb919b69",
         "RaportointikantaService.scala"                             -> "8f151f971984b09167f781b7e465a259",
         "RaportointikantaStatusServlet.scala"                       -> "9fd6f796adfb2034cce0151b7330cd1a",
         "RaportointikantaTestServlet.scala"                         -> "d457be86e60dd84545378ae415236d26",


### PR DESCRIPTION
Mätsää osasuorituksen rivi eri tavalla oppiaineen ja kurssin kanssa paremman lopputuloksen saavuttamiseksi. Aiemmin kurssi ei mätsännyt osasuorituksen riviin lainkaan, jos kurssin koulutusmoduulissa oli kieli määriteltynä.