### PR TITLE
TOR-1959: Mahdollisesti elegantimpi ratkaisu constraintien ikikiersiöön

### DIFF
--- a/web/app/types/fi/oph/koski/typemodel/Constraint.ts
+++ b/web/app/types/fi/oph/koski/typemodel/Constraint.ts
@@ -5,6 +5,10 @@ import { DateConstraint, isDateConstraint } from './DateConstraint'
 import { LiteralConstraint, isLiteralConstraint } from './LiteralConstraint'
 import { NumberConstraint, isNumberConstraint } from './NumberConstraint'
 import { ObjectConstraint, isObjectConstraint } from './ObjectConstraint'
+import {
+  ObjectRefConstraint,
+  isObjectRefConstraint
+} from './ObjectRefConstraint'
 import { OptionalConstraint, isOptionalConstraint } from './OptionalConstraint'
 import { RecordConstraint, isRecordConstraint } from './RecordConstraint'
 import { StringConstraint, isStringConstraint } from './StringConstraint'
@@ -23,6 +27,7 @@ export type Constraint =
   | LiteralConstraint
   | NumberConstraint
   | ObjectConstraint
+  | ObjectRefConstraint
   | OptionalConstraint
   | RecordConstraint
   | StringConstraint
@@ -36,6 +41,7 @@ export const isConstraint = (a: any): a is Constraint =>
   isLiteralConstraint(a) ||
   isNumberConstraint(a) ||
   isObjectConstraint(a) ||
+  isObjectRefConstraint(a) ||
   isOptionalConstraint(a) ||
   isRecordConstraint(a) ||
   isStringConstraint(a) ||

--- a/web/app/types/fi/oph/koski/typemodel/ObjectRefConstraint.ts
+++ b/web/app/types/fi/oph/koski/typemodel/ObjectRefConstraint.ts
@@ -1,0 +1,25 @@
+/**
+ * ObjectRefConstraint
+ *
+ * @see `fi.oph.koski.typemodel.ObjectRefConstraint`
+ */
+export type ObjectRefConstraint = {
+  $class: 'fi.oph.koski.typemodel.ObjectRefConstraint'
+  class: string
+  type: 'ref'
+}
+
+export const ObjectRefConstraint = (o: {
+  class: string
+  type?: 'ref'
+}): ObjectRefConstraint => ({
+  $class: 'fi.oph.koski.typemodel.ObjectRefConstraint',
+  type: 'ref',
+  ...o
+})
+
+ObjectRefConstraint.className =
+  'fi.oph.koski.typemodel.ObjectRefConstraint' as const
+
+export const isObjectRefConstraint = (a: any): a is ObjectRefConstraint =>
+  a?.$class === 'fi.oph.koski.typemodel.ObjectRefConstraint'


### PR DESCRIPTION
constraints-api heitti stack overflow'n, kun sitä kutsuttiin tietotyypille, jossa on rekursiivinen rakenne.
Ongelma paikattiin toisessa branchissa asettamalla maksimisyvyys constrantien rakentamiselle, mutta se
aiheuttaa epäelegantteja, syviä json-puita, joissa asiat toistuvat. Se on ratkaisuna kuitenkin yhteensopiva
selaimessa ajettavien validaatioiden kanssa.

Tässä pr:ssä on tallessa yritelmä ratkaista ongelma objektireferenssien avulla, mutta tämän myötä
myös selainpään koodia piti laajentaa. Testien puutteen takia tämä on tässä pidossa nyt toistaiseksi
erillisenä pullarina, jonka voi cherry-pickata tai mergetä mukaan tarvittaessa.
