### PR TITLE
Älä lisää YTR-kokeen virheellistä sisällytettyä suoritusta;

### DIFF
--- a/src/main/resources/mockdata/ytr/laaja_080380-2432_140380-336X_220680-7850_240680-087S_060807A7787.json
+++ b/src/main/resources/mockdata/ytr/laaja_080380-2432_140380-336X_220680-7850_240680-087S_060807A7787.json
@@ -1510,7 +1510,12 @@
             ]
           }
         ],
-        "includedExams": []
+        "includedExams": [
+          {
+            "examId": "A",
+            "examinationPeriod": "2011S"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
raportointikantaan varsinaisen kokeen tutkintokokonaisuuteen. Jätetään rivi lisäämättä toistaiseksi.