### PR TITLE
TOR-1933: Älä näytä yo-todistuksen-latausta linkkijaossa

### DIFF
--- a/web/app/suoritus/OmatTiedotSuoritustaulukko.jsx
+++ b/web/app/suoritus/OmatTiedotSuoritustaulukko.jsx
@@ -28,6 +28,9 @@ import Http from '../util/http'
 import * as Bacon from 'baconjs'
 import { YoTodistus } from '../components-v2/yotutkinto/YoTodistus'
 
+const isOmatTiedotPage = () =>
+  window.location.pathname.startsWith('/koski/omattiedot')
+
 const OmatTiedotSuoritustaulukko = ({
   suorituksetModel,
   nested,
@@ -72,7 +75,7 @@ const OmatTiedotSuoritustaulukko = ({
           />
         ))
       )}
-      {isYlioppilastutkinto(parentSuoritus) && (
+      {isYlioppilastutkinto(parentSuoritus) && isOmatTiedotPage() && (
         <YoTodistus oppijaOid={context.oppijaOid} testId="yoTodistus" />
       )}
     </div>

--- a/web/app/util/koskiApi.ts
+++ b/web/app/util/koskiApi.ts
@@ -161,10 +161,8 @@ export const peruutaSuostumus = (
   )
 
 export const fetchYoTodistusState = (oppijaOid: string, language: string) =>
-  handleExpiredSession(
-    apiGet<YtrCertificateResponse>(
-      apiUrl(`yotodistus/status/${language}/${oppijaOid}`)
-    )
+  apiGet<YtrCertificateResponse>(
+    apiUrl(`yotodistus/status/${language}/${oppijaOid}`)
   )
 
 export const generateYoTodistus = (oppijaOid: string, language: string) =>

--- a/web/test/spec/omatTiedotSpec.js
+++ b/web/test/spec/omatTiedotSpec.js
@@ -1093,11 +1093,7 @@ describe('Omat tiedot', function () {
               '2012 kevät Ruotsi, keskipitkä oppimäärä 166 Cum laude approbatur\n' +
               '2012 kevät Englanti, pitkä oppimäärä 210 Cum laude approbatur\n' +
               '2012 kevät Maantiede 26 Magna cum laude approbatur\n' +
-              '2012 kevät Matematiikan koe, lyhyt oppimäärä 59 Laudatur\n' +
-              'Ylioppilastodistus\n' +
-              'Todistuksen kieli\n' +
-              ':\n' +
-              'Lataa todistus'
+              '2012 kevät Matematiikan koe, lyhyt oppimäärä 59 Laudatur'
           )
         })
       })


### PR DESCRIPTION
- Näytä yo-todistuksen lataus vain omat tiedot -sivulla
- Ei uudelleenlatausta, jos yo-todistus-api palauttaa 401;
