### PR TITLE
TOR-2002 korjaus Migrin tietomalliin

### DIFF
--- a/src/main/scala/fi/oph/koski/migri/ConvertMigriSchema.scala
+++ b/src/main/scala/fi/oph/koski/migri/ConvertMigriSchema.scala
@@ -256,13 +256,14 @@ object ConvertMigriSchema {
                 case _ => None
               },
               tunnustettu = osasuoritus match {
-                case x: MahdollisestiTunnustettu
-                  if lisätiedotKoodiarvonTunnisteEquals("mukautettu", osasuoritus) =>
+                case x: MahdollisestiTunnustettu =>
                   x.tunnustettu.map(tunnustaminen => MigriOsaamisenTunnustaminen(tunnustaminen.selite))
                 case _ => None
               },
               lisätiedot = osasuoritus match {
-                case x: TutkinnonOsanSuoritus => x.lisätiedot
+                case x: TutkinnonOsanSuoritus
+                  if lisätiedotKoodiarvonTunnisteEquals("mukautettu", osasuoritus) =>
+                  x.lisätiedot
                 case _ => None
               },
               suoritettuErityisenäTutkintona = osasuoritus match {
@@ -301,13 +302,14 @@ object ConvertMigriSchema {
                   )),
                   tyyppi = osasuorituksenOsasuoritus.tyyppi,
                   tunnustettu = osasuorituksenOsasuoritus  match {
-                    case x: MahdollisestiTunnustettu
-                      if lisätiedotKoodiarvonTunnisteEquals("mukautettu", osasuorituksenOsasuoritus) =>
+                    case x: MahdollisestiTunnustettu =>
                       x.tunnustettu.map(tunnustaminen => MigriOsaamisenTunnustaminen(tunnustaminen.selite))
                     case _ => None
                   },
                   lisätiedot = osasuorituksenOsasuoritus match {
-                    case x: TutkinnonOsanSuoritus => x.lisätiedot
+                    case x: TutkinnonOsanSuoritus
+                      if lisätiedotKoodiarvonTunnisteEquals("mukautettu", osasuorituksenOsasuoritus) =>
+                      x.lisätiedot
                     case _ => None
                   }
                 )

--- a/src/main/scala/fi/oph/koski/migri/MigriSchema.scala
+++ b/src/main/scala/fi/oph/koski/migri/MigriSchema.scala
@@ -141,8 +141,8 @@ case class MigriOsasuoritus(
   arviointi: Option[List[MigriArviointi]],
   tyyppi: Koodistokoodiviite,
   tutkinnonOsanRyhmä: Option[Koodistokoodiviite],
-  tunnustettu: Option[MigriOsaamisenTunnustaminen], //vain jos lisätiedoissta löytyy koodiarvo "mukautettu"
-  lisätiedot: Option[List[AmmatillisenTutkinnonOsanLisätieto]],
+  tunnustettu: Option[MigriOsaamisenTunnustaminen],
+  lisätiedot: Option[List[AmmatillisenTutkinnonOsanLisätieto]], //vain jos lisätiedoissta löytyy koodiarvo "mukautettu"
   osasuoritukset: Option[List[MigriOsasuorituksenOsasuoritus]],
   suoritettuErityisenäTutkintona: Option[Boolean],
   @KoodistoUri("virtaopsuorluokittelu")
@@ -153,8 +153,8 @@ case class MigriOsasuorituksenOsasuoritus(
   koulutusmoduuli: MigriOsasuorituksenKoulutusmoduuli,
   arviointi: Option[List[MigriArviointi]],
   tyyppi: Koodistokoodiviite,
-  tunnustettu: Option[MigriOsaamisenTunnustaminen], //vain jos lisätiedoissta löytyy koodiarvo "mukautettu"
-  lisätiedot: Option[List[AmmatillisenTutkinnonOsanLisätieto]]
+  tunnustettu: Option[MigriOsaamisenTunnustaminen],
+  lisätiedot: Option[List[AmmatillisenTutkinnonOsanLisätieto]] //vain jos lisätiedoissta löytyy koodiarvo "mukautettu"
 )
 
 case class MigriOsasuorituksenKoulutusmoduuli(


### PR DESCRIPTION
Korjaus: tunnustettu-kenttä aina mukaan, lisätiedot-kenttä vain jos mukautettu löytyy