### PR TITLE
TOR-2002 korjaa migrin rajapinnan amiksen aliosasuoritusten konversio

### DIFF
--- a/src/main/scala/fi/oph/koski/documentation/ExamplesAmmatillinen.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesAmmatillinen.scala
@@ -519,23 +519,25 @@ object AmmatillinenOldExamples {
   lazy val mukautettu = oppija(opiskeluoikeus = opiskeluoikeus(
     tutkinto = autoalanPerustutkinnonSuoritus().copy(suoritustapa = suoritustapaOps),
     osat = Some(List(
-      YhteisenAmmatillisenTutkinnonOsanSuoritus(
-        koulutusmoduuli = YhteinenTutkinnonOsa(Koodistokoodiviite("101053", Some("Viestintä- ja vuorovaikutusosaaminen"), "tutkinnonosat", None), true, Some(LaajuusOsaamispisteissä(11))),
-        lisätiedot = Some(List(AmmatillisenTutkinnonOsanLisätieto(
-          Koodistokoodiviite("mukautettu", "ammatillisentutkinnonosanlisatieto"),
-          "Tutkinnon osan ammattitaitovaatimuksia ja osaamisen arviointi on mukautettu (ja/tai niistä on poikettu) ammatillisesta peruskoulutuksesta annetun lain\n(630/1998, muutos 246/2015) 19 a (ja/tai 21) §:n perusteella"))),
-        suorituskieli = None,
-        alkamispäivä = None,
-        toimipiste = Some(stadinToimipiste),
-        arviointi = Some(List(arviointiKiitettävä.copy(kuvaus=Some("Erinomaista kehitystä")))),
-        vahvistus = vahvistusValinnaisellaTittelillä(date(2014, 11, 8), stadinAmmattiopisto),
-        tutkinnonOsanRyhmä = yhteisetTutkinnonOsat,
-        osasuoritukset = Some(List(
-          YhteisenTutkinnonOsanOsaAlueenSuoritus(koulutusmoduuli = AmmatillisenTutkinnonÄidinkieli(Koodistokoodiviite("AI", "ammatillisenoppiaineet"), pakollinen = true, kieli = Koodistokoodiviite("AI1", "oppiaineaidinkielijakirjallisuus"), laajuus = Some(LaajuusOsaamispisteissä(11))), arviointi = Some(List(arviointiKiitettävä))),
-        ))
-      )
+      mukautettuTutkinnonOsa
     ))
   ))
+
+  lazy val mukautettuTutkinnonOsa = YhteisenAmmatillisenTutkinnonOsanSuoritus(
+    koulutusmoduuli = YhteinenTutkinnonOsa(Koodistokoodiviite("101053", Some("Viestintä- ja vuorovaikutusosaaminen"), "tutkinnonosat", None), true, Some(LaajuusOsaamispisteissä(11))),
+    lisätiedot = Some(List(AmmatillisenTutkinnonOsanLisätieto(
+      Koodistokoodiviite("mukautettu", "ammatillisentutkinnonosanlisatieto"),
+      "Tutkinnon osan ammattitaitovaatimuksia ja osaamisen arviointi on mukautettu (ja/tai niistä on poikettu) ammatillisesta peruskoulutuksesta annetun lain\n(630/1998, muutos 246/2015) 19 a (ja/tai 21) §:n perusteella"))),
+    suorituskieli = None,
+    alkamispäivä = None,
+    toimipiste = Some(stadinToimipiste),
+    arviointi = Some(List(arviointiKiitettävä.copy(kuvaus = Some("Erinomaista kehitystä")))),
+    vahvistus = vahvistusValinnaisellaTittelillä(date(2014, 11, 8), stadinAmmattiopisto),
+    tutkinnonOsanRyhmä = yhteisetTutkinnonOsat,
+    osasuoritukset = Some(List(
+      YhteisenTutkinnonOsanOsaAlueenSuoritus(koulutusmoduuli = AmmatillisenTutkinnonÄidinkieli(Koodistokoodiviite("AI", "ammatillisenoppiaineet"), pakollinen = true, kieli = Koodistokoodiviite("AI1", "oppiaineaidinkielijakirjallisuus"), laajuus = Some(LaajuusOsaamispisteissä(11))), arviointi = Some(List(arviointiKiitettävä))),
+    ))
+  )
 
   lazy val muunAmmatillisenTutkinnonOsanSuoritus = MuunAmmatillisenTutkinnonOsanSuoritus(
     koulutusmoduuli = MuuValtakunnallinenTutkinnonOsa(Koodistokoodiviite("104052", "tutkinnonosat"), true, None),

--- a/src/main/scala/fi/oph/koski/migri/ConvertMigriSchema.scala
+++ b/src/main/scala/fi/oph/koski/migri/ConvertMigriSchema.scala
@@ -261,7 +261,7 @@ object ConvertMigriSchema {
                 case _ => None
               },
               lisätiedot = osasuoritus match {
-                case x: TutkinnonOsanSuoritus
+                case x: AmmatillisenTutkinnonOsanLisätiedollinen
                   if lisätiedotKoodiarvonTunnisteEquals("mukautettu", osasuoritus) =>
                   x.lisätiedot
                 case _ => None
@@ -307,7 +307,7 @@ object ConvertMigriSchema {
                     case _ => None
                   },
                   lisätiedot = osasuorituksenOsasuoritus match {
-                    case x: TutkinnonOsanSuoritus
+                    case x: AmmatillisenTutkinnonOsanLisätiedollinen
                       if lisätiedotKoodiarvonTunnisteEquals("mukautettu", osasuorituksenOsasuoritus) =>
                       x.lisätiedot
                     case _ => None
@@ -341,7 +341,7 @@ object ConvertMigriSchema {
   }
 
   private def lisätiedotKoodiarvonTunnisteEquals(koodiarvo: String, suoritus: Suoritus): Boolean = suoritus match {
-    case t: TutkinnonOsanSuoritus => t.lisätiedot.exists(_.exists(_.tunniste.koodiarvo == koodiarvo))
+    case t: AmmatillisenTutkinnonOsanLisätiedollinen => t.lisätiedot.exists(_.exists(_.tunniste.koodiarvo == koodiarvo))
     case _ => false
   }
 }


### PR DESCRIPTION
Mätsää aliosasuoritusten lisätiedot oikeaan traittiin väärän sijaan.