### PR TITLE
TOR-2009: Estä hetujen päätyminen logille OpenSearch-id:n kautta

### DIFF
--- a/src/main/scala/fi/oph/koski/log/LogUtils.scala
+++ b/src/main/scala/fi/oph/koski/log/LogUtils.scala
@@ -4,6 +4,6 @@ object LogUtils {
   val HETU_MASK = "******-****"
 
   def maskSensitiveInformation(s: String): String = {
-    s.replaceAll("\\b[0-9]{6}[-AaBbCcDdEeFfXxYyWwVvUu+][0-9]{3}[0-9A-Za-z]\\b", HETU_MASK)
+    s.replaceAll("[0-9]{6}[-AaBbCcDdEeFfXxYyWwVvUu+][0-9]{3}[0-9A-Za-z]\\b", HETU_MASK)
   }
 }

--- a/src/test/scala/fi/oph/koski/log/LogMaskingPatternConverterSpec.scala
+++ b/src/test/scala/fi/oph/koski/log/LogMaskingPatternConverterSpec.scala
@@ -28,6 +28,10 @@ class LogMaskingPatternConverterSpec extends AnyFreeSpec with TestEnvironment wi
         logger.info("Hetu: 040404-0404")
         latestMaskedJsonMessage should equal(s"Hetu: ${HETU_MASK}")
       }
+      "JsonTemplateLayout: MaskedLogstashJsonEventLayoutV1.json, OpenSearch id" in {
+        logger.info("Id: 1.2.246.562.24.00000000040_040404-0404")
+        latestMaskedJsonMessage should equal(s"Id: 1.2.246.562.24.00000000040_${HETU_MASK}")
+      }
     }
     "Hetujen maskaus ja viestin lyhennys" - {
       "PatternLayout: %cm" in {


### PR DESCRIPTION
\b ei laske alaviivan ja numeron väliä "word boundaryksi"
