### PR TITLE
TOR-2033 Salli maksuttomuustiedon siirtäminen ESH S5-vuosiluokalle

### DIFF
--- a/src/main/scala/fi/oph/koski/schema/EuropeanSchoolOfHelsinki.scala
+++ b/src/main/scala/fi/oph/koski/schema/EuropeanSchoolOfHelsinki.scala
@@ -33,6 +33,19 @@ case class EuropeanSchoolOfHelsinkiOpiskeluoikeus(
 
   def vuosiluokkasuorituksetJärjestyksessä: List[EuropeanSchoolOfHelsinkiPäätasonSuoritus] =
     suoritukset.sortBy(_.suorituksenJärjestysKriteeriAlustaLoppuun)
+
+}
+
+object EuropeanSchoolOfHelsinkiOpiskeluoikeus {
+  def vuosiluokallaMahdollisestiMaksuttomuusLisätieto(
+    koulutusmoduulinUri: String,
+    koulutusmoduulinKoodiarvo: String
+  ): Boolean = (koulutusmoduulinUri, koulutusmoduulinKoodiarvo) match {
+    case ("europeanschoolofhelsinkiluokkaaste", "S5") => true
+    case ("europeanschoolofhelsinkiluokkaaste", "S6") => true
+    case ("europeanschoolofhelsinkiluokkaaste", "S7") => true
+    case _ => false
+  }
 }
 
 /******************************************************************************

--- a/src/main/scala/fi/oph/koski/suoritusjako/aktiivisetjapaattyneetopinnot/AktiivisetJaPaattyneetOpinnotESHSchema.scala
+++ b/src/main/scala/fi/oph/koski/suoritusjako/aktiivisetjapaattyneetopinnot/AktiivisetJaPaattyneetOpinnotESHSchema.scala
@@ -33,6 +33,7 @@ case class AktiivisetJaPäättyneetOpinnotEuropeanSchoolOfHelsinkiPäätasonSuor
   koulutusmoduuli: AktiivisetJaPäättyneetOpinnotESHKoulutusmoduuli,
   vahvistus: Option[Vahvistus],
   toimipiste: Option[Toimipiste],
+  @KoodistoKoodiarvo("europeanschoolofhelsinkivuosiluokkasecondarylower")
   @KoodistoKoodiarvo("europeanschoolofhelsinkivuosiluokkasecondaryupper")
   @KoodistoKoodiarvo("ebtutkinto")
   tyyppi: schema.Koodistokoodiviite,

--- a/src/main/scala/fi/oph/koski/suoritusjako/aktiivisetjapaattyneetopinnot/AktiivisetJaPaattyneetOpinnotService.scala
+++ b/src/main/scala/fi/oph/koski/suoritusjako/aktiivisetjapaattyneetopinnot/AktiivisetJaPaattyneetOpinnotService.scala
@@ -55,6 +55,7 @@ class AktiivisetJaPäättyneetOpinnotService(application: KoskiApplication) exte
           opiskeluoikeus.suoritukset
             .filter(josInternationalSchoolNiinLukiotaVastaava)
             .filter(josYOTutkintoNiinVahvistettu)
+            .filter(vähintäänS5josESHSecondaryLower)
         )
       }.filter(_.suoritukset.nonEmpty)
   }
@@ -85,6 +86,14 @@ class AktiivisetJaPäättyneetOpinnotService(application: KoskiApplication) exte
     o match {
       case ko: AktiivisetJaPäättyneetOpinnotKoskeenTallennettavaOpiskeluoikeus => ko.oid.map(kuoriOpiskeluoikeusOidit.contains).getOrElse(false)
       case _ => false
+    }
+  }
+
+  private def vähintäänS5josESHSecondaryLower(s: Suoritus): Boolean = {
+    s match {
+      case s: AktiivisetJaPäättyneetOpinnotEuropeanSchoolOfHelsinkiPäätasonSuoritus
+        if s.tyyppi.koodiarvo == "europeanschoolofhelsinkivuosiluokkasecondarylower" => s.koulutusmoduuli.tunniste.koodiarvo == "S5"
+      case _ => true
     }
   }
 }

--- a/src/main/scala/fi/oph/koski/validation/MaksuttomuusValidation.scala
+++ b/src/main/scala/fi/oph/koski/validation/MaksuttomuusValidation.scala
@@ -4,9 +4,7 @@ package fi.oph.koski.validation
 import fi.oph.koski.henkilo.LaajatOppijaHenkilöTiedot
 import fi.oph.koski.http.{HttpStatus, KoskiErrorCategory}
 import fi.oph.koski.opiskeluoikeus.{CompositeOpiskeluoikeusRepository, Päivämääräväli}
-import fi.oph.koski.oppivelvollisuustieto.Oppivelvollisuustiedot
-import fi.oph.koski.raportointikanta.RaportointiDatabase
-import fi.oph.koski.schema._
+import fi.oph.koski.schema.{_}
 import fi.oph.koski.util.{DateOrdering, FinnishDateFormat}
 import fi.oph.koski.valpas.opiskeluoikeusrepository.ValpasRajapäivätService
 
@@ -80,6 +78,8 @@ object MaksuttomuusValidation {
     opiskeluoikeus.suoritukset.collectFirst {
       case myp: MYPVuosiluokanSuoritus
         if InternationalSchoolOpiskeluoikeus.onLukiotaVastaavaInternationalSchoolinSuoritus(myp.tyyppi.koodiarvo, myp.koulutusmoduuli.tunniste.koodiarvo) => myp
+      case esh: EuropeanSchoolOfHelsinkiVuosiluokanSuoritus
+        if EuropeanSchoolOfHelsinkiOpiskeluoikeus.vuosiluokallaMahdollisestiMaksuttomuusLisätieto(esh.koulutusmoduuli.tunniste.koodistoUri, esh.koulutusmoduuli.tunniste.koodiarvo) => esh
       case s: SuoritusVaatiiMahdollisestiMaksuttomuusTiedonOpiskeluoikeudelta => s
     }.isDefined
 

--- a/src/test/scala/fi/oph/koski/api/misc/MaksuttomuusSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/misc/MaksuttomuusSpec.scala
@@ -452,16 +452,28 @@ class MaksuttomuusSpec extends AnyFreeSpec with OpiskeluoikeusTestMethodsAmmatil
       tila = EuropeanSchoolOfHelsinkiOpiskeluoikeudenTila(List(EuropeanSchoolOfHelsinkiOpiskeluoikeusjakso(date(2021, 8, 1), LukioExampleData.opiskeluoikeusAktiivinen))),
       lisätiedot = Some(lisätiedot)
     )
+    val s4Luokka = ExamplesEuropeanSchoolOfHelsinki.s4.copy(alkamispäivä = Some(date(2021, 8, 1)), vahvistus = None)
     val s5Luokka = ExamplesEuropeanSchoolOfHelsinki.s5.copy(alkamispäivä = Some(date(2021, 8, 1)), vahvistus = None)
     val s6luokka = ExamplesEuropeanSchoolOfHelsinki.s6.copy(alkamispäivä = Some(date(2021, 8, 1)), vahvistus = None)
+    val s7luokka = ExamplesEuropeanSchoolOfHelsinki.s7.copy(alkamispäivä = Some(date(2021, 8, 1)), vahvistus = None)
 
+    "Maksuttomuus-tiedon voi siirtää jos opiskeluoikeudella on s5-vuosiluokan suoritus" in {
+      putOpiskeluoikeus(opiskeluoikeus.withSuoritukset(List(s5Luokka)), KoskiSpecificMockOppijat.vuonna2004SyntynytPeruskouluValmis2021) {
+        verifyResponseStatusOk()
+      }
+    }
     "Maksuttomuus-tiedon voi siirtää jos opiskeluoikeudella on s6-vuosiluokan suoritus, koska se tulkitaan 'lukiotason suoritukseksi'" in {
       putOpiskeluoikeus(opiskeluoikeus.withSuoritukset(List(s6luokka)), KoskiSpecificMockOppijat.vuonna2004SyntynytPeruskouluValmis2021) {
         verifyResponseStatusOk()
       }
     }
+    "Maksuttomuus-tiedon voi siirtää jos opiskeluoikeudella on s7-vuosiluokan suoritus, koska se tulkitaan 'lukiotason suoritukseksi'" in {
+      putOpiskeluoikeus(opiskeluoikeus.withSuoritukset(List(s7luokka)), KoskiSpecificMockOppijat.vuonna2004SyntynytPeruskouluValmis2021) {
+        verifyResponseStatusOk()
+      }
+    }
     "Maksuttomuus-tietoa ei voi siirtää jos on pelkästään muun vuosiluokan suorituksia" in {
-      putOpiskeluoikeus(opiskeluoikeus.withSuoritukset(List(s5Luokka)), KoskiSpecificMockOppijat.vuonna2004SyntynytPeruskouluValmis2021) {
+      putOpiskeluoikeus(opiskeluoikeus.withSuoritukset(List(s4Luokka)), KoskiSpecificMockOppijat.vuonna2004SyntynytPeruskouluValmis2021) {
         verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation("Tieto koulutuksen maksuttomuudesta ei ole relevantti tässä opiskeluoikeudessa, sillä koulutus ei siirrettyjen tietojen perusteella kelpaa oppivelvollisuuden suorittamiseen (tarkista, että koulutuskoodi, käytetyn opetussuunnitelman perusteen diaarinumero, suorituksen tyyppi ja/tai suoritustapa ovat oikein)."))
       }
     }

--- a/tiedonsiirtoprotokollan_muutoshistoria.md
+++ b/tiedonsiirtoprotokollan_muutoshistoria.md
@@ -1,3 +1,7 @@
+## 25.08.2023
+- Helsingin Eurooppalaisen koulun siirtoon muutos:
+  - Vuosiluokalle S5 sallitaan maksuttomuustiedon lisääminen
+
 ## 21.06.2023
 - TUVA-opiskeluoikeuden siirtoon muutoksia 1.8.2023 alkaen:
   - TUVA-opiskeluoikeuden päätason suorituksen laajuuteen lasketaan jatkossa vain Hyväksytty-arvosanalla arvioidut osasuoritukset.

--- a/validaation_muutoshistoria.md
+++ b/validaation_muutoshistoria.md
@@ -1,5 +1,8 @@
 # Koskeen tallennettavien tietojen validaatiosäännöt
 
+## 25.8.2023
+- Helsingin Eurooppalaisen koulun vuosiluokalle S5 sallitaan maksuttomuustiedon lisääminen
+
 ## 17.8.2023
 - Pidennetyn oppivelvollisuuden ja erityisen tuen ajanjaksojen validaatiota tarkennettu terminaalitilaisen opiskeluoikeuden osalta.
 

--- a/web/app/types/fi/oph/koski/suoritusjako/aktiivisetjapaattyneetopinnot/AktiivisetJaPaattyneetOpinnotEuropeanSchoolOfHelsinkiPaatasonSuoritus.ts
+++ b/web/app/types/fi/oph/koski/suoritusjako/aktiivisetjapaattyneetopinnot/AktiivisetJaPaattyneetOpinnotEuropeanSchoolOfHelsinkiPaatasonSuoritus.ts
@@ -17,7 +17,9 @@ export type AktiivisetJaPäättyneetOpinnotEuropeanSchoolOfHelsinkiPäätasonSuo
     toimipiste?: Toimipiste
     tyyppi: Koodistokoodiviite<
       string,
-      'europeanschoolofhelsinkivuosiluokkasecondaryupper' | 'ebtutkinto'
+      | 'europeanschoolofhelsinkivuosiluokkasecondarylower'
+      | 'europeanschoolofhelsinkivuosiluokkasecondaryupper'
+      | 'ebtutkinto'
     >
   }
 
@@ -28,7 +30,9 @@ export const AktiivisetJaPäättyneetOpinnotEuropeanSchoolOfHelsinkiPäätasonSu
     toimipiste?: Toimipiste
     tyyppi: Koodistokoodiviite<
       string,
-      'europeanschoolofhelsinkivuosiluokkasecondaryupper' | 'ebtutkinto'
+      | 'europeanschoolofhelsinkivuosiluokkasecondarylower'
+      | 'europeanschoolofhelsinkivuosiluokkasecondaryupper'
+      | 'ebtutkinto'
     >
   }): AktiivisetJaPäättyneetOpinnotEuropeanSchoolOfHelsinkiPäätasonSuoritus => ({
     $class:


### PR DESCRIPTION
Päivitetään maksuttomuusvalidaatiota niin että S5 kelpaa