### PR TITLE
TOR-1732: Pikkukorjauksia Kela-apiin

### DIFF
--- a/.github/skip_tiedonsiirtoprotokollan_muutoshistoria.md
+++ b/.github/skip_tiedonsiirtoprotokollan_muutoshistoria.md
@@ -1,3 +1,4 @@
 Tee tähän tiedostoon jokin muutos, kun tiedonsiirtoprotokollan_muutoshistoria.md -testi valittaa mahdollisesta muutoksesta, mutta kyseessä on esimerkiksi refaktorointi tai muu validoinnin toimintaan vaikuttamaton muutos.
 
 TOR-2061 - ei oikeaa muutosta
+TOR-1732

--- a/src/main/scala/fi/oph/koski/kela/KelaAmmatillinenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaAmmatillinenSchema.scala
@@ -3,7 +3,7 @@ package fi.oph.koski.kela
 import fi.oph.koski.koskiuser.Rooli
 import fi.oph.koski.schema
 import fi.oph.koski.schema.OppisopimuksenPurkaminen
-import fi.oph.koski.schema.annotation.{Deprecated, Example, KoodistoKoodiarvo, SensitiveData}
+import fi.oph.koski.schema.annotation.{Deprecated, Example, KoodistoKoodiarvo, KoodistoUri, SensitiveData}
 import fi.oph.scalaschema.annotation.{DefaultValue, Description, RegularExpression, Title}
 
 import java.time.{LocalDate, LocalDateTime}
@@ -115,7 +115,9 @@ case class KelaAmmatillinenOsasuoritus(
   toinenTutkintonimike: Option[Boolean],
   näyttö: Option[Näyttö],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
-  lisätiedot: Option[List[AmmatillisenTutkinnonOsanLisätieto]]
+  lisätiedot: Option[List[AmmatillisenTutkinnonOsanLisätieto]],
+  @KoodistoUri("ammatillisensuorituksenkorotus")
+  korotettu: Option[KelaKoodistokoodiviite],
 ) extends Osasuoritus {
   def withEmptyArvosana: KelaAmmatillinenOsasuoritus = copy(
     arviointi = arviointi.map(_.map(_.withEmptyArvosana)),

--- a/src/main/scala/fi/oph/koski/kela/KelaAmmatillinenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaAmmatillinenSchema.scala
@@ -182,7 +182,8 @@ case class NäytönSuoritusaika(
 case class NäytönArviointi(
   @Deprecated("Ei palauteta Kela-API:ssa. Kenttä on näkyvissä skeemassa vain teknisistä syistä.")
   arvosana: Option[schema.Koodistokoodiviite],
-  hyväksytty: Option[Boolean]
+  hyväksytty: Option[Boolean],
+  päivä: LocalDate,
 ) {
   def withEmptyArvosana: NäytönArviointi = copy(
     arvosana = None,

--- a/src/main/scala/fi/oph/koski/kela/KelaAmmatillinenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaAmmatillinenSchema.scala
@@ -65,7 +65,8 @@ case class KelaAmmatillisenOpiskeluoikeudenLisätiedot(
   opiskeluvalmiuksiaTukevatOpinnot: Option[List[KelaOpiskeluvalmiuksiaTukevienOpintojenJakso]],
   vankilaopetuksessa: Option[List[KelaAikajakso]],
   maksuttomuus: Option[List[KelaMaksuttomuus]],
-  oikeuttaMaksuttomuuteenPidennetty: Option[List[KelaOikeuttaMaksuttomuuteenPidennetty]]
+  oikeuttaMaksuttomuuteenPidennetty: Option[List[KelaOikeuttaMaksuttomuuteenPidennetty]],
+  koulutusvienti: Option[Boolean],
 ) extends OpiskeluoikeudenLisätiedot
 
 @Title("Ammatillisen koulutuksen suoritus")

--- a/src/main/scala/fi/oph/koski/kela/KelaAmmatillinenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaAmmatillinenSchema.scala
@@ -3,8 +3,8 @@ package fi.oph.koski.kela
 import fi.oph.koski.koskiuser.Rooli
 import fi.oph.koski.schema
 import fi.oph.koski.schema.OppisopimuksenPurkaminen
-import fi.oph.koski.schema.annotation.{Deprecated, KoodistoKoodiarvo, SensitiveData}
-import fi.oph.scalaschema.annotation.{DefaultValue, Description, Title}
+import fi.oph.koski.schema.annotation.{Deprecated, Example, KoodistoKoodiarvo, SensitiveData}
+import fi.oph.scalaschema.annotation.{DefaultValue, Description, RegularExpression, Title}
 
 import java.time.{LocalDate, LocalDateTime}
 
@@ -235,7 +235,12 @@ case class Koulutussopimusjakso(
   loppu: Option[LocalDate],
   työssäoppimispaikka: Option[schema.LocalizedString],
   paikkakunta: KelaKoodistokoodiviite,
-  maa: KelaKoodistokoodiviite
+  maa: KelaKoodistokoodiviite,
+  @Description("Työssäoppimispaikan Y-tunnus")
+  @RegularExpression("^\\d{7}-\\d$")
+  @Example("1234567-8")
+  @Title("Työssäoppimispaikan Y-tunnus")
+  työssäoppimispaikanYTunnus: Option[String],
 )
 
 case class Järjestämismuoto (

--- a/src/main/scala/fi/oph/koski/kela/KelaAmmatillinenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaAmmatillinenSchema.scala
@@ -130,7 +130,7 @@ case class KelaAmmatillisenOsasuorituksenArviointi(
   arvosana: Option[schema.Koodistokoodiviite],
   hyväksytty: Option[Boolean],
   päivä: Option[LocalDate]
-) extends OsasuorituksenArvionti {
+) extends OsasuorituksenArviointi {
   def withEmptyArvosana: KelaAmmatillisenOsasuorituksenArviointi = copy(
     arvosana = None,
     hyväksytty = arvosana.map(schema.AmmatillinenKoodistostaLöytyväArviointi.hyväksytty)

--- a/src/main/scala/fi/oph/koski/kela/KelaDIASchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaDIASchema.scala
@@ -89,7 +89,7 @@ case class KelaDIAOsasuorituksenArvionti(
   arvosana: Option[schema.Koodistokoodiviite],
   hyväksytty: Option[Boolean],
   päivä: Option[LocalDate]
-) extends OsasuorituksenArvionti {
+) extends OsasuorituksenArviointi {
   def withEmptyArvosana: KelaDIAOsasuorituksenArvionti = copy(
     arvosana = None,
     hyväksytty = Some(true)

--- a/src/main/scala/fi/oph/koski/kela/KelaEBSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaEBSchema.scala
@@ -1,0 +1,111 @@
+package fi.oph.koski.kela
+
+import fi.oph.koski.schema.annotation.{KoodistoKoodiarvo, KoodistoUri}
+import fi.oph.koski.schema.{Arvioitsija, HenkilövahvistusPaikkakunnalla, Koodistokoodiviite, OpiskeluoikeudenTyyppi}
+import fi.oph.scalaschema.annotation.Title
+
+import java.time.{LocalDate, LocalDateTime}
+
+@Title("EB-tutkinnon opiskeluoikeus")
+case class KelaEBOpiskeluoikeus(
+  oid: Option[String],
+  versionumero: Option[Int],
+  aikaleima: Option[LocalDateTime],
+  oppilaitos: Option[Oppilaitos],
+  koulutustoimija: Option[Koulutustoimija],
+  arvioituPäättymispäivä: Option[LocalDate],
+  tila: KelaEBOpiskeluoikeudenTila,
+  suoritukset: List[KelaEBTutkinnonSuoritus],
+  @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.ebtutkinto.koodiarvo)
+  tyyppi: Koodistokoodiviite,
+  organisaatioHistoria: Option[List[OrganisaatioHistoria]],
+  organisaatiohistoria: Option[List[OrganisaatioHistoria]],
+) extends KelaOpiskeluoikeus {
+  def withEmptyArvosana: KelaEBOpiskeluoikeus = copy(suoritukset = suoritukset.map(_.withEmptyArvosana))
+
+  override def withOrganisaatiohistoria: KelaEBOpiskeluoikeus = copy(
+    organisaatioHistoria = organisaatiohistoria,
+    organisaatiohistoria = None
+  )
+
+  override def sisältyyOpiskeluoikeuteen: Option[SisältäväOpiskeluoikeus] = None
+  override def lisätiedot: Option[OpiskeluoikeudenLisätiedot] = None
+}
+
+@Title("EB-tutkinnon opiskeluoikeuden tila")
+case class KelaEBOpiskeluoikeudenTila(
+  opiskeluoikeusjaksot: List[KelaEBOpiskeluoikeudenJakso]
+) extends OpiskeluoikeudenTila
+
+@Title("EB-tutkinnon opiskeluoikeuden jakso")
+case class KelaEBOpiskeluoikeudenJakso(
+  @KoodistoUri("koskiopiskeluoikeudentila")
+  @KoodistoKoodiarvo("eronnut")
+  @KoodistoKoodiarvo("lasna")
+  @KoodistoKoodiarvo("mitatoity")
+  @KoodistoKoodiarvo("valmistunut")
+  tila: KelaKoodistokoodiviite,
+  alku: LocalDate,
+) extends Opiskeluoikeusjakso
+
+@Title("EB-tutkinnon suoritus")
+case class KelaEBTutkinnonSuoritus(
+  koulutusmoduuli: KelaEBTutkinto,
+  toimipiste: Toimipiste,
+  vahvistus: Option[HenkilövahvistusPaikkakunnalla],
+  @Title("Koulutus")
+  @KoodistoKoodiarvo("ebtutkinto")
+  tyyppi: Koodistokoodiviite,
+  override val osasuoritukset: Option[List[KelaEBTutkinnonOsasuoritus]] = None
+) extends Suoritus {
+  override def withEmptyArvosana: KelaEBTutkinnonSuoritus = this
+}
+
+@Title("EB-tutkinnon osasuoritus")
+case class KelaEBTutkinnonOsasuoritus(
+  koulutusmoduuli: KelaESHSecondaryGradeOppiaine,
+  @KoodistoKoodiarvo("ebtutkinnonosasuoritus")
+  tyyppi: Koodistokoodiviite = Koodistokoodiviite(koodiarvo = "ebtutkinnonosasuoritus", koodistoUri = "suorituksentyyppi"),
+  suorituskieli: Koodistokoodiviite,
+  osasuoritukset: Option[List[KelaEBOppiaineenAlaosasuoritus]] = None
+) extends Osasuoritus {
+  override def withEmptyArvosana: Osasuoritus = copy(osasuoritukset = osasuoritukset.map(_.map(_.withEmptyArvosana)))
+}
+
+@Title("EB-oppiaineen alaosasuoritus")
+case class KelaEBOppiaineenAlaosasuoritus(
+  @Title("Arviointikomponentti")
+  koulutusmoduuli: KelaEBOppiaineKomponentti,
+  arviointi: Option[List[KelaEBArviointi]] = None,
+  @KoodistoKoodiarvo("ebtutkinnonalaosasuoritus")
+  tyyppi: Koodistokoodiviite = Koodistokoodiviite(koodiarvo = "ebtutkinnonalaosasuoritus", koodistoUri = "suorituksentyyppi")
+) extends Osasuoritus {
+  override def withEmptyArvosana: KelaEBOppiaineenAlaosasuoritus = copy(arviointi = None)
+}
+
+@Title("EB-oppiainekomponentti")
+case class KelaEBOppiaineKomponentti(
+  @KoodistoUri("ebtutkinnonoppiaineenkomponentti")
+  @KoodistoKoodiarvo("Final")
+  @KoodistoKoodiarvo("Oral")
+  @KoodistoKoodiarvo("Written")
+  tunniste: Koodistokoodiviite
+)
+
+@Title("EB-tutkinnon arviointi")
+case class KelaEBArviointi(
+  @KoodistoUri("arviointiasteikkoeuropeanschoolofhelsinkifinalmark")
+  arvosana: Koodistokoodiviite,
+  päivä: Option[LocalDate],
+  arvioitsijat: Option[List[Arvioitsija]] = None
+)
+
+@Title("EB-tutkinto")
+case class KelaEBTutkinto(
+  @KoodistoUri("koulutus")
+  @KoodistoKoodiarvo("301104")
+  tunniste: Koodistokoodiviite = Koodistokoodiviite("301104", "koulutus"),
+  @KoodistoKoodiarvo("21")
+  koulutustyyppi: Option[Koodistokoodiviite] = None,
+  curriculum: Koodistokoodiviite = Koodistokoodiviite("2023", "europeanschoolofhelsinkicurriculum")
+) extends SuorituksenKoulutusmoduuli

--- a/src/main/scala/fi/oph/koski/kela/KelaESHSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaESHSchema.scala
@@ -1,13 +1,11 @@
 package fi.oph.koski.kela
 
+import fi.oph.koski.schema
 import fi.oph.koski.koskiuser.Rooli
-import fi.oph.koski.schema.{HenkilövahvistusPaikkakunnalla, Koodistokoodiviite, OpiskeluoikeudenTyyppi, Päivämäärävahvistus}
 import fi.oph.koski.schema.annotation.{KoodistoKoodiarvo, KoodistoUri, SensitiveData}
 import fi.oph.scalaschema.annotation.Title
 
 import java.time.{LocalDate, LocalDateTime}
-
-// TODO: TOR-2052 - EB-tutkinto rinnalle
 
 @Title("European School of Helsingin opiskeluoikeus")
 case class KelaESHOpiskeluoikeus(
@@ -19,8 +17,8 @@ case class KelaESHOpiskeluoikeus(
   arvioituPäättymispäivä: Option[LocalDate],
   tila: KelaESHOpiskeluoikeudenTila,
   suoritukset: List[KelaESHPäätasonSuoritus],
-  @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.europeanschoolofhelsinki.koodiarvo)
-  tyyppi: Koodistokoodiviite,
+  @KoodistoKoodiarvo(schema.OpiskeluoikeudenTyyppi.europeanschoolofhelsinki.koodiarvo)
+  tyyppi: schema.Koodistokoodiviite,
   lisätiedot: Option[KelaESHOpiskeluoikeudenLisätiedot],
   organisaatioHistoria: Option[List[OrganisaatioHistoria]],
   organisaatiohistoria: Option[List[OrganisaatioHistoria]],
@@ -51,7 +49,7 @@ case class KelaESHOpiskeluoikeudenJakso(
   tila: KelaKoodistokoodiviite,
   alku: LocalDate,
   @KoodistoKoodiarvo("6")
-  opintojenRahoitus: Option[Koodistokoodiviite],
+  opintojenRahoitus: Option[schema.Koodistokoodiviite],
 ) extends Opiskeluoikeusjakso
 
 @Title("European School of Helsingin päätason suoritus")
@@ -63,11 +61,12 @@ trait KelaESHPäätasonSuoritus extends Suoritus {
 case class KelaESHSecondaryLowerVuosiluokanSuoritus(
   koulutusmoduuli: KelaESHSecondaryLowerLuokkaAste,
   toimipiste: Toimipiste,
-  vahvistus: Option[HenkilövahvistusPaikkakunnalla],
+  vahvistus: Option[Vahvistus],
   @KoodistoUri("suorituksentyyppi")
   @KoodistoKoodiarvo("europeanschoolofhelsinkivuosiluokkasecondarylower")
-  tyyppi: Koodistokoodiviite,
-  jääLuokalle: Boolean,
+  tyyppi: schema.Koodistokoodiviite,
+  @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
+  jääLuokalle: Option[Boolean],
   osasuoritukset: Option[List[KelaESHSecondaryLowerOppiaineenSuoritus]],
 ) extends KelaESHPäätasonSuoritus {
   def withEmptyArvosana: KelaESHSecondaryLowerVuosiluokanSuoritus = copy(
@@ -83,12 +82,12 @@ case class KelaESHSecondaryLowerLuokkaAste(
   @KoodistoKoodiarvo("S3")
   @KoodistoKoodiarvo("S4")
   @KoodistoKoodiarvo("S5")
-  tunniste: Koodistokoodiviite,
+  tunniste: schema.Koodistokoodiviite,
   @KoodistoUri("europeanschoolofhelsinkicurriculum")
-  curriculum: Koodistokoodiviite,
+  curriculum: schema.Koodistokoodiviite,
   @KoodistoUri("koulutustyyppi")
   @KoodistoKoodiarvo("21")
-  koulutustyyppi: Option[Koodistokoodiviite],
+  koulutustyyppi: Option[schema.Koodistokoodiviite],
 ) extends SuorituksenKoulutusmoduuli
 
 
@@ -100,19 +99,21 @@ case class KelaESHSecondaryLowerOppiaineenSuoritus(
   arviointi: Option[List[KelaESHArviointi]],
   @KoodistoUri("suorituksentyyppi")
   @KoodistoKoodiarvo("europeanschoolofhelsinkiosasuoritussecondarylower")
-  tyyppi: Koodistokoodiviite,
+  tyyppi: schema.Koodistokoodiviite,
 ) extends Osasuoritus {
-  def withEmptyArvosana: KelaESHSecondaryLowerOppiaineenSuoritus = copy(arviointi = None)
+  def withEmptyArvosana: KelaESHSecondaryLowerOppiaineenSuoritus = copy(
+    arviointi = arviointi.map(_.map(_.withEmptyArvosana))
+  )
 }
 
 @Title("Secondary upper vuosiluokan suoritus")
 case class KelaESHSecondaryUpperVuosiluokanSuoritus(
   koulutusmoduuli: KelaESHSecondaryUpperLuokkaAste,
   toimipiste: Toimipiste,
-  vahvistus: Option[HenkilövahvistusPaikkakunnalla],
+  vahvistus: Option[Vahvistus],
   @KoodistoUri("suorituksentyyppi")
   @KoodistoKoodiarvo("europeanschoolofhelsinkivuosiluokkasecondaryupper")
-  tyyppi: Koodistokoodiviite,
+  tyyppi: schema.Koodistokoodiviite,
   jääLuokalle: Boolean,
   osasuoritukset: Option[List[KelaESHSecondaryUpperOppiaineenSuoritus]],
 ) extends KelaESHPäätasonSuoritus {
@@ -126,12 +127,12 @@ case class KelaESHSecondaryUpperLuokkaAste(
   @KoodistoUri("europeanschoolofhelsinkiluokkaaste")
   @KoodistoKoodiarvo("S6")
   @KoodistoKoodiarvo("S7")
-  tunniste: Koodistokoodiviite,
+  tunniste: schema.Koodistokoodiviite,
   @KoodistoUri("europeanschoolofhelsinkicurriculum")
-  curriculum: Koodistokoodiviite,
+  curriculum: schema.Koodistokoodiviite,
   @KoodistoUri("koulutustyyppi")
   @KoodistoKoodiarvo("21")
-  koulutustyyppi: Option[Koodistokoodiviite],
+  koulutustyyppi: Option[schema.Koodistokoodiviite],
 ) extends SuorituksenKoulutusmoduuli
 
 @Title("Secondary upper oppiaineen suoritus")
@@ -147,9 +148,11 @@ case class KelaESHSecondaryUpperOppiaineenSuoritusS6(
   arviointi: Option[List[KelaESHArviointi]],
   @KoodistoUri("suorituksentyyppi")
   @KoodistoKoodiarvo("europeanschoolofhelsinkiosasuorituss6")
-  tyyppi: Koodistokoodiviite,
+  tyyppi: schema.Koodistokoodiviite,
 ) extends KelaESHSecondaryUpperOppiaineenSuoritus {
-  def withEmptyArvosana: KelaESHSecondaryUpperOppiaineenSuoritusS6 = copy(arviointi = None)
+  def withEmptyArvosana: KelaESHSecondaryUpperOppiaineenSuoritusS6 = copy(
+    arviointi = arviointi.map(_.map(_.withEmptyArvosana))
+  )
 }
 
 @Title("Secondary upper vuosiluokan suoritus")
@@ -160,11 +163,11 @@ case class KelaESHSecondaryUpperOppiaineenSuoritusS7(
   arviointi: Option[List[KelaESHArviointi]],
   @KoodistoUri("suorituksentyyppi")
   @KoodistoKoodiarvo("europeanschoolofhelsinkiosasuorituss7")
-  tyyppi: Koodistokoodiviite,
+  tyyppi: schema.Koodistokoodiviite,
   osasuoritukset: Option[List[KelaESHS7OppiaineenAlaosasuoritus]],
 ) extends KelaESHSecondaryUpperOppiaineenSuoritus {
   def withEmptyArvosana: KelaESHSecondaryUpperOppiaineenSuoritusS7 = copy(
-    arviointi = None,
+    arviointi = arviointi.map(_.map(_.withEmptyArvosana)),
     osasuoritukset = osasuoritukset.map(_.map(_.withEmptyArvosana)),
   )
 }
@@ -175,16 +178,16 @@ trait KelaESHSecondaryGradeOppiaine extends SuorituksenKoulutusmoduuli
 @Title("European School of Helsingin kielioppiaine")
 case class KelaESHKielioppiaine(
   @KoodistoUri("europeanschoolofhelsinkikielioppiaine")
-  tunniste: Koodistokoodiviite,
+  tunniste: schema.Koodistokoodiviite,
   laajuus: Option[KelaLaajuus],
   @KoodistoUri("kieli")
-  kieli: Koodistokoodiviite,
+  kieli: schema.Koodistokoodiviite,
 ) extends KelaESHSecondaryGradeOppiaine
 
 @Title("European School of Helsingin muu oppiaine")
 case class KelaESHMuuOppiaine(
   @KoodistoUri("europeanschoolofhelsinkimuuoppiaine")
-  tunniste: Koodistokoodiviite,
+  tunniste: schema.Koodistokoodiviite,
   laajuus: Option[KelaLaajuus],
 ) extends KelaESHSecondaryGradeOppiaine
 
@@ -194,24 +197,29 @@ case class KelaESHS7OppiaineenAlaosasuoritus(
   arviointi: Option[List[KelaESHArviointi]],
   @KoodistoUri("suorituksentyyppi")
   @KoodistoKoodiarvo("europeanschoolofhelsinkialaosasuorituss7")
-  tyyppi: Koodistokoodiviite,
+  tyyppi: schema.Koodistokoodiviite,
 ) extends Suoritus {
   def osasuoritukset: Option[List[Osasuoritus]] = None
-  def withEmptyArvosana: KelaESHS7OppiaineenAlaosasuoritus = this.copy(arviointi = None)
+  def withEmptyArvosana: KelaESHS7OppiaineenAlaosasuoritus = this.copy(
+    arviointi = arviointi.map(_.map(_.withEmptyArvosana))
+  )
 }
 
 @Title("European School of Helsingin S7-luokan oppiainekomponentti")
 case class KelaESHS7Oppiainekomponentti(
   @KoodistoUri("europeanschoolofhelsinkis7oppiaineenkomponentti")
-  tunniste: Koodistokoodiviite,
+  tunniste: schema.Koodistokoodiviite,
 ) extends SuorituksenKoulutusmoduuli
 
 case class KelaESHArviointi(
+  arvosana: Option[schema.Koodistokoodiviite],
   päivä: Option[LocalDate],
   hyväksytty: Option[Boolean],
-) extends OsasuorituksenArvionti {
-  override def arvosana: Option[Koodistokoodiviite] = None
-  override def withEmptyArvosana: OsasuorituksenArvionti = this
+) extends OsasuorituksenArviointi {
+  override def withEmptyArvosana: KelaESHArviointi = this.copy(
+    arvosana = None,
+    hyväksytty = arvosana.map(schema.EuropeanSchoolOfHelsinkiArviointi.hyväksytty)
+  )
 }
 
 @Title("European School of Helsingin lisätiedot")

--- a/src/main/scala/fi/oph/koski/kela/KelaIBSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaIBSchema.scala
@@ -77,7 +77,7 @@ case class KelaIBOsasuorituksenArvionti(
   arvosana: Option[schema.Koodistokoodiviite],
   hyväksytty: Option[Boolean],
   päivä: Option[LocalDate]
-) extends OsasuorituksenArvionti {
+) extends OsasuorituksenArviointi {
   def withEmptyArvosana: KelaIBOsasuorituksenArvionti = copy(
     arvosana = None,
     hyväksytty = arvosana.map(a => schema.IBArviointi.hyväksytty(a) && schema.CoreRequirementsArvionti.hyväksytty(a))

--- a/src/main/scala/fi/oph/koski/kela/KelaIBSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaIBSchema.scala
@@ -59,6 +59,7 @@ case class KelaIBPäätasonSuoritus(
 case class KelaIBOsasuoritus(
   koulutusmoduuli: KelaIBOsasuorituksenKoulutusmoduuli,
   arviointi: Option[List[KelaIBOsasuorituksenArvionti]],
+  predictedArviointi: Option[List[KelaIBOsasuorituksenArvionti]],
   osasuoritukset: Option[List[KelaIBOsasuoritus]],
   tyyppi: schema.Koodistokoodiviite,
   tila: Option[KelaKoodistokoodiviite],

--- a/src/main/scala/fi/oph/koski/kela/KelaInternationalSchoolSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaInternationalSchoolSchema.scala
@@ -1,13 +1,10 @@
 package fi.oph.koski.kela
 
 import fi.oph.koski.schema
-import fi.oph.koski.schema.OpiskeluoikeudenTyyppi
 import fi.oph.koski.schema.annotation.KoodistoKoodiarvo
 import fi.oph.scalaschema.annotation.{Description, Title}
 
 import java.time.{LocalDate, LocalDateTime}
-
-// TODO: TOR-1685 Eurooppalainen koulu, lisää vastaava ESH:lle
 
 @Title("International school opiskeluoikeus")
 @Description("International school opiskeluoikeus")
@@ -21,7 +18,7 @@ case class KelaInternationalSchoolOpiskeluoikeus(
   tila: KelaOpiskeluoikeudenTila,
   suoritukset: List[KelaInternationalSchoolPäätasonSuoritus],
   lisätiedot: Option[KelaInternationalSchoolOpiskeluoikeudenLisätiedot],
-  @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.internationalschool.koodiarvo)
+  @KoodistoKoodiarvo(schema.OpiskeluoikeudenTyyppi.internationalschool.koodiarvo)
   tyyppi: schema.Koodistokoodiviite,
   organisaatioHistoria: Option[List[OrganisaatioHistoria]],
   organisaatiohistoria: Option[List[OrganisaatioHistoria]]
@@ -75,7 +72,7 @@ case class KelaInternationalSchoolOsasuorituksenArvionti(
   arvosana: Option[schema.Koodistokoodiviite],
   hyväksytty: Option[Boolean],
   päivä: Option[LocalDate]
-) extends OsasuorituksenArvionti {
+) extends OsasuorituksenArviointi {
   def withEmptyArvosana: KelaInternationalSchoolOsasuorituksenArvionti = copy(
     arvosana = None,
     hyväksytty = arvosana.map(schema.InternationalSchoolArviointi.hyväksytty)

--- a/src/main/scala/fi/oph/koski/kela/KelaLukionSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaLukionSchema.scala
@@ -1,7 +1,7 @@
 package fi.oph.koski.kela
 
 import fi.oph.koski.schema
-import fi.oph.koski.schema.OpiskeluoikeudenTyyppi
+import fi.oph.koski.schema.{OmanÄidinkielenOpinnotLaajuusOpintopisteinä, OpiskeluoikeudenTyyppi, PuhviKoe2019, SuullisenKielitaidonKoe2019}
 import fi.oph.koski.schema.annotation.KoodistoKoodiarvo
 import fi.oph.scalaschema.annotation.{Description, Title}
 
@@ -51,6 +51,9 @@ case class KelaLukionPäätasonSuoritus(
   oppimäärä: Option[KelaKoodistokoodiviite],
   vahvistus: Option[Vahvistus],
   osasuoritukset: Option[List[KelaLukionOsasuoritus]],
+  omanÄidinkielenOpinnot: Option[OmanÄidinkielenOpinnotLaajuusOpintopisteinä] = None,
+  puhviKoe: Option[PuhviKoe2019] = None,
+  suullisenKielitaidonKokeet: Option[List[SuullisenKielitaidonKoe2019]] = None,
   tyyppi: schema.Koodistokoodiviite,
   tila: Option[KelaKoodistokoodiviite]
 ) extends Suoritus {

--- a/src/main/scala/fi/oph/koski/kela/KelaLukionSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaLukionSchema.scala
@@ -17,7 +17,7 @@ case class KelaLukionOpiskeluoikeus(
   koulutustoimija: Option[Koulutustoimija],
   sisältyyOpiskeluoikeuteen: Option[SisältäväOpiskeluoikeus],
   arvioituPäättymispäivä: Option[LocalDate],
-  tila: KelaOpiskeluoikeudenTila,
+  tila: KelaOpiskeluoikeudenTilaRahoitustiedoilla,
   suoritukset: List[KelaLukionPäätasonSuoritus],
   lisätiedot: Option[KelaLukionOpiskeluoikeudenLisätiedot],
   @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.lukiokoulutus.koodiarvo)

--- a/src/main/scala/fi/oph/koski/kela/KelaLuvaSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaLuvaSchema.scala
@@ -1,7 +1,6 @@
 package fi.oph.koski.kela
 
 import fi.oph.koski.schema
-import fi.oph.koski.schema.OpiskeluoikeudenTyyppi
 import fi.oph.koski.schema.annotation.KoodistoKoodiarvo
 import fi.oph.scalaschema.annotation.{Description, Title}
 
@@ -20,7 +19,7 @@ case class KelaLuvaOpiskeluoikeus(
   tila: KelaOpiskeluoikeudenTila,
   suoritukset: List[KelaLuvaPäätasonSuoritus],
   lisätiedot: Option[KelaLuvaOpiskeluoikeudenLisätiedot],
-  @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.luva.koodiarvo)
+  @KoodistoKoodiarvo(schema.OpiskeluoikeudenTyyppi.luva.koodiarvo)
   tyyppi: schema.Koodistokoodiviite,
   organisaatioHistoria: Option[List[OrganisaatioHistoria]],
   organisaatiohistoria: Option[List[OrganisaatioHistoria]]
@@ -80,7 +79,7 @@ case class KelaLuvaOsasuorituksenArvionti(
   arvosana: Option[schema.Koodistokoodiviite],
   hyväksytty: Option[Boolean],
   päivä: Option[LocalDate]
-) extends OsasuorituksenArvionti {
+) extends OsasuorituksenArviointi {
   def withEmptyArvosana: KelaLuvaOsasuorituksenArvionti = copy(
     arvosana = None,
     hyväksytty = arvosana.map(schema.YleissivistävänKoulutuksenArviointi.hyväksytty)

--- a/src/main/scala/fi/oph/koski/kela/KelaOpiskeluoikeusRepository.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaOpiskeluoikeusRepository.scala
@@ -49,7 +49,6 @@ with
       left join linkitetty on linkitetty.oppija_master_oid = haettu_oppija.oppija_master_oid
     where opiskeluoikeus.koulutusmuoto = any($palautettavatOpiskeluoikeudenTyypit)
       and 'vstvapaatavoitteinenkoulutus' != any(suoritustyypit) -- VST vapaatavoitteiset ei palauteta Kelalle, koska muuten pitäisi jotenkin käsitellä suostumuksen peruutukset
-      and 'vstjotpakoulutus' != any(suoritustyypit) -- VST Jotpa ei palauteta Kelalle toistaiseksi
       and mitatoity = false
     order by oppija_master_oid
   )

--- a/src/main/scala/fi/oph/koski/kela/KelaOppijaConverter.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaOppijaConverter.scala
@@ -65,6 +65,7 @@ object KelaOppijaConverter extends Logging {
         case s: schema.OppivelvollisilleSuunnattuVapaanSivistystyönKoulutuksenSuoritus => s
         case s: schema.OppivelvollisilleSuunnattuMaahanmuuttajienKotoutumiskoulutuksenSuoritus => s
         case s: schema.VapaanSivistystyönLukutaitokoulutuksenSuoritus => s
+        case s: schema.VapaanSivistystyönJotpaKoulutuksenSuoritus => s
       }
       if (suoritukset.isEmpty) None else Some(opiskeluoikeus.withSuoritukset(suoritukset))
     }

--- a/src/main/scala/fi/oph/koski/kela/KelaPerusopetuksenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaPerusopetuksenSchema.scala
@@ -2,7 +2,7 @@ package fi.oph.koski.kela
 
 import fi.oph.koski.koskiuser.Rooli
 import fi.oph.koski.schema
-import fi.oph.koski.schema.OpiskeluoikeudenTyyppi
+import fi.oph.koski.schema.{OmanÄidinkielenOpinnotLaajuusVuosiviikkotunteina, OpiskeluoikeudenTyyppi}
 import fi.oph.koski.schema.annotation.{KoodistoKoodiarvo, SensitiveData}
 import fi.oph.scalaschema.annotation.{Description, Discriminator, OnlyWhen, Title}
 
@@ -61,7 +61,8 @@ case class KelaPerusopetuksenSuoritus(
   tyyppi: schema.Koodistokoodiviite,
   tila: Option[KelaKoodistokoodiviite],
   alkamispäivä: Option[LocalDate],
-  jääLuokalle: Option[Boolean]
+  jääLuokalle: Option[Boolean],
+  omanÄidinkielenOpinnot: Option[OmanÄidinkielenOpinnotLaajuusVuosiviikkotunteina] = None
 ) extends Suoritus {
   def withEmptyArvosana: KelaPerusopetuksenSuoritus = copy(
     osasuoritukset = osasuoritukset.map(_.map(_.withEmptyArvosana))

--- a/src/main/scala/fi/oph/koski/kela/KelaPerusopetuksenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaPerusopetuksenSchema.scala
@@ -87,7 +87,7 @@ case class KelaPerusopetuksenOsasuorituksenArviointi(
   arvosana: Option[schema.Koodistokoodiviite],
   hyväksytty: Option[Boolean],
   päivä: Option[LocalDate]
-) extends OsasuorituksenArvionti {
+) extends OsasuorituksenArviointi {
   def withEmptyArvosana: KelaPerusopetuksenOsasuorituksenArviointi = copy(
     arvosana = None,
     hyväksytty = arvosana.map(schema.YleissivistävänKoulutuksenArviointi.hyväksytty)

--- a/src/main/scala/fi/oph/koski/kela/KelaSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaSchema.scala
@@ -120,7 +120,7 @@ case class KelaOpiskeluoikeusjakso(
 case class KelaOpiskeluoikeusjaksoRahoituksella(
   alku: LocalDate,
   tila: KelaKoodistokoodiviite,
-
+  opintojenRahoitus: Option[KelaKoodistokoodiviite]
 ) extends Opiskeluoikeusjakso
 
 trait Opiskeluoikeusjakso {
@@ -195,12 +195,12 @@ case class OsaamisenTunnustaminen(selite: schema.LocalizedString, rahoituksenPii
 case class Vahvistus(päivä: LocalDate)
 
 @Title("Osasuorituksen arviointi")
-trait OsasuorituksenArvionti{
+trait OsasuorituksenArviointi{
   @Deprecated("Ei palauteta Kela-API:ssa. Kenttä on näkyvissä skeemassa vain teknisistä syistä.")
   def arvosana: Option[schema.Koodistokoodiviite]
   def hyväksytty: Option[Boolean]
   def päivä: Option[LocalDate]
-  def withEmptyArvosana: OsasuorituksenArvionti
+  def withEmptyArvosana: OsasuorituksenArviointi
 }
 
 case class Oppilaitos(

--- a/src/main/scala/fi/oph/koski/kela/KelaSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaSchema.scala
@@ -31,6 +31,7 @@ object KelaSchema {
     "tuva",
     "muukuinsaanneltykoulutus",
     "europeanschoolofhelsinki",
+    "ebtutkinto",
   ).filter(_.nonEmpty)
 
   def kelallePalautettavatOpiskeluoikeustyypit(config: Config): List[String] = {

--- a/src/main/scala/fi/oph/koski/kela/KelaSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaSchema.scala
@@ -103,6 +103,10 @@ case class KelaOpiskeluoikeudenTila(
   opiskeluoikeusjaksot: List[KelaOpiskeluoikeusjakso]
 ) extends OpiskeluoikeudenTila
 
+case class KelaOpiskeluoikeudenTilaRahoitustiedoilla(
+  opiskeluoikeusjaksot: List[KelaOpiskeluoikeusjaksoRahoituksella]
+) extends OpiskeluoikeudenTila
+
 trait OpiskeluoikeudenTila {
   def opiskeluoikeusjaksot: List[Opiskeluoikeusjakso]
 }
@@ -110,6 +114,12 @@ trait OpiskeluoikeudenTila {
 case class KelaOpiskeluoikeusjakso(
   alku: LocalDate,
   tila: KelaKoodistokoodiviite,
+) extends Opiskeluoikeusjakso
+
+case class KelaOpiskeluoikeusjaksoRahoituksella(
+  alku: LocalDate,
+  tila: KelaKoodistokoodiviite,
+
 ) extends Opiskeluoikeusjakso
 
 trait Opiskeluoikeusjakso {

--- a/src/main/scala/fi/oph/koski/kela/KelaTutkintokoulutukseenValmentavanKoulutuksenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaTutkintokoulutukseenValmentavanKoulutuksenSchema.scala
@@ -57,7 +57,7 @@ case class KelaTuvaOpiskeluoikeudenLisätiedot(
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
   vaativanErityisenTuenYhteydessäJärjestettäväMajoitus: Option[List[KelaAikajakso]],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
-  erityinenTuki: Option[List[KelaAikajakso]],
+  erityisenTuenPäätökset: Option[List[KelaAikajakso]],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
   vaativanErityisenTuenErityinenTehtävä: Option[List[KelaAikajakso]],
   ulkomaanjaksot: Option[List[Ulkomaanjakso]],

--- a/src/main/scala/fi/oph/koski/kela/KelaTutkintokoulutukseenValmentavanKoulutuksenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaTutkintokoulutukseenValmentavanKoulutuksenSchema.scala
@@ -100,7 +100,7 @@ case class KelaTuvaOsasuorituksenArvionti(
   arvosana: Option[schema.Koodistokoodiviite],
   hyväksytty: Option[Boolean],
   päivä: Option[LocalDate]
-) extends OsasuorituksenArvionti {
+) extends OsasuorituksenArviointi {
   def withEmptyArvosana: KelaTuvaOsasuorituksenArvionti = copy(
     arvosana = None,
     hyväksytty = arvosana.map(

--- a/src/main/scala/fi/oph/koski/kela/KelaVapaanSivistystyönSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaVapaanSivistystyönSchema.scala
@@ -82,6 +82,36 @@ case class KelaVapaanSivistystyönMaahanmuuttajienKotoutumisenSuoritus(
   )
 }
 
+@Title("Jatkuvaan oppimiseen suunnattu vapaan sivistystyön koulutuksen suoritus")
+case class KelaVapaanSivistystyönJotpaSuoritus(
+  koulutusmoduuli: KelaVapaanSivistystyönSuorituksenKoulutusmoduuli,
+  toimipiste: Option[Toimipiste],
+  vahvistus: Option[Vahvistus],
+  osasuoritukset: Option[List[KelaVapaanSivistystyönJotpaOsasuoritus]],
+  @KoodistoKoodiarvo("vstjotpakoulutus")
+  tyyppi: schema.Koodistokoodiviite,
+  tila: Option[KelaKoodistokoodiviite],
+) extends VstSuoritus {
+  def withEmptyArvosana: KelaVapaanSivistystyönJotpaSuoritus = copy(
+    osasuoritukset = osasuoritukset.map(_.map(_.withEmptyArvosana))
+  )
+}
+
+@Title("Jatkuvaan oppimiseen suunnattu vapaan sivistystyön koulutuksen osasuoritus")
+case class KelaVapaanSivistystyönJotpaOsasuoritus(
+  koulutusmoduuli: KelaVapaanSivistystyönOsasuorituksenKoulutusmoduuli,
+  arviointi: Option[List[KelaVSTOsasuorituksenArviointi]],
+  osasuoritukset: Option[List[KelaVapaanSivistystyönJotpaOsasuoritus]],
+  @KoodistoKoodiarvo("vstjotpakoulutuksenosasuoritus")
+  tyyppi: schema.Koodistokoodiviite,
+  tila: Option[KelaKoodistokoodiviite],
+) extends Osasuoritus {
+  def withEmptyArvosana: KelaVapaanSivistystyönJotpaOsasuoritus = copy(
+    arviointi = arviointi.map(_.map(_.withEmptyArvosana)),
+    osasuoritukset = osasuoritukset.map(_.map(_.withEmptyArvosana))
+  )
+}
+
 trait VstSuoritus extends Suoritus {
   def withEmptyArvosana: VstSuoritus
 }

--- a/src/main/scala/fi/oph/koski/kela/KelaVapaanSivistystyönSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaVapaanSivistystyönSchema.scala
@@ -161,7 +161,7 @@ case class KelaVSTOsasuorituksenArviointi (
   arvosana: Option[schema.Koodistokoodiviite],
   hyväksytty: Option[Boolean],
   päivä: Option[LocalDate]
-) extends OsasuorituksenArvionti {
+) extends OsasuorituksenArviointi {
   def withEmptyArvosana: KelaVSTOsasuorituksenArviointi = copy(
     arvosana = None,
     hyväksytty = arvosana.map(schema.VapaanSivistystyönKoulutuksenArviointi.hyväksytty)
@@ -180,7 +180,7 @@ case class VSTMaahanmuuttajienKotoutumiskoulutuksenKieliopintojenArviointi (
   luetunYmmärtämisenTaitotaso: Option[VSTKielenTaitotasonArviointi],
   @Deprecated("Poistettu palautettavien tietojen joukosta")
   kirjoittamisenTaitotaso: Option[VSTKielenTaitotasonArviointi]
-) extends OsasuorituksenArvionti {
+) extends OsasuorituksenArviointi {
   def withEmptyArvosana: VSTMaahanmuuttajienKotoutumiskoulutuksenKieliopintojenArviointi = copy(
     arvosana = None,
     hyväksytty = arvosana.map(schema.VapaanSivistystyönKoulutuksenArviointi.hyväksytty),

--- a/src/main/scala/fi/oph/koski/kela/KelaYlioppilastutkintoSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaYlioppilastutkintoSchema.scala
@@ -131,6 +131,6 @@ case class KelaYlioppilastutkinnonOsasuorituksenArvionti(
   arvosana: Option[schema.Koodistokoodiviite],
   hyväksytty: Option[Boolean],
   päivä: Option[LocalDate]
-) extends OsasuorituksenArvionti {
+) extends OsasuorituksenArviointi {
   override def withEmptyArvosana: KelaYlioppilastutkinnonOsasuorituksenArvionti = copy(arvosana = None)
 }

--- a/src/main/scala/fi/oph/koski/schema/Ammatillinen.scala
+++ b/src/main/scala/fi/oph/koski/schema/Ammatillinen.scala
@@ -69,7 +69,7 @@ case class AmmatillisenOpiskeluoikeudenLisätiedot(
   sisäoppilaitosmainenMajoitus: Option[List[Aikajakso]] = None,
   @Description("Vaativan erityisen tuen yhteydessä järjestettävä majoitus. Lista alku-loppu päivämääräpareja. Rahoituksen laskennassa käytettävä tieto.")
   @Tooltip("Vaativan erityisen tuen yhteydessä järjestettävä majoitus (aloitus- ja loppupäivä). Voi olla useita erillisiä jaksoja. Rahoituksen laskennassa käytettävä tieto.")
-  @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KAIKKI_TIEDOT, Rooli.LUOTTAMUKSELLINEN_KELA_SUPPEA, Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
+  @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KAIKKI_TIEDOT, Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
   vaativanErityisenTuenYhteydessäJärjestettäväMajoitus: Option[List[Aikajakso]] = None,
   @Description("Tieto siitä että oppija on erityisopetuksessa, aloituspäivä ja loppupäivä. Lista alku-loppu päivämääräpareja. Rahoituksen laskennassa käytettävä tieto.")
   @Tooltip("Tieto siitä että oppija on erityisopetuksessa. Merkitään erityisopetuksen alku- ja loppupäivä. Voi olla useita erillisiä jaksoja. Rahoituksen laskennassa käytettävä tieto.")

--- a/src/main/scala/fi/oph/koski/schema/MuuKuinSäänneltyKoulutus.scala
+++ b/src/main/scala/fi/oph/koski/schema/MuuKuinSäänneltyKoulutus.scala
@@ -80,9 +80,13 @@ case class MuunKuinSäännellynKoulutuksenArviointi(
   arvosana: Koodistokoodiviite,
   arviointipäivä: Option[LocalDate],
 ) extends KoodistostaLöytyväArviointi {
-  override def hyväksytty: Boolean = true
+  override def hyväksytty: Boolean = MuunKuinSäännellynKoulutuksenArviointi.hyväksytty(arvosana)
   override def arvosanaKirjaimin: LocalizedString = LocalizedString.finnish(arvosana.koodiarvo)
   override def arvioitsijat: Option[List[SuorituksenArvioitsija]] = None
+}
+
+object MuunKuinSäännellynKoulutuksenArviointi {
+  def hyväksytty(arvosana: Koodistokoodiviite): Boolean = arvosana.koodiarvo == "hyvaksytty"
 }
 
 case class MuunKuinSäännellynKoulutuksenOsasuoritus(

--- a/src/main/scala/fi/oph/koski/schema/TutkintokoulutukseenValmentavaKoulutuksenLisätiedot.scala
+++ b/src/main/scala/fi/oph/koski/schema/TutkintokoulutukseenValmentavaKoulutuksenLisätiedot.scala
@@ -26,7 +26,7 @@ case class TutkintokoulutukseenValmentavanOpiskeluoikeudenAmmatillisenLuvanLisä
   sisäoppilaitosmainenMajoitus: Option[List[Aikajakso]] = None,
   @Description("Vaativan erityisen tuen yhteydessä järjestettävä majoitus. Lista alku-loppu päivämääräpareja. Rahoituksen laskennassa käytettävä tieto.")
   @Tooltip("Vaativan erityisen tuen yhteydessä järjestettävä majoitus (aloitus- ja loppupäivä). Voi olla useita erillisiä jaksoja. Rahoituksen laskennassa käytettävä tieto.")
-  @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KAIKKI_TIEDOT, Rooli.LUOTTAMUKSELLINEN_KELA_SUPPEA, Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
+  @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KAIKKI_TIEDOT, Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
   vaativanErityisenTuenYhteydessäJärjestettäväMajoitus: Option[List[Aikajakso]] = None,
   @Description("Tieto siitä että oppija on erityisopetuksessa, aloituspäivä ja loppupäivä. Lista alku-loppu päivämääräpareja. Rahoituksen laskennassa käytettävä tieto.")
   @Tooltip("Tieto siitä että oppija on erityisopetuksessa. Merkitään erityisopetuksen alku- ja loppupäivä. Voi olla useita erillisiä jaksoja. Rahoituksen laskennassa käytettävä tieto.")

--- a/src/test/scala/fi/oph/koski/json/SensitiveAndRedundantDataFilterSpec.scala
+++ b/src/test/scala/fi/oph/koski/json/SensitiveAndRedundantDataFilterSpec.scala
@@ -107,7 +107,7 @@ class SensitiveAndRedundantDataFilterSpec extends AnyFreeSpec with TestEnvironme
   "Käyttäjä jolla on suppeat luottamuksellisten tietojen oikeudet näkee suppeiden oikeuksien mukaiset arkaluontoiset tiedot" in {
     implicit val suppeatOikeudet = MockUsers.kelaSuppeatOikeudet.toKoskiSpecificSession(käyttöoikeusRepository)
     roundtrip[AikuistenPerusopetuksenOpiskeluoikeudenLisätiedot](aikuistenPerusopetuksenOpiskeluoikeudenLisätiedot) should equal(AikuistenPerusopetuksenOpiskeluoikeudenLisätiedot(sisäoppilaitosmainenMajoitus = aikajaksot))
-    roundtrip[AmmatillisenOpiskeluoikeudenLisätiedot](ammatillisenOpiskeluoikeudenLisätiedot) should equal(AmmatillisenOpiskeluoikeudenLisätiedot(sisäoppilaitosmainenMajoitus=aikajaksot,vaativanErityisenTuenYhteydessäJärjestettäväMajoitus=aikajaksot,vankilaopetuksessa=aikajaksot, hojks=None))
+    roundtrip[AmmatillisenOpiskeluoikeudenLisätiedot](ammatillisenOpiskeluoikeudenLisätiedot) should equal(AmmatillisenOpiskeluoikeudenLisätiedot(sisäoppilaitosmainenMajoitus=aikajaksot,vankilaopetuksessa=aikajaksot, hojks=None))
     roundtrip[DIAOpiskeluoikeudenLisätiedot](diaOpiskeluoikeudenLisätiedot).pidennettyPäättymispäivä should equal(true)
     roundtrip[EsiopetuksenOpiskeluoikeudenLisätiedot](esiopetuksenOpiskeluoikeudenLisätiedot) should equal(EsiopetuksenOpiskeluoikeudenLisätiedot(majoitusetu=Some(aikajakso)))
     roundtrip[LukionOpiskeluoikeudenLisätiedot](lukionOpiskeluoikeudenLisätiedot) should equal(LukionOpiskeluoikeudenLisätiedot(pidennettyPäättymispäivä=true, sisäoppilaitosmainenMajoitus=aikajaksot))

--- a/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
+++ b/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
@@ -169,6 +169,15 @@ class KelaSpec
         lisätiedot.koulutusvienti shouldBe Some(true)
       }
     }
+    "Palauttaa näytön arviointipäivän" in {
+      postHetu(KoskiSpecificMockOppijat.ammatillisenOsittainenRapsa.hetu.get, user = MockUsers.kelaLaajatOikeudet) {
+        verifyResponseStatusOk()
+        val oppija = JsonSerializer.parse[KelaOppija](body)
+        val suoritus = oppija.opiskeluoikeudet.head.suoritukset.head.asInstanceOf[KelaAmmatillinenPäätasonSuoritus]
+        val näyttöjenArviointipäivät = suoritus.osasuoritukset.get.flatMap(_.näyttö).map(_.arviointi.map(_.päivä))
+        näyttöjenArviointipäivät shouldBe List(Some(LocalDate.of(2014, 10, 20)))
+      }
+    }
   }
 
   "Usean oppijan rajapinta" - {

--- a/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
+++ b/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
@@ -75,6 +75,20 @@ class KelaSpec
       }
     }
 
+    "Palauttaa TUVA-perusopetuksen erityisen tuen jaksot" in {
+      postHetu(KoskiSpecificMockOppijat.tuvaPerus.hetu.get, user = MockUsers.kelaLaajatOikeudet) {
+        verifyResponseStatusOk()
+        val oppija = JsonSerializer.parse[KelaOppija](body)
+        oppija.opiskeluoikeudet.length should be(1)
+
+        val tuvaOpiskeluoikeus = oppija.opiskeluoikeudet.last match {
+          case x: KelaTutkintokoulutukseenValmentavanOpiskeluoikeus => x
+        }
+        tuvaOpiskeluoikeus.järjestämislupa.koodiarvo shouldBe "perusopetus"
+        tuvaOpiskeluoikeus.lisätiedot.get.erityisenTuenPäätökset.get should have length (1)
+      }
+    }
+
     "Palauttaa tiedon 'täydentääTutkintoa' kun kyseessä on Muu ammatillinen koulutus" in {
       postHetu(KoskiSpecificMockOppijat.muuAmmatillinen.hetu.get, user = MockUsers.kelaLaajatOikeudet) {
         verifyResponseStatusOk()

--- a/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
+++ b/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
@@ -527,6 +527,25 @@ class KelaSpec
     }
   }
 
+  "Palauttaa lukio-opintoihin liittyvät puhvit yms" in {
+    postHetu(KoskiSpecificMockOppijat.uusiLukio.hetu.get, user = MockUsers.kelaLaajatOikeudet) {
+      verifyResponseStatusOk()
+
+      val oppija = JsonSerializer.parse[KelaOppija](body)
+      oppija.opiskeluoikeudet.length should be(1)
+
+      val lukioOpiskeluoikeus = oppija.opiskeluoikeudet.collectFirst {
+        case x: KelaLukionOpiskeluoikeus => x
+      }.head
+
+      val päätasonSuoritus = lukioOpiskeluoikeus.suoritukset.head
+
+      päätasonSuoritus.puhviKoe should not be (None)
+      päätasonSuoritus.omanÄidinkielenOpinnot should not be (None)
+      päätasonSuoritus.suullisenKielitaidonKokeet should not be (None)
+    }
+  }
+
   private def getHetu[A](hetu: String, user: MockUser = MockUsers.kelaSuppeatOikeudet)(f: => A)= {
     authGet(s"kela/$hetu", user)(f)
   }

--- a/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
+++ b/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
@@ -178,6 +178,17 @@ class KelaSpec
         näyttöjenArviointipäivät shouldBe List(Some(LocalDate.of(2014, 10, 20)))
       }
     }
+    "Palauttaa IB:n predicted grade -arvioinnin" in {
+      postHetu(KoskiSpecificMockOppijat.ibPredicted.hetu.get, user = MockUsers.kelaLaajatOikeudet) {
+        verifyResponseStatusOk()
+        val oppija = JsonSerializer.parse[KelaOppija](body)
+        val suoritus = oppija.opiskeluoikeudet.head.suoritukset
+          .collect { case s: KelaIBPäätasonSuoritus if s.koulutusmoduuli.tunniste.koodiarvo == "301102" => s }
+          .head
+        val osasuoritus = suoritus.osasuoritukset.get.head
+        osasuoritus.predictedArviointi.get.head.päivä shouldBe Some(LocalDate.of(2016, 6, 4))
+      }
+    }
   }
 
   "Usean oppijan rajapinta" - {

--- a/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
+++ b/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
@@ -362,12 +362,6 @@ class KelaSpec
     }
   }
 
-  "Vapaan sivistystyön opiskeluoikeuksista ei välitetä Jotpa-koulutuksen suorituksia" in {
-    postHetu(KoskiSpecificMockOppijat.vstJotpaKeskenOppija.hetu.get) {
-      verifyResponseStatus(404, KoskiErrorCategory.notFound.oppijaaEiLöydyTaiEiOikeuksia("Oppijaa (hetu) ei löydy tai käyttäjällä ei ole oikeuksia tietojen katseluun."))
-    }
-  }
-
   "Opiskeluoikeuden versiohistorian haku tuottaa AuditLogin" in {
     resetFixtures
     val opiskeluoikeus = lastOpiskeluoikeusByHetu(KoskiSpecificMockOppijat.amis)
@@ -443,11 +437,7 @@ class KelaSpec
 
   "Palauttaa European School of Helsinki -opiskeluoikeuden" in {
     postHetu(KoskiSpecificMockOppijat.europeanSchoolOfHelsinki.hetu.get, user = MockUsers.kelaLaajatOikeudet) {
-      verifyResponseStatusOk()
-
       val oppija = JsonSerializer.parse[KelaOppija](body)
-      oppija.opiskeluoikeudet.length should be(1)
-
       val eshOpiskeluoikeus = oppija.opiskeluoikeudet.last match { case x: KelaESHOpiskeluoikeus => x }
 
       eshOpiskeluoikeus.oppilaitos.get.oid shouldBe EuropeanSchoolOfHelsinki.oppilaitos
@@ -560,6 +550,22 @@ class KelaSpec
       val pts = lukioOpiskeluoikeus.suoritukset.find(p => p.tyyppi.koodiarvo == "perusopetuksenoppimaara").get
 
       pts.omanÄidinkielenOpinnot should not be (None)
+    }
+  }
+
+  "Palauttaa vst-jotpan opiskeluoikeuden" in {
+    postHetu(KoskiSpecificMockOppijat.vstJotpaKeskenOppija.hetu.get, user = MockUsers.kelaLaajatOikeudet) {
+      verifyResponseStatusOk()
+
+      val oppija = JsonSerializer.parse[KelaOppija](body)
+      oppija.opiskeluoikeudet.length should be(1)
+
+      val jotpaOpiskeluoikeus = oppija.opiskeluoikeudet.last match {
+        case x: KelaVapaanSivistystyönOpiskeluoikeus => x
+      }
+
+      jotpaOpiskeluoikeus.suoritukset.length shouldBe 1
+      jotpaOpiskeluoikeus.suoritukset.head.tyyppi.koodiarvo should be("vstjotpakoulutus")
     }
   }
 

--- a/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
+++ b/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
@@ -546,6 +546,23 @@ class KelaSpec
     }
   }
 
+  "Palauttaa perusopetuksen kentän omanÄidinkielenOpinnot" in {
+    postHetu(KoskiSpecificMockOppijat.ysiluokkalainen.hetu.get, user = MockUsers.kelaLaajatOikeudet) {
+      verifyResponseStatusOk()
+
+      val oppija = JsonSerializer.parse[KelaOppija](body)
+      oppija.opiskeluoikeudet.length should be(1)
+
+      val lukioOpiskeluoikeus = oppija.opiskeluoikeudet.collectFirst {
+        case x: KelaPerusopetuksenOpiskeluoikeus => x
+      }.head
+
+      val pts = lukioOpiskeluoikeus.suoritukset.find(p => p.tyyppi.koodiarvo == "perusopetuksenoppimaara").get
+
+      pts.omanÄidinkielenOpinnot should not be (None)
+    }
+  }
+
   private def getHetu[A](hetu: String, user: MockUser = MockUsers.kelaSuppeatOikeudet)(f: => A)= {
     authGet(s"kela/$hetu", user)(f)
   }

--- a/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
+++ b/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
@@ -532,6 +532,13 @@ class KelaSpec
 
       päätasonSuoritus.puhviKoe should not be (None)
       päätasonSuoritus.omanÄidinkielenOpinnot should not be (None)
+      päätasonSuoritus.omanÄidinkielenOpinnot.get.osasuoritukset should not be (None)
+      päätasonSuoritus.omanÄidinkielenOpinnot.get.osasuoritukset.get.length should not equal(0)
+      päätasonSuoritus.omanÄidinkielenOpinnot.get.osasuoritukset.get.foreach { osasuoritus =>
+        osasuoritus.arviointi.foreach(_.foreach { arviointi =>
+          arviointi.arvosana should be (None)
+          arviointi.hyväksytty.isDefined should be (true)
+        })}
       päätasonSuoritus.suullisenKielitaidonKokeet should not be (None)
     }
   }

--- a/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
+++ b/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
@@ -161,6 +161,14 @@ class KelaSpec
         verifyResponseStatus(500)
       }
     }
+    "Palauttaa koulutusvientitiedon" in {
+      postHetu(KoskiSpecificMockOppijat.amisKoulutusvienti.hetu.get, user = MockUsers.kelaLaajatOikeudet) {
+        verifyResponseStatusOk()
+        val oppija = JsonSerializer.parse[KelaOppija](body)
+        val lisätiedot = oppija.opiskeluoikeudet.head.lisätiedot.get.asInstanceOf[KelaAmmatillisenOpiskeluoikeudenLisätiedot]
+        lisätiedot.koulutusvienti shouldBe Some(true)
+      }
+    }
   }
 
   "Usean oppijan rajapinta" - {

--- a/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
+++ b/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
@@ -111,6 +111,8 @@ class KelaSpec
         suoritus.osaamisenHankkimistavat.map(oht => oht.last.osaamisenHankkimistapa.isInstanceOf[OppisopimuksellinenOsaamisenHankkimistapa]).shouldBe(Some(true))
         val hankkimistapa = suoritus.osaamisenHankkimistavat.map(oht => oht.last.osaamisenHankkimistapa.asInstanceOf[OppisopimuksellinenOsaamisenHankkimistapa])
         hankkimistapa.get.oppisopimus.oppisopimuksenPurkaminen.exists(_.päivä.equals(LocalDate.of(2013, 3, 20))).shouldBe(true)
+
+        suoritus.koulutussopimukset.get.head.työssäoppimispaikanYTunnus shouldBe Some("1572860-0")
       }
     }
 

--- a/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
+++ b/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
@@ -576,6 +576,26 @@ class KelaSpec
     }
   }
 
+  "Palauttaa EB-tutkinnon" in {
+    postHetu(KoskiSpecificMockOppijat.europeanSchoolOfHelsinki.hetu.get, user = MockUsers.kelaLaajatOikeudet) {
+      verifyResponseStatusOk()
+
+      val oppija = JsonSerializer.parse[KelaOppija](body)
+      oppija.opiskeluoikeudet.length should be(2) // ESH & EB
+
+      val ebTutkinnot = oppija.opiskeluoikeudet collect {
+        case x: KelaEBOpiskeluoikeus => x
+      }
+
+      ebTutkinnot.length shouldBe 1
+      val ebTutkinto = ebTutkinnot.head
+      ebTutkinto.suoritukset.length shouldBe 1
+      val suoritus = ebTutkinto.suoritukset.head
+      suoritus.tyyppi.koodiarvo shouldBe "ebtutkinto"
+      suoritus.osasuoritukset.get.length shouldBe 3
+    }
+  }
+
   private def getHetu[A](hetu: String, user: MockUser = MockUsers.kelaSuppeatOikeudet)(f: => A)= {
     authGet(s"kela/$hetu", user)(f)
   }


### PR DESCRIPTION
- Lukion tilatiedon yhteyteen rahoitustieto
- Lisää koulutussopimusjaksolle Y-tunnus
- Palauta ammatillisen koulutusvientitieto
- Palauta ammatillisen näytön päivämäärä
- Predicted grade IB-opiskeluoikeuteen
- Ammatillisen koulutuksen korotus
- Vaativan erityisen tuen yhteydessä järjestettävä majoitus -tieto vain laajemmille Kela-oikeuksille
