### PR TITLE
Suppress owasp warning for netty 4.1.94

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <suppress until="2023-11-01Z">
+    <notes>netty-handler-4.1.94.Final.jar - update postponed since netty is just a test dependency for aws s3</notes>
+    <packageUrl regex="true">^pkg:maven/io\.netty/netty\-handler@.*$</packageUrl>
+    <vulnerabilityName>CVE-2023-4586</vulnerabilityName>
+  </suppress>
   <suppress until="2023-07-01Z">
     <notes>guava-32.0.0-jre.jar Patch not available on 2023-06-02 - update postponed by month</notes>
     <cve>CVE-2023-2976</cve>


### PR DESCRIPTION
Test dependency for aws s3, waits for aws sdk patch