### PR TITLE
Suppress cve-2023-4586 for a while

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -2,8 +2,8 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until="2023-11-01Z">
     <notes>netty-handler-4.1.94.Final.jar - update postponed since netty is just a test dependency for aws s3</notes>
-    <packageUrl regex="true">^pkg:maven/io\.netty/netty\-handler@.*$</packageUrl>
-    <vulnerabilityName>CVE-2023-4586</vulnerabilityName>
+    <packageUrl regex="true">^pkg:maven/io\.netty/netty\-transport@.*$</packageUrl>
+    <cve>CVE-2023-4586</cve>
   </suppress>
   <suppress until="2023-07-01Z">
     <notes>guava-32.0.0-jre.jar Patch not available on 2023-06-02 - update postponed by month</notes>


### PR DESCRIPTION
… since netty is just a test dependency for aws s3