### PR TITLE
TOR-1959: Fronttivalidaatioiden fiksauksia

### DIFF
--- a/web/app/components-v2/containers/EditorContainer.tsx
+++ b/web/app/components-v2/containers/EditorContainer.tsx
@@ -199,7 +199,11 @@ export const EditorContainer = <T extends Opiskeluoikeus>(
       <div key={suoritusIndex}>{props.children}</div>
 
       <EditBar form={props.form} onSave={onSave} />
-      {props.form.isSaved && <Snackbar>{'Tallennettu'}</Snackbar>}
+      {props.form.isSaved && (
+        <Snackbar testId="opiskeluoikeus.saveSnackbar">
+          {'Tallennettu'}
+        </Snackbar>
+      )}
     </article>
   )
 }

--- a/web/app/components-v2/forms/FormModel.ts
+++ b/web/app/components-v2/forms/FormModel.ts
@@ -138,13 +138,14 @@ export const useForm = <O extends object>(
     [editMode, initialData, validate]
   )
 
-  const { push: setErrors } = globalErrors
+  const { push: setErrors, clearAll: clearErrors } = globalErrors
   const save: FormModelProp<'save'> = useCallback(
     async <T>(
       api: (data: O) => Promise<ApiResponse<T>>,
       merge: (response: T) => (data: O) => O
     ) => {
       if (editMode) {
+        clearErrors()
         pipe(
           await api(data),
           tap((response) =>
@@ -158,7 +159,7 @@ export const useForm = <O extends object>(
         )
       }
     },
-    [data, editMode, setErrors]
+    [clearErrors, data, editMode, setErrors]
   )
 
   const root: FormModelProp<'root'> = useMemo(() => $.optic_<O>(), [])

--- a/web/app/components-v2/messages/GlobalErrors.tsx
+++ b/web/app/components-v2/messages/GlobalErrors.tsx
@@ -10,7 +10,7 @@ export const GlobalErrors: React.FC = () => {
     <div className="GlobalErrors">
       <ContentContainer>
         <div className="GlobalErrors__container">
-          <ul className="GlobalErrors__list">
+          <ul className="GlobalErrors__list" data-testid="globalErrors">
             {state.errors.map((error, index) => (
               <li className="GlobalErrors__message" key={index}>
                 {error.message}

--- a/web/app/components-v2/messages/Snackbar.tsx
+++ b/web/app/components-v2/messages/Snackbar.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react'
 import { LocalizedString } from '../../types/fi/oph/koski/schema/LocalizedString'
 import { Trans } from '../texts/Trans'
+import { CommonProps, testId } from '../CommonProps'
 
-export type SnackbarProps = {
+export type SnackbarProps = CommonProps<{
   timeout?: number
   children: string | LocalizedString
-}
+}>
 
 export const Snackbar: React.FC<SnackbarProps> = (props) => {
   const [visible, setVisible] = useState(true)
@@ -15,7 +16,11 @@ export const Snackbar: React.FC<SnackbarProps> = (props) => {
   }, [props.timeout])
 
   return visible ? (
-    <aside className="Snackbar" onClick={() => setVisible(false)}>
+    <aside
+      className="Snackbar"
+      onClick={() => setVisible(false)}
+      {...testId(props)}
+    >
       <Trans>{props.children}</Trans>
     </aside>
   ) : null

--- a/web/app/vst/VSTEditor.tsx
+++ b/web/app/vst/VSTEditor.tsx
@@ -17,7 +17,6 @@ import { FormOptic, useForm } from '../components-v2/forms/FormModel'
 import { AdaptedOpiskeluoikeusEditorProps } from '../components-v2/interoperability/useUiAdapter'
 import { Spacer } from '../components-v2/layout/Spacer'
 import {
-  LaajuusEdit,
   LaajuusView,
   laajuusSum
 } from '../components-v2/opiskeluoikeus/LaajuusField'
@@ -48,18 +47,13 @@ import {
 import { Trans } from '../components-v2/texts/Trans'
 import { Infobox } from '../components/Infobox'
 import { t } from '../i18n/i18n'
-import { Koodistokoodiviite } from '../types/fi/oph/koski/schema/Koodistokoodiviite'
-import { LaajuusOpintopisteissä } from '../types/fi/oph/koski/schema/LaajuusOpintopisteissa'
-import { OppivelvollisilleSuunnatunVapaanSivistystyönOsasuoritus } from '../types/fi/oph/koski/schema/OppivelvollisilleSuunnatunVapaanSivistystyonOsasuoritus'
-import { VSTKotoutumiskoulutuksenKokonaisuudenOsasuoritus2022 } from '../types/fi/oph/koski/schema/VSTKotoutumiskoulutuksenKokonaisuudenOsasuoritus2022'
+import { Arviointi } from '../types/fi/oph/koski/schema/Arviointi'
 import { VSTKotoutumiskoulutuksenOhjauksenSuoritus2022 } from '../types/fi/oph/koski/schema/VSTKotoutumiskoulutuksenOhjauksenSuoritus2022'
-import { VapaanSivistystyönJotpaKoulutuksenOsasuorituksenSuoritus } from '../types/fi/oph/koski/schema/VapaanSivistystyonJotpaKoulutuksenOsasuorituksenSuoritus'
-import { VapaanSivistystyönLukutaitokoulutuksenKokonaisuudenSuoritus } from '../types/fi/oph/koski/schema/VapaanSivistystyonLukutaitokoulutuksenKokonaisuudenSuoritus'
-import { VapaanSivistystyönMaahanmuuttajienKotoutumiskoulutuksenKokonaisuudenSuoritus } from '../types/fi/oph/koski/schema/VapaanSivistystyonMaahanmuuttajienKotoutumiskoulutuksenKokonaisuudenSuoritus'
 import { VapaanSivistystyönOpiskeluoikeus } from '../types/fi/oph/koski/schema/VapaanSivistystyonOpiskeluoikeus'
 import { VapaanSivistystyönPäätasonSuoritus } from '../types/fi/oph/koski/schema/VapaanSivistystyonPaatasonSuoritus'
-import { VapaanSivistystyönVapaatavoitteisenKoulutuksenOsasuorituksenSuoritus } from '../types/fi/oph/koski/schema/VapaanSivistystyonVapaatavoitteisenKoulutuksenOsasuorituksenSuoritus'
+import { parasArviointi } from '../util/arvioinnit'
 import { append } from '../util/fp/arrays'
+import { formatNumber, sum } from '../util/numbers'
 import { useOsasuorituksetExpand } from './../osasuoritus/hooks'
 import { VSTLisatiedot } from './VSTLisatiedot'
 import {
@@ -82,11 +76,6 @@ import {
   isPerusteellinenVSTKoulutusmoduuli,
   isVSTOsasuoritusArvioinnilla
 } from './typeguards'
-import { parasArviointi } from '../util/arvioinnit'
-import { Arviointi } from '../types/fi/oph/koski/schema/Arviointi'
-import { formatNumber, sum } from '../util/numbers'
-import { pipe } from 'fp-ts/lib/function'
-import { subTestId } from '../components-v2/CommonProps'
 
 type VSTEditorProps =
   AdaptedOpiskeluoikeusEditorProps<VapaanSivistystyönOpiskeluoikeus>

--- a/web/app/vst/VSTEditor.tsx
+++ b/web/app/vst/VSTEditor.tsx
@@ -18,7 +18,8 @@ import { AdaptedOpiskeluoikeusEditorProps } from '../components-v2/interoperabil
 import { Spacer } from '../components-v2/layout/Spacer'
 import {
   LaajuusEdit,
-  LaajuusView
+  LaajuusView,
+  laajuusSum
 } from '../components-v2/opiskeluoikeus/LaajuusField'
 import {
   OpintokokonaisuusEdit,
@@ -85,6 +86,7 @@ import { parasArviointi } from '../util/arvioinnit'
 import { Arviointi } from '../types/fi/oph/koski/schema/Arviointi'
 import { formatNumber, sum } from '../util/numbers'
 import { pipe } from 'fp-ts/lib/function'
+import { subTestId } from '../components-v2/CommonProps'
 
 type VSTEditorProps =
   AdaptedOpiskeluoikeusEditorProps<VapaanSivistystyönOpiskeluoikeus>
@@ -304,11 +306,7 @@ export const VSTEditor: React.FC<VSTEditorProps> = (props) => {
           {isLaajuuksellinenVSTKoulutusmoduuli(
             päätasonSuoritus.suoritus.koulutusmoduuli
           ) && (
-            <KeyValueRow
-              label="Laajuus"
-              indent={2}
-              testId={`${päätasonSuoritus.testId}.koulutuksen-laajuus`}
-            >
+            <KeyValueRow label="Laajuus" indent={2}>
               <FormField
                 form={form}
                 path={päätasonSuoritus.path
@@ -316,17 +314,14 @@ export const VSTEditor: React.FC<VSTEditorProps> = (props) => {
                   .guard(isLaajuuksellinenVSTKoulutusmoduuli)
                   .prop('laajuus')}
                 view={LaajuusView}
-                edit={LaajuusEdit}
-                editProps={{
-                  createLaajuus: (arvo: number) =>
-                    LaajuusOpintopisteissä({
-                      arvo,
-                      yksikkö: Koodistokoodiviite({
-                        koodistoUri: 'opintojenlaajuusyksikko',
-                        koodiarvo: '2'
-                      })
-                    })
-                }}
+                auto={laajuusSum(
+                  päätasonSuoritus.path
+                    .prop('osasuoritukset')
+                    .elems()
+                    .path('koulutusmoduuli.laajuus'),
+                  form.state
+                )}
+                testId={`${päätasonSuoritus.testId}.laajuus`}
               />
             </KeyValueRow>
           )}

--- a/web/app/vst/VSTOsasuoritusProperties.tsx
+++ b/web/app/vst/VSTOsasuoritusProperties.tsx
@@ -764,7 +764,6 @@ export const osasuoritusToTableRow = ({
         path={osasuoritus.path('arviointi')}
         view={ParasArvosanaView}
         edit={(arvosanaProps) => {
-          console.log('arvosanaProps', arvosanaProps)
           if (osasuoritusValue === undefined) {
             return null
           }

--- a/web/test/e2e/pages/oppija/KoskiOppijaPageV2.ts
+++ b/web/test/e2e/pages/oppija/KoskiOppijaPageV2.ts
@@ -1,4 +1,4 @@
-import { Page, expect } from '@playwright/test'
+import { Locator, Page, expect } from '@playwright/test'
 import { build, BuiltIdNode, IdNodeObject } from './uiV2builder/builder'
 
 export class KoskiOppijaPageV2<T extends IdNodeObject<string>> {
@@ -8,12 +8,20 @@ export class KoskiOppijaPageV2<T extends IdNodeObject<string>> {
   suoritusIndex: number
   osasuoritusIndex: number
 
+  saveBtn: Locator
+  saveSnackbar: Locator
+  errors: Locator
+
   constructor(page: Page, idHierarchy: T) {
     this.page = page
     this.$ = build(page, idHierarchy)
     this.suoritusIndex = 0
     this.osasuoritusIndex = 0
     this.editMode = false
+
+    this.saveBtn = page.getByTestId('opiskeluoikeus.save')
+    this.saveSnackbar = page.getByTestId('opiskeluoikeus.saveSnackbar')
+    this.errors = page.getByTestId('globalErrors')
   }
 
   async goto(oppijaOid: string) {
@@ -93,5 +101,19 @@ export class KoskiOppijaPageV2<T extends IdNodeObject<string>> {
     await this.$.suoritukset(
       this.suoritusIndex
     ).suorituksenVahvistus.edit.merkitseKeskeneräiseksi.click()
+  }
+
+  async tallenna() {
+    await this.saveBtn.click()
+    await this.page.waitForLoadState('networkidle')
+    await this.saveSnackbar.waitFor({ state: 'visible', timeout: 3000 })
+    expect(await this.errors.isVisible()).toBeFalsy()
+    this.editMode = false
+  }
+
+  async tallennaVirheellisenä(...errors: string[]) {
+    await this.saveBtn.click()
+    await this.page.waitForLoadState('networkidle')
+    expect(await this.errors.textContent()).toEqual(errors.join(''))
   }
 }

--- a/web/test/e2e/pages/oppija/KoskiVSTOppijaPage.ts
+++ b/web/test/e2e/pages/oppija/KoskiVSTOppijaPage.ts
@@ -70,6 +70,10 @@ export class KoskiVSTOppijaPage extends KoskiOppijaPageV2<
     await this.$.suoritukset(0).osasuoritukset(index).delete.click()
   }
 
+  async suorituksenLaajuus() {
+    return this.$.suoritukset(0).laajuus.value()
+  }
+
   async laajuudetYhteensä() {
     return this.$.suoritukset(0).yhteensa.value()
   }
@@ -297,6 +301,7 @@ const VapaanSivistystyönTestIds = {
     peruste: {
       koulutusmoduuli: FormField(Label, Select)
     },
+    laajuus: FormField(Label),
 
     suorituksenVahvistus: SuorituksenVahvistus(),
     expand: Button,

--- a/web/test/e2e/pages/oppija/KoskiVSTOppijaPage.ts
+++ b/web/test/e2e/pages/oppija/KoskiVSTOppijaPage.ts
@@ -190,7 +190,7 @@ export class VSTOsasuoritus {
   async arvostelunPvm() {
     return this.osasuoritus.properties
       .arviointi(0)
-      [this.editMode ? 'edit' : 'view'].päivä.value()
+      [this.editMode ? 'edit' : 'value'].päivä.value()
   }
 
   async setKuvaus(kuvaus: string) {
@@ -270,7 +270,7 @@ const VapaanSivistystyönOsasuoritusTestIds = (_index: number) => ({
   nimi: FormField(Label),
   properties: {
     arviointi: arrayOf({
-      view: {
+      value: {
         arvosana: Label,
         päivä: Label
       },

--- a/web/test/e2e/pages/oppija/uiV2builder/Select.ts
+++ b/web/test/e2e/pages/oppija/uiV2builder/Select.ts
@@ -1,15 +1,15 @@
 import { createControl } from './controls'
 
-export const Select = createControl((_self, child) => {
+export const Select = createControl((self, child) => {
   const showOptions = async () => {
     await child('input').click()
   }
 
   return {
     set: async (key: string) => {
-      await _self.page().waitForLoadState('networkidle')
       await showOptions()
       await child(`options.${key}.item`).click()
+      await child('options').waitFor({ state: 'hidden' })
     },
     value: async () => {
       return await child('input').inputValue()

--- a/web/test/e2e/vst.spec.ts
+++ b/web/test/e2e/vst.spec.ts
@@ -1283,6 +1283,10 @@ test.describe('Vapaa sivistystyö', () => {
         expect(await vstOppijaPage.suorituksenLaajuus()).toEqual('6 op')
 
         await vstOppijaPage.tallenna()
+
+        expect(await vstOppijaPage.osasuoritus(1).nimi()).toEqual(nimi)
+        expect(await vstOppijaPage.osasuoritus(1).laajuus()).toEqual('1 op')
+        expect(await vstOppijaPage.suorituksenLaajuus()).toEqual('6 op')
       })
 
       test('Vaihda laajuutta ja arvosanaa', async ({ vstOppijaPage }) => {
@@ -1301,6 +1305,13 @@ test.describe('Vapaa sivistystyö', () => {
         expect(await osasuoritus.arvosana()).toEqual('Hyväksytty')
 
         await vstOppijaPage.tallenna()
+
+        const tallennettuOsasuoritus = vstOppijaPage.osasuoritus(0)
+        expect(await tallennettuOsasuoritus.nimi()).toEqual(
+          'Sienestämisen kokonaisuus'
+        )
+        expect(await tallennettuOsasuoritus.laajuus()).toEqual('5 op')
+        expect(await tallennettuOsasuoritus.arvosana()).toEqual('Hyväksytty')
       })
 
       test('Vaihda arvostelun päivämäärää', async ({ vstOppijaPage }) => {
@@ -1310,6 +1321,9 @@ test.describe('Vapaa sivistystyö', () => {
         expect(await osasuoritus.arvostelunPvm()).toEqual('1.1.2022')
 
         await vstOppijaPage.tallenna()
+
+        const tallennettuOsasuoritus = vstOppijaPage.osasuoritus(0)
+        expect(await tallennettuOsasuoritus.arvostelunPvm()).toEqual('1.1.2022')
       })
 
       test('Lisää alaosasuoritus', async ({ vstOppijaPage }) => {
@@ -1447,6 +1461,12 @@ test.describe('Vapaa sivistystyö', () => {
         )
 
         await vstOppijaPage.tallenna()
+
+        await foreachAsync(Object.values(kokonaisuudet))(async (nimi, i) => {
+          const kokonaisuus = vstOppijaPage.osasuoritus(i)
+          expect(await kokonaisuus.nimi()).toEqual(nimi)
+          expect(await kokonaisuus.laajuus()).toEqual('2 op')
+        })
       })
 
       test('Vaihda laajuutta, arvosanaa ja taitotasoa', async ({
@@ -1474,6 +1494,11 @@ test.describe('Vapaa sivistystyö', () => {
         expect(await osasuoritus.taitotaso()).toEqual('C1.1')
 
         await vstOppijaPage.tallenna()
+
+        const tallennettu = vstOppijaPage.osasuoritus(0)
+        expect(await tallennettu.laajuus()).toEqual('20 op')
+        expect(await tallennettu.arvosana()).toEqual('Hyväksytty')
+        expect(await tallennettu.taitotaso()).toEqual('C1.1')
       })
 
       test('Vaihda arvostelun päivämäärää', async ({ vstOppijaPage }) => {
@@ -1483,6 +1508,9 @@ test.describe('Vapaa sivistystyö', () => {
         expect(await osasuoritus.arvostelunPvm()).toEqual('1.1.2022')
 
         await vstOppijaPage.tallenna()
+
+        const tallennettu = vstOppijaPage.osasuoritus(0)
+        expect(await tallennettu.arvostelunPvm()).toEqual('1.1.2022')
       })
 
       test('Tilan muokkaaminen', async ({ vstOppijaPage }) => {
@@ -1661,6 +1689,11 @@ test.describe('Vapaa sivistystyö', () => {
         await osasuoritus.alaosasuoritus(0).setLaajuus(5)
 
         await vstOppijaPage.tallenna()
+
+        const tallennettu = vstOppijaPage.osasuoritus(0)
+        expect(await tallennettu.nimi()).toEqual(
+          'Arjen taidot ja elämänhallinta'
+        )
       })
 
       test('Alaosasuorituksen poisto', async ({ vstOppijaPage }) => {
@@ -1795,6 +1828,16 @@ test.describe('Vapaa sivistystyö', () => {
         )
 
         await vstOppijaPage.tallenna()
+
+        const tallennettu = vstOppijaPage.osasuoritus(0)
+        await foreachAsync(Object.entries(kieliopinnot))(
+          async ([koodi, nimi], i) => {
+            const alaosasuoritus = tallennettu.alaosasuoritus(i)
+            expect(await alaosasuoritus.nimi()).toEqual(nimi)
+            expect(await alaosasuoritus.laajuus()).toEqual(`${i + 1} op`)
+            expect(await alaosasuoritus.arvosana()).toEqual('A1.1')
+          }
+        )
       })
 
       test('Yhteiskunta- ja työelämäosaaminen', async ({ vstOppijaPage }) => {
@@ -1826,6 +1869,15 @@ test.describe('Vapaa sivistystyö', () => {
         )
 
         await vstOppijaPage.tallenna()
+
+        const tallennettu = vstOppijaPage.osasuoritus(1)
+        await foreachAsync(Object.values(yhteiskuntaopinnot))(
+          async (nimi, i) => {
+            const alaosasuoritus = tallennettu.alaosasuoritus(i)
+            expect(await alaosasuoritus.nimi()).toEqual(nimi)
+            expect(await alaosasuoritus.laajuus()).toEqual(`${i + 1} op`)
+          }
+        )
       })
 
       test('Valinnaiset opinnot', async ({ vstOppijaPage }) => {
@@ -1845,6 +1897,11 @@ test.describe('Vapaa sivistystyö', () => {
         expect(await alaosasuoritus.kuvaus()).toEqual('Toimii')
 
         await vstOppijaPage.tallenna()
+
+        const tallennettu = vstOppijaPage.osasuoritus(3).alaosasuoritus(0)
+        expect(await tallennettu.nimi()).toEqual('Testaaminen')
+        expect(await tallennettu.laajuus()).toEqual('10 op')
+        expect(await tallennettu.kuvaus()).toEqual('Toimii')
       })
 
       test('Tilan muokkaaminen', async ({ vstOppijaPage }) => {
@@ -1944,6 +2001,13 @@ test.describe('Vapaa sivistystyö', () => {
         expect(await vstOppijaPage.laajuudetYhteensä()).toEqual('6 op')
 
         await vstOppijaPage.tallenna()
+
+        await foreachAsync(osasuoritukset)(async (nimi, i) => {
+          const osasuoritus = vstOppijaPage.osasuoritus(i)
+          expect(await osasuoritus.nimi()).toEqual(nimi)
+          expect(await osasuoritus.laajuus()).toEqual(`${i + 1} op`)
+          expect(await osasuoritus.arvosana()).toEqual('Hyväksytty')
+        })
       })
 
       test('Tilan muokkaaminen', async ({ vstOppijaPage }) => {

--- a/web/test/e2e/vst.spec.ts
+++ b/web/test/e2e/vst.spec.ts
@@ -152,7 +152,7 @@ test.describe('Vapaa sivistystyö', () => {
           page.getByTestId('suoritukset.0.peruste.value')
         ).toHaveText('OPH-2984-2017')
         await expect(
-          page.getByTestId('suoritukset.0.koulutuksen-laajuus.value')
+          page.getByTestId('suoritukset.0.laajuus.value')
         ).toHaveText('80 op')
 
         const osasuoritukset = [
@@ -1261,7 +1261,7 @@ test.describe('Vapaa sivistystyö', () => {
     })
   })
 
-  test.describe('Muokkanäkymä', () => {
+  test.describe('Muokkausnäkymä', () => {
     const expect = _expect.configure({
       timeout: 2000
     })
@@ -1275,31 +1275,32 @@ test.describe('Vapaa sivistystyö', () => {
 
       test('Uuden osasuorituksen lisäys', async ({ vstOppijaPage }) => {
         const nimi = 'Lopeta turha kiihkoilu'
-        await expect(await vstOppijaPage.osasuoritusOptions()).toEqual([
-          'Lisää osasuoritus'
-        ])
         await vstOppijaPage.addNewOsasuoritus(nimi)
         await expect(await vstOppijaPage.osasuoritusOptions()).toEqual([
           'Lisää osasuoritus',
           nimi
         ])
-        expect(await vstOppijaPage.laajuudetYhteensä()).toEqual('6 op')
+        expect(await vstOppijaPage.suorituksenLaajuus()).toEqual('6 op')
+
+        await vstOppijaPage.tallenna()
       })
 
       test('Vaihda laajuutta ja arvosanaa', async ({ vstOppijaPage }) => {
         const osasuoritus = vstOppijaPage.osasuoritus(0)
-        await osasuoritus.setLaajuus(3)
+        await osasuoritus.setLaajuus(5)
         await osasuoritus.setVapaatavoitteinenArvosana(4)
 
         expect(await osasuoritus.nimi()).toEqual('Sienestämisen kokonaisuus')
-        expect(await osasuoritus.laajuus()).toEqual('3')
+        expect(await osasuoritus.laajuus()).toEqual('5')
         expect(await osasuoritus.arvosana()).toEqual('4')
 
         await osasuoritus.setSuoritusarvosana(true, true)
 
         expect(await osasuoritus.nimi()).toEqual('Sienestämisen kokonaisuus')
-        expect(await osasuoritus.laajuus()).toEqual('3')
+        expect(await osasuoritus.laajuus()).toEqual('5')
         expect(await osasuoritus.arvosana()).toEqual('Hyväksytty')
+
+        await vstOppijaPage.tallenna()
       })
 
       test('Vaihda arvostelun päivämäärää', async ({ vstOppijaPage }) => {
@@ -1307,6 +1308,8 @@ test.describe('Vapaa sivistystyö', () => {
         await osasuoritus.expand()
         await osasuoritus.setArvostelunPvm('1.1.2022')
         expect(await osasuoritus.arvostelunPvm()).toEqual('1.1.2022')
+
+        await vstOppijaPage.tallenna()
       })
 
       test('Lisää alaosasuoritus', async ({ vstOppijaPage }) => {
@@ -1320,6 +1323,11 @@ test.describe('Vapaa sivistystyö', () => {
           nimi
         ])
         await expect(await osasuoritus.alaosasuoritus(1).nimi()).toEqual(nimi)
+
+        await vstOppijaPage.tallennaVirheellisenä(
+          'Valmiiksi merkityllä suorituksella SK-K (Sienestämisen kokonaisuus) on keskeneräinen osasuoritus Sienien tunnistaminen 2 (Sienien tunnistaminen 2)',
+          'Suorituksen SK-K (Sienestämisen kokonaisuus) osasuoritusten laajuuksien summa 6.0 ei vastaa suorituksen laajuutta 5.0'
+        )
       })
 
       test('Osasuorituksen poisto', async ({ vstOppijaPage }) => {
@@ -1334,6 +1342,10 @@ test.describe('Vapaa sivistystyö', () => {
         // Kärkeen noussut osasuoritus pitäisi olla sama mikä luotiin hetki sitten
         const osasuoritus2 = vstOppijaPage.osasuoritus(0)
         expect(await osasuoritus.nimi()).toEqual(nimi)
+
+        await vstOppijaPage.tallennaVirheellisenä(
+          'Vapaatavoitteisella vapaan sivistystyön koulutuksella tulee olla vähintään yksi arvioitu osasuoritus'
+        )
       })
 
       test('Alaosasuorituksen poisto', async ({ vstOppijaPage }) => {
@@ -1349,6 +1361,11 @@ test.describe('Vapaa sivistystyö', () => {
 
         // Kärkeen noussut alaosasuoritus pitäisi olla sama mikä luotiin hetki sitten
         expect(await osasuoritus.alaosasuoritus(0).nimi()).toEqual(nimi)
+
+        await vstOppijaPage.tallennaVirheellisenä(
+          'Valmiiksi merkityllä suorituksella SK-K (Sienestämisen kokonaisuus) on keskeneräinen osasuoritus Testikurssi (Testikurssi)',
+          'Suorituksen SK-K (Sienestämisen kokonaisuus) osasuoritusten laajuuksien summa 1.0 ei vastaa suorituksen laajuutta 5.0'
+        )
       })
 
       test('Tilan muokkaaminen', async ({ vstOppijaPage }) => {
@@ -1362,6 +1379,11 @@ test.describe('Vapaa sivistystyö', () => {
         await tila.modal.submit.click()
         expect(await tila.items(0).date.value()).toEqual('1.1.2022')
         expect(await tila.items(0).tila.value()).toEqual('Keskeytynyt')
+
+        await vstOppijaPage.tallennaVirheellisenä(
+          'suoritus.vahvistus.päivä (2022-05-31) oltava sama tai aiempi kuin päättymispäivä (2022-01-01)',
+          "Vahvistetulla vapaan sivistystyön vapaatavoitteisella koulutuksella ei voi olla päättävänä tilana 'Keskeytynyt'"
+        )
       })
 
       test('Suorituksen vahvistus', async ({ vstOppijaPage }) => {
@@ -1380,6 +1402,10 @@ test.describe('Vapaa sivistystyö', () => {
           'Reijo',
           'Rehtori',
           '1.1.2023'
+        )
+
+        await vstOppijaPage.tallennaVirheellisenä(
+          'lessThanMinimumNumberOfItems: opiskeluoikeudet.0.tila.opiskeluoikeusjaksot'
         )
       })
     })
@@ -1416,9 +1442,11 @@ test.describe('Vapaa sivistystyö', () => {
           await kokonaisuus.setLaajuus(2)
           expect(await kokonaisuus.laajuus()).toEqual('2')
         })
-        expect(await vstOppijaPage.laajuudetYhteensä()).toEqual(
+        expect(await vstOppijaPage.suorituksenLaajuus()).toEqual(
           `${Object.values(kokonaisuudet).length * 2} op`
         )
+
+        await vstOppijaPage.tallenna()
       })
 
       test('Vaihda laajuutta, arvosanaa ja taitotasoa', async ({
@@ -1444,6 +1472,8 @@ test.describe('Vapaa sivistystyö', () => {
         expect(await osasuoritus.laajuus()).toEqual('20')
         expect(await osasuoritus.arvosana()).toEqual('Hyväksytty')
         expect(await osasuoritus.taitotaso()).toEqual('C1.1')
+
+        await vstOppijaPage.tallenna()
       })
 
       test('Vaihda arvostelun päivämäärää', async ({ vstOppijaPage }) => {
@@ -1451,6 +1481,8 @@ test.describe('Vapaa sivistystyö', () => {
         await osasuoritus.expand()
         await osasuoritus.setArvostelunPvm('1.1.2022')
         expect(await osasuoritus.arvostelunPvm()).toEqual('1.1.2022')
+
+        await vstOppijaPage.tallenna()
       })
 
       test('Tilan muokkaaminen', async ({ vstOppijaPage }) => {
@@ -1463,6 +1495,8 @@ test.describe('Vapaa sivistystyö', () => {
         expect(await tila.items(0).tila.value()).toEqual('Läsnä')
         expect(await tila.items(1).date.value()).toEqual('1.1.2023')
         expect(await tila.items(1).tila.value()).toEqual('Valmistunut')
+
+        await vstOppijaPage.tallenna()
       })
 
       test('Suorituksen vahvistus', async ({ vstOppijaPage }) => {
@@ -1478,6 +1512,10 @@ test.describe('Vapaa sivistystyö', () => {
           'Reijo',
           'Rehtori',
           '1.1.2023'
+        )
+
+        await vstOppijaPage.tallennaVirheellisenä(
+          'lessThanMinimumNumberOfItems: opiskeluoikeudet.0.tila.opiskeluoikeusjaksot'
         )
       })
     })
@@ -1515,8 +1553,14 @@ test.describe('Vapaa sivistystyö', () => {
             expect(await osasuoritus.laajuus()).toEqual('2')
           }
         )
+
         expect(await vstOppijaPage.laajuudetYhteensä()).toEqual(
           `${Object.values(osaamiskokonaisuudet).length * 2} op`
+        )
+
+        await vstOppijaPage.tallennaVirheellisenä(
+          'Päätason suoritus koulutus/999909 on vahvistettu, mutta sillä ei ole 53 opintopisteen edestä hyväksytyksi arvioituja suorituksia',
+          'Päätason suoritus koulutus/999909 on vahvistettu, mutta sillä on hyväksytyksi arvioituja osaamiskokonaisuuksia, joiden laajuus on alle 4 opintopistettä'
         )
       })
 
@@ -1554,6 +1598,10 @@ test.describe('Vapaa sivistystyö', () => {
             expect(await kokonaisuus.laajuus()).toEqual(`${i + 1}`)
           }
         )
+
+        await vstOppijaPage.tallennaVirheellisenä(
+          'Päätason suoritus koulutus/999909 on vahvistettu, mutta sillä ei ole 53 opintopisteen edestä hyväksytyksi arvioituja suorituksia'
+        )
       })
 
       test('Paikallisen suuntautumisopinnon lisäys', async ({
@@ -1579,6 +1627,26 @@ test.describe('Vapaa sivistystyö', () => {
         expect(await paikallinen.nimi()).toEqual('Työelämäharjoittelu')
         expect(await paikallinen.laajuus()).toEqual('3')
         expect(await paikallinen.arvosana()).toEqual('Hyväksytty')
+
+        await vstOppijaPage.tallennaVirheellisenä(
+          'Päätason suoritus koulutus/999909 on vahvistettu, mutta sillä ei ole 53 opintopisteen edestä hyväksytyksi arvioituja suorituksia'
+        )
+      })
+
+      test('Osaamiskokonaisuuden lisäys olemassaolevaan opintokokonaisuuteen', async ({
+        vstOppijaPage
+      }) => {
+        const osaamiskokonaisuus = vstOppijaPage.osasuoritus(0)
+        await osaamiskokonaisuus.expand()
+        await osaamiskokonaisuus.addPaikallinenOpintokokonaisuus('Testi')
+
+        const opintokokonaisuus = osaamiskokonaisuus.alaosasuoritus(0)
+        await opintokokonaisuus.setLaajuus(3)
+        expect(await opintokokonaisuus.laajuus()).toEqual('3')
+        await opintokokonaisuus.setSuoritusarvosana(true)
+        expect(await opintokokonaisuus.arvosana()).toEqual('Hyväksytty')
+
+        await vstOppijaPage.tallenna()
       })
 
       test('Vaihda laajuutta ja arvosanaa', async ({ vstOppijaPage }) => {
@@ -1591,6 +1659,8 @@ test.describe('Vapaa sivistystyö', () => {
 
         await osasuoritus.expand()
         await osasuoritus.alaosasuoritus(0).setLaajuus(5)
+
+        await vstOppijaPage.tallenna()
       })
 
       test('Alaosasuorituksen poisto', async ({ vstOppijaPage }) => {
@@ -1600,6 +1670,10 @@ test.describe('Vapaa sivistystyö', () => {
         expect(await head.nimi()).toEqual('Arjen rahankäyttö')
         await head.delete()
         expect(await head.nimi()).toEqual('Mielen liikkeet')
+
+        await vstOppijaPage.tallennaVirheellisenä(
+          'Päätason suoritus koulutus/999909 on vahvistettu, mutta sillä on hyväksytyksi arvioituja osaamiskokonaisuuksia, joiden laajuus on alle 4 opintopistettä'
+        )
       })
 
       test('Tilan muokkaaminen', async ({ vstOppijaPage }) => {
@@ -1615,6 +1689,8 @@ test.describe('Vapaa sivistystyö', () => {
         expect(await tila.items(1).date.value()).toEqual('1.1.2023')
         expect(await tila.items(1).tila.value()).toEqual('Valmistunut')
         expect(await tila.add.isVisible()).toBeFalsy()
+
+        await vstOppijaPage.tallenna()
       })
 
       test('Suorituksen vahvistus', async ({ vstOppijaPage }) => {
@@ -1630,6 +1706,10 @@ test.describe('Vapaa sivistystyö', () => {
           'Reijo',
           'Rehtori',
           '1.1.2023'
+        )
+
+        await vstOppijaPage.tallennaVirheellisenä(
+          'lessThanMinimumNumberOfItems: opiskeluoikeudet.0.tila.opiskeluoikeusjaksot'
         )
       })
     })
@@ -1670,7 +1750,13 @@ test.describe('Vapaa sivistystyö', () => {
             }
           }
         )
-        expect(await vstOppijaPage.laajuudetYhteensä()).toEqual('10 op')
+        expect(await vstOppijaPage.suorituksenLaajuus()).toEqual('10 op')
+
+        await vstOppijaPage.tallennaVirheellisenä(
+          'Kielten ja viestinnän osasuoritusta ei voi hyväksyä ennen kuin kaikki pakolliset alaosasuoritukset on arvioitu',
+          'Oppiaineen laajuus puuttuu',
+          'Oppiaineen laajuus puuttuu'
+        )
       })
 
       test('Kieli- ja viestintäosaamisen muokkaaminen', async ({
@@ -1707,6 +1793,8 @@ test.describe('Vapaa sivistystyö', () => {
             expect(await alaosasuoritus.arvosana()).toEqual('A1.1')
           }
         )
+
+        await vstOppijaPage.tallenna()
       })
 
       test('Yhteiskunta- ja työelämäosaaminen', async ({ vstOppijaPage }) => {
@@ -1736,6 +1824,8 @@ test.describe('Vapaa sivistystyö', () => {
             expect(await alaosasuoritus.laajuus()).toEqual(`${i + 1}`)
           }
         )
+
+        await vstOppijaPage.tallenna()
       })
 
       test('Valinnaiset opinnot', async ({ vstOppijaPage }) => {
@@ -1753,6 +1843,8 @@ test.describe('Vapaa sivistystyö', () => {
         await alaosasuoritus.expand()
         await alaosasuoritus.setKuvaus('Toimii')
         expect(await alaosasuoritus.kuvaus()).toEqual('Toimii')
+
+        await vstOppijaPage.tallenna()
       })
 
       test('Tilan muokkaaminen', async ({ vstOppijaPage }) => {
@@ -1770,13 +1862,27 @@ test.describe('Vapaa sivistystyö', () => {
         expect(await tila.items(1).date.value()).toEqual('1.1.2023')
         expect(await tila.items(1).tila.value()).toEqual('Valmistunut')
         expect(await tila.add.isVisible()).toBeFalsy()
+
+        await vstOppijaPage.tallennaVirheellisenä(
+          'Suoritukselta koulutus/999910 puuttuu vahvistus, vaikka opiskeluoikeus on tilassa Valmistunut',
+          'Kielten ja viestinnän osasuoritusta ei voi hyväksyä ennen kuin kaikki pakolliset alaosasuoritukset on arvioitu',
+          "Oppiaineen 'Yhteiskunta- ja työelämäosaaminen' suoritettu laajuus liian suppea (12.0 op, pitäisi olla vähintään 20.0 op)",
+          "Oppiaineen 'Työssäoppiminen' suoritettu laajuus liian suppea (4.0 op, pitäisi olla vähintään 8.0 op)"
+        )
       })
 
       test('Perusteen vaihtaminen', async ({ vstOppijaPage }) => {
+        await vstOppijaPage.setPeruste('OPH-123-2021')
+        expect(await vstOppijaPage.peruste()).toEqual(
+          'OPH-123-2021 Aikuisten maahanmuuttajien kotoutumiskoulutuksen opetussuunnitelman perusteet 2012'
+        )
+
         await vstOppijaPage.setPeruste('OPH-649-2022')
         expect(await vstOppijaPage.peruste()).toEqual(
           'OPH-649-2022 Aikuisten maahanmuuttajien kotoutumiskoulutuksen opetussuunnitelman perusteet 2012'
         )
+
+        await vstOppijaPage.tallenna()
       })
 
       test('Suorituksen vahvistus', async ({ vstOppijaPage }) => {
@@ -1790,6 +1896,13 @@ test.describe('Vapaa sivistystyö', () => {
           'Reijo',
           'Rehtori',
           '1.1.2023'
+        )
+
+        await vstOppijaPage.tallennaVirheellisenä(
+          'Kielten ja viestinnän osasuoritusta ei voi hyväksyä ennen kuin kaikki pakolliset alaosasuoritukset on arvioitu',
+          "Oppiaineen 'Yhteiskunta- ja työelämäosaaminen' suoritettu laajuus liian suppea (12.0 op, pitäisi olla vähintään 20.0 op)",
+          "Oppiaineen 'Työssäoppiminen' suoritettu laajuus liian suppea (4.0 op, pitäisi olla vähintään 8.0 op)",
+          "Oppiaineen 'Ohjaus' suoritettu laajuus liian suppea (4.0 op, pitäisi olla vähintään 7.0 op)"
         )
       })
     })
@@ -1829,6 +1942,8 @@ test.describe('Vapaa sivistystyö', () => {
           ...osasuoritukset
         ])
         expect(await vstOppijaPage.laajuudetYhteensä()).toEqual('6 op')
+
+        await vstOppijaPage.tallenna()
       })
 
       test('Tilan muokkaaminen', async ({ vstOppijaPage }) => {
@@ -1862,6 +1977,10 @@ test.describe('Vapaa sivistystyö', () => {
           '(Jatkuvan oppimisen ja työllisyyden palvelukeskuksen rahoitus)'
         )
         expect(await tila.add.isVisible()).toBeFalsy()
+
+        await vstOppijaPage.tallennaVirheellisenä(
+          "Vahvistamattomalla jatkuvaan oppimiseen suunnatulla vapaan sivistystyön koulutuksella ei voi olla päättävänä tilana 'Hyväksytysti suoritettu'"
+        )
       })
 
       test('Suorituksen vahvistus', async ({ vstOppijaPage }) => {
@@ -1889,6 +2008,8 @@ test.describe('Vapaa sivistystyö', () => {
         expect(
           await vstOppijaPage.isMerkitseKeskeneräiseksiDisabled()
         ).toBeTruthy()
+
+        await vstOppijaPage.tallenna()
       })
     })
   })


### PR DESCRIPTION
- Käytä desimaalierottimena pilkkua
- Poista vanhat virheet näkyvistä ennen tallennusta
- Lisää tallennuksen yritys jokaisen muokkaustestin perään
- Poista unohtunut console.log
- Importien siivous
- fixup! Lisää tallennuksen yritys jokaisen muokkaustestin perään
