### PR TITLE
TOR-2086: VST-korjauksia

### DIFF
--- a/web/app/components-v2/containers/EditorContainer.tsx
+++ b/web/app/components-v2/containers/EditorContainer.tsx
@@ -170,18 +170,18 @@ export const EditorContainer = <T extends Opiskeluoikeus>(
           view={OrganisaatiohistoriaView}
         />
         <Spacer />
-        <FlatButton
-          onClick={(e) => {
-            e.preventDefault()
-            setLisatiedotOpen((prev) => !prev)
-          }}
-        >
-          {lisatiedotOpen
-            ? 'lisatiedot:sulje_lisatiedot'
-            : 'lisatiedot:nayta_lisatiedot'}
-        </FlatButton>
         {LisätiedotContainer !== undefined && lisatiedotOpen && (
           <>
+            <FlatButton
+              onClick={(e) => {
+                e.preventDefault()
+                setLisatiedotOpen((prev) => !prev)
+              }}
+            >
+              {lisatiedotOpen
+                ? 'lisatiedot:sulje_lisatiedot'
+                : 'lisatiedot:nayta_lisatiedot'}
+            </FlatButton>
             <Spacer />
             <LisätiedotContainer form={props.form} />
             <Spacer />

--- a/web/app/components-v2/opiskeluoikeus/SuorituksenVahvistus.tsx
+++ b/web/app/components-v2/opiskeluoikeus/SuorituksenVahvistus.tsx
@@ -39,6 +39,7 @@ export type SuorituksenVahvistusFieldProps<
   suoritusPath: FormOptic<T, S>
   organisaatio?: Oppilaitos | Koulutustoimija
   disableAdd?: boolean
+  disableRemoval?: boolean
 }>
 
 export const SuorituksenVahvistusField = <
@@ -48,7 +49,8 @@ export const SuorituksenVahvistusField = <
   props: SuorituksenVahvistusFieldProps<T, S>
 ): React.ReactElement => {
   const tila = viimeisinOpiskelujaksonTila(props.form.state.tila)
-  const disableRemoval = Boolean(tila && isValmistuvaTerminaalitila(tila))
+  const disableRemoval =
+    props.disableRemoval ?? Boolean(tila && isValmistuvaTerminaalitila(tila))
 
   return (
     <FormField

--- a/web/app/vst/kops/AddKOPSOsasuoritus.tsx
+++ b/web/app/vst/kops/AddKOPSOsasuoritus.tsx
@@ -1,26 +1,26 @@
 import React from 'react'
 import { useKoodistoFiller, useKoodistot } from '../../appstate/koodisto'
+import { TestIdLayer } from '../../appstate/useTestId'
 import { CommonProps } from '../../components-v2/CommonProps'
+import { Column, ColumnRow } from '../../components-v2/containers/Columns'
 import {
   Select,
   SelectOption,
   groupKoodistoToOptions
 } from '../../components-v2/controls/Select'
 import { FormModel, FormOptic } from '../../components-v2/forms/FormModel'
-import { OppivelvollisilleSuunnattuVapaanSivistystyönKoulutuksenSuoritus } from '../../types/fi/oph/koski/schema/OppivelvollisilleSuunnattuVapaanSivistystyonKoulutuksenSuoritus'
-import { VapaanSivistystyönOpiskeluoikeus } from '../../types/fi/oph/koski/schema/VapaanSivistystyonOpiskeluoikeus'
-import { Koodistokoodiviite } from '../../types/fi/oph/koski/schema/Koodistokoodiviite'
 import { t } from '../../i18n/i18n'
-import { append } from 'fp-ts/lib/Array'
-import { OppivelvollisilleSuunnatunVapaanSivistystyönOsasuoritus } from '../../types/fi/oph/koski/schema/OppivelvollisilleSuunnatunVapaanSivistystyonOsasuoritus'
-import { OppivelvollisilleSuunnatunVapaanSivistystyönOsaamiskokonaisuudenSuoritus } from '../../types/fi/oph/koski/schema/OppivelvollisilleSuunnatunVapaanSivistystyonOsaamiskokonaisuudenSuoritus'
-import { OppivelvollisilleSuunnatunVapaanSivistystyönValinnaistenSuuntautumisopintojenSuoritus } from '../../types/fi/oph/koski/schema/OppivelvollisilleSuunnatunVapaanSivistystyonValinnaistenSuuntautumisopintojenSuoritus'
-import { isKoodistoviiteOf } from '../../util/schema'
+import { Koodistokoodiviite } from '../../types/fi/oph/koski/schema/Koodistokoodiviite'
+import { OppivelvollisilleSuunnattuVapaanSivistystyönKoulutuksenSuoritus } from '../../types/fi/oph/koski/schema/OppivelvollisilleSuunnattuVapaanSivistystyonKoulutuksenSuoritus'
 import { OppivelvollisilleSuunnattuVapaanSivistystyönOsaamiskokonaisuus } from '../../types/fi/oph/koski/schema/OppivelvollisilleSuunnattuVapaanSivistystyonOsaamiskokonaisuus'
-import { laajuusOpintopisteissa } from '../common/constructors'
+import { OppivelvollisilleSuunnatunVapaanSivistystyönOsaamiskokonaisuudenSuoritus } from '../../types/fi/oph/koski/schema/OppivelvollisilleSuunnatunVapaanSivistystyonOsaamiskokonaisuudenSuoritus'
+import { OppivelvollisilleSuunnatunVapaanSivistystyönOsasuoritus } from '../../types/fi/oph/koski/schema/OppivelvollisilleSuunnatunVapaanSivistystyonOsasuoritus'
 import { OppivelvollisilleSuunnatunVapaanSivistystyönValinnaisetSuuntautumisopinnot } from '../../types/fi/oph/koski/schema/OppivelvollisilleSuunnatunVapaanSivistystyonValinnaisetSuuntautumisopinnot'
-import { Column, ColumnRow } from '../../components-v2/containers/Columns'
-import { TestIdLayer } from '../../appstate/useTestId'
+import { OppivelvollisilleSuunnatunVapaanSivistystyönValinnaistenSuuntautumisopintojenSuoritus } from '../../types/fi/oph/koski/schema/OppivelvollisilleSuunnatunVapaanSivistystyonValinnaistenSuuntautumisopintojenSuoritus'
+import { VapaanSivistystyönOpiskeluoikeus } from '../../types/fi/oph/koski/schema/VapaanSivistystyonOpiskeluoikeus'
+import { appendOptional } from '../../util/array'
+import { isKoodistoviiteOf } from '../../util/schema'
+import { laajuusOpintopisteissa } from '../common/constructors'
 
 export type AddKOPSOsasuoritusProps = CommonProps<{
   form: FormModel<VapaanSivistystyönOpiskeluoikeus>
@@ -36,14 +36,14 @@ export const AddKOPSOsasuoritus: React.FC<AddKOPSOsasuoritusProps> = ({
 }) => {
   const options = useOptions()
   const fillKoodistot = useKoodistoFiller()
-  const osasuoritukset = path.prop('osasuoritukset').optional()
+  const osasuoritukset = path.prop('osasuoritukset')
 
   const onAdd = async (option?: SelectOption<Koodistokoodiviite>) => {
     const tunniste = option?.value
     if (tunniste) {
       form.updateAt(
         osasuoritukset,
-        append(await fillKoodistot(createOsasuoritus(tunniste)))
+        appendOptional(await fillKoodistot(createOsasuoritus(tunniste)))
       )
     }
   }

--- a/web/app/vst/vapaatavoitteinen/VSTVapaatavoitteinenEditor.tsx
+++ b/web/app/vst/vapaatavoitteinen/VSTVapaatavoitteinenEditor.tsx
@@ -54,7 +54,6 @@ export const VSTVapaatavoitteinenEditor: React.FC<
         createOpiskeluoikeusjakso={
           createVstVapaatavoitteinenOpiskeluoikeusjakso
         }
-        lisätiedotContainer={VSTLisatiedot}
         onChangeSuoritus={onChangeSuoritus}
         opiskeluoikeusJaksoClassName="fi.oph.koski.schema.VapaanSivistystyönVapaatavoitteisenKoulutuksenOpiskeluoikeusjakso"
       >

--- a/web/app/vst/vapaatavoitteinen/VSTVapaatavoitteinenEditor.tsx
+++ b/web/app/vst/vapaatavoitteinen/VSTVapaatavoitteinenEditor.tsx
@@ -82,6 +82,7 @@ export const VSTVapaatavoitteinenEditor: React.FC<
           suoritusPath={päätasonSuoritus.path}
           organisaatio={organisaatio}
           disableAdd={suoritusVahvistettu}
+          disableRemoval={false}
         />
         <Spacer />
 

--- a/web/test/e2e/vst.spec.ts
+++ b/web/test/e2e/vst.spec.ts
@@ -1372,7 +1372,7 @@ test.describe('Vapaa sivistystyö', () => {
         // Palauta keskeneräiseksi
         expect(
           await vahvistaminen.edit.merkitseKeskeneräiseksi.isDisabled()
-        ).toBeTruthy()
+        ).toBeFalsy()
         await vstOppijaPage.$.opiskeluoikeus.tila.edit.items(0).remove.click()
         await vahvistaminen.edit.merkitseKeskeneräiseksi.click()
 


### PR DESCRIPTION
- Poista lisätiedot vapaatavoitteisilta
- Korjaa ensimmäisen kops-osasuorituksen lisäys
- Mahdollista vapaatavoitteisen vahvistuksen poisto terminaalitilalla
