### PR TITLE
TOR-2037 Uusi käyttöoikeus Migrille

### DIFF
--- a/src/main/scala/fi/oph/koski/http/KoskiErrorCategory.scala
+++ b/src/main/scala/fi/oph/koski/http/KoskiErrorCategory.scala
@@ -292,6 +292,7 @@ object KoskiErrorCategory {
     val vainVirkailija = subcategory("vainVirkailija", "Sallittu vain virkailija-käyttäjille")
     val vainKansalainen = subcategory("vainKansalainen", "Sallittu vain kansalainen-käyttäjille")
     val vainViranomainen = subcategory("vainViranomainen", "Sallittu vain viranomaisille")
+    val vainPalveluvayla = subcategory("vainPalveluvayla", "Sallittu vain palveluväyläkäyttäjälle")
     val vainTilastokeskus = subcategory("vainTilastokeskus", "Sallittu vain tilastokeskuskäyttäjälle")
     val kiellettyKäyttöoikeus = subcategory("kiellettyKäyttöoikeus", "Ei sallittu näillä käyttöoikeuksilla")
     val liianMontaSuoritusjakoa = subcategory("liianMontaSuoritusjakoa", "Käyttäjällä on jo maksimimäärä suoritusjakoja")

--- a/src/main/scala/fi/oph/koski/koskiuser/Kayttooikeus.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/Kayttooikeus.scala
@@ -22,9 +22,9 @@ object Rooli {
   val GLOBAALI_LUKU_KORKEAKOULU = "GLOBAALI_LUKU_KORKEAKOULU"
   val GLOBAALI_LUKU_MUU_KUIN_SAANNELTY = "GLOBAALI_LUKU_MUU_KUIN_SAANNELTY"
   val GLOBAALI_LUKU_TAITEENPERUSOPETUS = "GLOBAALI_LUKU_TAITEENPERUSOPETUS"
-  val TIEDONSIIRTO_LUOVUTUSPALVELU = "TIEDONSIIRTO_LUOVUTUSPALVELU"
   val TILASTOKESKUS = "TILASTOKESKUS"
   val VALVIRA = "VALVIRA"
+  val MIGRI = "MIGRI"
   val YTL = "YTL"
   val OPPIVELVOLLISUUSTIETO_RAJAPINTA = "OPPIVELVOLLISUUSTIETO_RAJAPINTA"
   val MITATOIDYT_OPISKELUOIKEUDET = "MITATOIDYT_OPISKELUOIKEUDET" // Ei käyttöoikeus-palvelussa
@@ -198,5 +198,11 @@ case class KäyttöoikeusViranomainen(globalPalveluroolit: List[Palvelurooli]) e
 
   override lazy val allowedOpiskeluoikeusTyypit: Set[String] = Käyttöoikeus.parseAllowedOpiskeluoikeudenTyypit(globalPalveluroolit, globalAccessType)
 
-  def isLuovutusPalveluAllowed: Boolean = globalPalveluroolit.contains(Palvelurooli("KOSKI", TIEDONSIIRTO_LUOVUTUSPALVELU))
+  def isLuovutusPalveluAllowed: Boolean = {
+    val luovutuspalveluRoolit = List(
+      Palvelurooli("KOSKI", Rooli.MIGRI)
+    )
+    luovutuspalveluRoolit.exists(globalPalveluroolit.contains)
+  }
+
 }

--- a/src/main/scala/fi/oph/koski/koskiuser/Kayttooikeus.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/Kayttooikeus.scala
@@ -26,6 +26,8 @@ object Rooli {
   val VALVIRA = "VALVIRA"
   val MIGRI = "MIGRI"
   val YTL = "YTL"
+  val HSL = "HSL"
+  val SUOMIFI = "SUOMIFI"
   val OPPIVELVOLLISUUSTIETO_RAJAPINTA = "OPPIVELVOLLISUUSTIETO_RAJAPINTA"
   val MITATOIDYT_OPISKELUOIKEUDET = "MITATOIDYT_OPISKELUOIKEUDET" // Ei käyttöoikeus-palvelussa
   val POISTETUT_OPISKELUOIKEUDET = "POISTETUT_OPISKELUOIKEUDET" // Ei käyttöoikeus-palvelussa
@@ -198,11 +200,12 @@ case class KäyttöoikeusViranomainen(globalPalveluroolit: List[Palvelurooli]) e
 
   override lazy val allowedOpiskeluoikeusTyypit: Set[String] = Käyttöoikeus.parseAllowedOpiskeluoikeudenTyypit(globalPalveluroolit, globalAccessType)
 
-  def isLuovutusPalveluAllowed: Boolean = {
-    val luovutuspalveluRoolit = List(
-      Palvelurooli("KOSKI", Rooli.MIGRI)
+  def isPalveluvaylaAllowed: Boolean = {
+    val palveluvaylaRoolit = List(
+      Palvelurooli("KOSKI", Rooli.HSL),
+      Palvelurooli("KOSKI", Rooli.SUOMIFI),
     )
-    luovutuspalveluRoolit.exists(globalPalveluroolit.contains)
+    palveluvaylaRoolit.exists(globalPalveluroolit.contains)
   }
 
 }

--- a/src/main/scala/fi/oph/koski/koskiuser/KoskiSpecificAuthenticationSupport.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/KoskiSpecificAuthenticationSupport.scala
@@ -18,7 +18,7 @@ trait KoskiSpecificAuthenticationSupport extends AuthenticationSupport with Kosk
         if (!session.hasPalvelurooli(_.palveluName == "KOSKI")) {
           haltWithStatus(KoskiErrorCategory.forbidden.kiellettyKäyttöoikeus("Ei sallittu ilman Koski-palvelun käyttöoikeuksia"))
         }
-        if (session.hasLuovutuspalveluAccess || session.hasTilastokeskusAccess || session.hasKelaAccess || session.hasYtlAccess || session.hasValviraAccess || session.hasMigriAccess) {
+        if (session.hasPalveluvaylaAccess || session.hasTilastokeskusAccess || session.hasKelaAccess || session.hasYtlAccess || session.hasValviraAccess || session.hasMigriAccess) {
           haltWithStatus(KoskiErrorCategory.forbidden.kiellettyKäyttöoikeus("Ei sallittu luovutuspalvelukäyttöoikeuksilla"))
         }
         user

--- a/src/main/scala/fi/oph/koski/koskiuser/KoskiSpecificAuthenticationSupport.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/KoskiSpecificAuthenticationSupport.scala
@@ -18,7 +18,7 @@ trait KoskiSpecificAuthenticationSupport extends AuthenticationSupport with Kosk
         if (!session.hasPalvelurooli(_.palveluName == "KOSKI")) {
           haltWithStatus(KoskiErrorCategory.forbidden.kiellettyKäyttöoikeus("Ei sallittu ilman Koski-palvelun käyttöoikeuksia"))
         }
-        if (session.hasLuovutuspalveluAccess || session.hasTilastokeskusAccess || session.hasKelaAccess || session.hasYtlAccess || session.hasValviraAccess) {
+        if (session.hasLuovutuspalveluAccess || session.hasTilastokeskusAccess || session.hasKelaAccess || session.hasYtlAccess || session.hasValviraAccess || session.hasMigriAccess) {
           haltWithStatus(KoskiErrorCategory.forbidden.kiellettyKäyttöoikeus("Ei sallittu luovutuspalvelukäyttöoikeuksilla"))
         }
         user

--- a/src/main/scala/fi/oph/koski/koskiuser/MockUsers.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/MockUsers.scala
@@ -382,12 +382,12 @@ object MockUsers {
     List("Vastuukayttajat")
   )
 
-  val luovutuspalveluKäyttäjä = KoskiMockUser(
+  val migriKäyttäjä = KoskiMockUser(
     "Luovutus",
-    "Lasse",
-    "1.2.246.562.24.99999988888",
-    Seq(OrganisaatioJaKäyttöoikeudet(MockOrganisaatiot.tilastokeskus, List(
-      PalveluJaOikeus("KOSKI", Rooli.TIEDONSIIRTO_LUOVUTUSPALVELU),
+    "Migri",
+    "1.2.246.562.24.99999988877",
+    Seq(OrganisaatioJaKäyttöoikeudet(MockOrganisaatiot.migri, List(
+      PalveluJaOikeus("KOSKI", Rooli.MIGRI),
       PalveluJaOikeus("KOSKI", Rooli.GLOBAALI_LUKU_PERUSOPETUS),
       PalveluJaOikeus("KOSKI", Rooli.GLOBAALI_LUKU_TOINEN_ASTE),
       PalveluJaOikeus("KOSKI", Rooli.GLOBAALI_LUKU_KORKEAKOULU),
@@ -396,22 +396,7 @@ object MockUsers {
     )))
   )
 
-  val luovutuspalveluKäyttäjäArkaluontoinen = KoskiMockUser(
-    "Arkaluontoinen",
-    "Antti",
-    "1.2.246.562.24.88888877777",
-    Seq(OrganisaatioJaKäyttöoikeudet(MockOrganisaatiot.tilastokeskus, List(
-      PalveluJaOikeus("KOSKI", Rooli.TIEDONSIIRTO_LUOVUTUSPALVELU),
-      PalveluJaOikeus("KOSKI", Rooli.LUOTTAMUKSELLINEN_KAIKKI_TIEDOT),
-      PalveluJaOikeus("KOSKI", Rooli.GLOBAALI_LUKU_PERUSOPETUS),
-      PalveluJaOikeus("KOSKI", Rooli.GLOBAALI_LUKU_TOINEN_ASTE),
-      PalveluJaOikeus("KOSKI", Rooli.GLOBAALI_LUKU_KORKEAKOULU),
-      PalveluJaOikeus("KOSKI", Rooli.GLOBAALI_LUKU_MUU_KUIN_SAANNELTY),
-      PalveluJaOikeus("KOSKI", Rooli.GLOBAALI_LUKU_TAITEENPERUSOPETUS),
-    )))
-  )
-
-  val suomiFiKäyttäjä = luovutuspalveluKäyttäjä.copy(
+  val suomiFiKäyttäjä = migriKäyttäjä.copy(
     firstname = "Suomi",
     lastname = "Fi",
     oid = "1.2.246.562.24.99999988889"
@@ -542,8 +527,7 @@ object MockUsers {
     perusopetusViranomainen,
     toinenAsteViranomainen,
     korkeakouluViranomainen,
-    luovutuspalveluKäyttäjä,
-    luovutuspalveluKäyttäjäArkaluontoinen,
+    migriKäyttäjä,
     suomiFiKäyttäjä,
     tilastokeskusKäyttäjä,
     valviraKäyttäjä,

--- a/src/main/scala/fi/oph/koski/koskiuser/MockUsers.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/MockUsers.scala
@@ -396,10 +396,32 @@ object MockUsers {
     )))
   )
 
-  val suomiFiKäyttäjä = migriKäyttäjä.copy(
-    firstname = "Suomi",
-    lastname = "Fi",
-    oid = "1.2.246.562.24.99999988889"
+  val hslKäyttäjä = KoskiMockUser(
+    "Palveluväylä",
+    "HSL",
+    "1.2.246.562.24.99999988899",
+    Seq(OrganisaatioJaKäyttöoikeudet(MockOrganisaatiot.hsl, List(
+      PalveluJaOikeus("KOSKI", Rooli.HSL),
+      PalveluJaOikeus("KOSKI", Rooli.GLOBAALI_LUKU_PERUSOPETUS),
+      PalveluJaOikeus("KOSKI", Rooli.GLOBAALI_LUKU_TOINEN_ASTE),
+      PalveluJaOikeus("KOSKI", Rooli.GLOBAALI_LUKU_KORKEAKOULU),
+      PalveluJaOikeus("KOSKI", Rooli.GLOBAALI_LUKU_MUU_KUIN_SAANNELTY),
+      PalveluJaOikeus("KOSKI", Rooli.GLOBAALI_LUKU_TAITEENPERUSOPETUS),
+    )))
+  )
+
+  val suomiFiKäyttäjä = KoskiMockUser(
+    "Palveluväylä",
+    "SuomiFi",
+    "1.2.246.562.24.99999988889",
+    Seq(OrganisaatioJaKäyttöoikeudet(MockOrganisaatiot.suomifi, List(
+      PalveluJaOikeus("KOSKI", Rooli.SUOMIFI),
+      PalveluJaOikeus("KOSKI", Rooli.GLOBAALI_LUKU_PERUSOPETUS),
+      PalveluJaOikeus("KOSKI", Rooli.GLOBAALI_LUKU_TOINEN_ASTE),
+      PalveluJaOikeus("KOSKI", Rooli.GLOBAALI_LUKU_KORKEAKOULU),
+      PalveluJaOikeus("KOSKI", Rooli.GLOBAALI_LUKU_MUU_KUIN_SAANNELTY),
+      PalveluJaOikeus("KOSKI", Rooli.GLOBAALI_LUKU_TAITEENPERUSOPETUS),
+    )))
   )
 
   val tilastokeskusKäyttäjä = KoskiMockUser(
@@ -529,6 +551,7 @@ object MockUsers {
     korkeakouluViranomainen,
     migriKäyttäjä,
     suomiFiKäyttäjä,
+    hslKäyttäjä,
     tilastokeskusKäyttäjä,
     valviraKäyttäjä,
     esiopetusTallentaja,

--- a/src/main/scala/fi/oph/koski/koskiuser/RequiresMigri.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/RequiresMigri.scala
@@ -1,0 +1,22 @@
+package fi.oph.koski.koskiuser
+
+import fi.oph.koski.http.KoskiErrorCategory
+
+trait RequiresMigri extends KoskiSpecificAuthenticationSupport {
+  implicit def koskiSession: KoskiSpecificSession = koskiSessionOption.get
+
+  before() {
+    requiresMigri
+  }
+
+  private def requiresMigri {
+    getUser match {
+      case Left(status) if status.statusCode == 401 =>
+        haltWithStatus(status)
+      case _ =>
+        if (!koskiSessionOption.exists(_.hasMigriAccess)) {
+          haltWithStatus(KoskiErrorCategory.forbidden())
+        }
+    }
+  }
+}

--- a/src/main/scala/fi/oph/koski/koskiuser/RequiresPalveluvayla.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/RequiresPalveluvayla.scala
@@ -2,7 +2,7 @@ package fi.oph.koski.koskiuser
 
 import fi.oph.koski.http.KoskiErrorCategory
 
-trait RequiresLuovutuspalvelu extends KoskiSpecificAuthenticationSupport {
+trait RequiresPalveluvayla extends KoskiSpecificAuthenticationSupport {
   implicit def koskiSession: KoskiSpecificSession = koskiSessionOption.get
 
   before() {
@@ -10,8 +10,8 @@ trait RequiresLuovutuspalvelu extends KoskiSpecificAuthenticationSupport {
       case Left(status) if status.statusCode == 401 =>
         haltWithStatus(status)
       case _ =>
-        if (!koskiSessionOption.exists(_.hasLuovutuspalveluAccess)) {
-          haltWithStatus(KoskiErrorCategory.forbidden.vainViranomainen())
+        if (!koskiSessionOption.exists(_.hasPalveluvaylaAccess)) {
+          haltWithStatus(KoskiErrorCategory.forbidden.vainPalveluvayla())
         }
     }
   }

--- a/src/main/scala/fi/oph/koski/koskiuser/Session.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/Session.scala
@@ -77,8 +77,7 @@ class KoskiSpecificSession(
   // HUOM!
   // Kun lisäät uuden luovutuspalvelukäyttöoikeuden alle, muista lisätä se myös
   // KoskiSpecificAuthenticationSupport.requireVirkailijaOrPalvelukäyttäjä -metodiin
-  // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-  def hasLuovutuspalveluAccess: Boolean = globalViranomaisKäyttöoikeudet.exists(_.isLuovutusPalveluAllowed)
+  def hasPalveluvaylaAccess: Boolean = globalViranomaisKäyttöoikeudet.exists(_.isPalveluvaylaAllowed)
   def hasTilastokeskusAccess: Boolean = globalViranomaisKäyttöoikeudet.flatMap(_.globalPalveluroolit).contains(Palvelurooli("KOSKI", TILASTOKESKUS))
   def hasMitätöidytOpiskeluoikeudetAccess: Boolean = hasTilastokeskusAccess || hasYtlAccess || globalKäyttöoikeudet.exists(_.globalPalveluroolit.exists(_.rooli == MITATOIDYT_OPISKELUOIKEUDET))
   def hasPoistetutOpiskeluoikeudetAccess: Boolean = globalKäyttöoikeudet.exists(_.globalPalveluroolit.exists(_.rooli == POISTETUT_OPISKELUOIKEUDET))

--- a/src/main/scala/fi/oph/koski/koskiuser/Session.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/Session.scala
@@ -83,6 +83,7 @@ class KoskiSpecificSession(
   def hasMitätöidytOpiskeluoikeudetAccess: Boolean = hasTilastokeskusAccess || hasYtlAccess || globalKäyttöoikeudet.exists(_.globalPalveluroolit.exists(_.rooli == MITATOIDYT_OPISKELUOIKEUDET))
   def hasPoistetutOpiskeluoikeudetAccess: Boolean = globalKäyttöoikeudet.exists(_.globalPalveluroolit.exists(_.rooli == POISTETUT_OPISKELUOIKEUDET))
   def hasValviraAccess: Boolean = globalViranomaisKäyttöoikeudet.flatMap(_.globalPalveluroolit).contains(Palvelurooli("KOSKI", VALVIRA))
+  def hasMigriAccess: Boolean = globalViranomaisKäyttöoikeudet.flatMap(_.globalPalveluroolit).contains(Palvelurooli("KOSKI", MIGRI))
   def hasKelaAccess: Boolean = !globalViranomaisKäyttöoikeudet.flatMap(_.globalPalveluroolit).intersect(Set(Palvelurooli("KOSKI", LUOTTAMUKSELLINEN_KELA_LAAJA), Palvelurooli("KOSKI", LUOTTAMUKSELLINEN_KELA_SUPPEA))).isEmpty
   def hasYtlAccess: Boolean = globalViranomaisKäyttöoikeudet.flatMap(_.globalPalveluroolit).contains(Palvelurooli("KOSKI", YTL))
   // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/main/scala/fi/oph/koski/luovutuspalvelu/PalveluvaylaServlet.scala
+++ b/src/main/scala/fi/oph/koski/luovutuspalvelu/PalveluvaylaServlet.scala
@@ -2,13 +2,13 @@ package fi.oph.koski.luovutuspalvelu
 
 import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.http.KoskiErrorCategory
-import fi.oph.koski.koskiuser.RequiresLuovutuspalvelu
+import fi.oph.koski.koskiuser.RequiresPalveluvayla
 import fi.oph.koski.schema.LocalizedString
 import fi.oph.koski.servlet.NoCache
 
 import scala.xml.{Elem, Node, NodeSeq}
 
-class PalveluvaylaServlet(implicit val application: KoskiApplication) extends SoapServlet with RequiresLuovutuspalvelu with NoCache {
+class PalveluvaylaServlet(implicit val application: KoskiApplication) extends SoapServlet with RequiresPalveluvayla with NoCache {
   private val suomiFiService = new SuomiFiService(application)
 
   post("/suomi-fi-rekisteritiedot") {

--- a/src/main/scala/fi/oph/koski/migri/MigriServlet.scala
+++ b/src/main/scala/fi/oph/koski/migri/MigriServlet.scala
@@ -10,7 +10,7 @@ import fi.oph.koski.servlet.{KoskiSpecificApiServlet, NoCache, RawJsonResponse}
 import org.json4s.JValue
 import org.scalatra.auth.strategy.BasicAuthStrategy.BasicAuthRequest
 
-class MigriServlet(implicit val application: KoskiApplication) extends KoskiSpecificApiServlet with RequiresLuovutuspalvelu with NoCache {
+class MigriServlet(implicit val application: KoskiApplication) extends KoskiSpecificApiServlet with RequiresMigri with NoCache {
   lazy val migriService =
     if (Environment.isMockEnvironment(application.config)) new MockMigriService else new RemoteMigriService
 

--- a/src/main/scala/fi/oph/koski/mydata/ApiProxyServlet.scala
+++ b/src/main/scala/fi/oph/koski/mydata/ApiProxyServlet.scala
@@ -4,16 +4,16 @@ import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.henkilo.Hetu
 import fi.oph.koski.http.{HttpStatus, JsonErrorMessage, KoskiErrorCategory}
 import fi.oph.koski.json.JsonSerializer
-import fi.oph.koski.koskiuser.RequiresLuovutuspalvelu
+import fi.oph.koski.koskiuser.RequiresPalveluvayla
 import fi.oph.koski.log.Logging
 import fi.oph.koski.schema.TäydellisetHenkilötiedot
 import fi.oph.koski.schema.filter.MyDataOppija
-import fi.oph.koski.servlet.{KoskiSpecificApiServlet, InvalidRequestException, NoCache}
+import fi.oph.koski.servlet.{InvalidRequestException, KoskiSpecificApiServlet, NoCache}
 import org.scalatra.ContentEncodingSupport
 
 
 class ApiProxyServlet(implicit val application: KoskiApplication) extends KoskiSpecificApiServlet
-  with Logging with ContentEncodingSupport with NoCache with MyDataSupport with RequiresLuovutuspalvelu {
+  with Logging with ContentEncodingSupport with NoCache with MyDataSupport with RequiresPalveluvayla {
 
   post("/") {
     val memberId = getMemberId

--- a/src/main/scala/fi/oph/koski/organisaatio/MockOrganisaatioRepository.scala
+++ b/src/main/scala/fi/oph/koski/organisaatio/MockOrganisaatioRepository.scala
@@ -60,6 +60,8 @@ object MockOrganisaatiot {
   val tilastokeskus = "1.2.246.562.10.35939310928"
   val migri = "1.2.246.562.10.31453145314"
   val valvira = "1.2.246.562.10.52577249361"
+  val hsl = "1.2.246.562.10.31453145314"
+  val suomifi = "1.2.246.562.10.31453145314"
   val kuopionAikuislukio = "1.2.246.562.10.42923230215"
   val kallavedenLukio = "1.2.246.562.10.63813695861"
   object EuropeanSchoolOfHelsinki {

--- a/src/main/scala/fi/oph/koski/organisaatio/MockOrganisaatioRepository.scala
+++ b/src/main/scala/fi/oph/koski/organisaatio/MockOrganisaatioRepository.scala
@@ -58,6 +58,7 @@ object MockOrganisaatiot {
   val kiipulanAmmattiopistoNokianToimipaikka = "1.2.246.562.10.28100171934"
   val länsirannikonKoulutusOy = "1.2.246.562.10.82246911869"
   val tilastokeskus = "1.2.246.562.10.35939310928"
+  val migri = "1.2.246.562.10.31453145314"
   val valvira = "1.2.246.562.10.52577249361"
   val kuopionAikuislukio = "1.2.246.562.10.42923230215"
   val kallavedenLukio = "1.2.246.562.10.63813695861"

--- a/src/main/scala/fi/oph/koski/schema/FilterNonAnnotationableSensitiveData.scala
+++ b/src/main/scala/fi/oph/koski/schema/FilterNonAnnotationableSensitiveData.scala
@@ -43,7 +43,7 @@ object FilterNonAnnotationableSensitiveData {
         val lisätiedot = if(lisätiedollinen.lisätiedot.nonEmpty) {
           Some(lisätiedollinen.lisätiedot.toList.flatten.filter(
             _.tunniste.koodiarvo != "mukautettu" ||
-              user.sensitiveDataAllowed(Set(Rooli.LUOTTAMUKSELLINEN_KAIKKI_TIEDOT, Rooli.MIGRI))
+              user.sensitiveDataAllowed(Set(Rooli.LUOTTAMUKSELLINEN_KAIKKI_TIEDOT, Rooli.MIGRI, Rooli.HSL, Rooli.SUOMIFI))
           ))
         } else {
           None

--- a/src/main/scala/fi/oph/koski/schema/FilterNonAnnotationableSensitiveData.scala
+++ b/src/main/scala/fi/oph/koski/schema/FilterNonAnnotationableSensitiveData.scala
@@ -43,7 +43,7 @@ object FilterNonAnnotationableSensitiveData {
         val lisätiedot = if(lisätiedollinen.lisätiedot.nonEmpty) {
           Some(lisätiedollinen.lisätiedot.toList.flatten.filter(
             _.tunniste.koodiarvo != "mukautettu" ||
-              user.sensitiveDataAllowed(Set(Rooli.LUOTTAMUKSELLINEN_KAIKKI_TIEDOT, Rooli.TIEDONSIIRTO_LUOVUTUSPALVELU))
+              user.sensitiveDataAllowed(Set(Rooli.LUOTTAMUKSELLINEN_KAIKKI_TIEDOT, Rooli.MIGRI))
           ))
         } else {
           None

--- a/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
+++ b/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
@@ -207,7 +207,7 @@ case class Lukukausi_Ilmoittautumisjakso(
   @KoodistoUri("virtalukukausiilmtila")
   tila: Koodistokoodiviite,
   ylioppilaskunnanJäsen: Option[Boolean] = None,
-  @SensitiveData(Set(Rooli.TIEDONSIIRTO_LUOVUTUSPALVELU))
+  @SensitiveData(Set(Rooli.MIGRI))
   @Deprecated("Ei käytössä 1.1.2021 eteenpäin")
   ythsMaksettu: Option[Boolean] = None,
   @Title("Lukuvuosimaksu")

--- a/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
+++ b/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
@@ -207,7 +207,7 @@ case class Lukukausi_Ilmoittautumisjakso(
   @KoodistoUri("virtalukukausiilmtila")
   tila: Koodistokoodiviite,
   ylioppilaskunnanJäsen: Option[Boolean] = None,
-  @SensitiveData(Set(Rooli.MIGRI))
+  @SensitiveData(Set(Rooli.MIGRI, Rooli.HSL, Rooli.SUOMIFI))
   @Deprecated("Ei käytössä 1.1.2021 eteenpäin")
   ythsMaksettu: Option[Boolean] = None,
   @Title("Lukuvuosimaksu")

--- a/src/main/scala/fi/oph/koski/userdirectory/DirectoryClient.scala
+++ b/src/main/scala/fi/oph/koski/userdirectory/DirectoryClient.scala
@@ -61,6 +61,10 @@ object DirectoryClient {
     roolit.exists(r => Rooli.globaalitKoulutusmuotoRoolit.contains(r.rooli)) ||
       roolit.exists {
         case Palvelurooli("KOSKI", Rooli.MIGRI) => true
+        case Palvelurooli("KOSKI", Rooli.TILASTOKESKUS) => true
+        case Palvelurooli("KOSKI", Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA) => true
+        case Palvelurooli("KOSKI", Rooli.LUOTTAMUKSELLINEN_KELA_SUPPEA) => true
+        case Palvelurooli("KOSKI", Rooli.VALVIRA) => true
         case Palvelurooli("VALPAS", ValpasRooli.YTL) => true
         case Palvelurooli("VALPAS", ValpasRooli.KELA) => true
         case _ => false

--- a/src/main/scala/fi/oph/koski/userdirectory/DirectoryClient.scala
+++ b/src/main/scala/fi/oph/koski/userdirectory/DirectoryClient.scala
@@ -60,7 +60,7 @@ object DirectoryClient {
   private def hasViranomaisRooli(roolit: List[Palvelurooli]) =
     roolit.exists(r => Rooli.globaalitKoulutusmuotoRoolit.contains(r.rooli)) ||
       roolit.exists {
-        case Palvelurooli("KOSKI", Rooli.TIEDONSIIRTO_LUOVUTUSPALVELU) => true
+        case Palvelurooli("KOSKI", Rooli.MIGRI) => true
         case Palvelurooli("VALPAS", ValpasRooli.YTL) => true
         case Palvelurooli("VALPAS", ValpasRooli.KELA) => true
         case _ => false

--- a/src/test/scala/fi/oph/koski/api/misc/KäyttöoikeusryhmätSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/misc/KäyttöoikeusryhmätSpec.scala
@@ -341,10 +341,6 @@ class KäyttöoikeusryhmätSpec
     }
   }
 
-  "viranomainen jolla luovutuspalveluoikeudet ei voi kutsua muita apeja" - {
-    verifyMuidenApienKutsuminenEstetty(MockUsers.luovutuspalveluKäyttäjä)
-  }
-
   "Kela ei voi kutsua muita apeja" in {
     verifyMuidenApienKutsuminenEstetty(MockUsers.kelaLaajatOikeudet)
     verifyMuidenApienKutsuminenEstetty(MockUsers.kelaSuppeatOikeudet)
@@ -358,11 +354,8 @@ class KäyttöoikeusryhmätSpec
     verifyMuidenApienKutsuminenEstetty(MockUsers.valviraKäyttäjä)
   }
 
-  "viranomainen jolla ei ole luovutuspalveluoikeuksia ei voi kutsua migrin apia" - {
-    val requestBody = MigriHetuRequest(KoskiSpecificMockOppijat.eero.hetu.get)
-    post("api/luovutuspalvelu/migri/hetu", JsonSerializer.writeWithRoot(requestBody), headers = authHeaders(MockUsers.perusopetusViranomainen) ++ jsonContent) {
-      verifyResponseStatus(403, KoskiErrorCategory.forbidden.vainViranomainen())
-    }
+  "Migri ei voi kutsua muita apeja" in {
+    verifyMuidenApienKutsuminenEstetty(MockUsers.migriKäyttäjä)
   }
 
   private def verifyMuidenApienKutsuminenEstetty(user: MockUser) = {

--- a/src/test/scala/fi/oph/koski/json/SensitiveAndRedundantDataFilterSpec.scala
+++ b/src/test/scala/fi/oph/koski/json/SensitiveAndRedundantDataFilterSpec.scala
@@ -86,7 +86,7 @@ class SensitiveAndRedundantDataFilterSpec extends AnyFreeSpec with TestEnvironme
   }
 
   "Käyttäjä jolla on uusi kaikkiin luottamuksellisiin tietoihin oikeuttava käyttöoikeus näkee kaikki arkaluontoiset tiedot" in {
-    implicit val kaikkiOikeudet = MockUsers.luovutuspalveluKäyttäjäArkaluontoinen.toKoskiSpecificSession(käyttöoikeusRepository)
+    implicit val kaikkiOikeudet = MockUsers.tilastokeskusKäyttäjä.toKoskiSpecificSession(käyttöoikeusRepository)
     roundtrip[AikuistenPerusopetuksenOpiskeluoikeudenLisätiedot](aikuistenPerusopetuksenOpiskeluoikeudenLisätiedot) should equal(AikuistenPerusopetuksenOpiskeluoikeudenLisätiedot(sisäoppilaitosmainenMajoitus = aikajaksot))
     roundtrip[AmmatillisenOpiskeluoikeudenLisätiedot](ammatillisenOpiskeluoikeudenLisätiedot) should equal(ammatillisenOpiskeluoikeudenLisätiedot.copy(oikeusMaksuttomaanAsuntolapaikkaan = None))
     roundtrip[DIAOpiskeluoikeudenLisätiedot](diaOpiskeluoikeudenLisätiedot) should equal(diaOpiskeluoikeudenLisätiedot)

--- a/src/test/scala/fi/oph/koski/koskiuser/KoskiSpecificSessionSpec.scala
+++ b/src/test/scala/fi/oph/koski/koskiuser/KoskiSpecificSessionSpec.scala
@@ -421,7 +421,7 @@ object Responses {
       "organisaatiot" -> List(Map(
         "organisaatioOid" -> MockOrganisaatiot.migri,
         "kayttooikeudet" -> List(
-          Map("palvelu" -> "KOSKI", "oikeus" -> "MIGRI_RAJAPINTA_LUKUOIKEUS"),
+          Map("palvelu" -> "KOSKI", "oikeus" -> "MIGRI"),
           Map("palvelu" -> "KOSKI", "oikeus" -> "GLOBAALI_LUKU_PERUSOPETUS"),
           Map("palvelu" -> "KOSKI", "oikeus" -> "GLOBAALI_LUKU_TOINEN_ASTE"),
           Map("palvelu" -> "KOSKI", "oikeus" -> "GLOBAALI_LUKU_KORKEAKOULU"),

--- a/src/test/scala/fi/oph/koski/koskiuser/KoskiSpecificSessionSpec.scala
+++ b/src/test/scala/fi/oph/koski/koskiuser/KoskiSpecificSessionSpec.scala
@@ -140,13 +140,12 @@ class KoskiSpecificSessionSpec
         val session = createAndVerifySession("Kaisa", MockUsers.korkeakouluViranomainen.ldapUser)
         session.allowedOpiskeluoikeusTyypit should equal(Set(OpiskeluoikeudenTyyppi.korkeakoulutus.koodiarvo))
       }
-      "luovutuspalvelu arkaluontoisten tietojen oikeus" in {
-        val session = createAndVerifySession("Antti", MockUsers.luovutuspalveluKäyttäjäArkaluontoinen.ldapUser)
-        session.hasLuovutuspalveluAccess should be(true)
+      "tilastokeskus saa arkaluontoisenkin datan" in {
+        val session = createAndVerifySession("Teppo", MockUsers.tilastokeskusKäyttäjä.ldapUser)
         session.sensitiveDataAllowed(Set(Rooli.LUOTTAMUKSELLINEN_KAIKKI_TIEDOT)) should be(true)
       }
-      "luovutuspalvelu ei arkaluontoisten tietojen oikeuksia" in {
-        val session = createAndVerifySession("Lasse", MockUsers.luovutuspalveluKäyttäjä.ldapUser)
+      "migrillä ei arkaluontoisten tietojen oikeuksia" in {
+        val session = createAndVerifySession("Migri", MockUsers.migriKäyttäjä.ldapUser)
         session.hasLuovutuspalveluAccess should be(true)
         session.sensitiveDataAllowed(Set(Rooli.LUOTTAMUKSELLINEN_KAIKKI_TIEDOT)) should be(false)
       }
@@ -207,7 +206,7 @@ class KoskiSpecificSessionSpec
   private def mockEndpoints = {
     val käyttöoikeusUrl = "/kayttooikeus-service/kayttooikeus/kayttaja"
     def henkilöUrl(username: String) = {
-      val oid = MockUsers.users.find(_.username == username).map(_.oid).get
+      val oid = MockUsers.users.find(_.username == username).map(_.oid).getOrElse(throw new Exception("No oid found for user " + username))
       s"/oppijanumerorekisteri-service/henkilo/$oid"
     }
 
@@ -393,6 +392,20 @@ object Responses {
         "kayttooikeudet" -> List(Map("palvelu" -> "OPPIJANUMEROREKISTERI", "oikeus" -> "REKISTERINPITAJA"))
       ))
     )),
+    "Teppo" -> List(Map(
+      "oidHenkilo" -> MockUsers.tilastokeskusKäyttäjä.oid,
+      "organisaatiot" -> List(Map(
+        "organisaatioOid" -> MockOrganisaatiot.evira,
+        "kayttooikeudet" -> List(
+          Map("palvelu" -> "KOSKI", "oikeus" -> "TILASTOKESKUS"),
+          Map("palvelu" -> "KOSKI", "oikeus" -> "LUOTTAMUKSELLINEN_KAIKKI_TIEDOT"),
+          Map("palvelu" -> "KOSKI", "oikeus" -> "GLOBAALI_LUKU_PERUSOPETUS"),
+          Map("palvelu" -> "KOSKI", "oikeus" -> "GLOBAALI_LUKU_TOINEN_ASTE"),
+          Map("palvelu" -> "KOSKI", "oikeus" -> "GLOBAALI_LUKU_KORKEAKOULU"),
+          Map("palvelu" -> "KOSKI", "oikeus" -> "GLOBAALI_LUKU_MUU_KUIN_SAANNELTY"),
+          Map("palvelu" -> "KOSKI", "oikeus" -> "GLOBAALI_LUKU_TAITEENPERUSOPETUS"))
+      ))
+    )),
     "Kaisa" -> List(Map(
       "oidHenkilo" -> MockUsers.korkeakouluViranomainen.oid,
       "organisaatiot" -> List(Map(
@@ -404,31 +417,17 @@ object Responses {
         "kayttooikeudet" -> List()
       ))
     )),
-    "Antti" -> List(Map(
-      "oidHenkilo" -> MockUsers.luovutuspalveluKäyttäjäArkaluontoinen.oid,
+    "Migri" -> List(Map(
+      "oidHenkilo" -> MockUsers.migriKäyttäjä.oid,
       "organisaatiot" -> List(Map(
-        "organisaatioOid" -> MockOrganisaatiot.evira,
+        "organisaatioOid" -> MockOrganisaatiot.migri,
         "kayttooikeudet" -> List(
-          Map("palvelu" -> "KOSKI", "oikeus" -> "TIEDONSIIRTO_LUOVUTUSPALVELU"),
-          Map("palvelu" -> "KOSKI", "oikeus" -> "LUOTTAMUKSELLINEN_KAIKKI_TIEDOT"),
+          Map("palvelu" -> "KOSKI", "oikeus" -> "MIGRI_RAJAPINTA_LUKUOIKEUS"),
           Map("palvelu" -> "KOSKI", "oikeus" -> "GLOBAALI_LUKU_PERUSOPETUS"),
           Map("palvelu" -> "KOSKI", "oikeus" -> "GLOBAALI_LUKU_TOINEN_ASTE"),
           Map("palvelu" -> "KOSKI", "oikeus" -> "GLOBAALI_LUKU_KORKEAKOULU"),
           Map("palvelu" -> "KOSKI", "oikeus" -> "GLOBAALI_LUKU_MUU_KUIN_SAANNELTY"),
           Map("palvelu" -> "KOSKI", "oikeus" -> "GLOBAALI_LUKU_TAITEENPERUSOPETUS"))
-      ))
-    )),
-    "Lasse" -> List(Map(
-      "oidHenkilo" -> MockUsers.luovutuspalveluKäyttäjä.oid,
-      "organisaatiot" -> List(Map(
-        "organisaatioOid" -> MockOrganisaatiot.evira,
-        "kayttooikeudet" -> List(
-          Map("palvelu" -> "KOSKI", "oikeus" -> "TIEDONSIIRTO_LUOVUTUSPALVELU"),
-          Map("palvelu" -> "KOSKI", "oikeus" -> "GLOBAALI_LUKU_PERUSOPETUS"),
-          Map("palvelu" -> "KOSKI", "oikeus" -> "GLOBAALI_LUKU_TOINEN_ASTE"),
-          Map("palvelu" -> "KOSKI", "oikeus" -> "GLOBAALI_LUKU_KORKEAKOULU"),
-          Map("palvelu" -> "KOSKI", "oikeus" -> "GLOBAALI_LUKU_MUU_KUIN_SAANNELTY"),
-          Map("palvelu" -> "KOSKI", "oikeus" -> "GLOBAALI_LUKU_TAITEENPERUSOPETUS")),
       ))
     )),
     "esiopetus" -> List(Map(

--- a/src/test/scala/fi/oph/koski/koskiuser/KoskiSpecificSessionSpec.scala
+++ b/src/test/scala/fi/oph/koski/koskiuser/KoskiSpecificSessionSpec.scala
@@ -146,7 +146,6 @@ class KoskiSpecificSessionSpec
       }
       "migrillä ei arkaluontoisten tietojen oikeuksia" in {
         val session = createAndVerifySession("Migri", MockUsers.migriKäyttäjä.ldapUser)
-        session.hasLuovutuspalveluAccess should be(true)
         session.sensitiveDataAllowed(Set(Rooli.LUOTTAMUKSELLINEN_KAIKKI_TIEDOT)) should be(false)
       }
     }

--- a/src/test/scala/fi/oph/koski/luovutuspalvelu/PalveluvaylaSpec.scala
+++ b/src/test/scala/fi/oph/koski/luovutuspalvelu/PalveluvaylaSpec.scala
@@ -19,13 +19,13 @@ class PalveluvaylaSpec extends AnyFreeSpec with KoskiHttpSpec with Opiskeluoikeu
 
     "vaatii suomi.fi käyttäjän" in {
       MockUsers.users
-        .diff(List(MockUsers.luovutuspalveluKäyttäjäArkaluontoinen, MockUsers.luovutuspalveluKäyttäjä, MockUsers.suomiFiKäyttäjä))
+        .diff(List(MockUsers.migriKäyttäjä, MockUsers.tilastokeskusKäyttäjä, MockUsers.migriKäyttäjä, MockUsers.suomiFiKäyttäjä))
         .foreach { user =>
           postSuomiFiRekisteritiedot(user, KoskiSpecificMockOppijat.ylioppilas.hetu.get) {
             verifySOAPError("forbidden.vainViranomainen", "Sallittu vain viranomaisille")
           }
         }
-      postSuomiFiRekisteritiedot(MockUsers.luovutuspalveluKäyttäjä, KoskiSpecificMockOppijat.ylioppilas.hetu.get) {
+      postSuomiFiRekisteritiedot(MockUsers.migriKäyttäjä, KoskiSpecificMockOppijat.ylioppilas.hetu.get) {
         verifySOAPError("forbidden.kiellettyKäyttöoikeus", "Ei sallittu näillä käyttöoikeuksilla")
       }
       postSuomiFiRekisteritiedot(MockUsers.suomiFiKäyttäjä, KoskiSpecificMockOppijat.ylioppilas.hetu.get) {

--- a/src/test/scala/fi/oph/koski/luovutuspalvelu/PalveluvaylaSpec.scala
+++ b/src/test/scala/fi/oph/koski/luovutuspalvelu/PalveluvaylaSpec.scala
@@ -19,15 +19,12 @@ class PalveluvaylaSpec extends AnyFreeSpec with KoskiHttpSpec with Opiskeluoikeu
 
     "vaatii suomi.fi käyttäjän" in {
       MockUsers.users
-        .diff(List(MockUsers.migriKäyttäjä, MockUsers.tilastokeskusKäyttäjä, MockUsers.migriKäyttäjä, MockUsers.suomiFiKäyttäjä))
+        .diff(List(MockUsers.suomiFiKäyttäjä, MockUsers.hslKäyttäjä))
         .foreach { user =>
           postSuomiFiRekisteritiedot(user, KoskiSpecificMockOppijat.ylioppilas.hetu.get) {
-            verifySOAPError("forbidden.vainViranomainen", "Sallittu vain viranomaisille")
+            verifySOAPError("forbidden.vainPalveluvayla", "Sallittu vain palveluväyläkäyttäjälle")
           }
         }
-      postSuomiFiRekisteritiedot(MockUsers.migriKäyttäjä, KoskiSpecificMockOppijat.ylioppilas.hetu.get) {
-        verifySOAPError("forbidden.kiellettyKäyttöoikeus", "Ei sallittu näillä käyttöoikeuksilla")
-      }
       postSuomiFiRekisteritiedot(MockUsers.suomiFiKäyttäjä, KoskiSpecificMockOppijat.ylioppilas.hetu.get) {
         verifyResponseStatusOk()
       }

--- a/src/test/scala/fi/oph/koski/luovutuspalvelu/TilastokeskusSpec.scala
+++ b/src/test/scala/fi/oph/koski/luovutuspalvelu/TilastokeskusSpec.scala
@@ -67,7 +67,7 @@ class TilastokeskusSpec extends AnyFreeSpec with KoskiHttpSpec with Opiskeluoike
 
     "TILASTOKESKUS-käyttöoikeus ei toimi muualla" in {
       post("api/luovutuspalvelu/migri/hetu", JsonSerializer.writeWithRoot(MigriHetuRequest(KoskiSpecificMockOppijat.eero.hetu.get)), headers = authHeaders(MockUsers.tilastokeskusKäyttäjä) ++ jsonContent) {
-        verifyResponseStatus(403, KoskiErrorCategory.forbidden.vainViranomainen())
+        verifyResponseStatus(403, KoskiErrorCategory.forbidden("Käyttäjällä ei ole oikeuksia annetun organisaation tietoihin."))
       }
       authGet ("api/oppija", MockUsers.tilastokeskusKäyttäjä) {
         verifyResponseStatus(403, KoskiErrorCategory.forbidden.kiellettyKäyttöoikeus("Ei sallittu luovutuspalvelukäyttöoikeuksilla"))

--- a/src/test/scala/fi/oph/koski/migri/MigriServletSpec.scala
+++ b/src/test/scala/fi/oph/koski/migri/MigriServletSpec.scala
@@ -14,7 +14,7 @@ class MigriServletSpec extends AnyFreeSpec with KoskiHttpSpec with HttpSpecifica
       post(
         uri = "api/luovutuspalvelu/migri/hetu",
         body = "{\"hetu\": \"211097-402L\"}",
-        headers = authHeaders(MockUsers.luovutuspalveluKäyttäjä) ++ jsonContent
+        headers = authHeaders(MockUsers.migriKäyttäjä) ++ jsonContent
       ) {
         verifyResponseStatusOk()
         response.body should include ("1.2.246.562.24.00000000026")
@@ -25,7 +25,7 @@ class MigriServletSpec extends AnyFreeSpec with KoskiHttpSpec with HttpSpecifica
       post(
         uri = "api/luovutuspalvelu/migri/oid",
         body = "{\"oid\": \"1.2.246.562.24.00000000026\"}",
-        headers = authHeaders(MockUsers.luovutuspalveluKäyttäjä) ++ jsonContent
+        headers = authHeaders(MockUsers.migriKäyttäjä) ++ jsonContent
       ) {
         verifyResponseStatusOk()
         response.body should include ("211097-402L")
@@ -36,10 +36,10 @@ class MigriServletSpec extends AnyFreeSpec with KoskiHttpSpec with HttpSpecifica
       post(
         uri = "api/luovutuspalvelu/migri/valinta/oid",
         body = "{\"oids\": [\"1.2.246.562.24.51986460849\"]}",
-        headers = authHeaders(MockUsers.luovutuspalveluKäyttäjä) ++ jsonContent
+        headers = authHeaders(MockUsers.migriKäyttäjä) ++ jsonContent
       ) {
         verifyResponseStatusOk()
-        response.body should equal("{\"oids\":[\"1.2.246.562.24.51986460849\"],\"username\":\"Lasse\",\"password\":\"Lasse\"}")
+        response.body should equal("{\"oids\":[\"1.2.246.562.24.51986460849\"],\"username\":\"Migri\",\"password\":\"Migri\"}")
       }
     }
 
@@ -47,10 +47,10 @@ class MigriServletSpec extends AnyFreeSpec with KoskiHttpSpec with HttpSpecifica
       post(
         uri = "api/luovutuspalvelu/migri/valinta/hetut",
         body = "{\"hetut\": [\"170249-378D\"]}",
-        headers = authHeaders(MockUsers.luovutuspalveluKäyttäjä) ++ jsonContent
+        headers = authHeaders(MockUsers.migriKäyttäjä) ++ jsonContent
       ) {
         verifyResponseStatusOk()
-        response.body should equal("{\"hetus\":[\"170249-378D\"],\"username\":\"Lasse\",\"password\":\"Lasse\"}")
+        response.body should equal("{\"hetus\":[\"170249-378D\"],\"username\":\"Migri\",\"password\":\"Migri\"}")
       }
     }
   }

--- a/src/test/scala/fi/oph/koski/migri/MigriSpec.scala
+++ b/src/test/scala/fi/oph/koski/migri/MigriSpec.scala
@@ -16,7 +16,7 @@ import org.scalatest.matchers.should.Matchers
 
 class MigriSpec extends AnyFreeSpec with KoskiHttpSpec with OpiskeluoikeusTestMethodsAmmatillinen with Matchers with DirtiesFixtures {
 
-  val user = MockUsers.luovutuspalveluKäyttäjä
+  val user = MockUsers.migriKäyttäjä
 
   "Oppijaa ei löydy, palautetaan 404" in {
     postOid(eiKoskessa.oid, user) {

--- a/src/test/scala/fi/oph/koski/mydata/MyDataAPIProxyServletTest.scala
+++ b/src/test/scala/fi/oph/koski/mydata/MyDataAPIProxyServletTest.scala
@@ -72,17 +72,28 @@ class MyDataAPIProxyServletTest extends AnyFreeSpec with KoskiHttpSpec with Matc
     "Palauttaa 401 mikäli luovutuspalvelukäyttäjän tunnukset ovat väärät" in {
       KoskiApplicationForTests.mydataRepository.create(opiskelija.oid, memberId)
 
-      val wrongPasswordHeader = Map(basicAuthHeader(MockUsers.luovutuspalveluKäyttäjä.username, "wrong password"))
-      requestOpintoOikeudetWithoutAuthHeaders(opiskelija.hetu.get, wrongPasswordHeader ++ memberHeaders(memberCode)) {
-        status should equal(401)
-      }
+      val luovutuspalveluKäyttäjät = List(
+        MockUsers.ytlKäyttäjä,
+        MockUsers.valviraKäyttäjä,
+        MockUsers.kelaLaajatOikeudet,
+        MockUsers.kelaSuppeatOikeudet,
+        MockUsers.migriKäyttäjä,
+        MockUsers.tilastokeskusKäyttäjä
+      )
+
+      luovutuspalveluKäyttäjät.map(user => {
+        val wrongPasswordHeader = Map(basicAuthHeader(user.username, "wrong password"))
+        requestOpintoOikeudetWithoutAuthHeaders(opiskelija.hetu.get, wrongPasswordHeader ++ memberHeaders(memberCode)) {
+          status should equal(401)
+        }
+      })
     }
   }
 
   def memberHeaders(memberCode: String) = Map("X-ROAD-MEMBER" -> memberCode)
 
   def requestOpintoOikeudet[A](hetu: String, headers: Map[String, String])(f: => A) = {
-    requestOpintoOikeudetWithoutAuthHeaders(hetu, headers ++ authHeaders(MockUsers.luovutuspalveluKäyttäjä))(f)
+    requestOpintoOikeudetWithoutAuthHeaders(hetu, headers ++ authHeaders(MockUsers.migriKäyttäjä))(f)
   }
 
   def requestOpintoOikeudetWithoutAuthHeaders[A](hetu: String, headers: Map[String, String])(f: => A) = {

--- a/src/test/scala/fi/oph/koski/mydata/MyDataAPIProxyServletTest.scala
+++ b/src/test/scala/fi/oph/koski/mydata/MyDataAPIProxyServletTest.scala
@@ -18,6 +18,20 @@ class MyDataAPIProxyServletTest extends AnyFreeSpec with KoskiHttpSpec with Matc
   val memberId = "hsl"
   val memberCode = "2769790-1" // HSL
 
+  val luovutuspalveluKäyttäjät = List(
+    MockUsers.ytlKäyttäjä,
+    MockUsers.valviraKäyttäjä,
+    MockUsers.kelaLaajatOikeudet,
+    MockUsers.kelaSuppeatOikeudet,
+    MockUsers.migriKäyttäjä,
+    MockUsers.tilastokeskusKäyttäjä
+  )
+
+  val palveluväyläKäyttäjät = List(
+    MockUsers.suomiFiKäyttäjä,
+    MockUsers.hslKäyttäjä
+  )
+
   def application = KoskiApplicationForTests
 
   "ApiProxyServlet" - {
@@ -72,19 +86,31 @@ class MyDataAPIProxyServletTest extends AnyFreeSpec with KoskiHttpSpec with Matc
     "Palauttaa 401 mikäli luovutuspalvelukäyttäjän tunnukset ovat väärät" in {
       KoskiApplicationForTests.mydataRepository.create(opiskelija.oid, memberId)
 
-      val luovutuspalveluKäyttäjät = List(
-        MockUsers.ytlKäyttäjä,
-        MockUsers.valviraKäyttäjä,
-        MockUsers.kelaLaajatOikeudet,
-        MockUsers.kelaSuppeatOikeudet,
-        MockUsers.migriKäyttäjä,
-        MockUsers.tilastokeskusKäyttäjä
-      )
-
       luovutuspalveluKäyttäjät.map(user => {
         val wrongPasswordHeader = Map(basicAuthHeader(user.username, "wrong password"))
         requestOpintoOikeudetWithoutAuthHeaders(opiskelija.hetu.get, wrongPasswordHeader ++ memberHeaders(memberCode)) {
           status should equal(401)
+        }
+      })
+    }
+
+    "Palauttaa 200 mikäli HSL tai SUOMIFI" in {
+      KoskiApplicationForTests.mydataRepository.create(opiskelija.oid, memberId)
+
+      palveluväyläKäyttäjät.map(user => {
+        requestOpintoOikeudetWithoutAuthHeaders(opiskelija.hetu.get, memberHeaders(memberCode) ++ authHeaders(user)) {
+          status should equal(200)
+        }
+      })
+    }
+
+    "Palauttaa 403 mikäli ei palveluväyläkäyttäjä" in {
+      KoskiApplicationForTests.mydataRepository.create(opiskelija.oid, memberId)
+
+      luovutuspalveluKäyttäjät.map(user => {
+        requestOpintoOikeudetWithoutAuthHeaders(opiskelija.hetu.get, memberHeaders(memberCode) ++ authHeaders(user)) {
+          status should equal(403)
+          body should include("Sallittu vain palveluväyläkäyttäjälle")
         }
       })
     }
@@ -93,7 +119,7 @@ class MyDataAPIProxyServletTest extends AnyFreeSpec with KoskiHttpSpec with Matc
   def memberHeaders(memberCode: String) = Map("X-ROAD-MEMBER" -> memberCode)
 
   def requestOpintoOikeudet[A](hetu: String, headers: Map[String, String])(f: => A) = {
-    requestOpintoOikeudetWithoutAuthHeaders(hetu, headers ++ authHeaders(MockUsers.migriKäyttäjä))(f)
+    requestOpintoOikeudetWithoutAuthHeaders(hetu, headers ++ authHeaders(MockUsers.suomiFiKäyttäjä))(f)
   }
 
   def requestOpintoOikeudetWithoutAuthHeaders[A](hetu: String, headers: Map[String, String])(f: => A) = {

--- a/src/test/scala/fi/oph/koski/valvira/ValviraSpec.scala
+++ b/src/test/scala/fi/oph/koski/valvira/ValviraSpec.scala
@@ -30,7 +30,7 @@ class ValviraSpec extends AnyFreeSpec with KoskiHttpSpec with OpiskeluoikeusTest
       }
     }
     "Kutsuminen vaatii VALVIRA-käyttöoikeuden" in {
-      getHetu(KoskiSpecificMockOppijat.amis.hetu.get, user = MockUsers.luovutuspalveluKäyttäjä) {
+      getHetu(KoskiSpecificMockOppijat.amis.hetu.get, user = MockUsers.migriKäyttäjä) {
         verifyResponseStatus(403, KoskiErrorCategory.forbidden())
       }
     }

--- a/src/test/scala/fi/oph/koski/ytl/YtlSpec.scala
+++ b/src/test/scala/fi/oph/koski/ytl/YtlSpec.scala
@@ -322,7 +322,7 @@ class YtlSpec
         KoskiSpecificMockOppijat.amis
       ).map(_.hetu.get)
 
-      postHetut(hetut, None, MockUsers.luovutuspalveluKäyttäjäArkaluontoinen) {
+      postHetut(hetut, None, MockUsers.tilastokeskusKäyttäjä) {
         verifyResponseStatus(403, KoskiErrorCategory.forbidden.kiellettyKäyttöoikeus("Ei sallittu näillä käyttöoikeuksilla"))
       }
     }


### PR DESCRIPTION
- Lisää uusi rooli Migrille ja käsittele luovutuspalvelukäyttäjänä. 
- Lisää myös roolit HSL ja SUOMIFI ja erota palveluväyläkäyttäjät muista luovutuspalvelun käyttäjistä.
- Poista rooli TIEDONSIIRTO_LUOVUTUSPALVELU
