### PR TITLE
TOR-2111: VST: Muokkaustoiminnallisuus tiedonsiirroilla siirretyissä opiskeluoikeuksissa ja KOSKI-pääkäyttäjän pystyttävä mitätöimään opiskeluoikeus

### DIFF
--- a/src/main/scala/fi/oph/koski/documentation/ExamplesVapaaSivistystyöJotpa.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesVapaaSivistystyöJotpa.scala
@@ -45,6 +45,11 @@ object ExamplesVapaaSivistystyöJotpa {
         )),
         suoritukset = List(PäätasonSuoritus.suoritettu),
       )
+
+    lazy val keskeneräinenLähdejärjestelmästä: VapaanSivistystyönOpiskeluoikeus =
+      keskeneräinen.copy(
+        lähdejärjestelmänId = Some(LähdejärjestelmäId(Some("12385493"), Koodistokoodiviite("primus", "lahdejarjestelma")))
+      )
   }
 
   object PäätasonSuoritus {

--- a/src/main/scala/fi/oph/koski/fixture/KoskiSpecificDatabaseFixtureCreator.scala
+++ b/src/main/scala/fi/oph/koski/fixture/KoskiSpecificDatabaseFixtureCreator.scala
@@ -302,7 +302,8 @@ class KoskiSpecificDatabaseFixtureCreator(application: KoskiApplication) extends
       (KoskiSpecificMockOppijat.ammatilliseenTetäväänValmistavaMuuAmmatillinenVahvistettu, MuunAmmatillisenKoulutuksenExample.ammatilliseenTehtäväänValmistavaKoulutusOpiskeluoikeusVahvistettu),
       (KoskiSpecificMockOppijat.jotpaMuuKuinSäänneltySuoritettu, ExamplesMuuKuinSäänneltyKoulutus.Opiskeluoikeus.suoritettu),
       (KoskiSpecificMockOppijat.lukioVajaaSuoritus, ExamplesLukio2019.aktiivinenVähänOpiskeltuOppiaineenOppimääräOpiskeluoikeus),
-      (KoskiSpecificMockOppijat.pelkkäESH, ExamplesEuropeanSchoolOfHelsinki.opiskeluoikeus)
+      (KoskiSpecificMockOppijat.pelkkäESH, ExamplesEuropeanSchoolOfHelsinki.opiskeluoikeus),
+      (KoskiSpecificMockOppijat.tiedonsiirto, ExamplesVapaaSivistystyöJotpa.Opiskeluoikeus.keskeneräinenLähdejärjestelmästä),
     )
   }
 

--- a/web/app/components-v2/access/RequiresWriteAccess.tsx
+++ b/web/app/components-v2/access/RequiresWriteAccess.tsx
@@ -1,5 +1,15 @@
 import React from 'react'
 import { useVirkailijaUser } from '../../appstate/user'
+import { Opiskeluoikeus } from '../../types/fi/oph/koski/schema/Opiskeluoikeus'
 
-export const RequiresWriteAccess: React.FC<React.PropsWithChildren> = (props) =>
-  useVirkailijaUser()?.hasWriteAccess ? <>{props.children}</> : null
+export type RequiresWriteAccessProps = React.PropsWithChildren<{
+  opiskeluoikeus: Opiskeluoikeus
+}>
+
+export const RequiresWriteAccess: React.FC<RequiresWriteAccessProps> = (
+  props
+) =>
+  useVirkailijaUser()?.hasWriteAccess &&
+  props.opiskeluoikeus.lähdejärjestelmänId === undefined ? (
+    <>{props.children}</>
+  ) : null

--- a/web/app/components-v2/opiskeluoikeus/OpiskeluoikeusEditToolbar.tsx
+++ b/web/app/components-v2/opiskeluoikeus/OpiskeluoikeusEditToolbar.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { useApiMethod, useOnApiSuccess } from '../../api-fetch'
+import { TestIdLayer, TestIdText } from '../../appstate/useTestId'
 import { formatDateRange } from '../../date/date'
 import { t } from '../../i18n/i18n'
 import { Opiskeluoikeus } from '../../types/fi/oph/koski/schema/Opiskeluoikeus'
@@ -10,7 +11,7 @@ import { Column, ColumnRow } from '../containers/Columns'
 import { FlatButton } from '../controls/FlatButton'
 import { RaisedButton } from '../controls/RaisedButton'
 import { Trans } from '../texts/Trans'
-import { TestIdLayer, TestIdRoot, TestIdText } from '../../appstate/useTestId'
+import { useVirkailijaUser } from '../../appstate/user'
 
 export type OpiskeluoikeusEditToolbarProps = {
   opiskeluoikeus: Opiskeluoikeus
@@ -22,8 +23,9 @@ export type OpiskeluoikeusEditToolbarProps = {
 export const OpiskeluoikeusEditToolbar = (
   props: OpiskeluoikeusEditToolbarProps
 ) => {
-  const spans = props.editMode ? [12, 12] : [21, 3]
+  const spans = props.editMode ? [12, 12] : [16, 8]
   const opiskeluoikeusOid = getOpiskeluoikeusOid(props.opiskeluoikeus)
+  const hasAnyInvalidateAccess = useVirkailijaUser()?.hasAnyInvalidateAccess
 
   return (
     <ColumnRow>
@@ -47,17 +49,17 @@ export const OpiskeluoikeusEditToolbar = (
         span={{ default: spans[1], phone: 24 }}
         align={{ default: 'right', phone: 'left' }}
       >
+        {hasAnyInvalidateAccess && props.invalidatable && opiskeluoikeusOid && (
+          <MitätöintiButton opiskeluoikeusOid={opiskeluoikeusOid} />
+        )}
         <RequiresWriteAccess opiskeluoikeus={props.opiskeluoikeus}>
-          {props.editMode ? (
-            props.invalidatable &&
-            opiskeluoikeusOid && (
-              <MitätöintiButton opiskeluoikeusOid={opiskeluoikeusOid} />
-            )
-          ) : (
+          {!props.editMode ? (
             <RaisedButton fullWidth onClick={props.onStartEdit} testId="edit">
               {'Muokkaa'}
             </RaisedButton>
-          )}
+          ) : opiskeluoikeusOid && !hasAnyInvalidateAccess ? (
+            <MitätöintiButton opiskeluoikeusOid={opiskeluoikeusOid} />
+          ) : null}
         </RequiresWriteAccess>
       </Column>
     </ColumnRow>

--- a/web/app/components-v2/opiskeluoikeus/OpiskeluoikeusEditToolbar.tsx
+++ b/web/app/components-v2/opiskeluoikeus/OpiskeluoikeusEditToolbar.tsx
@@ -47,7 +47,7 @@ export const OpiskeluoikeusEditToolbar = (
         span={{ default: spans[1], phone: 24 }}
         align={{ default: 'right', phone: 'left' }}
       >
-        <RequiresWriteAccess>
+        <RequiresWriteAccess opiskeluoikeus={props.opiskeluoikeus}>
           {props.editMode ? (
             props.invalidatable &&
             opiskeluoikeusOid && (

--- a/web/test/e2e/pages/oppija/KoskiVSTOppijaPage.ts
+++ b/web/test/e2e/pages/oppija/KoskiVSTOppijaPage.ts
@@ -98,6 +98,11 @@ export class KoskiVSTOppijaPage extends KoskiOppijaPageV2<
       this.$.suoritukset(this.suoritusIndex).suorituksenVahvistus
     )
   }
+
+  async mitätöi() {
+    await this.$.opiskeluoikeus.invalidate.button.click()
+    await this.$.opiskeluoikeus.invalidate.confirm.click()
+  }
 }
 
 type VSTOsasuoritusSchema = BuiltIdNode<

--- a/web/test/e2e/pages/oppija/uiV2builder/OpiskeluoikeusHeader.ts
+++ b/web/test/e2e/pages/oppija/uiV2builder/OpiskeluoikeusHeader.ts
@@ -7,5 +7,10 @@ export const OpiskeluoikeusHeader = () => ({
   oid: Label,
   voimassaoloaika: Label,
   edit: Button,
+  invalidate: {
+    button: Button,
+    confirm: Button,
+    cancel: Button
+  },
   tila: OpiskeluoikeudenTila()
 })

--- a/web/test/e2e/vst.spec.ts
+++ b/web/test/e2e/vst.spec.ts
@@ -1,9 +1,7 @@
-import { sort } from 'fp-ts/lib/Array'
 import { foreachAsync, repeatAsync } from '../util/iterating'
 import { expect as _expect, test } from './base'
 import { KoskiVSTOppijaPage } from './pages/oppija/KoskiVSTOppijaPage'
 import { kansalainen, virkailija } from './setup/auth'
-import { KoskiKansalainenPage } from './pages/kansalainen/KoskiKansalainenPage'
 
 const kotoutumiskoulutus2022 = '1.2.246.562.24.00000000135'
 const oppivelvollisilleSuunnattu = '1.2.246.562.24.00000000143'
@@ -11,6 +9,7 @@ const jotpaKoulutus = '1.2.246.562.24.00000000140'
 const lukutaitokoulutus = '1.2.246.562.24.00000000107'
 const kansanopisto = '1.2.246.562.24.00000000105'
 const vstKoulutus = '1.2.246.562.24.00000000108'
+const jotpaKoulutusTiedonsiirto = '1.2.246.562.24.00000000058'
 
 const openOppijaPage =
   (oppijaOid: string, edit: boolean) =>
@@ -2040,6 +2039,36 @@ test.describe('Vapaa sivistystyö', () => {
         ).toBeTruthy()
 
         await vstOppijaPage.tallenna()
+      })
+    })
+  })
+
+  test.describe('Lähdejärjestelmästä siirretty opiskeluoikeus', () => {
+    test.describe('Käyttäjä jolla ei ole yleistä mitätöintioikeutta', () => {
+      test.use({ storageState: virkailija('kalle') })
+      test.beforeEach(openOppijaPage(jotpaKoulutusTiedonsiirto, false))
+
+      test('Muokkaus ja mitätöinti on estetty', async ({ vstOppijaPage }) => {
+        expect(
+          await vstOppijaPage.$.opiskeluoikeus.edit.isVisible()
+        ).toBeFalsy()
+        expect(
+          await vstOppijaPage.$.opiskeluoikeus.invalidate.button.isVisible()
+        ).toBeFalsy()
+      })
+    })
+
+    test.describe('Käyttäjä jolla on yleinen mitätöintioikeus', () => {
+      test.use({ storageState: virkailija('pää') })
+      test.beforeEach(openOppijaPage(jotpaKoulutusTiedonsiirto, false))
+
+      test('Muokkaus on estetty, mutta mitätöinti on onnistuu', async ({
+        vstOppijaPage
+      }) => {
+        expect(
+          await vstOppijaPage.$.opiskeluoikeus.edit.isVisible()
+        ).toBeFalsy()
+        await vstOppijaPage.mitätöi()
       })
     })
   })


### PR DESCRIPTION
- Lisää lähdejärjestelmällinen vst-oppija
- Piilota muokkaa-nappi lähdejärjestelmälliseltä vst-oppijalta
