### PR TITLE
TOR-2049: VST-/TPO-näkymien kälikorjauksia

### DIFF
--- a/src/main/resources/localization/koski-default-texts.json
+++ b/src/main/resources/localization/koski-default-texts.json
@@ -95,7 +95,7 @@
   "deprecated:Kenttä ei ole käytössä": "Kenttä ei ole käytössä",
   "deprecated:Tätä kenttää ei toistaiseksi käytetä.": "Tätä kenttää ei toistaiseksi käytetä.",
   "deprecated:Tietoa ei tule siirtää Koskeen.": "Tietoa ei tule siirtää Koskeen.",
-  "deprecated:Tätä tietoa ei tarvitse jatkossa..." : "Tätä tietoa ei tarvitse jatkossa välittää.",
+  "deprecated:Tätä tietoa ei tarvitse jatkossa...": "Tätä tietoa ei tarvitse jatkossa välittää.",
   "description:5-numeroinen oppilaitosnumero, esimerkiksi 00001": "5-numeroinen oppilaitosnumero, esimerkiksi 00001",
   "description:Aiemman, korvaavan suorituksen tiedot": "Aiemman, korvaavan suorituksen tiedot",
   "description:Aikajakson pituus (alku- ja loppupäivämäärä)": "Aikajakson pituus (alku- ja loppupäivämäärä)",
@@ -2656,11 +2656,12 @@
   "Yritys": "Yritys",
   "Yths maksettu": "Yths maksettu",
   "Y-tunnus": "Y-tunnus",
-  "description:Vapaan sivistystyön osaamismerkin tunnistetiedot" : "Vapaan sivistystyön osaamismerkin tunnistetiedot",
-  "Osaamismerkki" : "Osaamismerkki",
+  "description:Vapaan sivistystyön osaamismerkin tunnistetiedot": "Vapaan sivistystyön osaamismerkin tunnistetiedot",
+  "Osaamismerkki": "Osaamismerkki",
   "Vapaan sivistystyön osaamismerkki": "Vapaan sivistystyön osaamismerkki",
   "Haetaan kuvaa": "Haetaan kuvaa",
   "Kuvan hakeminen epäonnistui": "Kuvan hakeminen epäonnistui",
   "eperusteet_osaamismerkki_url_fragment": "/#/fi/osaamismerkki/",
-  "Osaamismerkit": "Osaamismerkit"
+  "Osaamismerkit": "Osaamismerkit",
+  "Poistu versiohistoriasta": "Poistu versiohistoriasta"
 }

--- a/web/app/appstate/useSearchParam.tsx
+++ b/web/app/appstate/useSearchParam.tsx
@@ -1,0 +1,10 @@
+import { useMemo } from 'react'
+
+export const useSearchParam = (key: string): string | null =>
+  useMemo(
+    () => new URLSearchParams(window.location.search).get(key),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [key, window.location.search]
+  )
+
+export const useVersionumero = () => useSearchParam('versionumero')

--- a/web/app/components-v2/opiskeluoikeus/OpiskeluoikeusEditToolbar.tsx
+++ b/web/app/components-v2/opiskeluoikeus/OpiskeluoikeusEditToolbar.tsx
@@ -12,6 +12,7 @@ import { FlatButton } from '../controls/FlatButton'
 import { RaisedButton } from '../controls/RaisedButton'
 import { Trans } from '../texts/Trans'
 import { useVirkailijaUser } from '../../appstate/user'
+import { useVersionumero } from '../../appstate/useSearchParam'
 
 export type OpiskeluoikeusEditToolbarProps = {
   opiskeluoikeus: Opiskeluoikeus
@@ -26,6 +27,7 @@ export const OpiskeluoikeusEditToolbar = (
   const spans = props.editMode ? [12, 12] : [16, 8]
   const opiskeluoikeusOid = getOpiskeluoikeusOid(props.opiskeluoikeus)
   const hasAnyInvalidateAccess = useVirkailijaUser()?.hasAnyInvalidateAccess
+  const editable = useVersionumero() === null
 
   return (
     <ColumnRow>
@@ -53,11 +55,11 @@ export const OpiskeluoikeusEditToolbar = (
           <MitätöintiButton opiskeluoikeusOid={opiskeluoikeusOid} />
         )}
         <RequiresWriteAccess opiskeluoikeus={props.opiskeluoikeus}>
-          {!props.editMode ? (
+          {!props.editMode && editable ? (
             <RaisedButton fullWidth onClick={props.onStartEdit} testId="edit">
               {'Muokkaa'}
             </RaisedButton>
-          ) : opiskeluoikeusOid && !hasAnyInvalidateAccess ? (
+          ) : opiskeluoikeusOid && !hasAnyInvalidateAccess && editable ? (
             <MitätöintiButton opiskeluoikeusOid={opiskeluoikeusOid} />
           ) : null}
         </RequiresWriteAccess>

--- a/web/app/components-v2/opiskeluoikeus/OpiskeluoikeusTitle.less
+++ b/web/app/components-v2/opiskeluoikeus/OpiskeluoikeusTitle.less
@@ -15,6 +15,9 @@
 
     .VersiohistoriaButton {
       position: relative;
+      .FlatButton {
+        color: white;
+      }
     }
 
     .VersiohistoriaList {

--- a/web/app/components-v2/opiskeluoikeus/OpiskeluoikeusTitle.tsx
+++ b/web/app/components-v2/opiskeluoikeus/OpiskeluoikeusTitle.tsx
@@ -5,6 +5,7 @@ import {
   useApiWithParams
 } from '../../api-fetch'
 import { TreeHook } from '../../appstate/tree'
+import { useVersionumero } from '../../appstate/useSearchParam'
 import { TestIdLayer, TestIdRoot, TestIdText } from '../../appstate/useTestId'
 import { useKansalainenTaiSuoritusjako } from '../../appstate/user'
 import {
@@ -150,6 +151,7 @@ const VersiohistoriaButton: React.FC<VersiohistoriaButtonProps> = (props) => {
     [versiohistoriaVisible]
   )
   const hideList = useCallback(() => setVersiohistoriaVisible(false), [])
+  const currentVersion = useVersionumero()
 
   return (
     <TestIdLayer id="versiohistoria">
@@ -160,7 +162,9 @@ const VersiohistoriaButton: React.FC<VersiohistoriaButtonProps> = (props) => {
           aria-expanded={versiohistoriaVisible}
           testId="button"
         >
-          {t('Versiohistoria')}
+          {currentVersion
+            ? `${t('Versionumero')}: v${currentVersion}`
+            : t('Versiohistoria')}
         </FlatButton>
         <PositionalPopup
           align="right"

--- a/web/app/components-v2/opiskeluoikeus/OpiskeluoikeusTitle.tsx
+++ b/web/app/components-v2/opiskeluoikeus/OpiskeluoikeusTitle.tsx
@@ -196,14 +196,15 @@ const VersiohistoriaList: React.FC<VersiohistoriaListProps> = (props) => {
     versiolistaCache
   )
 
+  const versioParam = useVersionumero()
+
   const currentVersion = useMemo(() => {
-    const v = parseQuery(window.location.search).versionumero
-    return v
-      ? parseInt(v)
+    return versioParam
+      ? parseInt(versioParam)
       : isSuccess(historia)
         ? last(historia.data)?.versionumero
         : undefined
-  }, [historia])
+  }, [historia, versioParam])
 
   return isSuccess(historia) ? (
     <TestIdLayer id="list">
@@ -229,6 +230,18 @@ const VersiohistoriaList: React.FC<VersiohistoriaListProps> = (props) => {
             </LinkButton>
           </li>
         ))}
+        {versioParam && (
+          <li className="VersiohistoriaList__item">
+            <LinkButton
+              href={currentQueryWith({
+                opiskeluoikeus: props.opiskeluoikeusOid,
+                versionumero: null
+              })}
+            >
+              {t('Poistu versiohistoriasta')}
+            </LinkButton>
+          </li>
+        )}
       </ul>
     </TestIdLayer>
   ) : null

--- a/web/app/components-v2/opiskeluoikeus/TodistuksellaNäkyvätLisätiedotField.tsx
+++ b/web/app/components-v2/opiskeluoikeus/TodistuksellaNäkyvätLisätiedotField.tsx
@@ -32,7 +32,7 @@ export const TodistuksellaNäkyvätLisätiedotEdit: React.FC<
     (e) => {
       e.preventDefault()
       const fi = e.target.value
-      onChange(Finnish({ fi }))
+      onChange(fi ? Finnish({ fi }) : undefined)
     },
     [onChange]
   )

--- a/web/app/util/url.ts
+++ b/web/app/util/url.ts
@@ -1,6 +1,6 @@
 import { fromEntries, isEmptyObject, ObjectEntry } from './fp/objects'
 
-export type LocationQueryIn = Record<string, string | number | boolean>
+export type LocationQueryIn = Record<string, string | number | boolean | null>
 export type LocationQueryOut = Record<string, string>
 
 export const queryString = (query: LocationQueryIn) =>
@@ -8,9 +8,10 @@ export const queryString = (query: LocationQueryIn) =>
     ? ''
     : '?' +
       Object.entries(query)
-        .map(
-          ([key, value]) =>
-            `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
+        .map(([key, value]) =>
+          value !== null
+            ? `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
+            : ''
         )
         .join('&')
 


### PR DESCRIPTION
- Indikoi paremmin että ollaan katsomassa oo:n versiota
- Piilota muokkaus- ja mitätöintinapit versiota katseltaessa
- Lisää nappi jolla poistutaan versioiden katselusta
- Korjaa todistuksen lisätietojen validointi
