### PR TITLE
TOR-2189: Dialogin kälikorjauksia

### DIFF
--- a/web/app/components-v2/containers/Modal.less
+++ b/web/app/components-v2/containers/Modal.less
@@ -16,6 +16,7 @@
   .Modal__content {
     background: white;
     max-width: 90%;
+    max-height: 90vh;
     min-width: 500px;
     box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.2);
   }
@@ -38,6 +39,8 @@
 
 .ModalBody {
   padding: @padding;
+  max-height: calc(100vh - 200px);
+  overflow-y: auto;
 }
 
 .ModalFooter {

--- a/web/app/components-v2/controls/KieliSelect.tsx
+++ b/web/app/components-v2/controls/KieliSelect.tsx
@@ -17,7 +17,15 @@ export type KieliSelectProps = Omit<
 
 export const KieliSelect = (props: KieliSelectProps) => {
   const options = useSuorituskielet()
-  return <Select options={options} {...props} />
+  const { initialValue, ...rest } = props
+  return (
+    <Select
+      autoselect
+      options={options}
+      initialValue={initialValue || 'kieli_FI'}
+      {...rest}
+    />
+  )
 }
 
 const useSuorituskielet = () => {

--- a/web/app/components-v2/controls/Select.less
+++ b/web/app/components-v2/controls/Select.less
@@ -48,6 +48,10 @@
     right: 0;
     z-index: 999999999;
 
+    &.Select__optionList--inline {
+      position: relative;
+    }
+
     max-height: 300px;
     overflow: scroll;
 

--- a/web/app/components-v2/controls/Select.tsx
+++ b/web/app/components-v2/controls/Select.tsx
@@ -1,27 +1,27 @@
 import * as A from 'fp-ts/Array'
-import { flow } from 'fp-ts/lib/function'
 import * as NEA from 'fp-ts/NonEmptyArray'
+import { flow } from 'fp-ts/lib/function'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   KoodistokoodiviiteKoodistonNimellä,
   KoodistokoodiviiteKoodistonNimelläOrd
 } from '../../appstate/koodisto'
-import { t } from '../../i18n/i18n'
-import { Koodistokoodiviite } from '../../types/fi/oph/koski/schema/Koodistokoodiviite'
-import { LocalizedString } from '../../types/fi/oph/koski/schema/LocalizedString'
-import { nonNull } from '../../util/fp/arrays'
-import { pluck } from '../../util/fp/objects'
-import { clamp, sum } from '../../util/numbers'
-import { textSearch } from '../../util/strings'
-import { common, CommonProps, cx } from '../CommonProps'
-import { Removable } from './Removable'
+import { Peruste } from '../../appstate/peruste'
 import {
   TestIdLayer,
   useParentTestId,
   useTestId
 } from '../../appstate/useTestId'
+import { t } from '../../i18n/i18n'
+import { Koodistokoodiviite } from '../../types/fi/oph/koski/schema/Koodistokoodiviite'
+import { LocalizedString } from '../../types/fi/oph/koski/schema/LocalizedString'
+import { nonNull } from '../../util/fp/arrays'
+import { pluck } from '../../util/fp/objects'
 import { koodistokoodiviiteId } from '../../util/koodisto'
-import { Peruste } from '../../appstate/peruste'
+import { clamp, sum } from '../../util/numbers'
+import { textSearch } from '../../util/strings'
+import { CommonProps, common, cx } from '../CommonProps'
+import { Removable } from './Removable'
 
 export type SelectProps<T> = CommonProps<{
   initialValue?: OptionKey
@@ -34,6 +34,7 @@ export type SelectProps<T> = CommonProps<{
   hideEmpty?: boolean
   disabled?: boolean
   autoselect?: boolean
+  inlineOptions?: boolean
   testId: string | number
 }>
 
@@ -117,6 +118,7 @@ export const Select = <T,>(props: SelectProps<T>) => {
                 options={select.options}
                 hoveredOption={select.hoveredOption}
                 onRemove={props.onRemove}
+                inlineOptions={props.inlineOptions}
                 {...select.dropdownEventListeners}
               />
             </TestIdLayer>
@@ -134,6 +136,7 @@ type OptionListProps<T> = CommonProps<{
   onClick: (o: SelectOption<T>, event: React.MouseEvent) => void
   onMouseOver: (o: SelectOption<T>, event: React.MouseEvent) => void
   onRemove?: (o: SelectOption<T>) => void
+  inlineOptions?: boolean
 }>
 
 const OptionList = <T,>(props: OptionListProps<T>): React.ReactElement => {
@@ -147,7 +150,9 @@ const OptionList = <T,>(props: OptionListProps<T>): React.ReactElement => {
 
   const { options, onRemove, ...rest } = props
 
-  const [maxHeight, setMaxHeight] = useState(300)
+  const [maxHeight, setMaxHeight] = useState(
+    props.inlineOptions ? undefined : 300
+  )
   useEffect(() => {
     const updateMaxHeight = () => {
       if (props.inputRef.current) {
@@ -168,7 +173,13 @@ const OptionList = <T,>(props: OptionListProps<T>): React.ReactElement => {
   }, [props.inputRef])
 
   return (
-    <ul {...common(props, ['Select__optionList'])} style={{ maxHeight }}>
+    <ul
+      {...common(props, [
+        'Select__optionList',
+        props.inlineOptions && 'Select__optionList--inline'
+      ])}
+      style={{ maxHeight }}
+    >
       {options.map((opt) => (
         <TestIdLayer key={opt.key} id={opt.key}>
           <li

--- a/web/app/uusiopiskeluoikeus/UusiOpiskeluoikeusForm.less
+++ b/web/app/uusiopiskeluoikeus/UusiOpiskeluoikeusForm.less
@@ -8,7 +8,9 @@
 .UusiOppijaForm {
   label {
     display: block;
-    padding-bottom: @baseline;
+    @media screen and (min-height: 1200px) {
+      padding-bottom: @baseline;
+    }
   }
 
   .labelgroup {
@@ -21,7 +23,9 @@
 
     label {
       min-height: auto;
-      padding-bottom: @baseline;
+      @media screen and (min-height: 1200px) {
+        padding-bottom: @baseline;
+      }
     }
   }
 

--- a/web/app/uusiopiskeluoikeus/UusiOpiskeluoikeusForm.tsx
+++ b/web/app/uusiopiskeluoikeus/UusiOpiskeluoikeusForm.tsx
@@ -18,6 +18,7 @@ import {
 } from './state/hooks'
 import { useUusiOpiskeluoikeusDialogState } from './state/state'
 import { SuoritusFields } from './suoritus/SuoritusFields'
+import { useHasOwnOrganisaatiot } from '../appstate/organisaatioHierarkia'
 
 export type UusiOpiskeluoikeusFormProps = {
   onResult: (opiskeluoikeus?: Opiskeluoikeus) => void
@@ -36,6 +37,7 @@ export const UusiOpiskeluoikeusForm = (props: UusiOpiskeluoikeusFormProps) => {
   const opintojenRahoitukset = useOpintojenRahoitus(state)
   const jotpaAsianumerot = useJotpaAsianumero(state)
   const defaultKieli = useDefaultKieli(state)
+  const spesifienOppilaitostenKäyttäjä = useHasOwnOrganisaatiot()
 
   useEffect(() => props.onResult(state.result), [props, state.result])
 
@@ -47,7 +49,7 @@ export const UusiOpiskeluoikeusForm = (props: UusiOpiskeluoikeusFormProps) => {
 
           <label>
             {t('Oppilaitos')}
-            {state.hankintakoulutus.value ? (
+            {state.hankintakoulutus.value || !spesifienOppilaitostenKäyttäjä ? (
               <OppilaitosSearch
                 value={state.oppilaitos.value}
                 onChange={state.oppilaitos.set}

--- a/web/app/uusiopiskeluoikeus/UusiOpiskeluoikeusForm.tsx
+++ b/web/app/uusiopiskeluoikeus/UusiOpiskeluoikeusForm.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react'
+import { useHasOwnOrganisaatiot } from '../appstate/organisaatioHierarkia'
 import { DateEdit } from '../components-v2/controls/DateField'
 import { KieliSelect } from '../components-v2/controls/KieliSelect'
 import { Select } from '../components-v2/controls/Select'
@@ -6,6 +7,7 @@ import { t } from '../i18n/i18n'
 import { Opiskeluoikeus } from '../types/fi/oph/koski/schema/Opiskeluoikeus'
 import { koodistokoodiviiteId } from '../util/koodisto'
 import { DialogMaksuttomuusSelect } from './components/DialogMaksuttomuusSelect'
+import { DialogSelect } from './components/DialogSelect'
 import { HankintakoulutusSelect } from './components/HankintakoulutusSelect'
 import { OppilaitosSearch } from './components/OppilaitosSearch'
 import { OppilaitosSelect, OrgType } from './components/OppilaitosSelect'
@@ -18,7 +20,6 @@ import {
 } from './state/hooks'
 import { useUusiOpiskeluoikeusDialogState } from './state/state'
 import { SuoritusFields } from './suoritus/SuoritusFields'
-import { useHasOwnOrganisaatiot } from '../appstate/organisaatioHierarkia'
 
 export type UusiOpiskeluoikeusFormProps = {
   onResult: (opiskeluoikeus?: Opiskeluoikeus) => void
@@ -70,6 +71,7 @@ export const UusiOpiskeluoikeusForm = (props: UusiOpiskeluoikeusFormProps) => {
         <label>
           {t('Opiskeluoikeus')}
           <Select
+            inlineOptions
             options={opiskeluoikeustyypit}
             initialValue={opiskeluoikeustyypit[0]?.key}
             value={
@@ -112,8 +114,7 @@ export const UusiOpiskeluoikeusForm = (props: UusiOpiskeluoikeusFormProps) => {
       {state.tila.visible && (
         <label>
           {t('Opiskeluoikeuden tila')}
-          <Select
-            autoselect
+          <DialogSelect
             options={tilat.options}
             initialValue={tilat.initialValue}
             value={state.tila.value && koodistokoodiviiteId(state.tila.value)}
@@ -126,8 +127,7 @@ export const UusiOpiskeluoikeusForm = (props: UusiOpiskeluoikeusFormProps) => {
       {opintojenRahoitukset.options.length > 0 && (
         <label>
           {t('Opintojen rahoitus')}
-          <Select
-            autoselect
+          <DialogSelect
             options={opintojenRahoitukset.options}
             initialValue={opintojenRahoitukset.initialValue}
             value={
@@ -143,8 +143,7 @@ export const UusiOpiskeluoikeusForm = (props: UusiOpiskeluoikeusFormProps) => {
       {jotpaAsianumerot.options.length > 0 && (
         <label>
           {t('JOTPA asianumero')}
-          <Select
-            autoselect
+          <DialogSelect
             options={jotpaAsianumerot.options}
             initialValue={jotpaAsianumerot.initialValue}
             value={

--- a/web/app/uusiopiskeluoikeus/components/DialogKoodistoSelect.tsx
+++ b/web/app/uusiopiskeluoikeus/components/DialogKoodistoSelect.tsx
@@ -1,12 +1,10 @@
 import React, { useMemo } from 'react'
 import { useKoodisto } from '../../appstate/koodisto'
-import {
-  Select,
-  groupKoodistoToOptions
-} from '../../components-v2/controls/Select'
+import { groupKoodistoToOptions } from '../../components-v2/controls/Select'
 import { Koodistokoodiviite } from '../../types/fi/oph/koski/schema/Koodistokoodiviite'
 import { koodistokoodiviiteId } from '../../util/koodisto'
 import { DialogField } from '../state/state'
+import { DialogSelect } from './DialogSelect'
 
 export type DialogKoodistoSelectProps<U extends string> = {
   state: DialogField<Koodistokoodiviite<U>>
@@ -26,8 +24,7 @@ export const DialogKoodistoSelect = <U extends string>(
   )
 
   return (
-    <Select
-      autoselect
+    <DialogSelect
       options={options}
       initialValue={props.default && `${props.koodistoUri}_${props.default}`}
       value={props.state.value && koodistokoodiviiteId(props.state.value)}

--- a/web/app/uusiopiskeluoikeus/components/DialogPaatasonSuoritusSelect.tsx
+++ b/web/app/uusiopiskeluoikeus/components/DialogPaatasonSuoritusSelect.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo } from 'react'
-import { Select } from '../../components-v2/controls/Select'
 import { koodistokoodiviiteId } from '../../util/koodisto'
 import { usePäätasonSuoritustyypit } from '../state/hooks'
 import { UusiOpiskeluoikeusDialogState } from '../state/state'
+import { DialogSelect } from './DialogSelect'
 
 export type DialogPäätasonSuoritusSelectProps = {
   state: UusiOpiskeluoikeusDialogState
@@ -28,8 +28,7 @@ export const DialogPäätasonSuoritusSelect = (
   )
 
   return (
-    <Select
-      autoselect
+    <DialogSelect
       options={filtered}
       initialValue={props.default && `suorituksentyyppi_${props.default}`}
       value={

--- a/web/app/uusiopiskeluoikeus/components/DialogPerusteSelect.tsx
+++ b/web/app/uusiopiskeluoikeus/components/DialogPerusteSelect.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo } from 'react'
 import { usePerusteSelectOptions } from '../../appstate/peruste'
 import { Select } from '../../components-v2/controls/Select'
-import { UusiOpiskeluoikeusDialogState } from '../state/state'
 import { t } from '../../i18n/i18n'
+import { UusiOpiskeluoikeusDialogState } from '../state/state'
 
 export type DialogPerusteSelectProps = {
   state: UusiOpiskeluoikeusDialogState
@@ -27,6 +27,7 @@ export const DialogPerusteSelect = <U extends string>(
     <label>
       {t('Peruste')}
       <Select
+        inlineOptions
         autoselect
         options={filtered}
         initialValue={props.default || options[0]?.value?.koodiarvo}

--- a/web/app/uusiopiskeluoikeus/components/DialogSelect.tsx
+++ b/web/app/uusiopiskeluoikeus/components/DialogSelect.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { Select, SelectProps } from '../../components-v2/controls/Select'
+
+export const DialogSelect = <T,>(props: SelectProps<T>) => (
+  <Select autoselect inlineOptions {...props} />
+)

--- a/web/app/uusiopiskeluoikeus/components/OppilaitosSearch.tsx
+++ b/web/app/uusiopiskeluoikeus/components/OppilaitosSearch.tsx
@@ -24,6 +24,7 @@ export const OppilaitosSearch = (props: OppilaitosSearchProps) => {
 
   return (
     <Select
+      inlineOptions
       options={options}
       value={props.value?.oid}
       onChange={onChange}

--- a/web/app/uusiopiskeluoikeus/components/OppilaitosSelect.tsx
+++ b/web/app/uusiopiskeluoikeus/components/OppilaitosSelect.tsx
@@ -1,11 +1,11 @@
 import { isEmpty } from 'fp-ts/lib/Array'
 import React, { useCallback, useMemo } from 'react'
 import { useOrganisaatioHierarkia } from '../../appstate/organisaatioHierarkia'
-import { Select, SelectOption } from '../../components-v2/controls/Select'
+import { SelectOption } from '../../components-v2/controls/Select'
 import { t } from '../../i18n/i18n'
 import { OrganisaatioHierarkia } from '../../types/fi/oph/koski/organisaatio/OrganisaatioHierarkia'
 import { intersects } from '../../util/array'
-import { nonNull } from '../../util/fp/arrays'
+import { DialogSelect } from './DialogSelect'
 
 export type OppilaitosSelectProps = {
   value?: OrganisaatioHierarkia
@@ -30,8 +30,7 @@ export const OppilaitosSelect = (props: OppilaitosSelectProps) => {
   )
 
   return (
-    <Select
-      autoselect
+    <DialogSelect
       options={options}
       value={props.value?.oid}
       onChange={onChange}

--- a/web/app/uusiopiskeluoikeus/suoritus/AmmatillinenKoulutusFields.tsx
+++ b/web/app/uusiopiskeluoikeus/suoritus/AmmatillinenKoulutusFields.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useMemo, useState } from 'react'
 import { isSuccess, useApiWithParams } from '../../api-fetch'
 import { useKoodisto } from '../../appstate/koodisto'
 import {
-  Select,
   SelectOption,
   groupKoodistoToOptions
 } from '../../components-v2/controls/Select'
@@ -16,6 +15,7 @@ import { fetchOppilaitoksenPerusteet } from '../../util/koskiApi'
 import { DialogKoodistoSelect } from '../components/DialogKoodistoSelect'
 import { DialogPäätasonSuoritusSelect } from '../components/DialogPaatasonSuoritusSelect'
 import { DialogPerusteSelect } from '../components/DialogPerusteSelect'
+import { DialogSelect } from '../components/DialogSelect'
 import {
   createAmmatilliseenTehtäväänValmistavaKoulutus,
   createPaikallinenMuuAmmatillinenKoulutus,
@@ -68,7 +68,7 @@ export const AmmatillinenKoulutusFields = (props: SuoritusFieldsProps) => {
       {props.state.tutkinto.visible && (
         <label>
           {t('Tutkinto')}
-          <Select
+          <DialogSelect
             options={tutkinnot.options}
             value={
               props.state.tutkinto.value &&
@@ -171,8 +171,7 @@ const MuuAmmatillinenKoulutusFields = (props: SuoritusFieldsProps) => {
     <>
       <label>
         {t('Koulutusmoduuli')}
-        <Select
-          autoselect
+        <DialogSelect
           options={muuAmmatillinenKoulutusOptions}
           value={koulutusmoduuli}
           onChange={(opt) => setKoulutusmoduuli(opt?.value)}
@@ -187,8 +186,7 @@ const MuuAmmatillinenKoulutusFields = (props: SuoritusFieldsProps) => {
       {koulutusmoduuli === 'ammatilliseentehtavaanvalmistavakoulutus' && (
         <label>
           {t('Ammatilliseen tehtävään valmistava koulutus')}
-          <Select
-            autoselect
+          <DialogSelect
             options={tunnisteOptions}
             value={tunniste}
             onChange={onAmmatilliseenTehtäväänValmistavaKoulutus}

--- a/web/app/uusiopiskeluoikeus/suoritus/TaiteenPerusopetusFields.tsx
+++ b/web/app/uusiopiskeluoikeus/suoritus/TaiteenPerusopetusFields.tsx
@@ -1,13 +1,11 @@
 import React, { useEffect, useMemo } from 'react'
 import { useKoodisto } from '../../appstate/koodisto'
-import {
-  Select,
-  groupKoodistoToOptions
-} from '../../components-v2/controls/Select'
+import { groupKoodistoToOptions } from '../../components-v2/controls/Select'
 import { t } from '../../i18n/i18n'
 import { koodistokoodiviiteId } from '../../util/koodisto'
 import { DialogKoodistoSelect } from '../components/DialogKoodistoSelect'
 import { DialogPerusteSelect } from '../components/DialogPerusteSelect'
+import { DialogSelect } from '../components/DialogSelect'
 import { usePäätasonSuoritustyypit } from '../state/hooks'
 import { UusiOpiskeluoikeusDialogState } from '../state/state'
 import { SuoritusFieldsProps } from './SuoritusFields'
@@ -50,8 +48,7 @@ export const TaiteenPerusopetusFields = (props: SuoritusFieldsProps) => {
       {props.state.tpoOppimäärä.value && (
         <label>
           {t('Suoritustyyppi')}
-          <Select
-            autoselect
+          <DialogSelect
             options={suoritustyypit}
             value={
               props.state.päätasonSuoritus.value &&
@@ -66,8 +63,7 @@ export const TaiteenPerusopetusFields = (props: SuoritusFieldsProps) => {
       {props.state.tpoToteutustapa.value && (
         <label>
           {t('Koulutuksen toteutustapa')}
-          <Select
-            autoselect
+          <DialogSelect
             options={toteutustavatOptions}
             value={
               props.state.tpoToteutustapa.value &&


### PR DESCRIPTION
- **Mahdollista organisaatiovalitsimen käyttö pääkäyttäjänä**
- **Tiukenna riviväliä matalemmilla resoilla**
- **Estä dialogin muuttuminen käyttökelvottomaksi ahtaalla ruudulla**
- **Korjaa hajonnut automaattinen kielivalinta**
