### PR TITLE
Korvaa docker-compose komento docker compose :lla

### DIFF
--- a/.github/actions/setup_backend/action.yml
+++ b/.github/actions/setup_backend/action.yml
@@ -38,7 +38,7 @@ runs:
       shell: bash
 
     - name: Start Postgres and OS containers
-      run: docker-compose up -d
+      run: docker compose up -d
       shell: bash
 
     - name: Compile tests

--- a/.github/workflows/all_tests.yml
+++ b/.github/workflows/all_tests.yml
@@ -16,7 +16,7 @@ jobs:
     name: Lint Koski
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Java 11
         uses: actions/setup-java@v3
@@ -58,7 +58,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     if: ${{ !contains(github.event.head_commit.message, '[skip-tests]') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
 
       - name: Check validation and documentation changes
@@ -70,7 +70,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     if: ${{ !contains(github.event.head_commit.message, '[skip-tests]') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
 
       - name: Check schema and documentation changes
@@ -82,7 +82,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     if: ${{ !contains(github.event.head_commit.message, '[skip-tests]') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
 
       - name: Check migration and database documentation changes
@@ -94,7 +94,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     if: ${{ !contains(github.event.head_commit.message, '[skip-tests]') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/koski_backend_test
         with:
           suites: |
@@ -105,7 +105,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     if: ${{ !contains(github.event.head_commit.message, '[skip-tests]') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/koski_backend_test
         with:
           suites: |
@@ -117,7 +117,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     if: ${{ !contains(github.event.head_commit.message, '[skip-tests]') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/koski_backend_test
         with:
           suites: |
@@ -130,7 +130,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     if: ${{ !contains(github.event.head_commit.message, '[skip-tests]') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/koski_backend_test
         with:
           suites: |
@@ -141,7 +141,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     if: ${{ !contains(github.event.head_commit.message, '[skip-tests]') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/koski_backend_test
         with:
           suites: |
@@ -178,7 +178,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     if: ${{ !contains(github.event.head_commit.message, '[skip-tests]') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/koski_backend_test
         with:
           suites: |
@@ -190,7 +190,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     if: ${{ !contains(github.event.head_commit.message, '[skip-tests]') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/koski_backend_test
         with:
           suites: |
@@ -211,7 +211,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     if: ${{ !contains(github.event.head_commit.message, '[skip-tests]') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/koski_backend_test
         with:
           suites: |
@@ -238,7 +238,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     if: ${{ !contains(github.event.head_commit.message, '[skip-tests]') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/koski_frontend_test
         with:
           shardIndex: ${{ matrix.shardIndex }}
@@ -248,7 +248,7 @@ jobs:
     name: Frontend unit tests
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node 16
         uses: actions/setup-node@v3
         with:
@@ -276,7 +276,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     if: ${{ !contains(github.event.head_commit.message, '[skip-tests]') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/koski_frontend_playwright_test
         with:
           shardIndex: ${{ matrix.shardIndex }}
@@ -292,7 +292,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     if: ${{ !contains(github.event.head_commit.message, '[skip-tests]') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/valpas_integration_test
         with:
           index: ${{ matrix.shardIndex }}
@@ -302,7 +302,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     if: ${{ !contains(github.event.head_commit.message, '[skip-tests]') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node 16
         uses: actions/setup-node@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.commithash }}
           # Number of commits to fetch. 0 indicates all history for all branches and tags.

--- a/.github/workflows/run_performance_tests.yml
+++ b/.github/workflows/run_performance_tests.yml
@@ -21,7 +21,7 @@ jobs:
     name: random-get-light
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Java 11
         uses: actions/setup-java@v3
@@ -73,7 +73,7 @@ jobs:
     name: insert-light
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Java 11
         uses: actions/setup-java@v3
@@ -125,7 +125,7 @@ jobs:
     name: mixed-overload
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Java 11
         uses: actions/setup-java@v3
@@ -177,7 +177,7 @@ jobs:
     name: valpas-organisaatio-listaus
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Java 11
         uses: actions/setup-java@v3
@@ -233,7 +233,7 @@ jobs:
     name: valpas-oppija-detaalit
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Java 11
         uses: actions/setup-java@v3

--- a/.github/workflows/run_security_checks.yml
+++ b/.github/workflows/run_security_checks.yml
@@ -10,7 +10,7 @@ jobs:
     name: Run owasp and snyk
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Java 11
         uses: actions/setup-java@v3

--- a/.github/workflows/run_smoketests.yml
+++ b/.github/workflows/run_smoketests.yml
@@ -9,7 +9,7 @@ jobs:
     name:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node 16
         uses: actions/setup-node@v3

--- a/.github/workflows/test_build_deploy_master.yml
+++ b/.github/workflows/test_build_deploy_master.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Configure AWS credentials for artifact upload
         uses: aws-actions/configure-aws-credentials@v1-node16
@@ -92,7 +92,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Configure AWS credentials for DEV environment
         uses: aws-actions/configure-aws-credentials@v1-node16
@@ -209,7 +209,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Configure AWS credentials for QA environment
         uses: aws-actions/configure-aws-credentials@v1-node16
@@ -327,7 +327,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Configure AWS credentials for PROD environment
         uses: aws-actions/configure-aws-credentials@v1-node16

--- a/.github/workflows/update_localizations.yml
+++ b/.github/workflows/update_localizations.yml
@@ -7,7 +7,7 @@ jobs:
     name: Update localizations
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Java 11
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/valpas_performance_tests.yml
+++ b/.github/workflows/valpas_performance_tests.yml
@@ -15,7 +15,7 @@ jobs:
     name: valpas-organisaatio-listaus
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Java 11
         uses: actions/setup-java@v3
@@ -70,7 +70,7 @@ jobs:
     name: valpas-oppija-detaalit
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Java 11
         uses: actions/setup-java@v3

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ cleandist = true
 mvn_argline =
 mvn_opts =
 
-DOCKER_COMPOSE = docker-compose
+DOCKER_COMPOSE = docker compose
 DOCKER_COMPOSE_OPTS = --force-recreate --renew-anon-volumes --build
 
 .PHONY: help
@@ -15,7 +15,7 @@ help:
 	@echo "make front	- Build front end"
 	@echo "make test	- Run unit tests"
 	@echo "make run	- Run previously built application in local environment"
-	@echo "make docker-dbs	- Start databases with docker-compose"
+	@echo "make docker-dbs	- Start databases with docker compose"
 	@echo "make watch	- Watch for changes in webapp files"
 	@echo "make clean	- Remove generated build data"
 	@echo "make dist version=<version> - Builds and verifies application version"

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ make run
 
 Avaa selaimessa [http://localhost:7021/koski/virkailija](http://localhost:7021/koski/virkailija). Selaimeen avautuu login-sivu, josta pääset eteenpäin käyttäjätunnuksella "kalle". Salasana on sama kuin käyttäjätunnus.
 
-Näin ajettuna sovellus käyttää paikallista PostgreSQL-kantaa ja OpenSearch-hakuindeksiä, jotka voi käynnistää docker-composella. Sovellus ei myöskään käytä mitään ulkoisia palveluja. Sillä on siis turvallista leikkiä.
+Näin ajettuna sovellus käyttää paikallista PostgreSQL-kantaa ja OpenSearch-hakuindeksiä, jotka voi käynnistää `docker compose`:lla. Sovellus ei myöskään käytä mitään ulkoisia palveluja. Sillä on siis turvallista leikkiä.
 
 Paikallisesti ajettaessa Jetty lataa resurssit hakemistosta `target/webapp`, jonka sisältö luodaan webpack-buildilla ([webpack.config.js](web/webpack.config.js)). Webpack-build muun muassa kopioi staattisia resursseja paikoilleen
 hakemistosta [`web/`](web/) ja sen alihakemistoista.
@@ -193,7 +193,7 @@ aja `make ts-types` uudelleen. Samoin voit lisätä käyttämiesi rajapintojen p
 
 Kehityskäyttöön tarvitaan PostgreSQL-tietokanta ja OpenSearch-hakuindeksi.
 
-Kehitystietokannat käynnistetään docker-composella. Tämän voi tehdä seuraavalla
+Kehitystietokannat käynnistetään `docker compose`:lla. Tämän voi tehdä seuraavalla
 komennolla:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Valppaan testikäyttäjistä on tietoa Valppaan käyttöliittymän [README.md:ss
 Nämä ovat keskeiset Koski-järjestelmässä käytettävät teknologiat. Lista kuvaa järjestelmän nykytilaa ja muuttuu matkan varrella
 tarpeen mukaan.
 
-- PostgreSQL 12.5 -tietokanta
+- PostgreSQL 15 -tietokanta
 - OpenSearch -hakuindeksi
 - Palvelinteknologiat
   - Scala 2.12 -ohjelmointikieli ja kääntäjä
@@ -111,6 +111,7 @@ Minimissään tarvitset nämä:
 - Maven 3 (osx: `brew install maven`)
 - Node.js (`.nvmrc`-tiedoston mukainen versio)
 - Docker PostgreSQL:n ja OpenSearchin ajamiseen konteissa
+- Docker compose (https://docs.docker.com/compose/install/)
 - Tekstieditori (kehitystiimi käyttää IntelliJ IDEA)
 
 ### Scala-kääntäjän konfiguraatio

--- a/sandbox/pull_rebuild_restart.sh
+++ b/sandbox/pull_rebuild_restart.sh
@@ -18,9 +18,9 @@ cd /home/ubuntu && \
 git clone https://github.com/Opetushallitus/koski.git && \
 cd /home/ubuntu/koski && \
 make build && \
-docker-compose down && \
+docker compose down && \
 docker volume ls -q | xargs docker volume rm && \
-docker-compose up -d && \
+docker compose up -d && \
 rm -rf /home/ubuntu/koski/log && \
 ln -s /home/ubuntu/log/ /home/ubuntu/koski/ && \
 sleep 30 && \


### PR DESCRIPTION
`docker-compose` -komento on korvattu `docker compose` -komennolla (huomaa puuttuva väliviiva).

Päivitetty samalla dokumentaatio ja korjattu workflowta testatessa havaitut GH `actions/checkout@v3` deprekaatiot.