### PR TITLE
TOR-2189: Opiskeluoikeuden luontidialogin bugikorjauksia

### DIFF
--- a/src/main/resources/localization/koski-default-texts.json
+++ b/src/main/resources/localization/koski-default-texts.json
@@ -2712,5 +2712,6 @@
   "raportti-excel-kolumni-ensimmainenArviointiPvm-comment": "TODO",
   "raportti-excel-kolumni-parasArviointiPvm-comment": "TODO",
   "raportti-excel-kolumni-parasArviointiArvosana-comment": "TODO",
-  "raportti-excel-kolumni-paattymispaiva-comment": "TODO"
+  "raportti-excel-kolumni-paattymispaiva-comment": "TODO",
+  "Osa tuloksista piilotettu. Rajaa tuloksia hakusanalla.": "Osa tuloksista piilotettu. Rajaa tuloksia hakusanalla."
 }

--- a/web/app/components-v2/controls/Select.tsx
+++ b/web/app/components-v2/controls/Select.tsx
@@ -37,6 +37,7 @@ export type SelectProps<T> = CommonProps<{
   disabled?: boolean
   autoselect?: boolean
   inlineOptions?: boolean
+  maxOptions?: number
   testId: string | number
 }>
 
@@ -125,6 +126,7 @@ export const Select = <T,>(props: SelectProps<T>) => {
                 hoveredOption={select.hoveredOption}
                 onRemove={props.onRemove}
                 inlineOptions={props.inlineOptions}
+                maxOptions={props.maxOptions}
                 {...select.dropdownEventListeners}
               />
             </TestIdLayer>
@@ -143,6 +145,7 @@ type OptionListProps<T> = CommonProps<{
   onMouseOver: (o: SelectOption<T>, event: React.MouseEvent) => void
   onRemove?: (o: SelectOption<T>) => void
   inlineOptions?: boolean
+  maxOptions?: number
 }>
 
 const OptionList = <T,>(props: OptionListProps<T>): React.ReactElement => {
@@ -155,6 +158,11 @@ const OptionList = <T,>(props: OptionListProps<T>): React.ReactElement => {
   }
 
   const { options, onRemove, ...rest } = props
+
+  const truncatedOptions = useMemo(
+    () => (props.maxOptions ? A.takeLeft(props.maxOptions)(options) : options),
+    [options, props.maxOptions]
+  )
 
   const [maxHeight, setMaxHeight] = useState(
     props.inlineOptions ? undefined : 300
@@ -186,7 +194,7 @@ const OptionList = <T,>(props: OptionListProps<T>): React.ReactElement => {
       ])}
       style={{ maxHeight }}
     >
-      {options.map((opt) => (
+      {truncatedOptions.map((opt) => (
         <TestIdLayer key={opt.key} id={opt.key}>
           <li
             className="Select__option"
@@ -217,6 +225,9 @@ const OptionList = <T,>(props: OptionListProps<T>): React.ReactElement => {
           </li>
         </TestIdLayer>
       ))}
+      {options.length !== truncatedOptions.length && (
+        <li>{t('Osa tuloksista piilotettu. Rajaa tuloksia hakusanalla.')}</li>
+      )}
     </ul>
   )
 }

--- a/web/app/components-v2/controls/Select.tsx
+++ b/web/app/components-v2/controls/Select.tsx
@@ -483,7 +483,7 @@ const filterOptions = <T,>(
     }
     const children = option.children?.filter(matchesQuery)
     return (children && A.isNonEmpty(children)) || isMatch(option.label)
-      ? option
+      ? { ...option, children }
       : null
   }
 

--- a/web/app/style/uusi-oppija.less
+++ b/web/app/style/uusi-oppija.less
@@ -49,7 +49,8 @@
   }
 
   .Select,
-  .DateEdit {
+  .DateEdit,
+  label {
     width: 500px;
   }
 

--- a/web/app/uusiopiskeluoikeus/components/DialogKoodistoSelect.tsx
+++ b/web/app/uusiopiskeluoikeus/components/DialogKoodistoSelect.tsx
@@ -36,6 +36,7 @@ export const DialogKoodistoSelect = <U extends string>(
       initialValue={props.default && `${props.koodistoUri}_${props.default}`}
       value={props.state.value && koodistokoodiviiteId(props.state.value)}
       onChange={(opt) => props.state.set(opt?.value)}
+      maxOptions={50}
       testId={props.testId}
     />
   )

--- a/web/test/spec/esiopetusSpec.js
+++ b/web/test/spec/esiopetusSpec.js
@@ -157,7 +157,6 @@ describe('Esiopetus', function () {
           expect(addOppija.toimipisteet()).to.deep.equal([
             'Helsingin yliopiston Viikin normaalikoulu',
             'Helsingin eurooppalainen koulu',
-            'International School of Helsinki',
             'Joensuun normaalikoulu (lakkautettu)',
             'Rantakylän normaalikoulu',
             'Savonlinnan normaalikoulu (lakkautettu)',


### PR DESCRIPTION
- **Älä nappaa kentälle fokusta klikkaamalla sen oikealle puolelle**
- **Filtteröi ryhmiteltyjen vaihtoehtojen lapsien filtteröinti**
- **Nopeuta pudotusvalikkoa rajoittamalla renderöityjä vaihtoehtoja**
