### PR TITLE
Aseta idle timeout konfiguroitavaksi Jetty-serverille

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -86,6 +86,9 @@ virta = {
 healthcheck.oppija.oid = "1.2.246.562.24.00000000001"
 
 sessionTimeoutMinutes=60
+// Default value of 30s for local
+// Reverse proxy or load balancer requires values close to its idle timeout value
+jettyIdleTimeoutSeconds=30
 
 schedule {
   henkilötiedotUpdateInterval="1m"

--- a/src/main/scala/fi/oph/koski/jettylauncher/JettyLauncher.scala
+++ b/src/main/scala/fi/oph/koski/jettylauncher/JettyLauncher.scala
@@ -16,6 +16,8 @@ import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder}
 import org.eclipse.jetty.util.thread.QueuedThreadPool
 import org.eclipse.jetty.webapp.WebAppContext
 
+import scala.concurrent.duration.DurationInt
+
 object JettyLauncher extends App with Logging {
   LogConfiguration.configureLogging()
 
@@ -91,9 +93,11 @@ class JettyLauncher(val port: Int, val application: KoskiApplication) extends Lo
     val httpConfig = new HttpConfiguration()
     httpConfig.addCustomizer( new ForwardedRequestCustomizer() )
     val connectionFactory = new HttpConnectionFactory( httpConfig )
-
     val connector = new ServerConnector(server, connectionFactory)
     connector.setPort(port)
+    val idleTimeoutMs = config.getLong("jettyIdleTimeoutSeconds") * 1000
+    logger.info(s"Setting Jetty idle connection timeout to $idleTimeoutMs ms")
+    connector.setIdleTimeout(idleTimeoutMs)
     server.addConnector(connector)
   }
 


### PR DESCRIPTION
Jetty asettaa idle timeoutin oletuksena 30 sekunniksi. Tämä on ongelma, koska ympäristöjen kuormantasaaja asettaa idle timeoutin 900 sekuntiin (15min), jolloin load balancer ei välttämättä havaitse "danglaamaan" jääviä TCP-yhteyksiä.

Tehdään mahdolliseksi asettaa Jetty HTTP timeout. Ympäristöissä timeoutin sopiva arvo on 905s