### PR TITLE
TOR-2182: Luokalle jääneiden massaluovutuskyselyyn tuki csv:lle

### DIFF
--- a/src/main/scala/fi/oph/koski/massaluovutus/MassaluovutusDocumentation.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/MassaluovutusDocumentation.scala
@@ -238,7 +238,8 @@ object QueryExamples {
       ValintalaskentaQueryDocumentation.outputFiles,
       application.config.getString("koski.root.url"),
     ))
-    case "LuokalleJaaneetJson" => asJson(MassaluovutusQueryLuokalleJaaneetExamples.query)
+    case "LuokalleJaaneetJson" => asJson(MassaluovutusQueryLuokalleJaaneetExamples.jsonQuery)
+    case "LuokalleJaaneetCsv" => asJson(MassaluovutusQueryLuokalleJaaneetExamples.csvQuery)
     case _ => None
   }
 

--- a/src/main/scala/fi/oph/koski/massaluovutus/luokallejaaneet/MassaluovutusQueryLuokalleJaaneetCsv.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/luokallejaaneet/MassaluovutusQueryLuokalleJaaneetCsv.scala
@@ -1,0 +1,48 @@
+package fi.oph.koski.massaluovutus.luokallejaaneet
+
+import fi.oph.koski.config.KoskiApplication
+import fi.oph.koski.http.HttpStatus
+import fi.oph.koski.koskiuser.KoskiSpecificSession
+import fi.oph.koski.massaluovutus.MassaluovutusUtils.{QueryResourceManager, defaultOrganisaatio}
+import fi.oph.koski.massaluovutus.{QueryFormat, QueryResultWriter}
+import fi.oph.koski.schema.annotation.EnumValues
+
+import scala.util.Using
+
+case class MassaluovutusQueryLuokalleJaaneetCsv(
+  `type`: String = "luokallejaaneet",
+  @EnumValues(Set(QueryFormat.csv))
+  format: String = QueryFormat.csv,
+  organisaatioOid: Option[String],
+) extends MassaluovutusQueryLuokalleJaaneet {
+  override def run(application: KoskiApplication, writer: QueryResultWriter)(implicit user: KoskiSpecificSession): Either[String, Unit] =
+    QueryResourceManager(logger) { mgr =>
+      implicit val manager: Using.Manager = mgr
+      val csvFile = writer.createCsv[CsvFields](s"luokalle_jaaneet_${organisaatioOid.get}", None)
+      forEachResult(application) { result => csvFile.put(CsvFields(result)) }
+      csvFile.save()
+    }
+
+  override def fillAndValidate(implicit user: KoskiSpecificSession): Either[HttpStatus, MassaluovutusQueryLuokalleJaaneet] =
+    if (organisaatioOid.isEmpty) {
+      defaultOrganisaatio.map(o => copy(organisaatioOid = Some(o)))
+    } else {
+      Right(this)
+    }
+}
+
+case class CsvFields(
+  opiskeluoikeudenOid: Option[String],
+  oppijanumero: String,
+  luokka: String,
+  versionumero: Option[Int],
+)
+
+object CsvFields {
+  def apply(r:  MassaluovutusQueryLuokalleJaaneetResult): CsvFields = CsvFields(
+    r.opiskeluoikeus.oid,
+    r.oppijaOid,
+    r.luokka,
+    r.opiskeluoikeus.versionumero,
+  )
+}

--- a/src/main/scala/fi/oph/koski/massaluovutus/luokallejaaneet/MassaluovutusQueryLuokalleJaaneetExamples.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/luokallejaaneet/MassaluovutusQueryLuokalleJaaneetExamples.scala
@@ -3,7 +3,11 @@ package fi.oph.koski.massaluovutus.luokallejaaneet
 import fi.oph.koski.organisaatio.MockOrganisaatiot
 
 object MassaluovutusQueryLuokalleJaaneetExamples {
-  val query: MassaluovutusQueryLuokalleJaaneet = MassaluovutusQueryLuokalleJaaneet(
+  val jsonQuery: MassaluovutusQueryLuokalleJaaneet = MassaluovutusQueryLuokalleJaaneetJson(
+    organisaatioOid = Some(MockOrganisaatiot.helsinginKaupunki)
+  )
+
+  val csvQuery: MassaluovutusQueryLuokalleJaaneet = MassaluovutusQueryLuokalleJaaneetCsv(
     organisaatioOid = Some(MockOrganisaatiot.helsinginKaupunki)
   )
 }

--- a/src/main/scala/fi/oph/koski/massaluovutus/luokallejaaneet/MassaluovutusQueryLuokalleJaaneetJson.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/luokallejaaneet/MassaluovutusQueryLuokalleJaaneetJson.scala
@@ -1,0 +1,28 @@
+package fi.oph.koski.massaluovutus.luokallejaaneet
+
+import fi.oph.koski.config.KoskiApplication
+import fi.oph.koski.http.HttpStatus
+import fi.oph.koski.koskiuser.KoskiSpecificSession
+import fi.oph.koski.massaluovutus.MassaluovutusUtils.defaultOrganisaatio
+import fi.oph.koski.massaluovutus.{QueryFormat, QueryResultWriter}
+import fi.oph.koski.schema.annotation.EnumValues
+
+case class MassaluovutusQueryLuokalleJaaneetJson(
+  `type`: String = "luokallejaaneet",
+  @EnumValues(Set(QueryFormat.json))
+  format: String = QueryFormat.json,
+  organisaatioOid: Option[String],
+) extends MassaluovutusQueryLuokalleJaaneet {
+  override def run(application: KoskiApplication, writer: QueryResultWriter)(implicit user: KoskiSpecificSession): Either[String, Unit] = {
+    forEachResult(application) { result =>
+      writer.putJson(s"${result.opiskeluoikeus.oid.getOrElse("")}_luokka_${result.luokka}", result)
+    }
+  }
+
+  override def fillAndValidate(implicit user: KoskiSpecificSession): Either[HttpStatus, MassaluovutusQueryLuokalleJaaneet] =
+    if (organisaatioOid.isEmpty) {
+      defaultOrganisaatio.map(o => copy(organisaatioOid = Some(o)))
+    } else {
+      Right(this)
+    }
+}

--- a/src/test/scala/fi/oph/koski/massaluovutus/MassaluovutusSpec.scala
+++ b/src/test/scala/fi/oph/koski/massaluovutus/MassaluovutusSpec.scala
@@ -8,13 +8,12 @@ import fi.oph.koski.http.KoskiErrorCategory
 import fi.oph.koski.json.JsonSerializer
 import fi.oph.koski.koskiuser.{KoskiSpecificSession, MockUsers, UserWithPassword}
 import fi.oph.koski.log.AuditLogTester
-import fi.oph.koski.massaluovutus.luokallejaaneet.MassaluovutusQueryLuokalleJaaneet
+import fi.oph.koski.massaluovutus.luokallejaaneet.{MassaluovutusQueryLuokalleJaaneet, MassaluovutusQueryLuokalleJaaneetJson}
 import fi.oph.koski.massaluovutus.organisaationopiskeluoikeudet.{MassaluovutusQueryOrganisaationOpiskeluoikeudet, MassaluovutusQueryOrganisaationOpiskeluoikeudetCsv, MassaluovutusQueryOrganisaationOpiskeluoikeudetJson, QueryOrganisaationOpiskeluoikeudetCsvDocumentation}
 import fi.oph.koski.massaluovutus.paallekkaisetopiskeluoikeudet.MassaluovutusQueryPaallekkaisetOpiskeluoikeudet
 import fi.oph.koski.massaluovutus.suoritusrekisteri.{SuoritusrekisteriMuuttuneetJalkeenQuery, SuoritusrekisteriOppijaOidsQuery}
 import fi.oph.koski.massaluovutus.valintalaskenta.ValintalaskentaQuery
 import fi.oph.koski.organisaatio.MockOrganisaatiot
-import fi.oph.koski.organisaatio.MockOrganisaatiot.jyväskylänNormaalikoulu
 import fi.oph.koski.raportit.RaportitService
 import fi.oph.koski.schema.KoskiSchema.strictDeserialization
 import fi.oph.koski.schema.{KoskeenTallennettavaOpiskeluoikeus, LocalizedString, PerusopetuksenVuosiluokanSuoritus}
@@ -895,19 +894,19 @@ class MassaluovutusSpec extends AnyFreeSpec with KoskiHttpSpec with Matchers wit
   "Luokalle jäämiset" - {
     "JSON" - {
       "Ei onnistu väärän organisaation tietoihin" in {
-        addQuery(MassaluovutusQueryLuokalleJaaneet(organisaatioOid = Some(MockOrganisaatiot.jyväskylänNormaalikoulu)), MockUsers.helsinkiKatselija) {
+        addQuery(MassaluovutusQueryLuokalleJaaneetJson(organisaatioOid = Some(MockOrganisaatiot.jyväskylänNormaalikoulu)), MockUsers.helsinkiKatselija) {
           verifyResponseStatus(403, KoskiErrorCategory.forbidden())
         }
       }
 
       "Ei onnistu, jos organisaatiota ei ole annettu, eikä sitä voida päätellä yksiselitteisesti" in {
-        addQuery(MassaluovutusQueryLuokalleJaaneet(organisaatioOid = None), MockUsers.kahdenOrganisaatioPalvelukäyttäjä) {
+        addQuery(MassaluovutusQueryLuokalleJaaneetJson(organisaatioOid = None), MockUsers.kahdenOrganisaatioPalvelukäyttäjä) {
           verifyResponseStatus(400, KoskiErrorCategory.badRequest.massaluovutus.eiYksiselitteinenOrganisaatio())
         }
       }
 
       "Ei onnistu ilman oikeuksia sensitiivisen datan lukemiseen" in {
-        addQuery(MassaluovutusQueryLuokalleJaaneet(organisaatioOid = Some(MockOrganisaatiot.jyväskylänNormaalikoulu)), MockUsers.tallentajaEiLuottamuksellinen) {
+        addQuery(MassaluovutusQueryLuokalleJaaneetJson(organisaatioOid = Some(MockOrganisaatiot.jyväskylänNormaalikoulu)), MockUsers.tallentajaEiLuottamuksellinen) {
           verifyResponseStatus(403, KoskiErrorCategory.forbidden())
         }
       }
@@ -915,7 +914,7 @@ class MassaluovutusSpec extends AnyFreeSpec with KoskiHttpSpec with Matchers wit
       "Kysely onnistuu ja palauttaa oikeat tiedostot" in {
         AuditLogTester.clearMessages()
         val user = MockUsers.helsinkiKatselija
-        val queryId = addQuerySuccessfully(MassaluovutusQueryLuokalleJaaneet(organisaatioOid = None), user) { response =>
+        val queryId = addQuerySuccessfully(MassaluovutusQueryLuokalleJaaneetJson(organisaatioOid = None), user) { response =>
           response.status should equal(QueryState.pending)
           response.query.asInstanceOf[MassaluovutusQueryLuokalleJaaneet].organisaatioOid should contain(MockOrganisaatiot.helsinginKaupunki)
           response.queryId
@@ -934,7 +933,7 @@ class MassaluovutusSpec extends AnyFreeSpec with KoskiHttpSpec with Matchers wit
       }
 
       "Toisen käyttäjän kyselyn tietoja ei voi hakea" in {
-        val queryId = addQuerySuccessfully(MassaluovutusQueryLuokalleJaaneet(organisaatioOid = None), MockUsers.helsinkiKatselija)(_.queryId)
+        val queryId = addQuerySuccessfully(MassaluovutusQueryLuokalleJaaneetJson(organisaatioOid = None), MockUsers.helsinkiKatselija)(_.queryId)
         getQuery(queryId, MockUsers.jyväskylänKatselijaEsiopetus) {
           verifyResponseStatus(404, KoskiErrorCategory.notFound())
         }


### PR DESCRIPTION
- **Lisää mahdollisuus ladata luokalle jääneet csv-tiedostona**
- **Lisää virherivit opiskeluoikeuksien kohdalle, joissa havaittiin rikkinäinen historia**
