### PR TITLE
TOR-2210: OmaData OAuth2: Palauta tiedonhyödyntäjälle 404 aina, jos oppijalla ei ole mitään opiskeluoikeuksia kannassa

### DIFF
--- a/src/main/resources/documentation/omadata_oauth2.md
+++ b/src/main/resources/documentation/omadata_oauth2.md
@@ -184,6 +184,19 @@ Esimerkki palautettavan datan rakenteesta:
         }
     }
 
+### Virhetilanteet
+
+OAuth2:n speksaamissa authorization ja token endpoint rajapinnoissa palautetaan virheilmoitukset speksin mukaisina. Esimerkiksi
+token endpointissa virhekoodi `400 Bad Request` ja sisältönä JSON, esimerkiksi:
+
+    {
+      "error" : "invalid_client",
+      "error_description" : "Varmenne puuttuu"
+    }
+
+Resource endpointeissa käytetään myös yleisempiä virhekoodeja. Esimerkiksi jos oppijalla ei ole tallennettuna mitään
+opiskeluoikeuksia KOSKI-palveluun tai KOSKI-palvelun kautta välitettäviin VIRTA- ja Ylioppilastutkintorekistereihin,
+palautetaan virhekoodi `404 Not Found`.
 
 ## Huomioita datan käsittelystä
 

--- a/src/main/scala/fi/oph/koski/suoritusjako/common/OpiskeluoikeusFacade.scala
+++ b/src/main/scala/fi/oph/koski/suoritusjako/common/OpiskeluoikeusFacade.scala
@@ -104,7 +104,7 @@ class OpiskeluoikeusFacade[OPISKELUOIKEUS: TypeTag](
     }
   }
 
-  def getAndConvertYtrData(
+  private def getAndConvertYtrData(
     masterHenkilö: LaajatOppijaHenkilöTiedot,
     useDownloadedYtr: Boolean,
     converter: schema.YlioppilastutkinnonOpiskeluoikeus => OPISKELUOIKEUS
@@ -119,7 +119,7 @@ class OpiskeluoikeusFacade[OPISKELUOIKEUS: TypeTag](
     }
   }
 
-  def fetchYtrOpiskeluoikeudet(
+  private def fetchYtrOpiskeluoikeudet(
     masterHenkilö: LaajatOppijaHenkilöTiedot,
     useDownloadedYtr: Boolean)
   : Seq[schema.YlioppilastutkinnonOpiskeluoikeus] = {
@@ -136,7 +136,7 @@ class OpiskeluoikeusFacade[OPISKELUOIKEUS: TypeTag](
     }
   }
 
-  def fetchDownloadedYtrOpiskeluoikeudet(
+  private def fetchDownloadedYtrOpiskeluoikeudet(
     masterHenkilö: LaajatOppijaHenkilöTiedot
   ): Seq[schema.YlioppilastutkinnonOpiskeluoikeus] = {
     application.oppijaFacade.findYtrDownloadedOppija(
@@ -148,7 +148,7 @@ class OpiskeluoikeusFacade[OPISKELUOIKEUS: TypeTag](
       .getOrElse(Seq.empty)
   }
 
-  def fetchYtrOpiskeluoikeudet(
+  private def fetchYtrOpiskeluoikeudet(
     masterHenkilö: LaajatOppijaHenkilöTiedot
   ): Seq[schema.YlioppilastutkinnonOpiskeluoikeus] = {
     application.ytr.findByOppija(masterHenkilö)(KoskiSpecificSession.systemUserTallennetutYlioppilastutkinnonOpiskeluoikeudet).collect {

--- a/src/test/scala/fi/oph/koski/hakemuspalvelu/HakemuspalveluServiceSpec.scala
+++ b/src/test/scala/fi/oph/koski/hakemuspalvelu/HakemuspalveluServiceSpec.scala
@@ -67,17 +67,31 @@ class HakemuspalveluServiceSpec
     }
   }
 
-  "Kosken testioppijoiden tiedot voi hakea ilman virheitä" in {
+  "Kosken testioppijoiden tiedot voi hakea, ja ne joko palauttavat tiedot tai 404" in {
+    // Tämä testi varmistaa, että mitään yllättäviä 500 tms. virheitä ei tapahdu, ja suuruusluokat on oikein, eli suurin osa testioppijoista löytyy, ja osa palauttaa 404.
     val oppijaOidit = KoskiSpecificMockOppijat.defaultOppijat
       .filter(o => o.henkilö.hetu.isEmpty || o.henkilö.hetu.exists(!KoskiApplicationForTests.virtaClient.asInstanceOf[MockVirtaClient].virheenAiheuttavaHetu(_)))
       .map(_.henkilö.oid)
 
     oppijaOidit.length should be > 100
 
-    oppijaOidit.foreach(oppijaOid => {
-      val result = hakemuspalveluService.findOppija(oppijaOid)
-      result.isRight should be(true)
-    })
+    val results = oppijaOidit.map(hakemuspalveluService.findOppija)
+
+    val (onnistuu, eiOnnistu) = results.partition(_.isRight)
+
+    val (eiOnnistu404, _) = eiOnnistu.partition(_.left.get.statusCode == 404)
+
+    onnistuu.length should be > 100
+    eiOnnistu.length should be > 20
+    eiOnnistu.length should be < 35
+    eiOnnistu.length should be(eiOnnistu404.length)
+  }
+
+  "Oppija, josta ei ole tietoja Koskessa/YTR:ssä/Virrassa, palauttaa 404" in {
+    val result = hakemuspalveluService.findOppija(KoskiSpecificMockOppijat.vainMitätöityjäOpiskeluoikeuksia.oid)
+
+    result.isLeft should be(true)
+    result.left.get.statusCode should be(404)
   }
 
   "Korkeakoulu" - {

--- a/src/test/scala/fi/oph/koski/omadataoauth2/unit/OmaDataOAuth2BackendSpec.scala
+++ b/src/test/scala/fi/oph/koski/omadataoauth2/unit/OmaDataOAuth2BackendSpec.scala
@@ -1,10 +1,11 @@
 package fi.oph.koski.omadataoauth2.unit
 
 import fi.oph.koski.aktiivisetjapaattyneetopinnot.AktiivisetJaPäättyneetOpinnotMuunKuinSäännellynKoulutuksenOpiskeluoikeus
-import fi.oph.koski.api.misc.OpiskeluoikeusTestMethods
+import fi.oph.koski.api.misc.{OpiskeluoikeusTestMethods, OpiskeluoikeusTestMethodsPerusopetus, PutOpiskeluoikeusTestMethods}
 import fi.oph.koski.db.KoskiTables.OAuth2JakoKaikki
 import fi.oph.koski.db.PostgresDriverWithJsonSupport.api._
-import fi.oph.koski.fixture.FixtureCreator
+import fi.oph.koski.documentation.PerusopetusExampleData
+import fi.oph.koski.fixture.{FixtureCreator, PerusopetuksenOpiskeluoikeusTestData}
 import fi.oph.koski.henkilo.KoskiSpecificMockOppijat
 import fi.oph.koski.http.KoskiErrorCategory
 import fi.oph.koski.json.JsonSerializer
@@ -27,6 +28,7 @@ class OmaDataOAuth2BackendSpec
     with OpiskeluoikeusTestMethods
     with SuoritetutTutkinnotVerifiers
     with AktiivisetJaPäättyneetOpinnotVerifiers
+    with OpiskeluoikeusTestMethodsPerusopetus
 {
   "authorization-server rajapinta" - {
     "voi kutsua, kun on käyttöoikeudet" in {
@@ -949,37 +951,72 @@ class OmaDataOAuth2BackendSpec
       }
     }
 
-    "kun oppijaa ei löydy lainkaan, palautetaan 404" in {
-      val olemassaolematonOppijaOid = FixtureCreator.generateOppijaOid(999999978)
-      val palveluKäyttäjä = MockUsers.omadataOAuth2KaikkiOikeudetPalvelukäyttäjä
-      val clientId = palveluKäyttäjä.username
+    val olemassaolematonOppijaOid = FixtureCreator.generateOppijaOid(999999978)
 
-      val scope = "HENKILOTIEDOT_SYNTYMAAIKA HENKILOTIEDOT_NIMI OPISKELUOIKEUDET_KAIKKI_TIEDOT"
+    Seq("OPISKELUOIKEUDET_KAIKKI_TIEDOT", "OPISKELUOIKEUDET_SUORITETUT_TUTKINNOT", "OPISKELUOIKEUDET_AKTIIVISET_JA_PAATTYNEET_OPINNOT").map(ooScope => {
+      s"Kun oppijan kaikki opiskeluoikeudet on mitätöity, palautetaan 404 - ${ooScope}" in {
+        val mitätöityOppijaOid = KoskiSpecificMockOppijat.vainMitätöityjäOpiskeluoikeuksia.oid
+        val palveluKäyttäjä = MockUsers.omadataOAuth2KaikkiOikeudetPalvelukäyttäjä
+        val clientId = palveluKäyttäjä.username
 
-      val pkce = createChallengeAndVerifier
+        val scope = s"HENKILOTIEDOT_SYNTYMAAIKA HENKILOTIEDOT_NIMI ${ooScope}"
 
-      KoskiApplicationForTests.omaDataOAuth2Repository.create(
-        code = "foo",
-        oppijaOid = olemassaolematonOppijaOid,
-        clientId,
-        scope,
-        codeChallenge = pkce.challenge,
-        redirectUri = validRedirectUri
-      ).isRight should be(true)
+        val pkce = createChallengeAndVerifier
 
-      val token = KoskiApplicationForTests.omaDataOAuth2Repository.createAccessTokenForCode(
-        "foo",
-        clientId,
-        pkce.challenge,
-        Some(validRedirectUri),
-        scope.split(" ").toSet
-      ).getOrElse(throw new Error("Internal error"))
-        .accessToken
+        KoskiApplicationForTests.omaDataOAuth2Repository.create(
+          code = s"foo${ooScope}",
+          oppijaOid = mitätöityOppijaOid,
+          clientId,
+          scope,
+          codeChallenge = pkce.challenge,
+          redirectUri = validRedirectUri
+        ).isRight should be(true)
 
-      postResourceServer(token, palveluKäyttäjä) {
-        verifyResponseStatus(404)
+        val token = KoskiApplicationForTests.omaDataOAuth2Repository.createAccessTokenForCode(
+            s"foo${ooScope}",
+            clientId,
+            pkce.challenge,
+            Some(validRedirectUri),
+            scope.split(" ").toSet
+          ).getOrElse(throw new Error("Internal error"))
+          .accessToken
+
+        postResourceServer(token, palveluKäyttäjä) {
+          verifyResponseStatus(404)
+        }
       }
-    }
+
+      s"kun oppijaa ei löydy lainkaan, palautetaan 404 - ${ooScope}" in {
+        val palveluKäyttäjä = MockUsers.omadataOAuth2KaikkiOikeudetPalvelukäyttäjä
+        val clientId = palveluKäyttäjä.username
+
+        val scope = s"HENKILOTIEDOT_SYNTYMAAIKA HENKILOTIEDOT_NIMI ${ooScope}"
+
+        val pkce = createChallengeAndVerifier
+
+        KoskiApplicationForTests.omaDataOAuth2Repository.create(
+          code = s"foobar${ooScope}",
+          oppijaOid = olemassaolematonOppijaOid,
+          clientId,
+          scope,
+          codeChallenge = pkce.challenge,
+          redirectUri = validRedirectUri
+        ).isRight should be(true)
+
+        val token = KoskiApplicationForTests.omaDataOAuth2Repository.createAccessTokenForCode(
+            s"foobar${ooScope}",
+            clientId,
+            pkce.challenge,
+            Some(validRedirectUri),
+            scope.split(" ").toSet
+          ).getOrElse(throw new Error("Internal error"))
+          .accessToken
+
+        postResourceServer(token, palveluKäyttäjä) {
+          verifyResponseStatus(404)
+        }
+      }
+    })
   }
 
   "suostumusten hallinta" - {
@@ -990,7 +1027,9 @@ class OmaDataOAuth2BackendSpec
     }
 
     "palauttaa kansalaisen antaman suostumuksen" in {
-      clearOppijanOpiskeluoikeudet(validKansalainen.oid)
+      setupOppijaWithOpiskeluoikeus(opiskeluoikeus = PerusopetusExampleData.päättötodistusOpiskeluoikeus(), henkilö = validKansalainen) {
+        verifyResponseStatusOk()
+      }
       val pkce = createChallengeAndVerifier
       val token = createAuthorizationAndToken(validKansalainen, pkce)
 
@@ -1007,8 +1046,9 @@ class OmaDataOAuth2BackendSpec
     }
 
     "suostumuksen voi perua, ja se aiheuttaa audit lokimerkinnän" in {
-      clearOppijanOpiskeluoikeudet(validKansalainen.oid)
-
+      setupOppijaWithOpiskeluoikeus(opiskeluoikeus = PerusopetusExampleData.päättötodistusOpiskeluoikeus(), henkilö = validKansalainen) {
+        verifyResponseStatusOk()
+      }
       val pkce = createChallengeAndVerifier
       val token = createAuthorizationAndToken(validKansalainen, pkce)
 
@@ -1043,8 +1083,9 @@ class OmaDataOAuth2BackendSpec
     }
 
     "toinen oppija ei voi perua toisen suostumusta" in {
-      clearOppijanOpiskeluoikeudet(validKansalainen.oid)
-
+      setupOppijaWithOpiskeluoikeus(opiskeluoikeus = PerusopetusExampleData.päättötodistusOpiskeluoikeus(), henkilö = validKansalainen) {
+        verifyResponseStatusOk()
+      }
       val pkce = createChallengeAndVerifier
       val token = createAuthorizationAndToken(validKansalainen, pkce)
 

--- a/src/test/scala/fi/oph/koski/suoritusjako/aktiivisetjapaattyneetopinnot/AktiivisetJaPaattyneetOpinnotServiceSpec.scala
+++ b/src/test/scala/fi/oph/koski/suoritusjako/aktiivisetjapaattyneetopinnot/AktiivisetJaPaattyneetOpinnotServiceSpec.scala
@@ -58,17 +58,31 @@ class AktiivisetJaPäättyneetOpinnotServiceSpec
     super.afterEach()
   }
 
-  "Kosken testioppijoiden tiedot voi hakea ilman virheitä" in {
+  "Kosken testioppijoiden tiedot voi hakea, ja ne joko palauttavat tiedot tai 404" in {
+    // Tämä testi varmistaa, että mitään yllättäviä 500 tms. virheitä ei tapahdu, ja suuruusluokat on oikein, eli suurin osa testioppijoista löytyy, ja osa palauttaa 404.
     val oppijaOidit = KoskiSpecificMockOppijat.defaultOppijat
       .filter(o => o.henkilö.hetu.isEmpty || o.henkilö.hetu.exists(!KoskiApplicationForTests.virtaClient.asInstanceOf[MockVirtaClient].virheenAiheuttavaHetu(_)))
       .map(_.henkilö.oid)
 
     oppijaOidit.length should be > 100
 
-    oppijaOidit.foreach(oppijaOid => {
-      val result = suoritusjakoService.findAktiivisetJaPäättyneetOpinnotOppija(oppijaOid)
-      result.isRight should be(true)
-    })
+    val result = oppijaOidit.map(suoritusjakoService.findAktiivisetJaPäättyneetOpinnotOppija)
+
+    val (onnistuu, eiOnnistu) = result.partition(_.isRight)
+
+    val (eiOnnistu404, _) = eiOnnistu.partition(_.left.get.statusCode == 404)
+
+    onnistuu.length should be > 100
+    eiOnnistu.length should be > 20
+    eiOnnistu.length should be < 35
+    eiOnnistu.length should be(eiOnnistu404.length)
+  }
+
+  "Oppija, josta ei ole tietoja Koskessa/YTR:ssä/Virrassa, palauttaa 404" in {
+    val result = suoritusjakoService.findAktiivisetJaPäättyneetOpinnotOppija(KoskiSpecificMockOppijat.vainMitätöityjäOpiskeluoikeuksia.oid)
+
+    result.isLeft should be(true)
+    result.left.get.statusCode should be(404)
   }
 
   "Palautetaan EQF- ja NQF-tietoja" in {

--- a/src/test/scala/fi/oph/koski/vkt/VktServiceSpec.scala
+++ b/src/test/scala/fi/oph/koski/vkt/VktServiceSpec.scala
@@ -66,17 +66,31 @@ class VktServiceSpec
     }
   }
 
-  "Kosken testioppijoiden tiedot voi hakea ilman virheitä" in {
+  "Kosken testioppijoiden tiedot voi hakea, ja ne joko palauttavat tiedot tai 404" in {
+    // Tämä testi varmistaa, että mitään yllättäviä 500 tms. virheitä ei tapahdu, ja suuruusluokat on oikein, eli suurin osa testioppijoista löytyy, ja osa palauttaa 404.
     val oppijaOidit = KoskiSpecificMockOppijat.defaultOppijat
       .filter(o => o.henkilö.hetu.isEmpty || o.henkilö.hetu.exists(!KoskiApplicationForTests.virtaClient.asInstanceOf[MockVirtaClient].virheenAiheuttavaHetu(_)))
       .map(_.henkilö.oid)
 
     oppijaOidit.length should be > 100
 
-    oppijaOidit.foreach(oppijaOid => {
-      val result = vktService.findOppija(oppijaOid)
-      result.isRight should be(true)
-    })
+    val results = oppijaOidit.map(vktService.findOppija)
+
+    val (onnistuu, eiOnnistu) = results.partition(_.isRight)
+
+    val (eiOnnistu404, _) = eiOnnistu.partition(_.left.get.statusCode == 404)
+
+    onnistuu.length should be > 100
+    eiOnnistu.length should be > 20
+    eiOnnistu.length should be < 35
+    eiOnnistu.length should be(eiOnnistu404.length)
+  }
+
+  "Oppija, josta ei ole tietoja Koskessa/YTR:ssä/Virrassa, palauttaa 404" in {
+    val result = vktService.findOppija(KoskiSpecificMockOppijat.vainMitätöityjäOpiskeluoikeuksia.oid)
+
+    result.isLeft should be(true)
+    result.left.get.statusCode should be(404)
   }
 
   "Korkeakoulu" - {


### PR DESCRIPTION
Ks. commit-viestit