### PR TITLE
TOR-2263: Korjaa väärä laajuuden yksikkö käytettäessä vanhaa tallennettua paikallista kurssia

### DIFF
--- a/web/app/ib/dialogs/UusiIBTutkintoOsasuoritusDialog.tsx
+++ b/web/app/ib/dialogs/UusiIBTutkintoOsasuoritusDialog.tsx
@@ -74,12 +74,11 @@ export const UusiIBTutkintoOsasuoritusDialog: AddOppiaineenOsasuoritusDialog<
         )
         state.tunniste.set(tunniste)
         state.kuvaus.set(kurssi?.kuvaus)
-        state.laajuus.set(kurssi?.laajuus)
       } else if (option?.value) {
         state.tunniste.set(option.value)
       }
     },
-    [ibKurssit, state.kuvaus, state.laajuus, state.tunniste]
+    [ibKurssit, state.kuvaus, state.tunniste]
   )
 
   const onPaikallinenKoulutus = useCallback(


### PR DESCRIPTION
Ei aseteta laajuutta tilakoneelle, vaan pakotetaan se päättelemään se itse päivämäärän perusteella
