### PR TITLE
TOR-2329: Kielitutkintojen muutoksia

### DIFF
--- a/.github/skip_tiedonsiirtoprotokollan_muutoshistoria.md
+++ b/.github/skip_tiedonsiirtoprotokollan_muutoshistoria.md
@@ -10,3 +10,4 @@ TOR-2238 - lisätty Arvioinniton-kantaluokka, mutta itse skeeman rakenne ei ole 
 TOR-2047 - Muutettu vain tietomallin käliin vaikuttavaa osaa, ei vaikutusta koulutusjärjestelmiin
 TOR-2222 - lisätty tietomalliin traitteja, jolla ei ole toiminnallisia vaikutuksia
 TOR-2298 - Poistettu kommentti koodista
+TOR-2329 - Ei oleellista muutosta vkt-tietomalliin

--- a/.github/skip_tiedonsiirtoprotokollan_muutoshistoria.md
+++ b/.github/skip_tiedonsiirtoprotokollan_muutoshistoria.md
@@ -10,4 +10,3 @@ TOR-2238 - lisätty Arvioinniton-kantaluokka, mutta itse skeeman rakenne ei ole 
 TOR-2047 - Muutettu vain tietomallin käliin vaikuttavaa osaa, ei vaikutusta koulutusjärjestelmiin
 TOR-2222 - lisätty tietomalliin traitteja, jolla ei ole toiminnallisia vaikutuksia
 TOR-2298 - Poistettu kommentti koodista
-TOR-2329 - Ei oleellista muutosta vkt-tietomalliin

--- a/src/main/resources/localization/koski-default-texts.json
+++ b/src/main/resources/localization/koski-default-texts.json
@@ -2826,5 +2826,8 @@
   "Y-tunnus": "Y-tunnus",
   "Testipaikka": "Testipaikka",
   "Testipäivä": "Testipäivä",
-  "Tutkinnon taso": "Tutkinnon taso"
+  "Tutkinnon taso": "Tutkinnon taso",
+  "Suoritettu": "Suoritettu",
+  "Tutkintosuorituksen vastaanottaja": "Tutkintosuorituksen vastaanottaja",
+  "Osakoe": "Osakoe"
 }

--- a/src/main/resources/localization/koski-default-texts.json
+++ b/src/main/resources/localization/koski-default-texts.json
@@ -2825,5 +2825,6 @@
   "Yths maksettu": "Yths maksettu",
   "Y-tunnus": "Y-tunnus",
   "Testipaikka": "Testipaikka",
-  "Testipäivä": "Testipäivä"
+  "Testipäivä": "Testipäivä",
+  "Tutkinnon taso": "Tutkinnon taso"
 }

--- a/src/main/resources/localization/koski-default-texts.json
+++ b/src/main/resources/localization/koski-default-texts.json
@@ -2829,5 +2829,6 @@
   "Tutkinnon taso": "Tutkinnon taso",
   "Suoritettu": "Suoritettu",
   "Tutkintosuorituksen vastaanottaja": "Tutkintosuorituksen vastaanottaja",
-  "Osakoe": "Osakoe"
+  "Osakoe": "Osakoe",
+  "Suorituspaikkakunta": "Suorituspaikkakunta"
 }

--- a/src/main/resources/localization/koski-default-texts.json
+++ b/src/main/resources/localization/koski-default-texts.json
@@ -2823,5 +2823,7 @@
   "Yritä uudestaan": "Yritä uudestaan",
   "Yritys": "Yritys",
   "Yths maksettu": "Yths maksettu",
-  "Y-tunnus": "Y-tunnus"
+  "Y-tunnus": "Y-tunnus",
+  "Testipaikka": "Testipaikka",
+  "Testipäivä": "Testipäivä"
 }

--- a/src/main/resources/mockdata/koodisto/koodit/vktkielitaito.json
+++ b/src/main/resources/mockdata/koodisto/koodit/vktkielitaito.json
@@ -2,7 +2,7 @@
   {
     "metadata": [
       {
-        "nimi": "Suullinen kielitaito",
+        "nimi": "Suullinen taito",
         "kuvaus": "",
         "lyhytNimi": "",
         "kieli": "FI"
@@ -18,7 +18,7 @@
   {
     "metadata": [
       {
-        "nimi": "Kirjallinen kielitaito",
+        "nimi": "Kirjallinen taito",
         "kuvaus": "",
         "lyhytNimi": "",
         "kieli": "FI"
@@ -34,7 +34,7 @@
   {
     "metadata": [
       {
-        "nimi": "Ymmärtämisen kielitaito",
+        "nimi": "Ymmärtämisen taito",
         "kuvaus": "",
         "lyhytNimi": "",
         "kieli": "FI"

--- a/src/main/scala/fi/oph/koski/documentation/ExamplesKielitutkinto.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesKielitutkinto.scala
@@ -2,6 +2,7 @@ package fi.oph.koski.documentation
 
 import fi.oph.koski.henkilo.MockOppijat.asUusiOppija
 import fi.oph.koski.henkilo.{KoskiSpecificMockOppijat, LaajatOppijaHenkilöTiedot}
+import fi.oph.koski.koskiuser.MockUsers.varsinaisSuomiKoulutustoimija
 import fi.oph.koski.organisaatio.MockOrganisaatiot
 import fi.oph.koski.schema._
 
@@ -139,9 +140,16 @@ object ExamplesKielitutkinto {
           kieli = Koodistokoodiviite(kieli, "kieli"),
         ),
         toimipiste = OidOrganisaatio(MockOrganisaatiot.varsinaisSuomenKansanopistoToimipiste),
-        vahvistus = if (osakokeidenArvosanat.contains("hylatty")) None else Some(Päivämäärävahvistus(
+        vahvistus = if (osakokeidenArvosanat.contains("hylatty")) None else Some(HenkilövahvistusValinnaisellaTittelilläJaValinnaisellaPaikkakunnalla(
           päivä = arviointipäivä,
           myöntäjäOrganisaatio = OidOrganisaatio(MockOrganisaatiot.varsinaisSuomenKansanopistoToimipiste),
+          myöntäjäHenkilöt = List(
+            OrganisaatiohenkilöValinnaisellaTittelillä(
+              nimi = "Vallu Vastaanottaja",
+              organisaatio = OidOrganisaatio(MockOrganisaatiot.varsinaisSuomenKansanopistoToimipiste),
+            )
+          ),
+          paikkakunta = Some(Koodistokoodiviite("853", "kunta")),
         )),
         osasuoritukset = Some(kielitaidot.map {
           case "kirjallinen" => Kielitaidot.Kirjallinen.suoritus(arviointipäivä, osakokeidenArvosanat)

--- a/src/main/scala/fi/oph/koski/documentation/ExamplesKielitutkinto.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesKielitutkinto.scala
@@ -237,10 +237,19 @@ object ExamplesKielitutkinto {
       }
 
       private def kielitaidonArviointi(osakokeidenArvosanat: List[String], pvm: LocalDate): Option[List[ValtionhallinnonKielitutkinnonArviointi]] =
-        if (osakokeidenArvosanat.contains("hylatty")) None else arviointi(osakokeidenArvosanat.head, pvm)
+        arviointi(Arviointi.huonoinArvosana(osakokeidenArvosanat), pvm)
 
       private def osakokeenArvosana(osakokeidenArvosanat: List[String], index: Int): String =
         osakokeidenArvosanat(index % osakokeidenArvosanat.length)
+    }
+
+    object Arviointi {
+      val arvosanajärjestys = List("hylatty", "tyydyttava", "hyva", "erinomainen")
+      implicit val order: Ordering[String] = Ordering.fromLessThan(
+        (a: String, b: String) => arvosanajärjestys.indexOf(a) < arvosanajärjestys.indexOf(b)
+      )
+
+      def huonoinArvosana(arvosanat: List[String]) = arvosanat.min
     }
   }
 

--- a/src/main/scala/fi/oph/koski/documentation/ExamplesKielitutkinto.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesKielitutkinto.scala
@@ -2,7 +2,6 @@ package fi.oph.koski.documentation
 
 import fi.oph.koski.henkilo.MockOppijat.asUusiOppija
 import fi.oph.koski.henkilo.{KoskiSpecificMockOppijat, LaajatOppijaHenkilöTiedot}
-import fi.oph.koski.koskiuser.MockUsers.varsinaisSuomiKoulutustoimija
 import fi.oph.koski.organisaatio.MockOrganisaatiot
 import fi.oph.koski.schema._
 

--- a/src/main/scala/fi/oph/koski/documentation/ExamplesKielitutkinto.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesKielitutkinto.scala
@@ -141,7 +141,7 @@ object ExamplesKielitutkinto {
         toimipiste = OidOrganisaatio(MockOrganisaatiot.varsinaisSuomenKansanopistoToimipiste),
         vahvistus = if (osakokeidenArvosanat.contains("hylatty")) None else Some(Päivämäärävahvistus(
           päivä = arviointipäivä,
-          myöntäjäOrganisaatio = OidOrganisaatio(MockOrganisaatiot.helsinginKaupunki),
+          myöntäjäOrganisaatio = OidOrganisaatio(MockOrganisaatiot.varsinaisSuomenKansanopistoToimipiste),
         )),
         osasuoritukset = Some(kielitaidot.map {
           case "kirjallinen" => Kielitaidot.Kirjallinen.suoritus(arviointipäivä, osakokeidenArvosanat)
@@ -188,24 +188,27 @@ object ExamplesKielitutkinto {
           ValtionhallinnonKielitutkinnonKirjallisenKielitaidonSuoritus(
             koulutusmoduuli = ValtionhallinnonKielitutkinnonKirjallinenKielitaito(),
             osasuoritukset = Some(List(
-              osakoe("kirjoittaminen", osakokeenArvosana(osakokeidenArvosanat, 0), pvm),
-              osakoe("tekstinymmartaminen", osakokeenArvosana(osakokeidenArvosanat, 1), pvm),
+              osakoe("kirjoittaminen", List(
+                "hylatty",
+                osakokeenArvosana(osakokeidenArvosanat, 0),
+              ), pvm),
+              osakoe("tekstinymmartaminen", List(osakokeenArvosana(osakokeidenArvosanat, 1)), pvm),
             )),
             arviointi = kielitaidonArviointi(osakokeidenArvosanat, pvm),
           )
 
-        def osakoe(osakoe: String, arvosana: String, arviointiPäivä: LocalDate): ValtionhallinnonKielitutkinnonKirjallisenKielitaidonOsakokeenSuoritus =
+        def osakoe(osakoe: String, arvosanat: List[String], arviointiPäivä: LocalDate): ValtionhallinnonKielitutkinnonKirjallisenKielitaidonOsakokeenSuoritus =
           ValtionhallinnonKielitutkinnonKirjallisenKielitaidonOsakokeenSuoritus(
             koulutusmoduuli = osakoe match {
               case "kirjoittaminen" => ValtionhallinnonKirjoittamisenOsakoe()
               case "tekstinymmartaminen" => ValtionhallinnonTekstinYmmärtämisenOsakoe()
             },
-            arviointi = Some(List(
+            arviointi = Some(arvosanat.zipWithIndex.map { case (arvosana, index) =>
               ValtionhallinnonKielitutkinnonArviointi(
                 arvosana = Koodistokoodiviite(arvosana, "vktarvosana"),
-                päivä = arviointiPäivä,
+                päivä = arviointiPäivä.plusMonths(index),
               )
-            ))
+            }),
           )
       }
 

--- a/src/main/scala/fi/oph/koski/koskiuser/Kayttooikeus.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/Kayttooikeus.scala
@@ -122,8 +122,8 @@ object Käyttöoikeus {
     }
   }
 
-  def parseAllowedOpiskeluoikeudenTyypit(roolit: List[Palvelurooli], accessTypes: List[AccessType.Value]): Set[String] = {
-    val kaikkiOpiskeluoikeusTyypit = OpiskeluoikeudenTyyppi.kaikkiTyypit.map(_.koodiarvo)
+  def parseAllowedOpiskeluoikeudenTyypit(roolit: List[Palvelurooli], accessTypes: List[AccessType.Value], isRootUser: Boolean = false): Set[String] = {
+    val kaikkiOpiskeluoikeusTyypit = OpiskeluoikeudenTyyppi.kaikkiTyypit(isRootUser).map(_.koodiarvo)
     val kayttajanRoolit = unifyRoolit(roolit).filter(_.palveluName == "KOSKI").map(_.rooli.toLowerCase).toSet
     val opiskeluoikeudenTyyppiRajoituksia = kayttajanRoolit.intersect(kaikkiOpiskeluoikeusTyypit).nonEmpty
 
@@ -195,7 +195,7 @@ case class KäyttöoikeusGlobal(globalPalveluroolit: List[Palvelurooli]) extends
     case _ => Nil
   }
 
-  override lazy val allowedOpiskeluoikeusTyypit: Set[String] = Käyttöoikeus.parseAllowedOpiskeluoikeudenTyypit(globalPalveluroolit, globalAccessType)
+  override lazy val allowedOpiskeluoikeusTyypit: Set[String] = Käyttöoikeus.parseAllowedOpiskeluoikeudenTyypit(globalPalveluroolit, globalAccessType, isRootUser = true)
 }
 
 trait OrgKäyttöoikeus extends Käyttöoikeus {

--- a/src/main/scala/fi/oph/koski/koskiuser/Session.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/Session.scala
@@ -53,7 +53,7 @@ class KoskiSpecificSession(
   lazy val varhaiskasvatusKoulutustoimijat: Set[Oid] = varhaiskasvatusKäyttöoikeudet.map(_.koulutustoimija.oid)
   lazy val hasKoulutustoimijaVarhaiskasvatuksenJärjestäjäAccess: Boolean = varhaiskasvatusKäyttöoikeudet.nonEmpty
   lazy val allowedOpiskeluoikeusTyypit: Set[String] = käyttöoikeudet.flatMap(_.allowedOpiskeluoikeusTyypit)
-  lazy val hasKoulutusmuotoRestrictions: Boolean = allowedOpiskeluoikeusTyypit != OpiskeluoikeudenTyyppi.kaikkiTyypit.map(_.koodiarvo)
+  lazy val hasKoulutusmuotoRestrictions: Boolean = allowedOpiskeluoikeusTyypit != OpiskeluoikeudenTyyppi.kaikkiTyypit(isRoot).map(_.koodiarvo)
   lazy val kaikkiKäyttöoikeudet: Set[Käyttöoikeus] = käyttöoikeudet
 
   def organisationOids(accessType: AccessType.Value): Set[String] = orgKäyttöoikeudet.collect { case k: KäyttöoikeusOrg if k.organisaatioAccessType.contains(accessType) => k.organisaatio.oid }

--- a/src/main/scala/fi/oph/koski/luovutuspalvelu/TilastokeskusServlet.scala
+++ b/src/main/scala/fi/oph/koski/luovutuspalvelu/TilastokeskusServlet.scala
@@ -13,7 +13,7 @@ import fi.oph.koski.log._
 import fi.oph.koski.opiskeluoikeus.OpiskeluoikeusQueryFilter.{NotSuorituksenTyyppi, Poistettu}
 import fi.oph.koski.opiskeluoikeus.{OpiskeluoikeusQueryContext, OpiskeluoikeusQueryFilter, QueryOppijaHenkilö}
 import fi.oph.koski.schema.Henkilö.Oid
-import fi.oph.koski.schema.SuorituksenTyyppi.{vstosaamismerkki, vstvapaatavoitteinenkoulutus}
+import fi.oph.koski.schema.SuorituksenTyyppi.{valtionhallinnonKielitutkinto, vstosaamismerkki, vstvapaatavoitteinenkoulutus, yleinenKielitutkinto}
 import fi.oph.koski.schema._
 import fi.oph.koski.servlet.{KoskiSpecificApiServlet, NoCache, ObservableSupport}
 import fi.oph.koski.util.SortOrder.Ascending
@@ -45,6 +45,8 @@ case class TilastokeskusQueryContext(request: HttpServletRequest)(implicit koski
   val extraFilters = List(
     NotSuorituksenTyyppi(vstvapaatavoitteinenkoulutus),
     NotSuorituksenTyyppi(vstosaamismerkki),
+    NotSuorituksenTyyppi(yleinenKielitutkinto),
+    NotSuorituksenTyyppi(valtionhallinnonKielitutkinto),
     Poistettu(false)
   )
 

--- a/src/main/scala/fi/oph/koski/schema/Kielitutkinto.scala
+++ b/src/main/scala/fi/oph/koski/schema/Kielitutkinto.scala
@@ -129,6 +129,8 @@ trait ValtionhallinnonKielitutkinnonKielitaidonSuoritus extends Suoritus with Va
   @KoodistoKoodiarvo("valtionhallinnonkielitaito")
   def tyyppi: Koodistokoodiviite
   def arviointi: Option[List[ValtionhallinnonKielitutkinnonArviointi]]
+
+  override def kesken: Boolean = !arviointi.exists(_.exists(_.hyväksytty))
 }
 
 trait ValtionhallinnonKielitutkinnonKielitaito extends Koulutusmoduuli {

--- a/src/main/scala/fi/oph/koski/schema/Kielitutkinto.scala
+++ b/src/main/scala/fi/oph/koski/schema/Kielitutkinto.scala
@@ -102,7 +102,7 @@ case class ValtionhallinnonKielitutkinnonSuoritus(
   @Title("Koulutus")
   koulutusmoduuli: ValtionhallinnonKielitutkinto,
   toimipiste: OrganisaatioWithOid,
-  vahvistus: Option[Päivämäärävahvistus] = None,
+  vahvistus: Option[HenkilövahvistusValinnaisellaTittelilläJaValinnaisellaPaikkakunnalla] = None,
   override val osasuoritukset: Option[List[ValtionhallinnonKielitutkinnonKielitaidonSuoritus]],
   @KoodistoKoodiarvo("valtionhallinnonkielitutkinto")
   tyyppi: Koodistokoodiviite = Koodistokoodiviite("valtionhallinnonkielitutkinto", koodistoUri = "suorituksentyyppi"),

--- a/src/main/scala/fi/oph/koski/schema/Opiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/schema/Opiskeluoikeus.scala
@@ -150,6 +150,7 @@ trait Opiskeluoikeus extends Lähdejärjestelmällinen with OrganisaatioonLiitty
 
 object OpiskeluoikeudenTyyppi {
   private var tyypit: Set[Koodistokoodiviite] = Set()
+  private var rootUserTyypit: Set[Koodistokoodiviite] = Set()
 
   val aikuistenperusopetus = apply("aikuistenperusopetus")
   val ammatillinenkoulutus = apply("ammatillinenkoulutus")
@@ -170,15 +171,20 @@ object OpiskeluoikeudenTyyppi {
   val ebtutkinto = apply("ebtutkinto")
   val muukuinsaanneltykoulutus = apply("muukuinsaanneltykoulutus")
   val taiteenperusopetus = apply("taiteenperusopetus")
-  val kielitutkinto = apply("kielitutkinto")
+  val kielitutkinto = apply("kielitutkinto", vainGlobalUser = true)
 
-  private def apply(koodiarvo: String): Koodistokoodiviite = {
+  private def apply(koodiarvo: String, vainGlobalUser: Boolean = false): Koodistokoodiviite = {
     val tyyppi = Koodistokoodiviite(koodiarvo, "opiskeluoikeudentyyppi")
-    tyypit = tyypit + tyyppi
+    if (vainGlobalUser) {
+      rootUserTyypit += tyyppi
+    } else {
+      tyypit += tyyppi
+    }
     tyyppi
   }
 
-  def kaikkiTyypit: Set[Koodistokoodiviite] = tyypit
+  def kaikkiTyypit(isRootUser: Boolean): Set[Koodistokoodiviite] =
+    if (isRootUser) tyypit ++ rootUserTyypit else tyypit
 }
 
 trait KoskeenTallennettavaOpiskeluoikeus extends Opiskeluoikeus with LähdejärjestelmäkytkentäPurettavissa {

--- a/src/main/scala/fi/oph/koski/sso/LocalLoginServlet.scala
+++ b/src/main/scala/fi/oph/koski/sso/LocalLoginServlet.scala
@@ -15,7 +15,12 @@ class LocalLoginServlet(implicit val application: UserAuthenticationContext) ext
 
     loginRequestInBody match {
       case Some(Login(username, password)) =>
-        renderEither[AuthenticationUser](tryLogin(username, password).right.flatMap(user => setUser(Right(localLogin(user)))))
+        renderEither[AuthenticationUser](tryLogin(
+          username,
+          // Mahdollistaa testeille sotkun lisäämiseen salasanaan, jotta vältetään
+          // testejä blokkaava "salasanasi löytyi vuodettujen salasanojen listalta" -varoitus.
+          password.replaceAll("__.*", "")
+        ).right.flatMap(user => setUser(Right(localLogin(user)))))
       case None =>
         haltWithStatus(KoskiErrorCategory.badRequest("Login request missing from body"))
     }

--- a/src/test/scala/fi/oph/koski/api/misc/OppijaExamplesTest.scala
+++ b/src/test/scala/fi/oph/koski/api/misc/OppijaExamplesTest.scala
@@ -2,8 +2,10 @@ package fi.oph.koski.api.misc
 
 import fi.oph.koski.KoskiHttpSpec
 import fi.oph.koski.documentation.Examples.oppijaExamples
+import fi.oph.koski.documentation.ExamplesKielitutkinto
+import fi.oph.koski.documentation.ExamplesVapaaSivistystyöJotpa.Examples
 import fi.oph.koski.json.JsonSerializer
-import fi.oph.koski.koskiuser.MockUsers
+import fi.oph.koski.koskiuser.{KoskiMockUser, MockUsers}
 import fi.oph.koski.log.Logging
 import fi.oph.koski.schema.{Henkilö, HenkilöWithOid, UusiHenkilö}
 import org.scalatest.BeforeAndAfterAll
@@ -17,11 +19,14 @@ class OppijaExamplesTest extends AnyFreeSpec with Matchers with KoskiHttpSpec wi
   }
 
   "API examples" - {
+    val pääkäyttäjänäAjettavatEsimerkit = ExamplesKielitutkinto.examples
+
     oppijaExamples.foreach { example =>
       "PUT " + example.name in {
+        val user = if (pääkäyttäjänäAjettavatEsimerkit.contains(example)) MockUsers.paakayttaja else defaultUser
         val body = JsonSerializer.writeWithRoot(example.data).getBytes("utf-8")
         mitätöiOppijanKaikkiOpiskeluoikeudet(example.data.henkilö)
-        put("api/oppija", body = body, headers = authHeaders() ++ jsonContent) {
+        put("api/oppija", body = body, headers = authHeaders(user) ++ jsonContent) {
           verifyResponseStatusOk(example.statusCode)
           logger.info(example.name + ": OK")
         }

--- a/src/test/scala/fi/oph/koski/koskiuser/KaikilleOpiskeluoikeudenTyypeilleOnKayttooikeusSpec.scala
+++ b/src/test/scala/fi/oph/koski/koskiuser/KaikilleOpiskeluoikeudenTyypeilleOnKayttooikeusSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.should.Matchers
 
 class KaikilleOpiskeluoikeudenTyypeilleOnKayttooikeusSpec extends AnyFreeSpec with TestEnvironment with Matchers {
   "Kaikille opiskeluoikeuden tyypeille on määritelty Koskessa rooli" in {
-    OpiskeluoikeudenTyyppi.kaikkiTyypit.map(_.koodiarvo) should equal(Set(
+    OpiskeluoikeudenTyyppi.kaikkiTyypit(true).map(_.koodiarvo) should equal(Set(
       Rooli.AIKUISTENPERUSOPETUS,
       Rooli.AMMATILLINENKOULUTUS,
       Rooli.DIATUTKINTO,

--- a/src/test/scala/fi/oph/koski/koskiuser/KoskiSpecificSessionSpec.scala
+++ b/src/test/scala/fi/oph/koski/koskiuser/KoskiSpecificSessionSpec.scala
@@ -68,7 +68,7 @@ class KoskiSpecificSessionSpec
         createAndVerifySession("kalle", MockUsers.kalle.ldapUser)
       }
       "pääkäyttäjä" in {
-        val session = createAndVerifySession("pää", MockUsers.paakayttaja.ldapUser)
+        val session = createAndVerifySession("pää", MockUsers.paakayttaja.ldapUser, isRoot = true)
         session.hasGlobalReadAccess should be(true)
         session.isRoot should be(true)
         session.hasTiedonsiirronMitätöintiAccess(helsinginKaupunki, None)
@@ -153,7 +153,7 @@ class KoskiSpecificSessionSpec
     }
   }
 
-  private def createAndVerifySession(username: String, expected: DirectoryUser) = {
+  private def createAndVerifySession(username: String, expected: DirectoryUser, isRoot: Boolean = false) = {
     val authUser = AuthenticationUser.fromDirectoryUser(username, expected)
     val session = KoskiSpecificSession(authUser, req, käyttöoikeusRepository)
 
@@ -172,7 +172,7 @@ class KoskiSpecificSessionSpec
 
     val expectedAllowedOpiskeluoikeudenTyypit = expectedKäyttöoikeudet.flatMap(_.allowedOpiskeluoikeusTyypit)
     session.allowedOpiskeluoikeusTyypit should be(expectedAllowedOpiskeluoikeudenTyypit)
-    session.hasKoulutusmuotoRestrictions should be(expectedAllowedOpiskeluoikeudenTyypit != OpiskeluoikeudenTyyppi.kaikkiTyypit.map(_.koodiarvo))
+    session.hasKoulutusmuotoRestrictions should be(expectedAllowedOpiskeluoikeudenTyypit != OpiskeluoikeudenTyyppi.kaikkiTyypit(isRoot).map(_.koodiarvo))
     session
   }
 

--- a/src/test/scala/fi/oph/koski/luovutuspalvelu/TilastokeskusSpec.scala
+++ b/src/test/scala/fi/oph/koski/luovutuspalvelu/TilastokeskusSpec.scala
@@ -87,7 +87,7 @@ class TilastokeskusSpec extends AnyFreeSpec with KoskiHttpSpec with Opiskeluoike
     }
 
     "Sivuttaa" in {
-      resetFixtures
+      resetFixtures()
       val total = kaikkiOppijat.length
       total should be > 0
       (3 to total by 9).foreach { pageSize =>

--- a/tiedonsiirtoprotokollan_muutoshistoria.md
+++ b/tiedonsiirtoprotokollan_muutoshistoria.md
@@ -1,4 +1,4 @@
-## x.4.2025
+## xx.4.2025
 
 - Lisätty kielitutkinnon opiskeluoikeuteen valtionhallinon kielitutkinnot
 

--- a/valpas-web/package-lock.json
+++ b/valpas-web/package-lock.json
@@ -44,7 +44,7 @@
         "@typescript-eslint/parser": "^8.24.0",
         "babel-jest": "^29.7.0",
         "cheerio": "^1.0.0",
-        "chromedriver": "^133.0.1",
+        "chromedriver": "^135.0.1",
         "concurrently": "^9.1.2",
         "dotenv": "^16.4.7",
         "eslint": "^9.20.1",
@@ -4602,9 +4602,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "133.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-133.0.1.tgz",
-      "integrity": "sha512-Z9VrJ9547daetazzP4k+7COj0PTtkomvtt8OZr8swTzsqDOzG0Xymdxg0dUtptc4da3X9Zts1iZoxOkm7blx/g==",
+      "version": "135.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-135.0.1.tgz",
+      "integrity": "sha512-MLAS4t9dkttp1R1O2o/1nvtNIxg1dBTx7OE3ZCSrrFz+EFowd0wRAO7H5j918hw0i8+30yODq99p8CumvqRS9Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -14762,9 +14762,9 @@
       "dev": true
     },
     "chromedriver": {
-      "version": "133.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-133.0.1.tgz",
-      "integrity": "sha512-Z9VrJ9547daetazzP4k+7COj0PTtkomvtt8OZr8swTzsqDOzG0Xymdxg0dUtptc4da3X9Zts1iZoxOkm7blx/g==",
+      "version": "135.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-135.0.1.tgz",
+      "integrity": "sha512-MLAS4t9dkttp1R1O2o/1nvtNIxg1dBTx7OE3ZCSrrFz+EFowd0wRAO7H5j918hw0i8+30yODq99p8CumvqRS9Q==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.1.4",

--- a/valpas-web/package.json
+++ b/valpas-web/package.json
@@ -56,7 +56,7 @@
     "@typescript-eslint/parser": "^8.24.0",
     "babel-jest": "^29.7.0",
     "cheerio": "^1.0.0",
-    "chromedriver": "^133.0.1",
+    "chromedriver": "^135.0.1",
     "concurrently": "^9.1.2",
     "dotenv": "^16.4.7",
     "eslint": "^9.20.1",

--- a/valpas-web/test/integrationtests-env/browser/reset.ts
+++ b/valpas-web/test/integrationtests-env/browser/reset.ts
@@ -23,7 +23,7 @@ export const loginAs = async (
     await expectElementEventuallyVisible("#username")
   }, longTimeout)
   await (await $("#username")).sendKeys(username)
-  await (await $("#password")).sendKeys(username, Key.ENTER)
+  await (await $("#password")).sendKeys(username + "__xX1234$@", Key.ENTER)
   await driver.wait(
     until.elementLocated(By.css("article.page:not(#login-app)")),
     defaultTimeout,

--- a/web/app/components-v2/containers/EditorContainer.tsx
+++ b/web/app/components-v2/containers/EditorContainer.tsx
@@ -34,6 +34,7 @@ import { CHARCODE_ADD, Icon } from '../texts/Icon'
 import { Trans } from '../texts/Trans'
 import { isEmptyModelObject } from '../../util/objects'
 import { PathToken } from '../../util/laxModify'
+import { useVirkailijaUser } from '../../appstate/user'
 
 export type EditorContainerProps<T extends Opiskeluoikeus> =
   CommonPropsWithChildren<{
@@ -55,6 +56,7 @@ export type EditorContainerProps<T extends Opiskeluoikeus> =
     suorituksetVahvistettu?: boolean
     lisätiedotContainer?: React.FC<any>
     opiskeluoikeudenTilaEditor?: React.ReactNode
+    hideOpiskeluoikeusVoimassaoloaika?: boolean
   }>
 
 export type ActivePäätasonSuoritus<
@@ -71,6 +73,7 @@ export type ActivePäätasonSuoritus<
 export const EditorContainer = <T extends Opiskeluoikeus>(
   props: EditorContainerProps<T>
 ) => {
+  const virkailija = useVirkailijaUser()
   useConfirmUnload(props.form.editMode && props.form.hasChanged)
 
   const opiskeluoikeudenTilaPath = useMemo(
@@ -148,14 +151,17 @@ export const EditorContainer = <T extends Opiskeluoikeus>(
   return (
     <article {...common(props, ['EditorContainer'])}>
       <TestIdLayer id="opiskeluoikeus">
-        <OpiskeluoikeusEditToolbar
-          opiskeluoikeus={props.form.state}
-          editMode={props.form.editMode}
-          invalidatable={props.invalidatable}
-          onStartEdit={props.form.startEdit}
-        />
-
-        <Spacer />
+        {(!props.hideOpiskeluoikeusVoimassaoloaika || virkailija) && (
+          <>
+            <OpiskeluoikeusEditToolbar
+              opiskeluoikeus={props.form.state}
+              editMode={props.form.editMode}
+              invalidatable={props.invalidatable}
+              onStartEdit={props.form.startEdit}
+            />
+            <Spacer />
+          </>
+        )}
 
         {props.opiskeluoikeudenTilaEditor || (
           <>

--- a/web/app/components-v2/opiskeluoikeus/OpiskeluoikeusTitle.tsx
+++ b/web/app/components-v2/opiskeluoikeus/OpiskeluoikeusTitle.tsx
@@ -24,6 +24,7 @@ export type OpiskeluoikeusTitleProps = CommonProps<{
   // Nämä propertyt ylikirjoittavat opiskeluoikeudesta oletuksena tulkittavat arvot:
   oppilaitos?: string
   opiskeluoikeudenNimi?: string
+  pvmJaTila?: string
 }>
 
 const join = (...as: Array<string | undefined>) => as.filter(nonNull).join(', ')
@@ -47,17 +48,18 @@ export const OpiskeluoikeusTitle = (props: OpiskeluoikeusTitleProps) => {
       ? yearFromIsoDateString(props.opiskeluoikeus.päättymispäivä)
       : undefined
 
-  const vuodet =
+  const vuodet = () =>
     vainYhdenPäättävänTilanVuosi ||
     formatYearRange(
       props.opiskeluoikeus.alkamispäivä,
       props.opiskeluoikeus.päättymispäivä
     )
 
-  const aikaväliJaTila = join(
-    vuodet,
-    t(viimeisinOpiskelujaksonTila(props.opiskeluoikeus.tila)?.nimi)
-  )
+  const aikaväliJaTila = () =>
+    join(
+      vuodet(),
+      t(viimeisinOpiskelujaksonTila(props.opiskeluoikeus.tila)?.nimi)
+    )
 
   const oid: string | undefined = (props.opiskeluoikeus as any).oid
 
@@ -79,7 +81,7 @@ export const OpiskeluoikeusTitle = (props: OpiskeluoikeusTitleProps) => {
         >
           <TestIdText id="nimi">
             {otsikkoteksti} {'('}
-            <Lowercase>{aikaväliJaTila}</Lowercase>
+            <Lowercase>{props.pvmJaTila || aikaväliJaTila()}</Lowercase>
             {')'}
           </TestIdText>
         </Column>

--- a/web/app/components-v2/opiskeluoikeus/SuorituksenVahvistus.tsx
+++ b/web/app/components-v2/opiskeluoikeus/SuorituksenVahvistus.tsx
@@ -41,6 +41,7 @@ export type SuorituksenVahvistusFieldProps<
   organisaatio?: Oppilaitos | Koulutustoimija
   disableAdd?: boolean
   disableRemoval?: boolean
+  suoritettuText?: string
 }>
 
 export const SuorituksenVahvistusField = <
@@ -164,9 +165,14 @@ export const SuorituksenVahvistusEdit = <T extends Vahvistus>({
 
 type SuorituksenVahvistusProps = CommonPropsWithChildren<{
   vahvistus?: Vahvistus
+  suoritettuText?: string
+  keskenText?: string
+  hideVahvistus?: boolean
 }>
 
-const SuorituksenVahvistus: React.FC<SuorituksenVahvistusProps> = (props) => {
+export const SuorituksenVahvistus: React.FC<SuorituksenVahvistusProps> = (
+  props
+) => {
   const { vahvistus } = props
   const myöntäjäHenkilöt = useMemo(
     () =>
@@ -187,10 +193,12 @@ const SuorituksenVahvistus: React.FC<SuorituksenVahvistusProps> = (props) => {
     >
       <div className="SuorituksenVahvistus__status">
         <TestIdText id="status">
-          {vahvistus ? t('Suoritus valmis') : t('Suoritus kesken')}
+          {vahvistus
+            ? props.suoritettuText || t('Suoritus valmis')
+            : props.keskenText || t('Suoritus kesken')}
         </TestIdText>
       </div>
-      {vahvistus && (
+      {vahvistus && !props.hideVahvistus && (
         <>
           <div className="SuorituksenVahvistus__vahvistus">
             <TestIdText id="details">

--- a/web/app/kielitutkinto/KielitutkintoEditor.tsx
+++ b/web/app/kielitutkinto/KielitutkintoEditor.tsx
@@ -13,7 +13,12 @@ import { KielitutkinnonOpiskeluoikeus } from '../types/fi/oph/koski/schema/Kieli
 import { isValtionhallinnonKielitutkinnonSuoritus } from '../types/fi/oph/koski/schema/ValtionhallinnonKielitutkinnonSuoritus'
 import { isYleisenKielitutkinnonSuoritus } from '../types/fi/oph/koski/schema/YleisenKielitutkinnonSuoritus'
 import { ValtionhallinnonKielitutkintoEditor } from './ValtiohallinnonKielitutkintoEditor'
-import { YleinenKielitutkintoEditor } from './YleinenKielitutkintoEditor'
+import {
+  getJaksonAlkupäivä,
+  YleinenKielitutkintoEditor
+} from './YleinenKielitutkintoEditor'
+import { t } from '../i18n/i18n'
+import { ISO2FinnishDate } from '../date/date'
 
 export type KielitutkintoEditorProps =
   AdaptedOpiskeluoikeusEditorProps<KielitutkinnonOpiskeluoikeus>
@@ -24,11 +29,18 @@ export const KielitutkintoEditor: React.FC<KielitutkintoEditorProps> = (
   const opiskeluoikeusSchema = useSchema('KielitutkinnonOpiskeluoikeus')
   const form = useForm(props.opiskeluoikeus, false, opiskeluoikeusSchema)
 
+  const tutkinnonTyyppi = t(form.state.suoritukset[0].tyyppi.nimi)
+  const kieli = t(form.state.suoritukset[0].koulutusmoduuli.kieli.nimi)
+  const tutkintopäivä = ISO2FinnishDate(
+    getJaksonAlkupäivä(form.state.tila, 'lasna')
+  )
+
   return (
     <>
       <OpiskeluoikeusTitle
         opiskeluoikeus={form.state}
-        opiskeluoikeudenNimi="kielitutkinto"
+        opiskeluoikeudenNimi={`${tutkinnonTyyppi}, ${kieli}`}
+        pvmJaTila={tutkintopäivä}
       />
       <KielitutkinnonPäätasonSuoritusEditor {...props} form={form} />
     </>

--- a/web/app/kielitutkinto/KielitutkintoEditor.tsx
+++ b/web/app/kielitutkinto/KielitutkintoEditor.tsx
@@ -67,6 +67,7 @@ const KielitutkinnonPäätasonSuoritusEditor: React.FC<
       }
       testId={päätasonSuoritus.testId}
       opiskeluoikeudenTilaEditor={form.editMode ? null : <></>} // Piilota tilaeditori näyttökäyttöliittymästä
+      hideOpiskeluoikeusVoimassaoloaika
     >
       {hasPäätasonsuoritusOf(
         isYleisenKielitutkinnonSuoritus,

--- a/web/app/kielitutkinto/ValtiohallinnonKielitutkintoEditor.tsx
+++ b/web/app/kielitutkinto/ValtiohallinnonKielitutkintoEditor.tsx
@@ -34,6 +34,9 @@ import { Oppilaitos } from '../types/fi/oph/koski/schema/Oppilaitos'
 import { ValtionhallinnonKielitutkinnonKielitaidonSuoritus } from '../types/fi/oph/koski/schema/ValtionhallinnonKielitutkinnonKielitaidonSuoritus'
 import { ValtionhallinnonKielitutkinnonSuoritus } from '../types/fi/oph/koski/schema/ValtionhallinnonKielitutkinnonSuoritus'
 import { OsasuoritusOf } from '../util/schema'
+import { ValtionhallinnonKielitutkinnonKirjallisenKielitaidonOsakokeenSuoritus } from '../types/fi/oph/koski/schema/ValtionhallinnonKielitutkinnonKirjallisenKielitaidonOsakokeenSuoritus'
+import { ValtionhallinnonKielitutkinnonArviointi } from '../types/fi/oph/koski/schema/ValtionhallinnonKielitutkinnonArviointi'
+import { ISO2FinnishDate } from '../date/date'
 
 export type ValtionhallinnonKielitutkintoEditorProps = {
   form: FormModel<KielitutkinnonOpiskeluoikeus>
@@ -120,7 +123,7 @@ const kielitaitoToTableRow = ({
   osasuoritusIndex,
   form
 }: KielitaitoToTableRowParams): OsasuoritusRowData<
-  'Kielitaito' | 'Arviointipäivä' | 'Arvosana'
+  'Kielitaito' | 'Tutkintopäivä' | 'Arvosana'
 > => {
   const osasuoritusPath = suoritusPath
     .prop('osasuoritukset')
@@ -142,7 +145,7 @@ const kielitaitoToTableRow = ({
           testId="nimi"
         />
       ),
-      Arviointipäivä: (
+      Tutkintopäivä: (
         <FormField
           form={form}
           path={osasuoritusPath.path('arviointi')}
@@ -226,7 +229,7 @@ const osakoeToTableRow = ({
   osasuoritusIndex,
   form
 }: OsakoeToTableRowParams): OsasuoritusRowData<
-  'Osakoe' | 'Arviointipäivä' | 'Arvosana'
+  'Osakoe' | 'Tutkintopäivä' | 'Arvosana'
 > => {
   const osakoePath = kielitaidonSuoritusPath
     .prop('osasuoritukset')
@@ -238,7 +241,7 @@ const osakoeToTableRow = ({
     suoritusIndex,
     osasuoritusIndex,
     osasuoritusPath: kielitaidonSuoritusPath.prop('osasuoritukset').optional(),
-    expandable: false,
+    expandable: !!osakoe?.arviointi,
     columns: {
       Osakoe: (
         <FormField
@@ -248,7 +251,7 @@ const osakoeToTableRow = ({
           testId="nimi"
         />
       ),
-      Arviointipäivä: (
+      Tutkintopäivä: (
         <FormField
           form={form}
           path={osakoePath.path('arviointi')}
@@ -267,8 +270,37 @@ const osakoeToTableRow = ({
           }}
         />
       )
-    }
+    },
+    content: osakoe?.arviointi ? (
+      <OsakokeenArvioinnit arvioinnit={osakoe?.arviointi} />
+    ) : undefined
   }
+}
+
+type OsakokeenArvioinnitProps = {
+  arvioinnit: ValtionhallinnonKielitutkinnonArviointi[]
+}
+
+const OsakokeenArvioinnit: React.FC<OsakokeenArvioinnitProps> = ({
+  arvioinnit
+}) => {
+  const indentation = 4
+  return (
+    <>
+      <Spacer />
+      {arvioinnit.map((arviointi, index) => (
+        <KeyValueTable key={index}>
+          <KeyValueRow localizableLabel="Arvosana" indent={indentation}>
+            {t(arviointi.arvosana.nimi)}
+          </KeyValueRow>
+          <KeyValueRow localizableLabel="Arviointipäivä" indent={indentation}>
+            {ISO2FinnishDate(arviointi.päivä)}
+          </KeyValueRow>
+        </KeyValueTable>
+      ))}
+      <Spacer />
+    </>
+  )
 }
 
 const isCompletedSuoritus =

--- a/web/app/kielitutkinto/ValtiohallinnonKielitutkintoEditor.tsx
+++ b/web/app/kielitutkinto/ValtiohallinnonKielitutkintoEditor.tsx
@@ -90,22 +90,31 @@ type ValtiohallinnonKielitutkinnonTiedotProps = {
 
 const ValtiohallinnonKielitutkinnonTiedot: React.FC<
   ValtiohallinnonKielitutkinnonTiedotProps
-> = ({ päätasonSuoritus }) => (
-  <KeyValueTable>
-    <KeyValueRow localizableLabel="Tutkinnon taso">
-      {t(päätasonSuoritus.koulutusmoduuli.tunniste.nimi)}
-    </KeyValueRow>
-    <KeyValueRow localizableLabel="Kieli">
-      {t(päätasonSuoritus.koulutusmoduuli.kieli.nimi)}
-    </KeyValueRow>
-    {päätasonSuoritus.koulutusmoduuli.tunniste.koodiarvo ===
-      'hyvajatyydyttava' && (
-      <KeyValueRow localizableLabel="Tutkintosuorituksen vastaanottaja">
-        {t(päätasonSuoritus.toimipiste.nimi)}
+> = ({ päätasonSuoritus }) => {
+  const vastaanottajat = päätasonSuoritus.vahvistus?.myöntäjäHenkilöt
+
+  return (
+    <KeyValueTable>
+      <KeyValueRow localizableLabel="Tutkinnon taso">
+        {t(päätasonSuoritus.koulutusmoduuli.tunniste.nimi)}
       </KeyValueRow>
-    )}
-  </KeyValueTable>
-)
+      <KeyValueRow localizableLabel="Kieli">
+        {t(päätasonSuoritus.koulutusmoduuli.kieli.nimi)}
+      </KeyValueRow>
+      {päätasonSuoritus.koulutusmoduuli.tunniste.koodiarvo ===
+        'hyvajatyydyttava' && (
+        <>
+          <KeyValueRow localizableLabel="Tutkintosuorituksen vastaanottaja">
+            {vastaanottajat && vastaanottajat.map((v) => v.nimi).join(', ')}
+          </KeyValueRow>
+          <KeyValueRow localizableLabel="Suorituspaikkakunta">
+            {t(päätasonSuoritus.vahvistus?.paikkakunta?.nimi)}
+          </KeyValueRow>
+        </>
+      )}
+    </KeyValueTable>
+  )
+}
 
 type KielitaitoToTableRowParams = {
   form: FormModel<KielitutkinnonOpiskeluoikeus>

--- a/web/app/kielitutkinto/ValtiohallinnonKielitutkintoEditor.tsx
+++ b/web/app/kielitutkinto/ValtiohallinnonKielitutkintoEditor.tsx
@@ -25,7 +25,7 @@ import {
   OsasuoritusRowData,
   OsasuoritusTable
 } from '../components-v2/opiskeluoikeus/OsasuoritusTable'
-import { SuorituksenVahvistusField } from '../components-v2/opiskeluoikeus/SuorituksenVahvistus'
+import { SuorituksenVahvistus } from '../components-v2/opiskeluoikeus/SuorituksenVahvistus'
 import { t } from '../i18n/i18n'
 import { KielitutkinnonOpiskeluoikeudenTila } from '../types/fi/oph/koski/schema/KielitutkinnonOpiskeluoikeudenTila'
 import { KielitutkinnonOpiskeluoikeus } from '../types/fi/oph/koski/schema/KielitutkinnonOpiskeluoikeus'
@@ -60,10 +60,10 @@ export const ValtionhallinnonKielitutkintoEditor: React.FC<
 
       <Spacer />
 
-      <SuorituksenVahvistusField
-        form={form}
-        suoritusPath={päätasonSuoritus.path}
-        organisaatio={organisaatio}
+      <SuorituksenVahvistus
+        vahvistus={suoritus.vahvistus}
+        suoritettuText={t('Suoritettu')}
+        hideVahvistus
       />
 
       <Spacer />

--- a/web/app/kielitutkinto/ValtiohallinnonKielitutkintoEditor.tsx
+++ b/web/app/kielitutkinto/ValtiohallinnonKielitutkintoEditor.tsx
@@ -53,10 +53,7 @@ export const ValtionhallinnonKielitutkintoEditor: React.FC<
 
   return suoritus ? (
     <>
-      <ValtiohallinnonKielitutkinnonTiedot
-        päätasonSuoritus={suoritus}
-        tila={form.state.tila}
-      />
+      <ValtiohallinnonKielitutkinnonTiedot päätasonSuoritus={suoritus} />
 
       <Spacer />
 
@@ -86,19 +83,24 @@ export const ValtionhallinnonKielitutkintoEditor: React.FC<
 
 type ValtiohallinnonKielitutkinnonTiedotProps = {
   päätasonSuoritus: ValtionhallinnonKielitutkinnonSuoritus
-  tila: KielitutkinnonOpiskeluoikeudenTila
 }
 
 const ValtiohallinnonKielitutkinnonTiedot: React.FC<
   ValtiohallinnonKielitutkinnonTiedotProps
-> = ({ päätasonSuoritus, tila }) => (
+> = ({ päätasonSuoritus }) => (
   <KeyValueTable>
-    <KeyValueRow localizableLabel="Tutkinto">
+    <KeyValueRow localizableLabel="Tutkinnon taso">
       {t(päätasonSuoritus.koulutusmoduuli.tunniste.nimi)}
     </KeyValueRow>
     <KeyValueRow localizableLabel="Kieli">
       {t(päätasonSuoritus.koulutusmoduuli.kieli.nimi)}
     </KeyValueRow>
+    {päätasonSuoritus.koulutusmoduuli.tunniste.koodiarvo ===
+      'hyvajatyydyttava' && (
+      <KeyValueRow localizableLabel="Tutkintosuorituksen vastaanottaja">
+        {t(päätasonSuoritus.toimipiste.nimi)}
+      </KeyValueRow>
+    )}
   </KeyValueTable>
 )
 

--- a/web/app/kielitutkinto/ValtiohallinnonKielitutkintoEditor.tsx
+++ b/web/app/kielitutkinto/ValtiohallinnonKielitutkintoEditor.tsx
@@ -123,7 +123,7 @@ const kielitaitoToTableRow = ({
   osasuoritusIndex,
   form
 }: KielitaitoToTableRowParams): OsasuoritusRowData<
-  'Kielitaito' | 'Tutkintopäivä' | 'Arvosana'
+  'Tutkinto' | 'Tutkintopäivä' | 'Arvosana'
 > => {
   const osasuoritusPath = suoritusPath
     .prop('osasuoritukset')
@@ -137,7 +137,7 @@ const kielitaitoToTableRow = ({
     osasuoritusPath: suoritusPath.prop('osasuoritukset').optional(),
     expandable: true,
     columns: {
-      Kielitaito: (
+      Tutkinto: (
         <FormField
           form={form}
           path={osasuoritusPath.path('koulutusmoduuli.tunniste.nimi')}

--- a/web/app/kielitutkinto/YleinenKielitutkintoEditor.tsx
+++ b/web/app/kielitutkinto/YleinenKielitutkintoEditor.tsx
@@ -85,7 +85,10 @@ const YleisenKielitutkinnonTiedot: React.FC<
     <KeyValueRow localizableLabel="Kieli">
       {t(päätasonSuoritus.koulutusmoduuli.kieli.nimi)}
     </KeyValueRow>
-    <KeyValueRow localizableLabel="Tutkintopäivä">
+    <KeyValueRow localizableLabel="Testipaikka">
+      {t(päätasonSuoritus.toimipiste.nimi)}
+    </KeyValueRow>
+    <KeyValueRow localizableLabel="Testipäivä">
       {ISO2FinnishDate(getJaksonAlkupäivä(tila, 'lasna'))}
     </KeyValueRow>
     <KeyValueRow localizableLabel="Arviointipäivä">

--- a/web/app/kielitutkinto/YleinenKielitutkintoEditor.tsx
+++ b/web/app/kielitutkinto/YleinenKielitutkintoEditor.tsx
@@ -1,25 +1,21 @@
 import React from 'react'
+import { ActivePäätasonSuoritus } from '../components-v2/containers/EditorContainer'
 import {
   KeyValueRow,
   KeyValueTable
 } from '../components-v2/containers/KeyValueTable'
-import {
-  FormModel,
-  FormOptic,
-  getValue
-} from '../components-v2/forms/FormModel'
+import { FormModel, getValue } from '../components-v2/forms/FormModel'
 import { Spacer } from '../components-v2/layout/Spacer'
+import { SuorituksenVahvistus } from '../components-v2/opiskeluoikeus/SuorituksenVahvistus'
 import { ISO2FinnishDate } from '../date/date'
 import { t } from '../i18n/i18n'
+import { KielitutkinnonOpiskeluoikeudenTila } from '../types/fi/oph/koski/schema/KielitutkinnonOpiskeluoikeudenTila'
 import { KielitutkinnonOpiskeluoikeus } from '../types/fi/oph/koski/schema/KielitutkinnonOpiskeluoikeus'
+import { Koulutustoimija } from '../types/fi/oph/koski/schema/Koulutustoimija'
+import { Oppilaitos } from '../types/fi/oph/koski/schema/Oppilaitos'
+import { YleisenKielitutkinnonOsakokeenSuoritus } from '../types/fi/oph/koski/schema/YleisenKielitutkinnonOsakokeenSuoritus'
 import { YleisenKielitutkinnonSuoritus } from '../types/fi/oph/koski/schema/YleisenKielitutkinnonSuoritus'
 import { ykiParasArvosana } from './yleinenKielitutkinto'
-import { SuorituksenVahvistusField } from '../components-v2/opiskeluoikeus/SuorituksenVahvistus'
-import { ActivePäätasonSuoritus } from '../components-v2/containers/EditorContainer'
-import { Oppilaitos } from '../types/fi/oph/koski/schema/Oppilaitos'
-import { Koulutustoimija } from '../types/fi/oph/koski/schema/Koulutustoimija'
-import { KielitutkinnonOpiskeluoikeudenTila } from '../types/fi/oph/koski/schema/KielitutkinnonOpiskeluoikeudenTila'
-import { YleisenKielitutkinnonOsakokeenSuoritus } from '../types/fi/oph/koski/schema/YleisenKielitutkinnonOsakokeenSuoritus'
 
 export type YleinenKielitutkintoEditorProps = {
   form: FormModel<KielitutkinnonOpiskeluoikeus>
@@ -45,10 +41,10 @@ export const YleinenKielitutkintoEditor: React.FC<
 
       <Spacer />
 
-      <SuorituksenVahvistusField
-        form={form}
-        suoritusPath={päätasonSuoritus.path}
-        organisaatio={organisaatio}
+      <SuorituksenVahvistus
+        vahvistus={suoritus.vahvistus}
+        suoritettuText={t('Suoritettu')}
+        hideVahvistus
       />
 
       <Spacer />

--- a/web/app/kielitutkinto/YleinenKielitutkintoEditor.tsx
+++ b/web/app/kielitutkinto/YleinenKielitutkintoEditor.tsx
@@ -109,7 +109,7 @@ const YleisenKielitutkinnonOsanSuoritusEditor: React.FC<
   )
 }
 
-const getJaksonAlkupäivä = (
+export const getJaksonAlkupäivä = (
   tila: KielitutkinnonOpiskeluoikeudenTila,
   koodiarvo: string
 ): string | undefined =>

--- a/web/app/types/fi/oph/koski/schema/ValtionhallinnonKielitutkinnonSuoritus.ts
+++ b/web/app/types/fi/oph/koski/schema/ValtionhallinnonKielitutkinnonSuoritus.ts
@@ -3,7 +3,7 @@ import { LocalizedString } from './LocalizedString'
 import { ValtionhallinnonKielitutkinto } from './ValtionhallinnonKielitutkinto'
 import { OrganisaatioWithOid } from './OrganisaatioWithOid'
 import { ValtionhallinnonKielitutkinnonKielitaidonSuoritus } from './ValtionhallinnonKielitutkinnonKielitaidonSuoritus'
-import { Päivämäärävahvistus } from './Paivamaaravahvistus'
+import { HenkilövahvistusValinnaisellaTittelilläJaValinnaisellaPaikkakunnalla } from './HenkilovahvistusValinnaisellaTittelillaJaValinnaisellaPaikkakunnalla'
 
 /**
  * ValtionhallinnonKielitutkinnonSuoritus
@@ -20,7 +20,7 @@ export type ValtionhallinnonKielitutkinnonSuoritus = {
   koulutusmoduuli: ValtionhallinnonKielitutkinto
   toimipiste: OrganisaatioWithOid
   osasuoritukset?: Array<ValtionhallinnonKielitutkinnonKielitaidonSuoritus>
-  vahvistus?: Päivämäärävahvistus
+  vahvistus?: HenkilövahvistusValinnaisellaTittelilläJaValinnaisellaPaikkakunnalla
 }
 
 export const ValtionhallinnonKielitutkinnonSuoritus = (o: {
@@ -32,7 +32,7 @@ export const ValtionhallinnonKielitutkinnonSuoritus = (o: {
   koulutusmoduuli: ValtionhallinnonKielitutkinto
   toimipiste: OrganisaatioWithOid
   osasuoritukset?: Array<ValtionhallinnonKielitutkinnonKielitaidonSuoritus>
-  vahvistus?: Päivämäärävahvistus
+  vahvistus?: HenkilövahvistusValinnaisellaTittelilläJaValinnaisellaPaikkakunnalla
 }): ValtionhallinnonKielitutkinnonSuoritus => ({
   tyyppi: Koodistokoodiviite({
     koodiarvo: 'valtionhallinnonkielitutkinto',


### PR DESCRIPTION
- **Opiskeluoikeuden otsikkopalkkiin kielitutkinnon tyyppi, kieli ja tutkintopäivä**
- **Piilota opiskeluoikeuden voimassaoloaika**
- **Lisää päätason suoritukselle testipaikka; nimeä tutkintopäivä -> testipäivä**
- **Poista toisteista tietoa vahvistuspalkista**
- **Kielitaidolle siirretään hylätty-arvosana, jos osakoe on hylätty**
- **Tarkenna vkt-päätason suorituksen näytettävät kentät**
- **Näytä useasti suoritetun vkt-osakokeen arvosanat haitarissa**
