### PR TITLE
TOR-2354 Lisää osasuoritukset sure-tietomallin perusopetuksen oppimäärään

### DIFF
--- a/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureAikuistenPerusopetuksenOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureAikuistenPerusopetuksenOpiskeluoikeus.scala
@@ -7,7 +7,7 @@ import fi.oph.scalaschema.annotation.{Description, Title}
 
 import java.time.LocalDate
 
-@Title("Aikuisten perusopetus")
+@Title("Aikuisten perusopetuksen opiskeluoikeus")
 case class SureAikuistenPerusopetuksenOpiskeluoikeus(
   @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.aikuistenperusopetus.koodiarvo)
   tyyppi: Koodistokoodiviite,
@@ -44,7 +44,7 @@ object SureAikuistenPerusopetuksenSuoritus {
     }
 }
 
-@Title("Päättövaiheen suoritus")
+@Title("Aikuisten perusopetuksen oppimäärän suoritus")
 case class SureAikuistenPerusopetuksenOppimääränSuoritus(
   @KoodistoKoodiarvo("aikuistenperusopetuksenoppimaara")
   tyyppi: Koodistokoodiviite,
@@ -67,7 +67,7 @@ object SureAikuistenPerusopetuksenOppimääränSuoritus {
     )
 }
 
-@Title("Aineopintojen suoritus")
+@Title("Aikuisten perusopetuksen oppiaineen oppimäärän suoritus")
 case class SureAikuistenPerusopetuksenOppiaineenOppimääränSuoritus(
   @Description("Päättötodistukseen liittyvät oppiaineen suoritukset.")
   koulutusmoduuli: AikuistenPerusopetuksenOppiainenTaiEiTiedossaOppiaine,

--- a/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureAikuistenPerusopetuksenOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureAikuistenPerusopetuksenOpiskeluoikeus.scala
@@ -49,18 +49,18 @@ case class SureAikuistenPerusopetuksenOppimääränSuoritus(
   @KoodistoKoodiarvo("aikuistenperusopetuksenoppimaara")
   tyyppi: Koodistokoodiviite,
   alkamispäivä: Option[LocalDate],
-  vahvistuspäivä: Option[LocalDate],
+  vahvistus: Option[SureVahvistus],
   koulutusmoduuli: AikuistenPerusopetus,
   suorituskieli: Koodistokoodiviite,
   osasuoritukset: List[AikuistenPerusopetuksenOppiaineenSuoritus],
-) extends SureAikuistenPerusopetuksenSuoritus
+) extends SureAikuistenPerusopetuksenSuoritus with SureVahvistuksellinen
 
 object SureAikuistenPerusopetuksenOppimääränSuoritus {
   def apply(s: AikuistenPerusopetuksenOppimääränSuoritus): SureAikuistenPerusopetuksenOppimääränSuoritus =
     SureAikuistenPerusopetuksenOppimääränSuoritus(
       tyyppi = s.tyyppi,
       alkamispäivä = s.alkamispäivä,
-      vahvistuspäivä = s.vahvistus.map(_.päivä),
+      vahvistus = s.vahvistus.map(v => SureVahvistus(v.päivä)),
       koulutusmoduuli = s.koulutusmoduuli,
       suorituskieli = s.suorituskieli,
       osasuoritukset = s.osasuoritukset.toList.flatten,
@@ -73,7 +73,7 @@ case class SureAikuistenPerusopetuksenOppiaineenOppimääränSuoritus(
   koulutusmoduuli: AikuistenPerusopetuksenOppiainenTaiEiTiedossaOppiaine,
   toimipiste: OrganisaatioWithOid,
   arviointi: Option[List[PerusopetuksenOppiaineenArviointi]] = None,
-  vahvistus: Option[HenkilövahvistusPaikkakunnalla] = None,
+  vahvistus: Option[SureVahvistus] = None,
   suoritustapa: Koodistokoodiviite,
   suorituskieli: Koodistokoodiviite,
   muutSuorituskielet: Option[List[Koodistokoodiviite]] = None,
@@ -81,7 +81,7 @@ case class SureAikuistenPerusopetuksenOppiaineenOppimääränSuoritus(
   osasuoritukset: Option[List[AikuistenPerusopetuksenKurssinTaiAlkuvaiheenKurssinSuoritus]] = None,
   @KoodistoKoodiarvo("perusopetuksenoppiaineenoppimaara")
   tyyppi: Koodistokoodiviite = Koodistokoodiviite("perusopetuksenoppiaineenoppimaara", koodistoUri = "suorituksentyyppi")
-) extends SureAikuistenPerusopetuksenSuoritus
+) extends SureAikuistenPerusopetuksenSuoritus with SureVahvistuksellinen
 
 object SureAikuistenPerusopetuksenOppiaineenOppimääränSuoritus {
   def apply(s: AikuistenPerusopetuksenOppiaineenOppimääränSuoritus): SureAikuistenPerusopetuksenOppiaineenOppimääränSuoritus =
@@ -89,7 +89,7 @@ object SureAikuistenPerusopetuksenOppiaineenOppimääränSuoritus {
       koulutusmoduuli = s.koulutusmoduuli,
       toimipiste = s.toimipiste,
       arviointi = s.arviointi,
-      vahvistus = s.vahvistus,
+      vahvistus = s.vahvistus.map(v => SureVahvistus(v.päivä)),
       suoritustapa = s.suoritustapa,
       suorituskieli = s.suorituskieli,
       muutSuorituskielet = s.muutSuorituskielet,

--- a/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureAmmatillinenTutkinto.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureAmmatillinenTutkinto.scala
@@ -41,7 +41,7 @@ case class SureAmmatillisenTutkinnonSuoritus(
   @KoodistoKoodiarvo("ammatillinentutkinto")
   tyyppi: Koodistokoodiviite,
   alkamispäivä: Option[LocalDate],
-  vahvistuspäivä: Option[LocalDate],
+  vahvistus: Option[SureVahvistus],
   koulutusmoduuli: AmmatillinenTutkintoKoulutus,
   suorituskieli: Koodistokoodiviite,
   osasuoritukset: List[SureAmmatillisenTutkinnonOsasuoritus],
@@ -55,14 +55,14 @@ case class SureAmmatillisenTutkinnonSuoritus(
   keskiarvo: Option[Double],
 ) extends SureAmmatillinenPäätasonSuoritus
   with Suorituskielellinen
-  with Vahvistuspäivällinen
+  with SureVahvistuksellinen
 
 object SureAmmatillisenTutkinnonSuoritus {
   def apply(s: AmmatillisenTutkinnonSuoritus): SureAmmatillisenTutkinnonSuoritus =
     SureAmmatillisenTutkinnonSuoritus(
       tyyppi = s.tyyppi,
       alkamispäivä = s.alkamispäivä,
-      vahvistuspäivä = s.vahvistus.map(_.päivä),
+      vahvistus = s.vahvistus.map(v => SureVahvistus(v.päivä)),
       koulutusmoduuli = s.koulutusmoduuli,
       suorituskieli = s.suorituskieli,
       osasuoritukset = s.osasuoritukset.toList.flatten.map(SureAmmatillisenTutkinnonOsasuoritus.apply),
@@ -246,20 +246,20 @@ case class SureTelmaKoulutuksenSuoritus(
   @KoodistoKoodiarvo("telma")
   tyyppi: Koodistokoodiviite,
   alkamispäivä: Option[LocalDate],
-  vahvistuspäivä: Option[LocalDate],
+  vahvistus: Option[SureVahvistus],
   koulutusmoduuli: TelmaKoulutus,
   suorituskieli: Koodistokoodiviite,
   osasuoritukset: List[SureTelmaKoulutuksenOsanSuoritus],
 ) extends SureAmmatillinenPäätasonSuoritus
   with Suorituskielellinen
-  with Vahvistuspäivällinen
+  with SureVahvistuksellinen
 
 object SureTelmaKoulutuksenSuoritus {
   def apply(s: TelmaKoulutuksenSuoritus): SureTelmaKoulutuksenSuoritus =
     SureTelmaKoulutuksenSuoritus(
       tyyppi = s.tyyppi,
       alkamispäivä = s.alkamispäivä,
-      vahvistuspäivä = s.vahvistus.map(_.päivä),
+      vahvistus = s.vahvistus.map(v => SureVahvistus(v.päivä)),
       koulutusmoduuli = s.koulutusmoduuli,
       suorituskieli = s.suorituskieli,
       osasuoritukset = s.osasuoritukset.toList.flatten.map(SureTelmaKoulutuksenOsanSuoritus.apply),

--- a/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureDiaOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureDiaOpiskeluoikeus.scala
@@ -40,20 +40,20 @@ case class SureDIATutkinnonSuoritus(
   @KoodistoKoodiarvo("diatutkintovaihe")
   tyyppi: Koodistokoodiviite,
   alkamispäivä: Option[LocalDate],
-  vahvistuspäivä: Option[LocalDate],
+  vahvistus: Option[SureVahvistus],
   koulutusmoduuli: DIATutkinto,
   suorituskieli: Koodistokoodiviite,
   osasuoritukset: List[SureDIAOppiaineenTutkintovaiheenSuoritus],
 ) extends SureSuoritus
   with Suorituskielellinen
-  with Vahvistuspäivällinen
+  with SureVahvistuksellinen
 
 object SureDIATutkinnonSuoritus {
   def apply(s: DIATutkinnonSuoritus): SureDIATutkinnonSuoritus =
     SureDIATutkinnonSuoritus(
       tyyppi = s.tyyppi,
       alkamispäivä = s.alkamispäivä,
-      vahvistuspäivä = s.vahvistus.map(_.päivä),
+      vahvistus = s.vahvistus.map(v => SureVahvistus(v.päivä)),
       koulutusmoduuli = s.koulutusmoduuli,
       suorituskieli = s.suorituskieli,
       osasuoritukset =

--- a/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureDiaOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureDiaOpiskeluoikeus.scala
@@ -8,7 +8,7 @@ import fi.oph.scalaschema.annotation.Title
 
 import java.time.LocalDate
 
-@Title("DIA-tutkinto")
+@Title("DIA-tutkinnon opiskeluoikeus")
 case class SureDIAOpiskeluoikeus(
   @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.diatutkinto.koodiarvo)
   tyyppi: Koodistokoodiviite,

--- a/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureEBOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureEBOpiskeluoikeus.scala
@@ -7,7 +7,7 @@ import fi.oph.scalaschema.annotation.Title
 
 import java.time.LocalDate
 
-@Title("EB-tutkinto")
+@Title("EB-tutkinnon opiskeluoikeus")
 case class SureEBOpiskeluoikeus(
   @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.ebtutkinto.koodiarvo)
   tyyppi: Koodistokoodiviite,

--- a/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureEBOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureEBOpiskeluoikeus.scala
@@ -35,18 +35,18 @@ case class SureEBTutkinnonSuoritus(
   @KoodistoKoodiarvo("ebtutkinto")
   tyyppi: Koodistokoodiviite,
   alkamispäivä: Option[LocalDate],
-  vahvistuspäivä: Option[LocalDate],
+  vahvistus: Option[SureVahvistus],
   koulutusmoduuli: EBTutkinto,
   yleisarvosana: Option[Double],
   osasuoritukset: Option[List[SureEBTutkinnonOsasuoritus]],
-) extends SureSuoritus
+) extends SureSuoritus with SureVahvistuksellinen
 
 object SureEBTutkinnonSuoritus {
   def apply(pts: EBTutkinnonSuoritus): SureEBTutkinnonSuoritus =
     SureEBTutkinnonSuoritus(
       tyyppi = pts.tyyppi,
       alkamispäivä = pts.alkamispäivä,
-      vahvistuspäivä = pts.vahvistus.map(_.päivä),
+      vahvistus = pts.vahvistus.map(v => SureVahvistus(v.päivä)),
       koulutusmoduuli = pts.koulutusmoduuli,
       yleisarvosana = pts.yleisarvosana,
       osasuoritukset = pts.osasuoritukset.map(_.map(SureEBTutkinnonOsasuoritus.apply)),

--- a/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureIBOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureIBOpiskeluoikeus.scala
@@ -40,7 +40,7 @@ case class SureIBTutkinnonSuoritus(
   @KoodistoKoodiarvo("ibtutkinto")
   tyyppi: Koodistokoodiviite,
   alkamispäivä: Option[LocalDate],
-  vahvistuspäivä: Option[LocalDate],
+  vahvistus: Option[SureVahvistus],
   koulutusmoduuli: IBTutkinto,
   suorituskieli: Koodistokoodiviite,
   osasuoritukset: Option[List[SureIBTutkinnonOppiaine]],
@@ -50,14 +50,14 @@ case class SureIBTutkinnonSuoritus(
   lisäpisteet: Option[Koodistokoodiviite],
 ) extends SureSuoritus
   with Suorituskielellinen
-  with Vahvistuspäivällinen
+  with SureVahvistuksellinen
 
 object SureIBTutkinnonSuoritus {
   def apply(s: IBTutkinnonSuoritus): SureIBTutkinnonSuoritus =
     SureIBTutkinnonSuoritus(
       tyyppi = s.tyyppi,
       alkamispäivä = s.alkamispäivä,
-      vahvistuspäivä = s.vahvistus.map(_.päivä),
+      vahvistus = s.vahvistus.map(v => SureVahvistus(v.päivä)),
       koulutusmoduuli = s.koulutusmoduuli,
       suorituskieli = s.suorituskieli,
       osasuoritukset = s.osasuoritukset.map(_.flatMap {

--- a/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureIBOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureIBOpiskeluoikeus.scala
@@ -8,7 +8,7 @@ import fi.oph.scalaschema.annotation.Title
 
 import java.time.LocalDate
 
-@Title("IB-tutkinto")
+@Title("IB-tutkinnon opiskeluoikeus")
 case class SureIBOpiskeluoikeus(
   @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.ibtutkinto.koodiarvo)
   tyyppi: Koodistokoodiviite,

--- a/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureInternationalSchoolOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureInternationalSchoolOpiskeluoikeus.scala
@@ -41,13 +41,13 @@ case class SureDiplomaVuosiluokanSuoritus(
   @KoodistoKoodiarvo("internationalschooldiplomavuosiluokka")
   tyyppi: Koodistokoodiviite,
   alkamispäivä: Option[LocalDate],
-  vahvistuspäivä: Option[LocalDate],
+  vahvistus: Option[SureVahvistus],
   koulutusmoduuli: DiplomaLuokkaAste,
   suorituskieli: Koodistokoodiviite,
   osasuoritukset: List[SureDiplomaIBOppiaineenSuoritus],
 ) extends SureSuoritus
   with Suorituskielellinen
-  with Vahvistuspäivällinen
+  with SureVahvistuksellinen
 
 object SureDiplomaVuosiluokanSuoritus {
   def apply(s: DiplomaVuosiluokanSuoritus): Option[SureDiplomaVuosiluokanSuoritus] =
@@ -55,7 +55,7 @@ object SureDiplomaVuosiluokanSuoritus {
       SureDiplomaVuosiluokanSuoritus(
         tyyppi = s.tyyppi,
         alkamispäivä = s.alkamispäivä,
-        vahvistuspäivä = s.vahvistus.map(_.päivä),
+        vahvistus = s.vahvistus.map(v => SureVahvistus(v.päivä)),
         koulutusmoduuli = s.koulutusmoduuli,
         suorituskieli = s.suorituskieli,
         osasuoritukset = s.osasuoritukset.toList.flatten.map(SureDiplomaIBOppiaineenSuoritus.apply),

--- a/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureInternationalSchoolOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureInternationalSchoolOpiskeluoikeus.scala
@@ -8,7 +8,7 @@ import fi.oph.scalaschema.annotation.Title
 
 import java.time.LocalDate
 
-@Title("International School")
+@Title("International school opiskeluoikeus")
 case class SureInternationalSchoolOpiskeluoikeus(
   @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.internationalschool.koodiarvo)
   tyyppi: Koodistokoodiviite,
@@ -36,7 +36,7 @@ object SureInternationalSchoolOpiskeluoikeus {
     }
 }
 
-@Title("Diploma-vuosiluokan suoritus")
+@Title("Diploma vuosiluokan suoritus")
 case class SureDiplomaVuosiluokanSuoritus(
   @KoodistoKoodiarvo("internationalschooldiplomavuosiluokka")
   tyyppi: Koodistokoodiviite,

--- a/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureOpiskeluoikeus.scala
@@ -2,7 +2,7 @@ package fi.oph.koski.massaluovutus.suoritusrekisteri.opiskeluoikeus
 
 import fi.oph.koski.schema._
 import fi.oph.koski.schema.annotation.KoodistoUri
-import fi.oph.scalaschema.annotation.{Description, Discriminator, Title}
+import fi.oph.scalaschema.annotation.{Description, Discriminator}
 
 import java.time.LocalDate
 
@@ -30,8 +30,11 @@ trait SureSuoritus {
   def koulutusmoduuli: Koulutusmoduuli
 }
 
-trait Vahvistuspäivällinen {
-  @Description("Tutkinnon tai tutkinnon osan vahvistettu suorituspäivämäärä, eli päivämäärä jolloin suoritus on hyväksyttyä todennettua osaamista. Muoto YYYY-MM-DD")
-  def vahvistuspäivä: Option[LocalDate]
-
+trait SureVahvistuksellinen {
+  def vahvistus: Option[SureVahvistus]
 }
+
+case class SureVahvistus (
+  @Description("Tutkinnon tai tutkinnon osan vahvistettu suorituspäivämäärä, eli päivämäärä jolloin suoritus on hyväksyttyä todennettua osaamista. Muoto YYYY-MM-DD")
+  päivä: LocalDate
+)

--- a/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SurePerusopetuksenOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SurePerusopetuksenOpiskeluoikeus.scala
@@ -52,6 +52,7 @@ case class SureNuortenPerusopetuksenOppimääränSuoritus(
   koulutusmoduuli: NuortenPerusopetus,
   vahvistuspäivä: Option[LocalDate],
   suorituskieli: Koodistokoodiviite,
+  osasuoritukset: Option[List[NuortenPerusopetuksenOppiaineenSuoritus]]
 ) extends SurePerusopetuksenPäätasonSuoritus
   with Suorituskielellinen
   with Vahvistuspäivällinen
@@ -63,6 +64,7 @@ object SureNuortenPerusopetuksenOppimääränSuoritus {
       koulutusmoduuli = s.koulutusmoduuli,
       vahvistuspäivä = s.vahvistus.map(_.päivä),
       suorituskieli = s.suorituskieli,
+      osasuoritukset = s.osasuoritukset.map(_.collect { case os: NuortenPerusopetuksenOppiaineenSuoritus => os }),
     )
 }
 

--- a/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SurePerusopetuksenOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SurePerusopetuksenOpiskeluoikeus.scala
@@ -6,7 +6,7 @@ import fi.oph.scalaschema.annotation.{Description, OnlyWhen, Title}
 
 import java.time.LocalDate
 
-@Title("Perusopetus")
+@Title("Perusopetuksen opiskeluoikeus")
 case class SurePerusopetuksenOpiskeluoikeus(
   @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.perusopetus.koodiarvo)
   tyyppi: Koodistokoodiviite,
@@ -55,7 +55,7 @@ object SurePerusopetuksenPäätasonSuoritus {
   }
 }
 
-@Title("Oppimäärän suoritus")
+@Title("Nuorten perusopetuksen oppimäärän suoritus")
 case class SureNuortenPerusopetuksenOppimääränSuoritus(
   tyyppi: Koodistokoodiviite,
   koulutusmoduuli: NuortenPerusopetus,
@@ -80,7 +80,7 @@ object SureNuortenPerusopetuksenOppimääränSuoritus {
     )
 }
 
-@Title("Yhdeksännen vuosiluokan suoritus")
+@Title("Perusopetuksen vuosiluokan suoritus")
 case class SurePerusopetuksenYhdeksännenVuosiluokanSuoritus(
   tyyppi: Koodistokoodiviite,
   koulutusmoduuli: PerusopetuksenLuokkaAste,

--- a/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SurePerusopetuksenOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SurePerusopetuksenOpiskeluoikeus.scala
@@ -52,10 +52,12 @@ case class SureNuortenPerusopetuksenOppimääränSuoritus(
   koulutusmoduuli: NuortenPerusopetus,
   vahvistuspäivä: Option[LocalDate],
   suorituskieli: Koodistokoodiviite,
+  koulusivistyskieli: Option[List[Koodistokoodiviite]],
   osasuoritukset: Option[List[NuortenPerusopetuksenOppiaineenSuoritus]]
 ) extends SurePerusopetuksenPäätasonSuoritus
   with Suorituskielellinen
   with Vahvistuspäivällinen
+  with Koulusivistyskieli
 
 object SureNuortenPerusopetuksenOppimääränSuoritus {
   def apply(s: NuortenPerusopetuksenOppimääränSuoritus): SureNuortenPerusopetuksenOppimääränSuoritus =
@@ -64,6 +66,7 @@ object SureNuortenPerusopetuksenOppimääränSuoritus {
       koulutusmoduuli = s.koulutusmoduuli,
       vahvistuspäivä = s.vahvistus.map(_.päivä),
       suorituskieli = s.suorituskieli,
+      koulusivistyskieli = s.koulusivistyskieli,
       osasuoritukset = s.osasuoritukset.map(_.collect { case os: NuortenPerusopetuksenOppiaineenSuoritus => os }),
     )
 }
@@ -75,6 +78,7 @@ case class SurePerusopetuksenYhdeksännenVuosiluokanSuoritus(
   alkamispäivä: Option[LocalDate],
   vahvistuspäivä: Option[LocalDate],
   suorituskieli: Koodistokoodiviite,
+  jääLuokalle: Boolean,
   osasuoritukset: Option[List[NuortenPerusopetuksenOppiaineenSuoritus]],
 ) extends SurePerusopetuksenPäätasonSuoritus
   with Suorituskielellinen
@@ -88,6 +92,7 @@ object SurePerusopetuksenYhdeksännenVuosiluokanSuoritus {
       alkamispäivä = s.alkamispäivä,
       vahvistuspäivä = s.vahvistus.map(_.päivä),
       suorituskieli = s.suorituskieli,
+      jääLuokalle = s.jääLuokalle,
       osasuoritukset = s.osasuoritukset.map(_.collect { case os: NuortenPerusopetuksenOppiaineenSuoritus => os }),
     )
 }
@@ -135,6 +140,10 @@ case class SurePerusopetuksenOpiskeluoikeudenLisätiedot(
   @Description("Erityisen tuen päätökset alkamis- ja päättymispäivineen. Voi olla useita erillisiä jaksoja. Rahoituksen laskennassa käytettävä tieto.")
   @OksaUri("tmpOKSAID281", "henkilökohtainen opetuksen järjestämistä koskeva suunnitelma")
   erityisenTuenPäätökset: Option[List[SureErityisenTuenPäätös]] = None,
+
+  @Description("Oppilas on vuosiluokkiin sitomattomassa opetuksessa (kyllä/ei).")
+  @Title("Vuosiluokkiin sitomaton opetus")
+  vuosiluokkiinSitoutumatonOpetus: Boolean = false,
 )
 
 object SurePerusopetuksenOpiskeluoikeudenLisätiedot {
@@ -149,7 +158,8 @@ object SurePerusopetuksenOpiskeluoikeudenLisätiedot {
             Some(List(lt.erityisenTuenPäätös.get).map(SureErityisenTuenPäätös.apply))
           } else {
             None
-          }
+          },
+        vuosiluokkiinSitoutumatonOpetus = lt.vuosiluokkiinSitoutumatonOpetus
       ))
     } else {
       None

--- a/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SurePerusopetuksenOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SurePerusopetuksenOpiskeluoikeus.scala
@@ -59,13 +59,13 @@ object SurePerusopetuksenPäätasonSuoritus {
 case class SureNuortenPerusopetuksenOppimääränSuoritus(
   tyyppi: Koodistokoodiviite,
   koulutusmoduuli: NuortenPerusopetus,
-  vahvistuspäivä: Option[LocalDate],
+  vahvistus: Option[SureVahvistus],
   suorituskieli: Koodistokoodiviite,
   koulusivistyskieli: Option[List[Koodistokoodiviite]],
   osasuoritukset: Option[List[NuortenPerusopetuksenOppiaineenSuoritus]]
 ) extends SurePerusopetuksenPäätasonSuoritus
   with Suorituskielellinen
-  with Vahvistuspäivällinen
+  with SureVahvistuksellinen
   with Koulusivistyskieli
 
 object SureNuortenPerusopetuksenOppimääränSuoritus {
@@ -73,7 +73,7 @@ object SureNuortenPerusopetuksenOppimääränSuoritus {
     SureNuortenPerusopetuksenOppimääränSuoritus(
       tyyppi = s.tyyppi,
       koulutusmoduuli = s.koulutusmoduuli,
-      vahvistuspäivä = s.vahvistus.map(_.päivä),
+      vahvistus = s.vahvistus.map(v => SureVahvistus(v.päivä)),
       suorituskieli = s.suorituskieli,
       koulusivistyskieli = s.koulusivistyskieli,
       osasuoritukset = s.osasuoritukset.map(_.collect { case os: NuortenPerusopetuksenOppiaineenSuoritus => os }),
@@ -85,13 +85,13 @@ case class SurePerusopetuksenYhdeksännenVuosiluokanSuoritus(
   tyyppi: Koodistokoodiviite,
   koulutusmoduuli: PerusopetuksenLuokkaAste,
   alkamispäivä: Option[LocalDate],
-  vahvistuspäivä: Option[LocalDate],
+  vahvistus: Option[SureVahvistus],
   suorituskieli: Koodistokoodiviite,
   jääLuokalle: Boolean,
   osasuoritukset: Option[List[NuortenPerusopetuksenOppiaineenSuoritus]],
 ) extends SurePerusopetuksenPäätasonSuoritus
   with Suorituskielellinen
-  with Vahvistuspäivällinen
+  with SureVahvistuksellinen
 
 object SurePerusopetuksenYhdeksännenVuosiluokanSuoritus {
   def apply(s: PerusopetuksenVuosiluokanSuoritus, lisääOsasuoritukset: Boolean): SurePerusopetuksenYhdeksännenVuosiluokanSuoritus =
@@ -99,7 +99,7 @@ object SurePerusopetuksenYhdeksännenVuosiluokanSuoritus {
       tyyppi = s.tyyppi,
       koulutusmoduuli = s.koulutusmoduuli,
       alkamispäivä = s.alkamispäivä,
-      vahvistuspäivä = s.vahvistus.map(_.päivä),
+      vahvistus = s.vahvistus.map(v => SureVahvistus(v.päivä)),
       suorituskieli = s.suorituskieli,
       jääLuokalle = s.jääLuokalle,
       osasuoritukset = if(lisääOsasuoritukset) s.osasuoritukset.map(_.collect { case os: NuortenPerusopetuksenOppiaineenSuoritus => os }) else None,
@@ -112,7 +112,7 @@ case class SureNuortenPerusopetuksenOppiaineenOppimääränSuoritus(
   koulutusmoduuli: NuortenPerusopetuksenOppiainenTaiEiTiedossaOppiaine,
   toimipiste: OrganisaatioWithOid,
   arviointi: Option[List[PerusopetuksenOppiaineenArviointi]] = None,
-  vahvistus: Option[HenkilövahvistusPaikkakunnalla] = None,
+  vahvistus: Option[SureVahvistus] = None,
   suoritustapa: Koodistokoodiviite,
   @Description("Luokka-asteen tunniste (1-9). Minkä vuosiluokan mukaisesta oppiainesuorituksesta on kyse.")
   @KoodistoUri("perusopetuksenluokkaaste")
@@ -123,7 +123,7 @@ case class SureNuortenPerusopetuksenOppiaineenOppimääränSuoritus(
   todistuksellaNäkyvätLisätiedot: Option[LocalizedString] = None,
   @KoodistoKoodiarvo("nuortenperusopetuksenoppiaineenoppimaara")
   tyyppi: Koodistokoodiviite = Koodistokoodiviite("nuortenperusopetuksenoppiaineenoppimaara", koodistoUri = "suorituksentyyppi")
-) extends SurePerusopetuksenPäätasonSuoritus
+) extends SurePerusopetuksenPäätasonSuoritus with SureVahvistuksellinen
 
 object SureNuortenPerusopetuksenOppiaineenOppimääränSuoritus {
   def apply(s: NuortenPerusopetuksenOppiaineenOppimääränSuoritus): SureNuortenPerusopetuksenOppiaineenOppimääränSuoritus =
@@ -131,7 +131,7 @@ object SureNuortenPerusopetuksenOppiaineenOppimääränSuoritus {
       koulutusmoduuli = s.koulutusmoduuli,
       toimipiste = s.toimipiste,
       arviointi = s.arviointi,
-      vahvistus = s.vahvistus,
+      vahvistus = s.vahvistus.map(v => SureVahvistus(v.päivä)),
       suoritustapa = s.suoritustapa,
       luokkaAste = s.luokkaAste,
       suorituskieli = s.suorituskieli,

--- a/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureTutkintokoulutukseenValmentavanOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureTutkintokoulutukseenValmentavanOpiskeluoikeus.scala
@@ -36,16 +36,16 @@ object SureTutkintokoulutukseenValmentavanOpiskeluoikeus {
 case class SureTutkintokoulutukseenValmentavanKoulutuksenSuoritus(
   tyyppi: Koodistokoodiviite,
   alkamispäivä: Option[LocalDate],
-  vahvistuspäivä: Option[LocalDate],
+  vahvistus: Option[SureVahvistus],
   koulutusmoduuli:  TutkintokoulutukseenValmentavanKoulutus,
-) extends SureSuoritus
+) extends SureSuoritus with SureVahvistuksellinen
 
 object SureTutkintokoulutukseenValmentavanKoulutuksenSuoritus {
   def apply(s: TutkintokoulutukseenValmentavanKoulutuksenSuoritus): SureTutkintokoulutukseenValmentavanKoulutuksenSuoritus =
     SureTutkintokoulutukseenValmentavanKoulutuksenSuoritus(
       tyyppi = s.tyyppi,
       alkamispäivä = s.alkamispäivä,
-      vahvistuspäivä = s.vahvistus.map(_.päivä),
+      vahvistus = s.vahvistus.map(v => SureVahvistus(v.päivä)),
       koulutusmoduuli = s.koulutusmoduuli,
     )
 }

--- a/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureTutkintokoulutukseenValmentavanOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureTutkintokoulutukseenValmentavanOpiskeluoikeus.scala
@@ -7,7 +7,7 @@ import fi.oph.scalaschema.annotation.Title
 import java.time.LocalDate
 
 
-@Title("Tutkintokoulutukseen valmentava koulutus")
+@Title("Tutkintokoulutukseen valmentavan koulutuksen opiskeluoikeus")
 case class SureTutkintokoulutukseenValmentavanOpiskeluoikeus(
   @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.tuva.koodiarvo)
   tyyppi: Koodistokoodiviite,
@@ -32,7 +32,7 @@ object SureTutkintokoulutukseenValmentavanOpiskeluoikeus {
     )
 }
 
-@Title("TUVA-koulutuksen suoritus")
+@Title("Tutkintokoulutukseen valmentavan koulutuksen suoritustiedot")
 case class SureTutkintokoulutukseenValmentavanKoulutuksenSuoritus(
   tyyppi: Koodistokoodiviite,
   alkamispäivä: Option[LocalDate],

--- a/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureVapaaSivistystyo.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureVapaaSivistystyo.scala
@@ -41,20 +41,20 @@ case class SureOppivelvollisilleSuunnattuVapaanSivistystyönKoulutuksenSuoritus(
   @KoodistoKoodiarvo("vstoppivelvollisillesuunnattukoulutus")
   tyyppi: Koodistokoodiviite,
   alkamispäivä: Option[LocalDate],
-  vahvistuspäivä: Option[LocalDate],
+  vahvistus: Option[SureVahvistus],
   koulutusmoduuli: OppivelvollisilleSuunnattuVapaanSivistystyönKoulutus,
   suorituskieli: Koodistokoodiviite,
   osasuoritukset: List[SureOppivelvollisilleSuunnatunVapaanSivistystyönOsasuoritus],
 ) extends SureVapaanSivistystyönPäätasonSuoritus
   with Suorituskielellinen
-  with Vahvistuspäivällinen
+  with SureVahvistuksellinen
 
 object SureOppivelvollisilleSuunnattuVapaanSivistystyönKoulutuksenSuoritus {
   def apply(s: OppivelvollisilleSuunnattuVapaanSivistystyönKoulutuksenSuoritus): SureOppivelvollisilleSuunnattuVapaanSivistystyönKoulutuksenSuoritus =
     SureOppivelvollisilleSuunnattuVapaanSivistystyönKoulutuksenSuoritus(
       tyyppi = s.tyyppi,
       alkamispäivä = s.alkamispäivä,
-      vahvistuspäivä = s.vahvistus.map(_.päivä),
+      vahvistus = s.vahvistus.map(v => SureVahvistus(v.päivä)),
       koulutusmoduuli = s.koulutusmoduuli,
       suorituskieli = s.suorituskieli,
       osasuoritukset = s.osasuoritukset.toList.flatten.map {

--- a/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureVapaaSivistystyo.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suoritusrekisteri/opiskeluoikeus/SureVapaaSivistystyo.scala
@@ -6,7 +6,7 @@ import fi.oph.scalaschema.annotation.Title
 
 import java.time.LocalDate
 
-@Title("Vapaa sivistystyö")
+@Title("Vapaan sivistystyön opiskeluoikeus")
 case class SureVapaanSivistystyönOpiskeluoikeus(
   @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.vapaansivistystyonkoulutus.koodiarvo)
   tyyppi: Koodistokoodiviite,

--- a/src/test/scala/fi/oph/koski/massaluovutus/MassaluovutusSpec.scala
+++ b/src/test/scala/fi/oph/koski/massaluovutus/MassaluovutusSpec.scala
@@ -563,6 +563,10 @@ class MassaluovutusSpec extends AnyFreeSpec with KoskiHttpSpec with Matchers wit
 
       def tyyppi(v: JValue) = v \ "tyyppi" \ "koodiarvo"
       def suorituksenTunniste(v: JValue) = v \ "koulutusmoduuli" \ "tunniste" \ "koodiarvo"
+      def osasuoritustenMäärä(v: JValue) = v \ "osasuoritukset" match {
+        case JArray(list) => list.size
+        case _ => 0
+      }
       def viimeisinTila(v: JValue) = v \ "tila" \ "opiskeluoikeusjaksot" \ "tila" \ "koodiarvo" match {
         case JArray(list) => list.last
         case _ => JNothing
@@ -597,6 +601,16 @@ class MassaluovutusSpec extends AnyFreeSpec with KoskiHttpSpec with Matchers wit
           "201101", // Oppimäärän suoritus
           "9", // Ysiluokka
         ))
+      }
+
+      "Perusopetuksen oppimäärän suoritukselle palautetaan osasuoritukset" in {
+        val tunnisteetJaOsasuoritustenMäärät = getSuoritukset(Some("perusopetus"))
+          .filterNot(s => tyyppi(s).extract[String] == "nuortenperusopetuksenoppiaineenoppimaara")
+          .map(suoritus => suorituksenTunniste(suoritus).extract[String] -> osasuoritustenMäärä(suoritus))
+          .toMap
+
+        tunnisteetJaOsasuoritustenMäärät.get("9") shouldBe Some(0) // 9. vuosiluokan suoritus
+        tunnisteetJaOsasuoritustenMäärät.get("201101") shouldBe Some(23) // Oppimäärän suoritus
       }
 
       "Ammatillisesta koulutuksesta ei palautetaan vain kokonainen ammatillinen tutkinto ja telma" in {
@@ -765,6 +779,11 @@ class MassaluovutusSpec extends AnyFreeSpec with KoskiHttpSpec with Matchers wit
 
       def suorituksenTunniste(v: JValue) = v \ "koulutusmoduuli" \ "tunniste" \ "koodiarvo"
 
+      def osasuoritustenMäärä(v: JValue) = v \ "osasuoritukset" match {
+        case JArray(list) => list.size
+        case _ => 0
+      }
+
       def viimeisinTila(v: JValue) = v \ "tila" \ "opiskeluoikeusjaksot" \ "tila" \ "koodiarvo" match {
         case JArray(list) => list.last
         case _ => JNothing
@@ -799,6 +818,16 @@ class MassaluovutusSpec extends AnyFreeSpec with KoskiHttpSpec with Matchers wit
           "201101", // Oppimäärän suoritus
           "9", // Ysiluokka
         ))
+      }
+
+      "Perusopetuksen oppimäärän suoritukselle palautetaan osasuoritukset" in {
+        val tunnisteetJaOsasuoritustenMäärät = getSuoritukset(Some("perusopetus"))
+          .filterNot(s => tyyppi(s).extract[String] == "nuortenperusopetuksenoppiaineenoppimaara")
+          .map(suoritus => suorituksenTunniste(suoritus).extract[String] -> osasuoritustenMäärä(suoritus))
+          .toMap
+
+        tunnisteetJaOsasuoritustenMäärät.get("9") shouldBe Some(0) // 9. vuosiluokan suoritus
+        tunnisteetJaOsasuoritustenMäärät.get("201101") shouldBe Some(23) // Oppimäärän suoritus
       }
 
       "Ammatillisesta koulutuksesta ei palautetaan vain kokonainen ammatillinen tutkinto ja telma" in {

--- a/src/test/scala/fi/oph/koski/massaluovutus/MassaluovutusSpec.scala
+++ b/src/test/scala/fi/oph/koski/massaluovutus/MassaluovutusSpec.scala
@@ -593,23 +593,27 @@ class MassaluovutusSpec extends AnyFreeSpec with KoskiHttpSpec with Matchers wit
         ))
       }
 
-      "Nuorten perusopetuksesta palautetaan vain perusopetuksen päättötodistus" in {
+      "Nuorten perusopetuksesta palautetaan perusopetuksen päättötodistus sekä 7., 8. ja 9. vuosiluokan suoritukset" in {
         extractStrings(
           getSuoritukset(Some("perusopetus")).filterNot(s => tyyppi(s).extract[String] == "nuortenperusopetuksenoppiaineenoppimaara"),
           suorituksenTunniste
         ) should equal(List(
           "201101", // Oppimäärän suoritus
-          "9", // Ysiluokka
+          "7",  // Vuosiluokkien suoritukset
+          "8",
+          "9",
         ))
       }
 
-      "Perusopetuksen oppimäärän suoritukselle palautetaan osasuoritukset" in {
+      "Perusopetuksen suorituksille palautetaan oikea määrä osasuorituksia" in {
         val tunnisteetJaOsasuoritustenMäärät = getSuoritukset(Some("perusopetus"))
           .filterNot(s => tyyppi(s).extract[String] == "nuortenperusopetuksenoppiaineenoppimaara")
           .map(suoritus => suorituksenTunniste(suoritus).extract[String] -> osasuoritustenMäärä(suoritus))
           .toMap
 
-        tunnisteetJaOsasuoritustenMäärät.get("9") shouldBe Some(0) // 9. vuosiluokan suoritus
+        tunnisteetJaOsasuoritustenMäärät.get("7") shouldBe Some(0) // 7. vuosiluokan suoritus
+        tunnisteetJaOsasuoritustenMäärät.get("8") shouldBe Some(0) // 8. vuosiluokan suoritus
+        tunnisteetJaOsasuoritustenMäärät.get("9") shouldBe Some(0) // 9. vuosiluokan suoritus, voi myös sisältää osasuorituksia
         tunnisteetJaOsasuoritustenMäärät.get("201101") shouldBe Some(23) // Oppimäärän suoritus
       }
 
@@ -810,23 +814,27 @@ class MassaluovutusSpec extends AnyFreeSpec with KoskiHttpSpec with Matchers wit
         ))
       }
 
-      "Nuorten perusopetuksesta palautetaan vain perusopetuksen päättötodistus" in {
+      "Nuorten perusopetuksesta palautetaan perusopetuksen päättötodistus sekä 7., 8. ja 9. vuosiluokan suoritukset" in {
         extractStrings(
           getSuoritukset(Some("perusopetus")).filterNot(s => tyyppi(s).extract[String] == "nuortenperusopetuksenoppiaineenoppimaara"),
           suorituksenTunniste
         ) should equal(List(
           "201101", // Oppimäärän suoritus
-          "9", // Ysiluokka
+          "7",  // Vuosiluokkien suoritukset
+          "8",
+          "9",
         ))
       }
 
-      "Perusopetuksen oppimäärän suoritukselle palautetaan osasuoritukset" in {
+      "Perusopetuksen suorituksille palautetaan oikea määrä osasuorituksia" in {
         val tunnisteetJaOsasuoritustenMäärät = getSuoritukset(Some("perusopetus"))
           .filterNot(s => tyyppi(s).extract[String] == "nuortenperusopetuksenoppiaineenoppimaara")
           .map(suoritus => suorituksenTunniste(suoritus).extract[String] -> osasuoritustenMäärä(suoritus))
           .toMap
 
-        tunnisteetJaOsasuoritustenMäärät.get("9") shouldBe Some(0) // 9. vuosiluokan suoritus
+        tunnisteetJaOsasuoritustenMäärät.get("7") shouldBe Some(0) // 7. vuosiluokan suoritus
+        tunnisteetJaOsasuoritustenMäärät.get("8") shouldBe Some(0) // 8. vuosiluokan suoritus
+        tunnisteetJaOsasuoritustenMäärät.get("9") shouldBe Some(0) // 9. vuosiluokan suoritus, voi myös sisältää osasuorituksia
         tunnisteetJaOsasuoritustenMäärät.get("201101") shouldBe Some(23) // Oppimäärän suoritus
       }
 


### PR DESCRIPTION
Palauta rajapinnasta perusopetuksen oppimäärän osasuoritukset.

Käytä Kosken määriteltyä execution contextia MassaluovutusServicessä.