### PR TITLE
TOR-2354 lisää oppijaOid-kenttä Supa-rajapinnan opiskeluoikeuksille

### DIFF
--- a/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/SuorituspalveluQuery.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/SuorituspalveluQuery.scala
@@ -74,7 +74,7 @@ trait SuorituspalveluQuery extends MassaluovutusQueryParameters with Logging {
     val json = KoskiTables.KoskiOpiskeluoikeusTable.readAsJValue(row.data, row.oid, row.versionumero, row.aikaleima)
     application.validatingAndResolvingExtractor.extract[KoskeenTallennettavaOpiskeluoikeus](KoskiSchema.strictDeserialization)(json) match {
       case Right(oo: KoskeenTallennettavaOpiskeluoikeus) =>
-        SupaOpiskeluoikeusO(oo)
+        SupaOpiskeluoikeusO(oo, row.oppijaOid)
       case Left(errors) =>
         logger.warn(s"Error deserializing opiskeluoikeus: ${errors}")
         None

--- a/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/SuorituspalveluResponse.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/SuorituspalveluResponse.scala
@@ -2,13 +2,16 @@ package fi.oph.koski.massaluovutus.suorituspalvelu
 
 import fi.oph.koski.massaluovutus.suorituspalvelu.opiskeluoikeus._
 import fi.oph.koski.schema._
+import fi.oph.scalaschema.annotation.Description
 import fi.oph.scalaschema.{ClassSchema, SchemaToJson}
 import org.json4s.JValue
 
 import java.time.LocalDateTime
 
 case class SupaResponse(
+  @Description("Oppijan yksilöivä tunniste. Jos oppijalla on olemassa useita yksilöiviä tunnisteita, palautetaan tässä kentässä oppijanumero eli oppijan hallitseva tunniste.")
   oppijaOid: String,
+  @Description("Oppijan kaikki yksilöivät tunnisteet, joilla opiskeluoikeuksia on tallennettu Koski-tietovarantoon.")
   kaikkiOidit: Seq[String],
   aikaleima: LocalDateTime,
   opiskeluoikeudet: Seq[SupaOpiskeluoikeus],
@@ -20,17 +23,17 @@ object SupaResponse {
 }
 
 object SupaOpiskeluoikeusO {
-  def apply(oo: KoskeenTallennettavaOpiskeluoikeus): Option[SupaOpiskeluoikeus] =
+  def apply(oo: KoskeenTallennettavaOpiskeluoikeus, oppijaOid: String): Option[SupaOpiskeluoikeus] =
     oo match {
-      case o: PerusopetuksenOpiskeluoikeus => Some(SupaPerusopetuksenOpiskeluoikeus(o))
-      case o: AikuistenPerusopetuksenOpiskeluoikeus => Some(SupaAikuistenPerusopetuksenOpiskeluoikeus(o))
-      case o: AmmatillinenOpiskeluoikeus => Some(SupaAmmatillinenTutkinto(o))
-      case o: TutkintokoulutukseenValmentavanOpiskeluoikeus => Some(SupaTutkintokoulutukseenValmentavanOpiskeluoikeus(o))
-      case o: VapaanSivistystyönOpiskeluoikeus => Some(SupaVapaanSivistystyönOpiskeluoikeus(o))
-      case o: DIAOpiskeluoikeus => SupaDIAOpiskeluoikeus(o)
-      case o: EBOpiskeluoikeus => Some(SupaEBOpiskeluoikeus(o))
-      case o: IBOpiskeluoikeus => SupaIBOpiskeluoikeus(o)
-      case o: InternationalSchoolOpiskeluoikeus => SupaInternationalSchoolOpiskeluoikeus(o)
+      case o: PerusopetuksenOpiskeluoikeus => Some(SupaPerusopetuksenOpiskeluoikeus(o, oppijaOid))
+      case o: AikuistenPerusopetuksenOpiskeluoikeus => Some(SupaAikuistenPerusopetuksenOpiskeluoikeus(o, oppijaOid))
+      case o: AmmatillinenOpiskeluoikeus => Some(SupaAmmatillinenTutkinto(o, oppijaOid))
+      case o: TutkintokoulutukseenValmentavanOpiskeluoikeus => Some(SupaTutkintokoulutukseenValmentavanOpiskeluoikeus(o, oppijaOid))
+      case o: VapaanSivistystyönOpiskeluoikeus => Some(SupaVapaanSivistystyönOpiskeluoikeus(o, oppijaOid))
+      case o: DIAOpiskeluoikeus => SupaDIAOpiskeluoikeus(o, oppijaOid)
+      case o: EBOpiskeluoikeus => Some(SupaEBOpiskeluoikeus(o, oppijaOid))
+      case o: IBOpiskeluoikeus => SupaIBOpiskeluoikeus(o, oppijaOid)
+      case o: InternationalSchoolOpiskeluoikeus => SupaInternationalSchoolOpiskeluoikeus(o, oppijaOid)
       case _ => None
     }
 }

--- a/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaAikuistenPerusopetuksenOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaAikuistenPerusopetuksenOpiskeluoikeus.scala
@@ -9,6 +9,7 @@ import java.time.LocalDate
 
 @Title("Aikuisten perusopetuksen opiskeluoikeus")
 case class SupaAikuistenPerusopetuksenOpiskeluoikeus(
+  oppijaOid: String,
   @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.aikuistenperusopetus.koodiarvo)
   tyyppi: Koodistokoodiviite,
   oid: String,
@@ -19,8 +20,9 @@ case class SupaAikuistenPerusopetuksenOpiskeluoikeus(
 ) extends SupaOpiskeluoikeus
 
 object SupaAikuistenPerusopetuksenOpiskeluoikeus {
-  def apply(oo: AikuistenPerusopetuksenOpiskeluoikeus): SupaAikuistenPerusopetuksenOpiskeluoikeus =
+  def apply(oo: AikuistenPerusopetuksenOpiskeluoikeus, oppijaOid: String): SupaAikuistenPerusopetuksenOpiskeluoikeus =
     SupaAikuistenPerusopetuksenOpiskeluoikeus(
+      oppijaOid = oppijaOid,
       tyyppi = oo.tyyppi,
       oid = oo.oid.get,
       koulutustoimija = oo.koulutustoimija,

--- a/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaAmmatillinenTutkinto.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaAmmatillinenTutkinto.scala
@@ -9,6 +9,7 @@ import java.time.LocalDate
 @Title("Ammatillinen opiskeluoikeus")
 @Description("Ammatillisen koulutuksen opiskeluoikeus")
 case class SupaAmmatillinenOpiskeluoikeus(
+  oppijaOid: String,
   @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.ammatillinenkoulutus.koodiarvo)
   tyyppi: Koodistokoodiviite,
   oid: String,
@@ -19,8 +20,9 @@ case class SupaAmmatillinenOpiskeluoikeus(
 ) extends SupaOpiskeluoikeus
 
 object SupaAmmatillinenTutkinto {
-  def apply(oo: AmmatillinenOpiskeluoikeus): SupaAmmatillinenOpiskeluoikeus =
+  def apply(oo: AmmatillinenOpiskeluoikeus, oppijaOid: String): SupaAmmatillinenOpiskeluoikeus =
     SupaAmmatillinenOpiskeluoikeus(
+      oppijaOid = oppijaOid,
       tyyppi = oo.tyyppi,
       oid = oo.oid.get,
       koulutustoimija = oo.koulutustoimija,

--- a/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaDiaOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaDiaOpiskeluoikeus.scala
@@ -10,6 +10,7 @@ import java.time.LocalDate
 
 @Title("DIA-tutkinnon opiskeluoikeus")
 case class SupaDIAOpiskeluoikeus(
+  oppijaOid: String,
   @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.diatutkinto.koodiarvo)
   tyyppi: Koodistokoodiviite,
   oid: String,
@@ -20,9 +21,10 @@ case class SupaDIAOpiskeluoikeus(
 ) extends SupaOpiskeluoikeus
 
 object SupaDIAOpiskeluoikeus {
-  def apply(oo: DIAOpiskeluoikeus): Option[SupaDIAOpiskeluoikeus] =
+  def apply(oo: DIAOpiskeluoikeus, oppijaOid: String): Option[SupaDIAOpiskeluoikeus] =
     when (isValmistunut(oo)) {
       SupaDIAOpiskeluoikeus(
+        oppijaOid = oppijaOid,
         tyyppi = oo.tyyppi,
         oid = oo.oid.get,
         koulutustoimija = oo.koulutustoimija,

--- a/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaEBOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaEBOpiskeluoikeus.scala
@@ -9,6 +9,7 @@ import java.time.LocalDate
 
 @Title("EB-tutkinnon opiskeluoikeus")
 case class SupaEBOpiskeluoikeus(
+  oppijaOid: String,
   @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.ebtutkinto.koodiarvo)
   tyyppi: Koodistokoodiviite,
   oid: String,
@@ -19,8 +20,9 @@ case class SupaEBOpiskeluoikeus(
 ) extends SupaOpiskeluoikeus
 
 object SupaEBOpiskeluoikeus {
-  def apply(oo: EBOpiskeluoikeus): SupaEBOpiskeluoikeus =
+  def apply(oo: EBOpiskeluoikeus, oppijaOid: String): SupaEBOpiskeluoikeus =
     SupaEBOpiskeluoikeus(
+      oppijaOid = oppijaOid,
       tyyppi = oo.tyyppi,
       oid = oo.oid.get,
       koulutustoimija = oo.koulutustoimija,

--- a/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaIBOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaIBOpiskeluoikeus.scala
@@ -10,6 +10,7 @@ import java.time.LocalDate
 
 @Title("IB-tutkinnon opiskeluoikeus")
 case class SupaIBOpiskeluoikeus(
+  oppijaOid: String,
   @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.ibtutkinto.koodiarvo)
   tyyppi: Koodistokoodiviite,
   oid: String,
@@ -20,9 +21,10 @@ case class SupaIBOpiskeluoikeus(
 ) extends SupaOpiskeluoikeus
 
 object SupaIBOpiskeluoikeus {
-  def apply(oo: IBOpiskeluoikeus): Option[SupaIBOpiskeluoikeus] =
+  def apply(oo: IBOpiskeluoikeus, oppijaOid: String): Option[SupaIBOpiskeluoikeus] =
     when(isValmistunut(oo)) {
       SupaIBOpiskeluoikeus(
+        oppijaOid = oppijaOid,
         tyyppi = oo.tyyppi,
         oid = oo.oid.get,
         koulutustoimija = oo.koulutustoimija,

--- a/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaInternationalSchoolOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaInternationalSchoolOpiskeluoikeus.scala
@@ -10,6 +10,7 @@ import java.time.LocalDate
 
 @Title("International school opiskeluoikeus")
 case class SupaInternationalSchoolOpiskeluoikeus(
+  oppijaOid: String,
   @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.internationalschool.koodiarvo)
   tyyppi: Koodistokoodiviite,
   oid: String,
@@ -20,9 +21,10 @@ case class SupaInternationalSchoolOpiskeluoikeus(
 ) extends SupaOpiskeluoikeus
 
 object SupaInternationalSchoolOpiskeluoikeus {
-  def apply(oo: InternationalSchoolOpiskeluoikeus): Option[SupaOpiskeluoikeus] =
+  def apply(oo: InternationalSchoolOpiskeluoikeus, oppijaOid: String): Option[SupaOpiskeluoikeus] =
     when(isValmistunut(oo)) {
       SupaInternationalSchoolOpiskeluoikeus(
+        oppijaOid = oppijaOid,
         tyyppi = oo.tyyppi,
         oid = oo.oid.get,
         koulutustoimija = oo.koulutustoimija,

--- a/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaOpiskeluoikeus.scala
@@ -7,6 +7,9 @@ import fi.oph.scalaschema.annotation.{Description, Discriminator}
 import java.time.LocalDate
 
 trait SupaOpiskeluoikeus {
+  @Description("Oppijan yksilöivä tunniste, jolla kyseinen opiskeluoikeus on tallennettu Koski-tietovarantoon.")
+  def oppijaOid: String
+
   @Description("Opiskeluoikeuden tyyppi, jolla erotellaan eri koulutusmuotoihin (perusopetus, lukio, ammatillinen...) liittyvät opiskeluoikeudet")
   @KoodistoUri("opiskeluoikeudentyyppi")
   @Discriminator

--- a/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaPerusopetuksenOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaPerusopetuksenOpiskeluoikeus.scala
@@ -8,6 +8,7 @@ import java.time.LocalDate
 
 @Title("Perusopetuksen opiskeluoikeus")
 case class SupaPerusopetuksenOpiskeluoikeus(
+  oppijaOid: String,
   @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.perusopetus.koodiarvo)
   tyyppi: Koodistokoodiviite,
   oid: String,
@@ -19,8 +20,9 @@ case class SupaPerusopetuksenOpiskeluoikeus(
 ) extends SupaOpiskeluoikeus
 
 object SupaPerusopetuksenOpiskeluoikeus {
-  def apply(oo: PerusopetuksenOpiskeluoikeus): SupaPerusopetuksenOpiskeluoikeus =
+  def apply(oo: PerusopetuksenOpiskeluoikeus, oppijaOid: String): SupaPerusopetuksenOpiskeluoikeus =
     SupaPerusopetuksenOpiskeluoikeus(
+      oppijaOid = oppijaOid,
       tyyppi = oo.tyyppi,
       oid = oo.oid.get,
       koulutustoimija = oo.koulutustoimija,

--- a/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaTutkintokoulutukseenValmentavanOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaTutkintokoulutukseenValmentavanOpiskeluoikeus.scala
@@ -9,6 +9,7 @@ import java.time.LocalDate
 
 @Title("Tutkintokoulutukseen valmentavan koulutuksen opiskeluoikeus")
 case class SupaTutkintokoulutukseenValmentavanOpiskeluoikeus(
+  oppijaOid: String,
   @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.tuva.koodiarvo)
   tyyppi: Koodistokoodiviite,
   oid: String,
@@ -19,8 +20,9 @@ case class SupaTutkintokoulutukseenValmentavanOpiskeluoikeus(
 ) extends SupaOpiskeluoikeus
 
 object SupaTutkintokoulutukseenValmentavanOpiskeluoikeus {
-  def apply(oo: TutkintokoulutukseenValmentavanOpiskeluoikeus): SupaOpiskeluoikeus =
+  def apply(oo: TutkintokoulutukseenValmentavanOpiskeluoikeus, oppijaOid: String): SupaOpiskeluoikeus =
     SupaTutkintokoulutukseenValmentavanOpiskeluoikeus(
+      oppijaOid = oppijaOid,
       tyyppi = oo.tyyppi,
       oid = oo.oid.get,
       koulutustoimija = oo.koulutustoimija,

--- a/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaVapaaSivistystyo.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaVapaaSivistystyo.scala
@@ -8,6 +8,7 @@ import java.time.LocalDate
 
 @Title("Vapaan sivistystyön opiskeluoikeus")
 case class SupaVapaanSivistystyönOpiskeluoikeus(
+  oppijaOid: String,
   @KoodistoKoodiarvo(OpiskeluoikeudenTyyppi.vapaansivistystyonkoulutus.koodiarvo)
   tyyppi: Koodistokoodiviite,
   oid: String,
@@ -20,8 +21,9 @@ case class SupaVapaanSivistystyönOpiskeluoikeus(
 trait SupaVapaanSivistystyönPäätasonSuoritus extends SupaSuoritus
 
 object SupaVapaanSivistystyönOpiskeluoikeus {
-  def apply(oo: VapaanSivistystyönOpiskeluoikeus): SupaVapaanSivistystyönOpiskeluoikeus =
+  def apply(oo: VapaanSivistystyönOpiskeluoikeus, oppijaOid: String): SupaVapaanSivistystyönOpiskeluoikeus =
     SupaVapaanSivistystyönOpiskeluoikeus(
+      oppijaOid = oppijaOid,
       tyyppi = oo.tyyppi,
       oid = oo.oid.get,
       koulutustoimija = oo.koulutustoimija,


### PR DESCRIPTION
Kentässä siirretään se oppija oid, jolla kyseinen opiskeluoikeus on tallennettu Koskeen. Muutos selkeyttää millä oppijan tunnisteella opiskeluoikeus on tallennettu, kun oppijalla on olemassa enemmän kuin yksi oppija oid.