### PR TITLE
TOR-xxxx: ONR taas pois internal healthcheckistä

### DIFF
--- a/src/main/scala/fi/oph/koski/healthcheck/HealthChecker.scala
+++ b/src/main/scala/fi/oph/koski/healthcheck/HealthChecker.scala
@@ -37,7 +37,6 @@ trait HealthCheck extends Logging {
     Subsystem.ValpasDatabase,
     Subsystem.PerustiedotIndex,
     Subsystem.TiedonsiirtoIndex,
-    Subsystem.Oppijanumerorekisteri,
   )
 
   val externalSystems: Seq[String] = List(


### PR DESCRIPTION
Lisättiin vain siksi, että saatiin kontit konsistentimmin kaatumaan, jos/kun ThreadPool on täynnä.

Tämän voi mergetä, kunhan on todettu, että ThreadPool-korjaukset toimii.