### PR TITLE
OPHKOTO-17: VKT-validaation muutos

### DIFF
--- a/.github/skip_tiedonsiirtoprotokollan_muutoshistoria.md
+++ b/.github/skip_tiedonsiirtoprotokollan_muutoshistoria.md
@@ -12,3 +12,4 @@ TOR-2222 - lisätty tietomalliin traitteja, jolla ei ole toiminnallisia vaikutuk
 TOR-2298 - Poistettu kommentti koodista
 OPHKOTO-29 - Kovakoodattu sähköposti kielitutkintojen virheiden ilmoittamiseen
 OPHKOTO-28 - Bugikorjaus
+OPHKOTO-17 - muutos vaikuttaa validointiin

--- a/src/main/scala/fi/oph/koski/schema/Kielitutkinto.scala
+++ b/src/main/scala/fi/oph/koski/schema/Kielitutkinto.scala
@@ -130,7 +130,7 @@ trait ValtionhallinnonKielitutkinnonKielitaidonSuoritus extends Suoritus with Va
   def tyyppi: Koodistokoodiviite
   def arviointi: Option[List[ValtionhallinnonKielitutkinnonArviointi]]
 
-  override def kesken: Boolean = !arviointi.exists(_.exists(_.hyväksytty))
+  override def valmis: Boolean = arviointi.isDefined
 }
 
 trait ValtionhallinnonKielitutkinnonKielitaito extends Koulutusmoduuli {
@@ -187,7 +187,7 @@ trait ValtionhallinnonKielitutkinnonOsakokeenSuoritus extends Suoritus with Vahv
   def koulutusmoduuli: ValtionhallinnonKielitutkinnonOsakoe
   def arviointi: Option[List[ValtionhallinnonKielitutkinnonArviointi]]
 
-  override def valmis: Boolean = super.valmis && arviointi.exists(_.exists(_.hyväksytty))
+  override def valmis: Boolean = arviointi.isDefined
 }
 
 // Valtionhallinnon kielitutkinnon osakokeet

--- a/validaation_muutoshistoria.md
+++ b/validaation_muutoshistoria.md
@@ -1,5 +1,8 @@
 # Koskeen tallennettavien tietojen validaatiosäännöt
 
+# 4.7.2025
+
+- Valtionhallinnon kielitutkintojen validaatiota muutettu niin, että osakoe tai taito todetaan valmiiksi, kunhan sillä on mikä tahansa arviointi (myös hylätty).
 
 ## 30.6.2025
 
@@ -7,6 +10,7 @@
   - Muutos koskee VST vapaatavoitteisten, VST Jotpan ja muun kuin säännellyn koulutuksen opiskeluoikeuksia.
 
 ## 27.6.2025
+
 - Muutettu syksyllä voimaan tulevia tuen päätösten validaatioita; tuen päätös saa olla voimassa jo ennen opiskeluoikeuden alkua, mutta ei saa päättyä ennen opiskeluoikeuden alkua
 - Jos perusopetuksen vuosiluokan vahvistetun suorituksen osasuorituksella on rajattu oppimäärä, osasuorituksen arvosana voi olla vain "S" tai "5" riippuen vuosiluokasta.
 


### PR DESCRIPTION
Kielitutkintojen näkökulmasta suoritukset ovat aina valmiita, kunhan ne on arvioitu, vaikka lopputulos olisikin hylätty.
