### PR TITLE
Korjaa hajonnut perusopetuksen testi, kun vahvistus tulevaisuudessa

### DIFF
--- a/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
+++ b/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
@@ -1205,7 +1205,7 @@ class KoskiValidator(
                 HttpStatus.validate(sisältyyTuenPäätöksenJaksoon(vahvistuspvm))(KoskiErrorCategory.badRequest.validation.date(s"Tieto rajattuOppimäärä vaatii tukijakson suorituksen vahvistuspäivälle: $vahvistuspvm")),
               )
             case os: RajattavaOppimäärä if os.yksilöllistettyOppimäärä =>
-              HttpStatus.validate(vahvistuspvm.isBefore(yksilöllistettyOppimääräViimeinenKäyttöpäivä))(KoskiErrorCategory.badRequest.validation.date(s"Tietoa yksilöllistettyOppimäärä ei saa siirtää $yksilöllistettyOppimääräViimeinenKäyttöpäivä jälkeen alkaneelle suoritukselle"))
+              HttpStatus.validate(vahvistuspvm.isBefore(yksilöllistettyOppimääräViimeinenKäyttöpäivä.plusDays(1)))(KoskiErrorCategory.badRequest.validation.date(s"Tietoa yksilöllistettyOppimäärä ei saa siirtää $yksilöllistettyOppimääräViimeinenKäyttöpäivä jälkeen alkaneelle suoritukselle"))
             case _ => HttpStatus.ok
           }
         )

--- a/validaation_muutoshistoria.md
+++ b/validaation_muutoshistoria.md
@@ -1,4 +1,6 @@
 # Koskeen tallennettavien tietojen validaatiosäännöt
+## 2.9.2025
+- Korjattu perusopetuksen yksilöllistetyn oppimäärän validaatiota siten, että suorituksen voi vahvistaa vielä viimeisenä yksilöllistetyn oppimäärän käyttöpäivänä.
 ## 27.8.2025
  - Lisätty validaatio IB oppiaineen suoritusten laajuuksille. Uusille suorituksille ei sallita tunteja laajuudeksi
  - Poistettiin arvosanojen validointi IBDPCore ossuorituksilta

--- a/web/app/perusopetus/PerusopetuksenOppiaineRowEditor.jsx
+++ b/web/app/perusopetus/PerusopetuksenOppiaineRowEditor.jsx
@@ -115,7 +115,7 @@ export class PerusopetuksenOppiaineRowEditor extends React.Component {
             </td>
           )}
           {edit && (
-            <td>
+            <td className="remove-row">
               <a className="remove-value" onClick={() => pushRemoval(model)} />
             </td>
           )}

--- a/web/test/spec/perusopetusSpec_1.js
+++ b/web/test/spec/perusopetusSpec_1.js
@@ -108,6 +108,8 @@ describe('Perusopetus 1', function () {
               editor.edit,
               tilaJaVahvistus.merkitseValmiiksi,
               opinnot.tilaJaVahvistus.lisääVahvistus(future),
+              // Oppiaineella yksilöllistetty oppimäärä, jota ei voi enää lisätä 31.8.2026 jälkeen
+              opinnot.oppiaineet.oppiaine('BI').poista(),
               editor.saveChanges
             )
 


### PR DESCRIPTION
Korjaa samalla yksilöllistetyn oppimäärän validaation siten, että rajapäivänä lisätty vahvistus on kuitenkin sallittu