### PR TITLE
OPHKOTO-17: Salli kielitutkinnoille sama alku- ja päättymispäivä

### DIFF
--- a/src/main/scala/fi/oph/koski/schema/Kielitutkinto.scala
+++ b/src/main/scala/fi/oph/koski/schema/Kielitutkinto.scala
@@ -48,7 +48,7 @@ case class KielitutkinnonOpiskeluoikeudenOpiskeluoikeusjakso(
   @KoodistoKoodiarvo("paattynyt")
   @KoodistoKoodiarvo("mitatoity")
   tila: Koodistokoodiviite,
-) extends KoskiOpiskeluoikeusjakso
+) extends KoskiPäällekkäisenPäivämääränSallivaOpiskeluoikeusjakso
 
 trait KielitutkinnonPäätasonSuoritus extends KoskeenTallennettavaPäätasonSuoritus
 

--- a/src/main/scala/fi/oph/koski/schema/Opiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/schema/Opiskeluoikeus.scala
@@ -333,6 +333,8 @@ trait KoskiLomanSallivaLaajaOpiskeluoikeusjakso extends KoskiLaajaOpiskeluoikeus
   def tila: Koodistokoodiviite
 }
 
+trait KoskiPäällekkäisenPäivämääränSallivaOpiskeluoikeusjakso extends KoskiOpiskeluoikeusjakso
+
 trait Alkupäivällinen {
   @Description("Jakson alkamispäivämäärä. Muoto YYYY-MM-DD")
   def alku: LocalDate

--- a/tiedonsiirtoprotokollan_muutoshistoria.md
+++ b/tiedonsiirtoprotokollan_muutoshistoria.md
@@ -1,4 +1,4 @@
-## x.8.2025
+## 19.8.2025
 
 - Salli valtionhallinnon kielitutkinnon erinomaisen tason siirto ilman oppilaitosta
 

--- a/validaation_muutoshistoria.md
+++ b/validaation_muutoshistoria.md
@@ -1,5 +1,9 @@
 # Koskeen tallennettavien tietojen validaatiosäännöt
 
+## 19.9.2025
+
+- Salli kielitutkinnon opiskeluoikeudelle sama alku- ja päättymispäivämäärä.
+
 ## 18.9.2025
  - Lisätty validaatio nuorten perusopetuksen oppiaineiden luokka-asteille
    - Sallitaan useampi pakollisen saman oppiaineen suoritus eri luokka-asteilla ja yksi luokka-asteeton suoritus


### PR DESCRIPTION
Tyypillinen tapaus vkt-kielitutkinnoille on, että tutkinto ja arviointi ovat samana päivänä.
