### PR TITLE
Vammaisuusjaksojen validaation korjaus

### DIFF
--- a/src/test/scala/fi/oph/koski/api/oppijavalidation/OppijaValidationEsiopetusSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/oppijavalidation/OppijaValidationEsiopetusSpec.scala
@@ -948,6 +948,30 @@ class OppijaValidationEsiopetusSpec extends TutkinnonPerusteetTest[EsiopetuksenO
     }
   }
 
+  "Pidennetty oppivelvollisuus 1.8.2025 jälkeen ilman vammaisuusjaksoja, mutta tuen päätöksen jaksolla -> HTTP 200" in {
+    val pidennetty = Aikajakso(
+      alku = Some(date(2025, 8, 1)),
+      loppu = Some(date(2026, 5, 29)),
+    )
+    val tukijakso = Tukijakso(
+      alku = Some(date(2025, 8, 1)),
+      loppu = Some(date(2026, 5, 29)),
+    )
+
+    val oo = defaultOpiskeluoikeus.copy(
+      lisätiedot = Some(EsiopetuksenOpiskeluoikeudenLisätiedot(
+        pidennettyOppivelvollisuus = Some(pidennetty),
+        tuenPäätöksenJaksot = Some(List(tukijakso)),
+        vammainen = None,
+        vaikeastiVammainen = None,
+      ))
+    )
+
+    setupOppijaWithOpiskeluoikeus(oo) {
+      verifyResponseStatusOk()
+    }
+  }
+
   "Opiskeluoikeudet oppivelvollisuuden pidennyksen ja tuen päätöksien muutosten siirtymäajan (1.8.2025 - 1.8.2026) yli" - {
     def makeOpiskeluoikeus(
       tuenPäätöksenJaksot: Option[List[Tukijakso]] = None,


### PR DESCRIPTION
## Ennen tätä muutosta

- Esiopetuksessa pidennettyOppivelvollisuus vaati aina vammaisuusjaksojen (vammainen/vaikeastiVammainen) täydellisen kattavuuden ja viimeisen jakson päättymisen samana päivänä kuin pidennetty oppivelvollisuus.
- Vaatimus oli voimassa myös uuden mallin tuen päätöksen jaksojen (tuenPäätöksenJaksot) ollessa mukana 1.8.2025 jälkeen.

Tämä validaation toteutus ei ollut [Esiopetuksen tuen muutokset KOSKI-tietomalliin, -käyttöliittymiin ja tiedonsiirtovalidaatioihin](https://wiki.eduuni.fi/spaces/OPHPALV/pages/222563915/Toteutetut+uudet+ominaisuudet+KOSKI-tietomalliin+ja+-k%C3%A4ytt%C3%B6liittymiin#ToteutetutuudetominaisuudetKOSKItietomalliinjak%C3%A4ytt%C3%B6liittymiin-1.Esiopetus.4)-wiki dokumentaation mukainen.
## Tämän muutoksen jälkeen

- Jos pidennetty oppivelvollisuus ulottuu 1.8.2025 tai sen yli (määritelty konfiguraatiolla validaatiot.tukijaksotVoimaan) ja ajanjakso on katettu tuen päätöksen jaksolla (tai vanhan mallin erityisen tuen jaksolla), vammaisuusjaksoja ei enää vaadita.
- Vammaisuusjaksojen kattavuus- ja päättymispäivävaatimukset pysyvät ennallaan vain jaksoille, jotka päättyvät ennen 1.8.2025.

Terveisin,
eVaka tiimi