### PR TITLE
TOR-2387 korjaa suorituksen nimi päällekkäisten opiskeluoikeuksien raporttiin

### DIFF
--- a/src/main/resources/localization/koski-default-texts.json
+++ b/src/main/resources/localization/koski-default-texts.json
@@ -1556,6 +1556,7 @@
   "raportti-excel-arvioinnit-sheet-name": "Arvioinnit",
   "raportti-excel-default-value-aikuistenperusopetuksenoppimaara": "Aikuisten perusopetuksen oppimäärä",
   "raportti-excel-default-value-ammatillisenosia": "Ammatillisen tutkinnon osa/osia",
+  "raportti-excel-default-value-ammatillisenosia-useasta-tutkinnosta": "Ammatillisen tutkinnon osia useasta tutkinnosta",
   "raportti-excel-default-value-ammatillisensuoritus": "Ammatillisen tutkinnon suoritus",
   "raportti-excel-default-value-arvosana": "Arvosana",
   "raportti-excel-default-value-arvosana-puuttuu": "Arvosana puuttuu",

--- a/src/main/scala/fi/oph/koski/raportit/PaallekkaisetOpiskeluoikeudet.scala
+++ b/src/main/scala/fi/oph/koski/raportit/PaallekkaisetOpiskeluoikeudet.scala
@@ -294,6 +294,8 @@ object PaallekkaisetOpiskeluoikeudet extends Logging {
       case (_, ("aikuistenperusopetuksenoppimaara", _)) => t.get("raportti-excel-default-value-aikuistenperusopetuksenoppimaara")
       case (_, ("aikuistenperusopetuksenoppimaaranalkuvaihe", _)) => t.get("raportti-excel-default-value-aikuistenperusopetuksenoppimaara")
       case (_, ("perusopetuksenoppiaineenoppimaara", _)) => t.get("raportti-excel-default-value-perusopetuksenaineopiskelija")
+      case (_, ("ammatillinentutkintoosittainen", koulutusmoduuli)) if koulutusmoduuli == "ammatillinentutkintoosittainenuseastatutkinnosta" =>
+        t.get("raportti-excel-default-value-ammatillisenosia-useasta-tutkinnosta")
       case (_, ("ammatillinentutkintoosittainen", _)) => t.get("raportti-excel-default-value-ammatillisenosia")
       case (_, ("ammatillinentutkinto", _)) => t.get("raportti-excel-default-value-ammatillisensuoritus")
       case (acc, ("nayttotutkintoonvalmistavakoulutus", _)) if acc == t.get("raportti-excel-default-value-ammatillisenosia") => acc


### PR DESCRIPTION
ammatillisen tutkinnon osien suoritukselle useasta tutkinnosta