### PR TITLE
TOR-2386 SUPA-rajapinnan tietomalliin ammatillinentutkintoosittainen

### DIFF
--- a/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaAmmatillinenOsittainen.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaAmmatillinenOsittainen.scala
@@ -1,0 +1,185 @@
+package fi.oph.koski.massaluovutus.suorituspalvelu.opiskeluoikeus
+
+import fi.oph.koski.schema._
+import fi.oph.koski.schema.annotation.{KoodistoKoodiarvo, KoodistoUri, Scale, Tooltip}
+import fi.oph.scalaschema.annotation.{Description, MaxValue, MinValue, OnlyWhen, Title}
+
+import java.time.LocalDate
+
+trait SupaOsittaisenAmmatillisenTutkinnonOsanSuoritus {
+  def tyyppi: Koodistokoodiviite
+  def koulutusmoduuli: AmmatillisenTutkinnonOsa
+  def arviointi: Option[List[AmmatillinenArviointi]]
+}
+
+trait SupaOsittaisenJatkovalmiudetOsasuoritus extends SupaSuoritus
+
+@Title("Ammatillisen tutkinnon osa/osia")
+case class SupaAmmatillisenTutkinnonOsittainenSuoritus(
+  @KoodistoKoodiarvo("ammatillinentutkintoosittainen")
+  tyyppi: Koodistokoodiviite,
+  alkamispäivä: Option[LocalDate],
+  vahvistus: Option[SupaVahvistus],
+  koulutusmoduuli: AmmatillinenTutkintoKoulutus,
+  suorituskieli: Koodistokoodiviite,
+  osasuoritukset: List[SupaOsittaisenAmmatillisenTutkinnonOsanSuoritus],
+  @KoodistoKoodiarvo("ammatillinentutkintoosittainen")
+  suoritustapa: Koodistokoodiviite,
+  @MinValue(1) @MaxValue(5)
+  @Scale(2)
+  keskiarvo: Option[Double],
+  @Title("Korotettu painotettu keskiarvo")
+  @MinValue(1) @MaxValue(5)
+  @Scale(2)
+  korotettuKeskiarvo: Option[Double],
+  @Title("Korotetun suorituksen alkuperäinen opiskeluoikeus")
+  @Description("Korotetun suorituksen alkuperäinen opiskeluoikeus")
+  korotettuOpiskeluoikeusOid: Option[String]
+) extends SupaAmmatillinenPäätasonSuoritus
+  with Suorituskielellinen
+  with SupaVahvistuksellinen
+
+object SupaAmmatillisenTutkinnonOsittainenSuoritus {
+  def apply(s: AmmatillisenTutkinnonOsittainenSuoritus): SupaAmmatillisenTutkinnonOsittainenSuoritus =
+    SupaAmmatillisenTutkinnonOsittainenSuoritus(
+      tyyppi = s.tyyppi,
+      alkamispäivä = s.alkamispäivä,
+      vahvistus = s.vahvistus.map(v => SupaVahvistus(v.päivä)),
+      koulutusmoduuli = s.koulutusmoduuli,
+      suorituskieli = s.suorituskieli,
+      osasuoritukset = s.osasuoritukset.toList.flatten.map(SupaOsittaisenAmmatillisenTutkinnonOsanSuoritusmapper.apply),
+      suoritustapa = s.suoritustapa,
+      keskiarvo = s.keskiarvo,
+      korotettuKeskiarvo = s.korotettuKeskiarvo,
+      korotettuOpiskeluoikeusOid = s.korotettuOpiskeluoikeusOid
+    )
+}
+
+@Title("Yhteinen tutkinnon osan suoritus")
+case class SupaOsittaisenYhteisenAmmatillisenTutkinnonOsanSuoritus(
+  tyyppi: Koodistokoodiviite,
+  koulutusmoduuli: AmmatillisenTutkinnonOsa,
+  arviointi: Option[List[AmmatillinenArviointi]],
+  osasuoritukset: List[SupaOsittaisenYhteisenTutkinnonOsanOsaAlueenSuoritus]
+) extends SupaOsittaisenAmmatillisenTutkinnonOsanSuoritus
+
+@Title("Muun tutkinnon osan suoritus")
+case class SupaOsittaisenMuunAmmatillisenTutkinnonOsanSuoritus(
+  tyyppi: Koodistokoodiviite,
+  koulutusmoduuli: AmmatillisenTutkinnonOsa,
+  arviointi: Option[List[AmmatillinenArviointi]],
+  korotettu: Option[Koodistokoodiviite]
+) extends SupaOsittaisenAmmatillisenTutkinnonOsanSuoritus
+
+@Title("Yhteisten tutkinnon osien osa-alueita, lukio-opintoja tai muita jatko-opintovalmiuksia tukevia opintoja")
+case class SupaOsittaisenJatkoOpintovalmiuksiaTukevienOpintojenSuoritus(
+  tyyppi: Koodistokoodiviite,
+  koulutusmoduuli: AmmatillisenTutkinnonOsa,
+  arviointi: Option[List[AmmatillinenArviointi]],
+  osasuoritukset: List[SupaOsittaisenJatkovalmiudetOsasuoritus]
+) extends SupaOsittaisenAmmatillisenTutkinnonOsanSuoritus
+
+@Title("Korkeakouluopintoja")
+case class SupaOsittaisenKorkeakouluopintoSuoritus(
+  tyyppi: Koodistokoodiviite,
+  koulutusmoduuli: AmmatillisenTutkinnonOsa,
+  arviointi: Option[List[AmmatillinenArviointi]],
+  osasuoritukset: List[SupaKorkeakouluopintojenSuoritus]
+) extends SupaOsittaisenAmmatillisenTutkinnonOsanSuoritus
+
+@Title("Yhteisten tutkinnon osien osa-alueita, lukio-opintoja tai muita jatko-opintovalmiuksia tukevia opintoja")
+case class SupaOsittaisenYhteisenTutkinnonOsanOsaAlueenSuoritus(
+  @KoodistoKoodiarvo("ammatillisentutkinnonosanosaalue")
+  tyyppi: Koodistokoodiviite,
+  koulutusmoduuli: AmmatillisenTutkinnonOsanOsaAlue,
+  arviointi: Option[List[AmmatillinenArviointi]],
+  korotettu: Option[Koodistokoodiviite]
+) extends SupaOsittaisenJatkovalmiudetOsasuoritus
+
+@Title("Muiden opintovalmiuksia tukevien opintojen suoritus")
+case class SupaOsittaisenMuidenOpintovalmiuksiaTukevienOpintojenSuoritus(
+  @KoodistoKoodiarvo("ammatillinenmuitaopintovalmiuksiatukeviaopintoja")
+  tyyppi: Koodistokoodiviite,
+  koulutusmoduuli: PaikallinenOpintovalmiuksiaTukevaOpinto,
+  arviointi: Option[List[AmmatillinenArviointi]],
+  korotettu: Option[Koodistokoodiviite]
+) extends SupaOsittaisenJatkovalmiudetOsasuoritus
+
+@Title("Lukion oppiaineen tai lukion kurssin suoritus")
+case class SupaOsittaisenLukioOpintojenSuoritus(
+  @KoodistoKoodiarvo("ammatillinenlukionopintoja")
+  tyyppi: Koodistokoodiviite,
+  koulutusmoduuli: PaikallinenLukionOpinto,
+  arviointi: Option[List[AmmatillinenArviointi]]
+) extends SupaOsittaisenJatkovalmiudetOsasuoritus
+
+private object OsittainenJatkoOpintovalmiuksiaOsasuoritusMapper {
+  def apply(s: YhteistenTutkinnonOsienOsaAlueidenTaiLukioOpintojenTaiMuidenOpintovalmiuksiaTukevienOpintojenOsasuoritus
+           ): SupaOsittaisenJatkovalmiudetOsasuoritus = s match {
+    case ss: LukioOpintojenSuoritus =>
+      SupaOsittaisenLukioOpintojenSuoritus(ss.tyyppi, ss.koulutusmoduuli, ss.arviointi)
+    case ss: MuidenOpintovalmiuksiaTukevienOpintojenSuoritus =>
+      SupaOsittaisenMuidenOpintovalmiuksiaTukevienOpintojenSuoritus(ss)
+    case ss: YhteisenTutkinnonOsanOsaAlueenSuoritus =>
+      SupaOsittaisenYhteisenTutkinnonOsanOsaAlueenSuoritus(ss)
+  }
+}
+
+object SupaOsittaisenMuidenOpintovalmiuksiaTukevienOpintojenSuoritus {
+  def apply(s: MuidenOpintovalmiuksiaTukevienOpintojenSuoritus)
+  : SupaOsittaisenMuidenOpintovalmiuksiaTukevienOpintojenSuoritus =
+    SupaOsittaisenMuidenOpintovalmiuksiaTukevienOpintojenSuoritus(
+      tyyppi = s.tyyppi,
+      koulutusmoduuli = s.koulutusmoduuli,
+      arviointi = s.arviointi,
+      korotettu = s.korotettu
+    )
+}
+
+object SupaOsittaisenYhteisenTutkinnonOsanOsaAlueenSuoritus {
+  def apply(s: YhteisenTutkinnonOsanOsaAlueenSuoritus): SupaOsittaisenYhteisenTutkinnonOsanOsaAlueenSuoritus =
+    SupaOsittaisenYhteisenTutkinnonOsanOsaAlueenSuoritus(
+      tyyppi = s.tyyppi,
+      koulutusmoduuli = s.koulutusmoduuli,
+      arviointi = s.arviointi,
+      korotettu = s.korotettu
+    )
+}
+
+private object SupaOsittaisenAmmatillisenTutkinnonOsanSuoritusmapper {
+  def apply(s: OsittaisenAmmatillisenTutkinnonOsanSuoritus): SupaOsittaisenAmmatillisenTutkinnonOsanSuoritus = s match {
+    case ss: YhteisenOsittaisenAmmatillisenTutkinnonTutkinnonosanSuoritus =>
+      SupaOsittaisenYhteisenAmmatillisenTutkinnonOsanSuoritus(
+        tyyppi = ss.tyyppi,
+        koulutusmoduuli = ss.koulutusmoduuli,
+        arviointi = ss.arviointi,
+        osasuoritukset = ss.osasuoritukset.toList.flatten.map(SupaOsittaisenYhteisenTutkinnonOsanOsaAlueenSuoritus.apply)
+      )
+
+    case ss: MuunOsittaisenAmmatillisenTutkinnonTutkinnonosanSuoritus =>
+      SupaOsittaisenMuunAmmatillisenTutkinnonOsanSuoritus(
+        tyyppi = ss.tyyppi,
+        koulutusmoduuli = ss.koulutusmoduuli,
+        arviointi = ss.arviointi,
+        korotettu = ss.korotettu
+      )
+
+    case ss: OsittaisenAmmatillisenTutkinnonOsanJatkoOpintovalmiuksiaTukevienOpintojenSuoritus =>
+      SupaOsittaisenJatkoOpintovalmiuksiaTukevienOpintojenSuoritus(
+        tyyppi = ss.tyyppi,
+        koulutusmoduuli = ss.koulutusmoduuli,
+        arviointi = None,
+        osasuoritukset = ss.osasuoritukset.toList.flatten.map(
+          OsittainenJatkoOpintovalmiuksiaOsasuoritusMapper.apply
+        )
+      )
+
+    case ss: OsittaisenAmmatillisenTutkinnonOsanKorkeakouluopintoSuoritus =>
+      SupaOsittaisenKorkeakouluopintoSuoritus(
+        tyyppi = ss.tyyppi,
+        koulutusmoduuli = ss.koulutusmoduuli,
+        arviointi = None,
+        osasuoritukset = ss.osasuoritukset.toList.flatten.map(SupaKorkeakouluopintojenSuoritus.apply)
+      )
+  }
+}

--- a/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaAmmatillinenTutkinto.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaAmmatillinenTutkinto.scala
@@ -1,6 +1,6 @@
 package fi.oph.koski.massaluovutus.suorituspalvelu.opiskeluoikeus
 
-import fi.oph.koski.schema._
+import fi.oph.koski.schema.{OsittaisenAmmatillisenTutkinnonOsanSuoritus, _}
 import fi.oph.koski.schema.annotation.{KoodistoKoodiarvo, KoodistoUri, Scale, Tooltip}
 import fi.oph.scalaschema.annotation.{Description, MaxValue, MinValue, OnlyWhen, Title}
 
@@ -31,6 +31,7 @@ object SupaAmmatillinenTutkinto {
       suoritukset = oo.suoritukset.collect {
         case s: AmmatillisenTutkinnonSuoritus => SupaAmmatillisenTutkinnonSuoritus(s)
         case s: TelmaKoulutuksenSuoritus => SupaTelmaKoulutuksenSuoritus(s)
+        case s: AmmatillisenTutkinnonOsittainenSuoritus => SupaAmmatillisenTutkinnonOsittainenSuoritus(s)
       }
     )
 }
@@ -240,50 +241,6 @@ object SupaAmmatillisenTutkinnonOsasuoritus {
         )
     }
   }
-}
-
-@Title("TELMA-koulutuksen suoritus")
-@Description("Työhön ja itsenäiseen elämään valmentava koulutus (TELMA)")
-case class SupaTelmaKoulutuksenSuoritus(
-  @KoodistoKoodiarvo("telma")
-  tyyppi: Koodistokoodiviite,
-  alkamispäivä: Option[LocalDate],
-  vahvistus: Option[SupaVahvistus],
-  koulutusmoduuli: TelmaKoulutus,
-  suorituskieli: Koodistokoodiviite,
-  osasuoritukset: List[SupaTelmaKoulutuksenOsanSuoritus],
-) extends SupaAmmatillinenPäätasonSuoritus
-  with Suorituskielellinen
-  with SupaVahvistuksellinen
-
-object SupaTelmaKoulutuksenSuoritus {
-  def apply(s: TelmaKoulutuksenSuoritus): SupaTelmaKoulutuksenSuoritus =
-    SupaTelmaKoulutuksenSuoritus(
-      tyyppi = s.tyyppi,
-      alkamispäivä = s.alkamispäivä,
-      vahvistus = s.vahvistus.map(v => SupaVahvistus(v.päivä)),
-      koulutusmoduuli = s.koulutusmoduuli,
-      suorituskieli = s.suorituskieli,
-      osasuoritukset = s.osasuoritukset.toList.flatten.map(SupaTelmaKoulutuksenOsanSuoritus.apply),
-    )
-}
-
-@Title("TELMA-koulutuksen osan suoritus")
-@Description("Suoritettavan TELMA-koulutuksen osan tiedot")
-case class SupaTelmaKoulutuksenOsanSuoritus(
-  @KoodistoKoodiarvo("telmakoulutuksenosa")
-  tyyppi: Koodistokoodiviite,
-  koulutusmoduuli: TelmaKoulutuksenOsa,
-  arviointi: Option[List[TelmaJaValmaArviointi]],
-) extends SupaSuoritus
-
-object SupaTelmaKoulutuksenOsanSuoritus {
-  def apply(s: TelmaKoulutuksenOsanSuoritus): SupaTelmaKoulutuksenOsanSuoritus =
-    SupaTelmaKoulutuksenOsanSuoritus(
-      tyyppi = s.tyyppi,
-      koulutusmoduuli = s.koulutusmoduuli,
-      arviointi = s.arviointi
-    )
 }
 
 @Title("Yhteisen tutkinnon osan osa-alueen suoritus")

--- a/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaTelmaKoulutus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaTelmaKoulutus.scala
@@ -1,0 +1,53 @@
+package fi.oph.koski.massaluovutus.suorituspalvelu.opiskeluoikeus
+
+import fi.oph.koski.schema._
+import fi.oph.koski.schema.annotation.{ComplexObject, KoodistoKoodiarvo, Tooltip}
+import fi.oph.scalaschema.annotation.{Description, Title}
+
+import java.time.LocalDate
+
+
+@Title("TELMA-koulutuksen suoritus")
+@Description("Työhön ja itsenäiseen elämään valmentava koulutus (TELMA)")
+case class SupaTelmaKoulutuksenSuoritus(
+  @KoodistoKoodiarvo("telma")
+  tyyppi: Koodistokoodiviite,
+  alkamispäivä: Option[LocalDate],
+  vahvistus: Option[SupaVahvistus],
+  koulutusmoduuli: TelmaKoulutus,
+  suorituskieli: Koodistokoodiviite,
+  osasuoritukset: List[SupaTelmaKoulutuksenOsanSuoritus],
+) extends SupaAmmatillinenPäätasonSuoritus
+  with Suorituskielellinen
+  with SupaVahvistuksellinen
+
+object SupaTelmaKoulutuksenSuoritus {
+  def apply(s: TelmaKoulutuksenSuoritus): SupaTelmaKoulutuksenSuoritus =
+    SupaTelmaKoulutuksenSuoritus(
+      tyyppi = s.tyyppi,
+      alkamispäivä = s.alkamispäivä,
+      vahvistus = s.vahvistus.map(v => SupaVahvistus(v.päivä)),
+      koulutusmoduuli = s.koulutusmoduuli,
+      suorituskieli = s.suorituskieli,
+      osasuoritukset = s.osasuoritukset.toList.flatten.map(SupaTelmaKoulutuksenOsanSuoritus.apply),
+    )
+}
+
+@Title("TELMA-koulutuksen osan suoritus")
+@Description("Suoritettavan TELMA-koulutuksen osan tiedot")
+case class SupaTelmaKoulutuksenOsanSuoritus(
+  @KoodistoKoodiarvo("telmakoulutuksenosa")
+  tyyppi: Koodistokoodiviite,
+  koulutusmoduuli: TelmaKoulutuksenOsa,
+  arviointi: Option[List[TelmaJaValmaArviointi]],
+) extends SupaSuoritus
+
+object SupaTelmaKoulutuksenOsanSuoritus {
+  def apply(s: TelmaKoulutuksenOsanSuoritus): SupaTelmaKoulutuksenOsanSuoritus =
+    SupaTelmaKoulutuksenOsanSuoritus(
+      tyyppi = s.tyyppi,
+      koulutusmoduuli = s.koulutusmoduuli,
+      arviointi = s.arviointi
+    )
+}
+

--- a/src/test/scala/fi/oph/koski/massaluovutus/MassaluovutusSpec.scala
+++ b/src/test/scala/fi/oph/koski/massaluovutus/MassaluovutusSpec.scala
@@ -579,6 +579,7 @@ class MassaluovutusSpec extends AnyFreeSpec with KoskiHttpSpec with Matchers wit
         ) should equal(List(
           "aikuistenperusopetuksenoppimaara",
           "ammatillinentutkinto",
+          "ammatillinentutkintoosittainen",
           "diatutkintovaihe",
           "ebtutkinto",
           "ibtutkinto",
@@ -623,6 +624,7 @@ class MassaluovutusSpec extends AnyFreeSpec with KoskiHttpSpec with Matchers wit
           tyyppi
         ) should equal(List(
           "ammatillinentutkinto",
+          "ammatillinentutkintoosittainen",
           "telma"
         ))
       }
@@ -829,6 +831,7 @@ class MassaluovutusSpec extends AnyFreeSpec with KoskiHttpSpec with Matchers wit
         ) should equal(List(
           "aikuistenperusopetuksenoppimaara",
           "ammatillinentutkinto",
+          "ammatillinentutkintoosittainen",
           "diatutkintovaihe",
           "ebtutkinto",
           "ibtutkinto",
@@ -873,6 +876,7 @@ class MassaluovutusSpec extends AnyFreeSpec with KoskiHttpSpec with Matchers wit
           tyyppi
         ) should equal(List(
           "ammatillinentutkinto",
+          "ammatillinentutkintoosittainen",
           "telma"
         ))
       }


### PR DESCRIPTION
Lisätään SUPA-rajapinnan ammatillisen opiskeluoikeuden tietomalliin myös tyyppiä 'ammatillinentutkintoosittainen' oleva päätason suoritus