### PR TITLE
TOR-2219: Lisää iboTunniste-kentän UI IB-editoriin

### DIFF
--- a/web/app/ib/IBEditor.tsx
+++ b/web/app/ib/IBEditor.tsx
@@ -45,6 +45,7 @@ import { OsasuoritusOf } from '../util/schema'
 import { containsPaikallinenSuoritus } from '../util/suoritus'
 import { useBooleanState } from '../util/useBooleanState'
 import { IBLisätiedot } from './IBLisatiedot'
+import { IBOpiskeluoikeudenLisäkentät } from './IBOpiskeluoikeudenLisäkentät'
 import { IBPäätasonSuoritusTiedot } from './IBPaatasonSuoritusTiedot'
 import { UusiIBTutkintoOppiaineDialog } from './dialogs/UusiIBTutkintoOppiaineDialog'
 import { UusiIBTutkintoOsasuoritusDialog } from './dialogs/UusiIBTutkintoOsasuoritusDialog'
@@ -155,6 +156,7 @@ const IBPäätasonSuoritusEditor: React.FC<
       invalidatable={invalidatable}
       onChangeSuoritus={setPäätasonSuoritus}
       createOpiskeluoikeusjakso={LukionOpiskeluoikeusjakso}
+      additionalOpiskeluoikeusFields={IBOpiskeluoikeudenLisäkentät}
       lisätiedotContainer={IBLisätiedot}
       testId={päätasonSuoritus.testId}
       {...addSuoritusProps}

--- a/web/app/ib/IBOpiskeluoikeudenLisäkentät.tsx
+++ b/web/app/ib/IBOpiskeluoikeudenLisäkentät.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import {
+  KeyValueRow,
+  KeyValueTable
+} from '../components-v2/containers/KeyValueTable'
+import { TextEdit, TextView } from '../components-v2/controls/TextField'
+import { FormField } from '../components-v2/forms/FormField'
+import { FormModel } from '../components-v2/forms/FormModel'
+import { IBOpiskeluoikeus } from '../types/fi/oph/koski/schema/IBOpiskeluoikeus'
+
+interface IBOpiskeluoikeudenLisäkentätProps {
+  form: FormModel<IBOpiskeluoikeus>
+}
+
+export const IBOpiskeluoikeudenLisäkentät: React.FC<
+  IBOpiskeluoikeudenLisäkentätProps
+> = ({ form }) => {
+  return (
+    <KeyValueTable>
+      <KeyValueRow localizableLabel="IBO-tunniste">
+        <FormField
+          form={form}
+          path={form.root.prop('iboTunniste')}
+          view={TextView}
+          edit={TextEdit}
+          testId="iboTunniste"
+        />
+      </KeyValueRow>
+    </KeyValueTable>
+  )
+}


### PR DESCRIPTION
Kenttä näytetään ja sitä voi muokata opiskeluoikeustasolla
voimassaoloajan ja tilan välissä.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
