### PR TITLE
TOR-1050 Oma opintopolku loki organisaatiot

### DIFF
--- a/src/main/scala/fi/oph/koski/omaopintopolkuloki/AuditLogMockData.scala
+++ b/src/main/scala/fi/oph/koski/omaopintopolkuloki/AuditLogMockData.scala
@@ -221,6 +221,106 @@ object AuditLogMockData extends Logging {
       organizationOid = List(MockOrganisaatiot.helsinginKaupunki),
       raw = rawAuditlog("OPISKELUOIKEUS_KATSOMINEN")
     ),
+    // Koululaisen opiskeluoikeudet ovat Helsingin kaupungilla/Kulosaaren ala-asteella.
+    // Rivi sisältää "vieraan" Kuopion kaupungin, jonka suodatuksen pitää pudottaa pois.
+    MockData(
+      studentOid = KoskiSpecificMockOppijat.koululainen.oid,
+      time = "2026-04-09T12:00:00.104+03",
+      organizationOid = List(MockOrganisaatiot.kuopionKaupunki, MockOrganisaatiot.helsinginKaupunki),
+      raw = rawAuditlog("OPISKELUOIKEUS_KATSOMINEN")
+    ),
+    // OPH-katsoja nähnyt koululaisen tiedot. OPH näytetään aina, vieras org pudotetaan.
+    MockData(
+      studentOid = KoskiSpecificMockOppijat.koululainen.oid,
+      time = "2026-04-09T13:00:00.104+03",
+      organizationOid = List(Opetushallitus.organisaatioOid, MockOrganisaatiot.kuopionKaupunki),
+      raw = rawAuditlog("OPISKELUOIKEUS_KATSOMINEN")
+    ),
+    // KOSKI-oikeus sekä koulutustoimijaan että oppilaitokseen => molemmat jäävät, koulutustoimija ensin
+    MockData(
+      studentOid = KoskiSpecificMockOppijat.koululainen.oid,
+      time = "2026-04-09T14:00:00.104+03",
+      organizationOid = List(MockOrganisaatiot.kulosaarenAlaAste, MockOrganisaatiot.helsinginKaupunki),
+      raw = rawAuditlog("OPISKELUOIKEUS_KATSOMINEN")
+    ),
+    // KOSKI-oikeus kahteen oppilaitokseen => vain oppijan oma oppilaitos jää
+    MockData(
+      studentOid = KoskiSpecificMockOppijat.koululainen.oid,
+      time = "2026-04-09T15:00:00.104+03",
+      organizationOid = List(MockOrganisaatiot.stadinAmmattiopisto, MockOrganisaatiot.kulosaarenAlaAste),
+      raw = rawAuditlog("OPISKELUOIKEUS_KATSOMINEN")
+    ),
+
+    // demoNordea: lukio opiskeluoikeus Jyväskylän normaalikoulussa (oppilaitos), koulutustoimija Jyväskylän yliopisto.
+    // Rivit järjestetty UI-näkymän mukaan (uusin ensin). Samoiksi ryhmiksi yhdistyvät rivit peräkkäin.
+
+    // UI-rivi 1: "Digi- ja väestötietovirasto" (MyData/OAuth2, ei suodateta)
+    MockData(
+      studentOid = KoskiSpecificMockOppijat.demoNordea.oid,
+      time = "2026-01-19T09:00:00.000+03",
+      organizationOid = List(MockOrganisaatiot.dvv),
+      raw = rawAuditlog("OAUTH2_KATSOMINEN_KAIKKI_TIEDOT")
+    ),
+    // UI-rivi 2: "Helsingin kaupunki" (fallback — kumpikaan org ei matchaa opiskeluoikeuksiin)
+    MockData(
+      studentOid = KoskiSpecificMockOppijat.demoNordea.oid,
+      time = "2026-01-18T09:00:00.000+03",
+      organizationOid = List(MockOrganisaatiot.helsinginKaupunki, MockOrganisaatiot.kuopionKaupunki),
+      raw = rawAuditlog("OPISKELUOIKEUS_KATSOMINEN")
+    ),
+    // UI-rivi 3: "Jyväskylän yliopisto + Jyväskylän normaalikoulu" (molemmat matchaavat, koulutustoimija ensin)
+    MockData(
+      studentOid = KoskiSpecificMockOppijat.demoNordea.oid,
+      time = "2026-01-17T09:00:00.000+03",
+      organizationOid = List(MockOrganisaatiot.jyväskylänNormaalikoulu, MockOrganisaatiot.jyväskylänYliopisto),
+      raw = rawAuditlog("OPISKELUOIKEUS_KATSOMINEN")
+    ),
+    // UI-rivi 4: "Opetushallitus + Jyväskylän yliopisto" (OPH aina mukana, prioriteetti 0 > 1)
+    MockData(
+      studentOid = KoskiSpecificMockOppijat.demoNordea.oid,
+      time = "2026-01-16T09:00:00.000+03",
+      organizationOid = List(MockOrganisaatiot.jyväskylänYliopisto, Opetushallitus.organisaatioOid),
+      raw = rawAuditlog("OPISKELUOIKEUS_KATSOMINEN")
+    ),
+    // UI-rivi 5: "Opetushallitus" (yhdistyy kahdesta rivistä — pelkkä OPH + OPH jonka vieressä vieras org)
+    MockData(
+      studentOid = KoskiSpecificMockOppijat.demoNordea.oid,
+      time = "2026-01-15T09:00:00.000+03",
+      organizationOid = List(Opetushallitus.organisaatioOid, MockOrganisaatiot.helsinginKaupunki),
+      raw = rawAuditlog("OPISKELUOIKEUS_KATSOMINEN")
+    ),
+    MockData(
+      studentOid = KoskiSpecificMockOppijat.demoNordea.oid,
+      time = "2026-01-14T09:00:00.000+03",
+      organizationOid = List(Opetushallitus.organisaatioOid),
+      raw = rawAuditlog("OPISKELUOIKEUS_KATSOMINEN")
+    ),
+    // UI-rivi 6: "Jyväskylän normaalikoulu" (yhdistyy — pelkkä oppilaitos + oppilaitos jonka vierestä vieras putoaa)
+    MockData(
+      studentOid = KoskiSpecificMockOppijat.demoNordea.oid,
+      time = "2026-01-13T09:00:00.000+03",
+      organizationOid = List(MockOrganisaatiot.jyväskylänNormaalikoulu, MockOrganisaatiot.stadinAmmattiopisto),
+      raw = rawAuditlog("OPISKELUOIKEUS_KATSOMINEN")
+    ),
+    MockData(
+      studentOid = KoskiSpecificMockOppijat.demoNordea.oid,
+      time = "2026-01-11T09:00:00.000+03",
+      organizationOid = List(MockOrganisaatiot.jyväskylänNormaalikoulu),
+      raw = rawAuditlog("OPISKELUOIKEUS_KATSOMINEN")
+    ),
+    // UI-rivi 7: "Jyväskylän yliopisto" (yhdistyy — pelkkä koulutustoimija + koulutustoimija jonka vierestä vieras putoaa)
+    MockData(
+      studentOid = KoskiSpecificMockOppijat.demoNordea.oid,
+      time = "2026-01-12T09:00:00.000+03",
+      organizationOid = List(MockOrganisaatiot.jyväskylänYliopisto, MockOrganisaatiot.helsinginKaupunki),
+      raw = rawAuditlog("OPISKELUOIKEUS_KATSOMINEN")
+    ),
+    MockData(
+      studentOid = KoskiSpecificMockOppijat.demoNordea.oid,
+      time = "2026-01-10T09:00:00.000+03",
+      organizationOid = List(MockOrganisaatiot.jyväskylänYliopisto),
+      raw = rawAuditlog("OPISKELUOIKEUS_KATSOMINEN")
+    ),
 
   )
 

--- a/src/main/scala/fi/oph/koski/omaopintopolkuloki/AuditLogService.scala
+++ b/src/main/scala/fi/oph/koski/omaopintopolkuloki/AuditLogService.scala
@@ -8,7 +8,7 @@ import fi.oph.koski.http.{HttpStatus, KoskiErrorCategory}
 import fi.oph.koski.json.JsonSerializer
 import fi.oph.koski.log.Logging
 import fi.oph.koski.mydata.MyDataConfig
-import fi.oph.koski.schema.LocalizedString
+import fi.oph.koski.schema.{LocalizedString, Oppija}
 import fi.oph.koski.omaopintopolkuloki.AuditLogDynamoDB.AuditLogTableName
 import fi.oph.koski.schema.Henkilö.Oid
 import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, QueryRequest}
@@ -19,14 +19,14 @@ class AuditLogService(val application: KoskiApplication) extends Logging with My
   private val organisaatioRepository = application.organisaatioRepository
   private val dynamoDB = AuditLogDynamoDB.buildDb(application.config)
 
-  def queryLogsFromDynamo(masterOppijaOid: String): Either[HttpStatus, Seq[OrganisaationAuditLogit]] = {
+  def queryLogsFromDynamo(masterOppijaOid: String, allowedOrganisaatiot: AllowedOrganisaatiot): Either[HttpStatus, Seq[OrganisaationAuditLogit]] = {
     val kaikkiOppijanOidit = application.opintopolkuHenkilöFacade.findSlaveOids(masterOppijaOid).toSet + masterOppijaOid
 
     val queryResult = kaikkiOppijanOidit
       .iterator
       .flatMap(runQuery)
 
-    buildLogs(queryResult)
+    buildLogs(queryResult, allowedOrganisaatiot)
   }
 
   private def runQuery(oppijaOid: Oid): Iterator[util.Map[Oid, AttributeValue]] = {
@@ -91,12 +91,25 @@ class AuditLogService(val application: KoskiApplication) extends Logging with My
     AuditlogRow(organizationOid, raw, time)
   }
 
-  private def buildLogs(queryResult: Iterator[util.Map[Oid, AttributeValue]]): Either[HttpStatus, Seq[OrganisaationAuditLogit]] = {
+  private def buildLogs(queryResult: Iterator[util.Map[Oid, AttributeValue]], allowedOrganisaatiot: AllowedOrganisaatiot): Either[HttpStatus, Seq[OrganisaationAuditLogit]] = {
     val timestampsGrouped = queryResult
       .map(item => {
         val parsedRow = convertToAuditLogRow(item)
         val parsedRaw = JsonSerializer.parse[AuditlogRaw](parsedRow.raw, ignoreExtras = true)
-        val organisaatioOidit = parsedRow.organizationOid.sorted
+        // Suodatus koskee vain KOSKI-palvelun auditlogeja. Varda/kitu-rivit näytetään sellaisenaan.
+        val isKoskiLog = parsedRaw.serviceName == "koski"
+        val filteredOrganisaatiot =
+          if (!isKoskiLog || allowedOrganisaatiot.isEmpty) parsedRow.organizationOid
+          else {
+            val intersected = parsedRow.organizationOid.filter(oid =>
+              oid == Opetushallitus.organisaatioOid || allowedOrganisaatiot.contains(oid)
+            )
+            if (intersected.nonEmpty) intersected else parsedRow.organizationOid
+          }
+        // KOSKI-logeille järjestys: OPH > koulutustoimija > oppilaitos > muu
+        val organisaatioOidit =
+          if (isKoskiLog) filteredOrganisaatiot.sortBy(oid => (allowedOrganisaatiot.priority(oid), oid))
+          else filteredOrganisaatiot.sorted
         val timestampString = parsedRow.time
         val serviceName = parsedRaw.serviceName
         val isMyDataUse = parsedRaw.operation.startsWith("OAUTH2_KATSOMINEN") || parsedRow.organizationOid.headOption.exists(isMyDataOrg)
@@ -116,10 +129,10 @@ class AuditLogService(val application: KoskiApplication) extends Logging with My
         .map {
           case ((orgs, serviceName, isMyDataUse, isJakolinkkiUse), timestamps) =>
             HttpStatus.foldEithers(orgs.map(toOrganisaatio))
-              .map(orgs => OrganisaationAuditLogit(orgs, serviceName, isMyDataUse, isJakolinkkiUse, timestamps))
+              .map(orgs => OrganisaationAuditLogit(orgs, serviceName, isMyDataUse, isJakolinkkiUse, timestamps.sorted.reverse))
         }
         .toSeq
-    )
+    ).map(_.sortBy(_.timestamps.headOption)(Ordering[Option[String]].reverse))
   }
 
   private def toOrganisaatio(oid: String): Either[HttpStatus, Organisaatio] = {
@@ -138,6 +151,28 @@ class AuditLogService(val application: KoskiApplication) extends Logging with My
     } else {
       None
     }
+  }
+}
+
+object AuditLogService {
+  def allowedOrganisaatiot(oppija: Oppija): AllowedOrganisaatiot = {
+    val koulutustoimijat = oppija.opiskeluoikeudet.flatMap(_.koulutustoimija.map(_.oid)).toSet
+    val oppilaitokset = oppija.opiskeluoikeudet.flatMap(_.oppilaitos.map(_.oid)).toSet
+    AllowedOrganisaatiot(koulutustoimijat, oppilaitokset)
+  }
+}
+
+case class AllowedOrganisaatiot(
+  koulutustoimijat: Set[String],
+  oppilaitokset: Set[String]
+) {
+  def isEmpty: Boolean = koulutustoimijat.isEmpty && oppilaitokset.isEmpty
+  def contains(oid: String): Boolean = koulutustoimijat.contains(oid) || oppilaitokset.contains(oid)
+  def priority(oid: String): Int = {
+    if (oid == Opetushallitus.organisaatioOid) 0
+    else if (koulutustoimijat.contains(oid)) 1
+    else if (oppilaitokset.contains(oid)) 2
+    else 3
   }
 }
 

--- a/src/main/scala/fi/oph/koski/omaopintopolkuloki/OmaOpintoPolkuLokiServlet.scala
+++ b/src/main/scala/fi/oph/koski/omaopintopolkuloki/OmaOpintoPolkuLokiServlet.scala
@@ -4,6 +4,7 @@ import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.huoltaja.{HuollettavienHakuOnnistui}
 import fi.oph.koski.json.JsonSerializer
 import fi.oph.koski.koskiuser.RequiresKansalainen
+import fi.oph.koski.log.Logging
 import fi.oph.koski.servlet.{KoskiSpecificApiServlet, NoCache}
 
 case class AuditlogRequest(
@@ -11,7 +12,7 @@ case class AuditlogRequest(
 )
 
 class OmaOpintoPolkuLokiServlet(implicit val application: KoskiApplication) extends
-  RequiresKansalainen with KoskiSpecificApiServlet with NoCache {
+  RequiresKansalainen with KoskiSpecificApiServlet with NoCache with Logging {
 
   val auditLogs = new AuditLogService(application)
 
@@ -31,10 +32,26 @@ class OmaOpintoPolkuLokiServlet(implicit val application: KoskiApplication) exte
         case _ => List.empty
       }.headOption.getOrElse(session.oid)
 
+      val allowedOrganisaatiot = loadAllowedOrganisaatiot(personOid)
+
       renderEither(
-        auditLogs.queryLogsFromDynamo(personOid)
+        auditLogs.queryLogsFromDynamo(personOid, allowedOrganisaatiot)
       )
     })()
+  }
+
+  private def loadAllowedOrganisaatiot(personOid: String): AllowedOrganisaatiot = {
+    val oppijaResult =
+      if (personOid == session.oid) application.huoltajaService.findUserOppijaAllowEmpty(session)
+      else application.huoltajaService.findHuollettavaOppija(personOid)(session)
+
+    oppijaResult match {
+      case Right(withWarnings) =>
+        AuditLogService.allowedOrganisaatiot(withWarnings.getIgnoringWarnings)
+      case Left(status) =>
+        logger.warn(s"Opiskeluoikeuksien lataus oma-opintopolku-lokin organisaatiosuodatusta varten epäonnistui (personOid=$personOid): $status")
+        AllowedOrganisaatiot(Set.empty, Set.empty)
+    }
   }
 
   get("/whoami") {

--- a/src/test/scala/fi/oph/koski/omaopintopolkuloki/AuditLogServiceSpec.scala
+++ b/src/test/scala/fi/oph/koski/omaopintopolkuloki/AuditLogServiceSpec.scala
@@ -1,0 +1,76 @@
+package fi.oph.koski.omaopintopolkuloki
+
+import fi.oph.koski.documentation.AmmatillinenExampleData
+import fi.oph.koski.henkilo.KoskiSpecificMockOppijat
+import fi.oph.koski.organisaatio.Opetushallitus
+import fi.oph.koski.schema.{Koulutustoimija, Oppija, Oppilaitos}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class AuditLogServiceSpec extends AnyFreeSpec with Matchers {
+  "allowedOrganisaatiot" - {
+    "kerää koulutustoimija- ja oppilaitos-oidit opiskeluoikeuksista" in {
+      val oo1 = AmmatillinenExampleData.opiskeluoikeus().copy(
+        oppilaitos = Some(Oppilaitos("1.2.246.562.10.111")),
+        koulutustoimija = Some(Koulutustoimija("1.2.246.562.10.222"))
+      )
+      val oo2 = AmmatillinenExampleData.opiskeluoikeus().copy(
+        oppilaitos = Some(Oppilaitos("1.2.246.562.10.333")),
+        koulutustoimija = Some(Koulutustoimija("1.2.246.562.10.222"))
+      )
+      val oppija = Oppija(
+        KoskiSpecificMockOppijat.amis.toHenkilötiedotJaOid,
+        List(oo1, oo2)
+      )
+
+      val result = AuditLogService.allowedOrganisaatiot(oppija)
+      result.koulutustoimijat should equal(Set("1.2.246.562.10.222"))
+      result.oppilaitokset should equal(Set("1.2.246.562.10.111", "1.2.246.562.10.333"))
+    }
+
+    "sivuuttaa puuttuvat koulutustoimija- ja oppilaitos-viitteet" in {
+      val oo = AmmatillinenExampleData.opiskeluoikeus().copy(
+        oppilaitos = Some(Oppilaitos("1.2.246.562.10.444")),
+        koulutustoimija = None
+      )
+      val oppija = Oppija(
+        KoskiSpecificMockOppijat.amis.toHenkilötiedotJaOid,
+        List(oo)
+      )
+
+      val result = AuditLogService.allowedOrganisaatiot(oppija)
+      result.koulutustoimijat shouldBe empty
+      result.oppilaitokset should equal(Set("1.2.246.562.10.444"))
+    }
+
+    "palauttaa tyhjän joukon kun opiskeluoikeuksia ei ole" in {
+      val oppija = Oppija(
+        KoskiSpecificMockOppijat.amis.toHenkilötiedotJaOid,
+        List.empty
+      )
+
+      val result = AuditLogService.allowedOrganisaatiot(oppija)
+      result.isEmpty shouldBe true
+    }
+  }
+
+  "AllowedOrganisaatiot.priority" - {
+    val allowed = AllowedOrganisaatiot(
+      koulutustoimijat = Set("1.2.246.562.10.222"),
+      oppilaitokset = Set("1.2.246.562.10.111")
+    )
+
+    "OPH saa prioriteetin 0" in {
+      allowed.priority(Opetushallitus.organisaatioOid) shouldBe 0
+    }
+    "koulutustoimija saa prioriteetin 1" in {
+      allowed.priority("1.2.246.562.10.222") shouldBe 1
+    }
+    "oppilaitos saa prioriteetin 2" in {
+      allowed.priority("1.2.246.562.10.111") shouldBe 2
+    }
+    "tuntematon organisaatio saa prioriteetin 3" in {
+      allowed.priority("1.2.246.562.10.999") shouldBe 3
+    }
+  }
+}

--- a/src/test/scala/fi/oph/koski/omaopintopolkuloki/OmaOpintoPolkuLokiServletSpec.scala
+++ b/src/test/scala/fi/oph/koski/omaopintopolkuloki/OmaOpintoPolkuLokiServletSpec.scala
@@ -66,6 +66,35 @@ class OmaOpintoPolkuLokiServletSpec extends AnyFreeSpec with Matchers with Koski
         verifyResponseStatus(500, KoskiErrorCategory.internalError())
       }
     }
+    "Suodattaa pois organisaatiot, joissa kansalaisella ei ole opiskeluoikeutta" in {
+      val orgs = auditlogs(KoskiSpecificMockOppijat.koululainen).flatMap(_.organizations.map(_.oid)).toSet
+      orgs should contain (MockOrganisaatiot.helsinginKaupunki)
+      orgs should not contain (MockOrganisaatiot.kuopionKaupunki)
+    }
+    "Opetushallitus näytetään aina, vieras organisaatio suodatetaan pois" in {
+      val logs = auditlogs(KoskiSpecificMockOppijat.koululainen)
+      val ophRow = logs.find(_.organizations.exists(_.oid == Opetushallitus.organisaatioOid))
+      ophRow shouldBe defined
+      ophRow.get.organizations.map(_.oid) should contain (Opetushallitus.organisaatioOid)
+      ophRow.get.organizations.map(_.oid) should not contain (MockOrganisaatiot.kuopionKaupunki)
+    }
+    "Jos KOSKI-oikeus sekä koulutustoimijaan että oppilaitokseen, näytetään koulutustoimija ensin" in {
+      val logs = auditlogs(KoskiSpecificMockOppijat.koululainen)
+      val row = logs.find(l => l.organizations.exists(_.oid == MockOrganisaatiot.kulosaarenAlaAste) && l.organizations.exists(_.oid == MockOrganisaatiot.helsinginKaupunki))
+      row shouldBe defined
+      row.get.organizations.head.oid shouldBe MockOrganisaatiot.helsinginKaupunki
+    }
+    "Jos KOSKI-oikeus kahteen oppilaitokseen, näytetään se jossa kansalaisella on opiskeluoikeus" in {
+      val logs = auditlogs(KoskiSpecificMockOppijat.koululainen)
+      val orgs = logs.flatMap(_.organizations.map(_.oid)).toSet
+      orgs should contain (MockOrganisaatiot.kulosaarenAlaAste)
+      orgs should not contain (MockOrganisaatiot.stadinAmmattiopisto)
+    }
+    "Opetushallitus-rivi näytetään vaikka kansalaisella ei ole opiskeluoikeuksia siellä" in {
+      auditlogs(KoskiSpecificMockOppijat.aikuisOpiskelija).map(_.organizations.map(_.oid)) should contain theSameElementsAs List(
+        List(Opetushallitus.organisaatioOid)
+      )
+    }
     "Rajapinta vaatii kirjautumisen" in {
       post("api/omaopintopolkuloki/auditlogs",
         body = JsonSerializer.writeWithRoot(Map("hetu" -> "")),jsonContent


### PR DESCRIPTION
- **TOR-1050: Add allowedOrganisaatioOidit helper for /auditlogs filter**
- **TOR-1050: Filter /auditlogs response orgs by citizen's opiskeluoikeudet**
- **TOR-1050: Add /auditlogs filter test coverage**
