### PR TITLE
TOR-2594: Päivitä basic-ftp 5.2.1+ (CVE-2026-39983)

### DIFF
--- a/smoketests/.npmrc
+++ b/smoketests/.npmrc
@@ -2,6 +2,7 @@ frozen-lockfile=false
 
 # Avoid too-fresh packages (stability)
 minimum-release-age=4320
+minimum-release-age-exclude[]=basic-ftp
 
 # Disable postinstall scripts except for explicitly allowed
 ignore-scripts=true

--- a/smoketests/package.json
+++ b/smoketests/package.json
@@ -22,6 +22,11 @@
     "pnpm": ">=10.28.2"
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
+  "pnpm": {
+    "overrides": {
+      "basic-ftp": ">=5.2.1"
+    }
+  },
   "devDependencies": {
     "@types/node": "^25.5.0"
   }

--- a/smoketests/pnpm-lock.yaml
+++ b/smoketests/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  basic-ftp: '>=5.2.1'
+
 importers:
 
   .:
@@ -149,8 +152,8 @@ packages:
   bare-url@2.3.2:
     resolution: {integrity: sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==}
 
-  basic-ftp@5.2.0:
-    resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
+  basic-ftp@5.2.2:
+    resolution: {integrity: sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==}
     engines: {node: '>=10.0.0'}
 
   buffer-crc32@0.2.13:
@@ -615,7 +618,7 @@ snapshots:
     dependencies:
       bare-path: 3.0.0
 
-  basic-ftp@5.2.0: {}
+  basic-ftp@5.2.2: {}
 
   buffer-crc32@0.2.13: {}
 
@@ -724,7 +727,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.2.0
+      basic-ftp: 5.2.2
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:


### PR DESCRIPTION
Korjaa Trivy-haavoittuvuushavainto smoketests/pnpm-lock.yaml:ssa.
Lisää pnpm override basic-ftp-paketille ja ohita minimum-release-age
kyseiselle paketille, jotta tietoturvapäivitykset eivät viivästy.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
