### PR TITLE
TOR-2585 Fix smoketests after ci node update

### DIFF
--- a/smoketests/src/omadata-oauth2-sample.ts
+++ b/smoketests/src/omadata-oauth2-sample.ts
@@ -158,7 +158,10 @@ const runTest = async (environment: Environment) =>
       `Running omadata-oauth2-sample smoke test (${environment}) – attempt ${attempt}/${RETRIES}`
     );
 
-    const browser = await puppeteer.launch({ headless: true });
+    const browser = await puppeteer.launch({
+      headless: true,
+      args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    });
     const isLocal = environment === "local";
     const page = await browser.newPage();
 

--- a/smoketests/src/qa-kansalainen.ts
+++ b/smoketests/src/qa-kansalainen.ts
@@ -69,6 +69,7 @@ const runTest = async (
 
     const browser = await puppeteer.launch({
       headless: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
     });
     const page = await browser.newPage();
     const resultOk = await tryToLogin(page);


### PR DESCRIPTION
Ubuntu 23.10+ GitHub runners restrict unprivileged user namespaces
via AppArmor, which prevents Chrome's sandbox from starting. CI
runners are ephemeral and only visit trusted URLs, so disabling
the sandbox is safe and the documented workaround.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
