### PR TITLE
Supa rajapinta: korjaa international school suoritusten palautus

### DIFF
--- a/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaInternationalSchoolOpiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/opiskeluoikeus/SupaInternationalSchoolOpiskeluoikeus.scala
@@ -59,7 +59,7 @@ case class SupaDiplomaVuosiluokanSuoritus(
 
 object SupaDiplomaVuosiluokanSuoritus {
   def apply(s: DiplomaVuosiluokanSuoritus): Option[SupaDiplomaVuosiluokanSuoritus] =
-    when (s.valmis && s.koulutusmoduuli.tunniste.koodiarvo == "12") {
+    when (s.koulutusmoduuli.tunniste.koodiarvo == "12") {
       SupaDiplomaVuosiluokanSuoritus(
         tyyppi = s.tyyppi,
         alkamispäivä = s.alkamispäivä,

--- a/src/test/scala/fi/oph/koski/massaluovutus/MassaluovutusSpec.scala
+++ b/src/test/scala/fi/oph/koski/massaluovutus/MassaluovutusSpec.scala
@@ -845,6 +845,16 @@ class MassaluovutusSpec extends AnyFreeSpec with MassaluovutusTestMethods with M
           ))
         }
 
+        "International School -opiskeluoikeuden suoritukset palautetaan" in {
+          extractStrings(
+            getOpiskeluoikeudet(Some("internationalschool")),
+            viimeisinTila
+          ) should equal(List(
+            "lasna",
+            "valmistunut"
+          ))
+        }
+
         "Opiskeluoikeudet sisältävät versionumeron ja aikaleiman sekä opiskeluoikeuden alkamis- ja päättymispäivän" in {
           val oos = getOpiskeluoikeudet()
             .filterNot(v => (v \ "poistettu").extractOpt[Boolean].contains(true))
@@ -1271,6 +1281,16 @@ class MassaluovutusSpec extends AnyFreeSpec with MassaluovutusTestMethods with M
         "IB-tutkinnon suoritukset palautetaan" in {
           extractStrings(
             getOpiskeluoikeudet(Some("ibtutkinto")),
+            viimeisinTila
+          ) should equal(List(
+            "lasna",
+            "valmistunut"
+          ))
+        }
+
+        "International School -opiskeluoikeuden suoritukset palautetaan" in {
+          extractStrings(
+            getOpiskeluoikeudet(Some("internationalschool")),
             viimeisinTila
           ) should equal(List(
             "lasna",


### PR DESCRIPTION
Palauta myös keskeneräiset international schoolin suoritukset, kun keskeneräiset opiskeluoikeudet palautetaan nyt myös.