### PR TITLE
TOR-2597 Kevennä isojen koodistojen kälikäsittelyä

### DIFF
--- a/src/main/resources/localization/koski-default-texts.json
+++ b/src/main/resources/localization/koski-default-texts.json
@@ -2509,6 +2509,7 @@
   "Tarkastele huollettavasi tietoja": "Tarkastele huollettavasi tietoja",
   "Tarkemmat tiedot luovutettavista henkilötiedoista": "Tarkemmat tiedot luovutettavista henkilötiedoista löydät KOSKI-palvelun Wiki -sivustolta:",
   "Tarkemmat tiedot luovutettavista henkilötiedoista löydät KOSKI-palvelun CSC Wiki -sivustolta": "Tarkemmat tiedot luovutettavista henkilötiedoista löydät KOSKI-palvelun Wiki -sivustolta",
+  "Tarkenna hakua nähdäksesi lisää vaihtoehtoja": "Tarkenna hakua nähdäksesi lisää vaihtoehtoja",
   "Taso": "Taso",
   "Tässä listataan aktiiviset ja päättyneet opinnot otsikkotasolla. Tarkemmat tiedot löytyvät koneluettavassa muodossa yllä olevasta linkistä": "Tässä listataan aktiiviset ja päättyneet opinnot otsikkotasolla. Tarkemmat tiedot löytyvät koneluettavassa muodossa yllä olevasta linkistä.",
   "Tässä listataan suoritetut tutkinnot otsikkotasolla. Tarkemmat tiedot löytyvät koneluettavassa muodossa yllä olevasta linkistä": "Tässä listataan suoritetut tutkinnot otsikkotasolla. Tarkemmat tiedot löytyvät koneluettavassa muodossa yllä olevasta linkistä.",

--- a/web/app/components/Dropdown.jsx
+++ b/web/app/components/Dropdown.jsx
@@ -12,6 +12,8 @@ import { elementWithLoadingIndicator } from './AjaxLoadingIndicator'
 import { t } from '../i18n/i18n'
 import { buildClassNames } from './classnames'
 
+const MAX_VISIBLE_OPTIONS = 100
+
 /*
   options: [] or Observable []
   keyValue: item => string
@@ -59,7 +61,10 @@ export default ({
     queryFilter
   )
   const allOptionsP = filteredOptionsP.map((opts) => {
-    const truncated = opts.length > MAX_VISIBLE_OPTIONS
+    // Rajoita näkyvät vaihtoehdot vain, kun suodatinkenttä on käytössä –
+    // muuten käyttäjällä ei olisi keinoa päästä käsiksi rajauksen taakse
+    // jääviin vaihtoehtoihin.
+    const truncated = enableFilter && opts.length > MAX_VISIBLE_OPTIONS
     const visible = truncated ? opts.slice(0, MAX_VISIBLE_OPTIONS) : opts
     return {
       options: visible.concat(newItem ? [newItem] : []),
@@ -337,8 +342,6 @@ export default ({
     </span>
   )
 }
-
-const MAX_VISIBLE_OPTIONS = 100
 
 const queryFilter = (options, query, displayValue) => {
   if (!query) return options

--- a/web/app/components/Dropdown.jsx
+++ b/web/app/components/Dropdown.jsx
@@ -328,7 +328,7 @@ export default ({
                     <li
                       key="__truncation_hint__"
                       className="truncation-hint"
-                      role="note"
+                      role="presentation"
                     >
                       {t('Tarkenna hakua nähdäksesi lisää vaihtoehtoja')}
                     </li>

--- a/web/app/components/Dropdown.jsx
+++ b/web/app/components/Dropdown.jsx
@@ -58,9 +58,14 @@ export default ({
     Bacon.constant(displayValue),
     queryFilter
   )
-  const allOptionsP = filteredOptionsP.map((opts) =>
-    opts.concat(newItem ? [newItem] : [])
-  )
+  const allOptionsP = filteredOptionsP.map((opts) => {
+    const truncated = opts.length > MAX_VISIBLE_OPTIONS
+    const visible = truncated ? opts.slice(0, MAX_VISIBLE_OPTIONS) : opts
+    return {
+      options: visible.concat(newItem ? [newItem] : []),
+      truncated
+    }
+  })
   let inputElem = null
   let listElem = null
   const handleOnBlur = () => openAtom.set(false)
@@ -133,10 +138,7 @@ export default ({
       queryAtom.set(undefined)
     }
   }
-  const handleMouseOver = (allOptions, o) => {
-    const index = allOptions.findIndex(
-      (option) => keyValue(option) === keyValue(o)
-    )
+  const handleMouseOver = (index) => {
     selectionIndexAtom.set(index)
   }
   const isNewItem = (allOptions, o, i) => newItem && i === allOptions.length - 1
@@ -157,7 +159,7 @@ export default ({
   return (
     <span>
       {elementWithLoadingIndicator(
-        allOptionsP.map((allOptions) => {
+        allOptionsP.map(({ options: allOptions, truncated }) => {
           const grouped =
             R.keys(
               R.groupBy((opt) => opt.groupName)(
@@ -236,84 +238,96 @@ export default ({
                   data-testid="koodisto-dropdown-all-options"
                   role="listbox"
                 >
-                  {flatMapArray(allOptions, (o, i) => {
-                    const isNew = isNewItem(allOptions, o, i)
-                    const isZeroValue = keyValue(o) === 'eivalintaa'
-                    const itemClassName = Bacon.combineWith(
-                      (s, r, a) => s + r + a,
-                      selectionIndexAtom.map((selectionIndex) =>
-                        buildClassNames([
-                          'option',
-                          i === selectionIndex &&
-                            isOptionEnabled(o) &&
-                            'selected',
-                          isNew && 'new-item',
-                          isZeroValue && 'zero-value'
-                        ])
-                      ),
-                      removeIndexAtom.map((removeIndex) =>
-                        removeIndex === i ? ' removing' : ''
-                      ),
-                      isOptionEnabled(o) ? '' : ' option-disabled'
-                    )
-                    const itemElement = (
-                      <li
-                        role="listitem"
-                        key={keyValue(o) || displayValue(o)}
-                        aria-label={displayValue(o)}
-                        className={itemClassName}
-                        onMouseDown={(e) => {
-                          selectOption(e, o)
-                        }}
-                        onClick={(e) => {
-                          selectOption(e, o)
-                        }}
-                        onMouseOver={() => handleMouseOver(allOptions, o)}
-                        data-testid={itemTestId(o)}
-                      >
-                        {isNew ? (
-                          <span data-testid={'new-item'}>
-                            <span className="plus">{''}</span>
-                            {displayValue(newItem)}
-                          </span>
-                        ) : isRemovable(o) ? (
-                          <span className="removable-option" title={removeText}>
-                            {displayValue(o)}
-                            <a
-                              className="remove-value"
-                              onMouseDown={(e) => {
-                                selectRemoval(e, o)
-                              }}
-                              onClick={(e) => {
-                                selectRemoval(e, o)
-                              }}
-                              onMouseOver={() => removeIndexAtom.set(i)}
-                              onMouseLeave={() =>
-                                removeIndexAtom.set(undefined)
-                              }
-                            />
-                          </span>
-                        ) : (
-                          displayValue(o)
-                        )}
-                      </li>
-                    )
-                    const groupName =
-                      grouped &&
-                      (i === 0 || allOptions[i - 1].groupName !== o.groupName)
-                        ? o.groupName
-                        : ''
-                    if (groupName) {
-                      return [
-                        <li key={groupName} className="group-header">
-                          {groupName}
-                        </li>,
-                        itemElement
-                      ]
-                    } else {
-                      return [itemElement]
-                    }
-                  })}
+                  {Bacon.combineWith(
+                    selectionIndexAtom,
+                    removeIndexAtom,
+                    (selectionIndex, removeIndex) =>
+                      flatMapArray(allOptions, (o, i) => {
+                        const isNew = isNewItem(allOptions, o, i)
+                        const isZeroValue = keyValue(o) === 'eivalintaa'
+                        const itemClassName =
+                          buildClassNames([
+                            'option',
+                            i === selectionIndex &&
+                              isOptionEnabled(o) &&
+                              'selected',
+                            isNew && 'new-item',
+                            isZeroValue && 'zero-value'
+                          ]) +
+                          (removeIndex === i ? ' removing' : '') +
+                          (isOptionEnabled(o) ? '' : ' option-disabled')
+                        const itemElement = (
+                          <li
+                            role="listitem"
+                            key={keyValue(o) || displayValue(o)}
+                            aria-label={displayValue(o)}
+                            className={itemClassName}
+                            onMouseDown={(e) => {
+                              selectOption(e, o)
+                            }}
+                            onClick={(e) => {
+                              selectOption(e, o)
+                            }}
+                            onMouseOver={() => handleMouseOver(i)}
+                            data-testid={itemTestId(o)}
+                          >
+                            {isNew ? (
+                              <span data-testid={'new-item'}>
+                                <span className="plus">{''}</span>
+                                {displayValue(newItem)}
+                              </span>
+                            ) : isRemovable(o) ? (
+                              <span
+                                className="removable-option"
+                                title={removeText}
+                              >
+                                {displayValue(o)}
+                                <a
+                                  className="remove-value"
+                                  onMouseDown={(e) => {
+                                    selectRemoval(e, o)
+                                  }}
+                                  onClick={(e) => {
+                                    selectRemoval(e, o)
+                                  }}
+                                  onMouseOver={() => removeIndexAtom.set(i)}
+                                  onMouseLeave={() =>
+                                    removeIndexAtom.set(undefined)
+                                  }
+                                />
+                              </span>
+                            ) : (
+                              displayValue(o)
+                            )}
+                          </li>
+                        )
+                        const groupName =
+                          grouped &&
+                          (i === 0 ||
+                            allOptions[i - 1].groupName !== o.groupName)
+                            ? o.groupName
+                            : ''
+                        if (groupName) {
+                          return [
+                            <li key={groupName} className="group-header">
+                              {groupName}
+                            </li>,
+                            itemElement
+                          ]
+                        } else {
+                          return [itemElement]
+                        }
+                      })
+                  )}
+                  {truncated && (
+                    <li
+                      key="__truncation_hint__"
+                      className="truncation-hint"
+                      role="note"
+                    >
+                      {t('Tarkenna hakua nähdäksesi lisää vaihtoehtoja')}
+                    </li>
+                  )}
                 </ul>
               )}
             </div>
@@ -323,6 +337,8 @@ export default ({
     </span>
   )
 }
+
+const MAX_VISIBLE_OPTIONS = 100
 
 const queryFilter = (options, query, displayValue) => {
   if (!query) return options

--- a/web/app/style/dropdown.less
+++ b/web/app/style/dropdown.less
@@ -115,6 +115,13 @@
         font-weight: bold;
         color: @color-darkgray;
       }
+
+      &.truncation-hint {
+        color: @color-darkgray;
+        font-style: italic;
+        cursor: default;
+        border-top: 1px solid #e4e4e4;
+      }
     }
   }
 

--- a/web/test/page/pageApi.js
+++ b/web/test/page/pageApi.js
@@ -141,11 +141,31 @@ function Page(mainElement) {
               click(findSingle('.select', S(input)), 'click')()
             }
 
-            var result = S(input)
-              .find('.options li.option')
-              .filter(function (i_, v) {
-                return $(v).text().includes(value)
-              })[index]
+            var findOption = function () {
+              return S(input)
+                .find('.options li.option')
+                .filter(function (i_, v) {
+                  return $(v).text().includes(value)
+                })[index]
+            }
+
+            var result = findOption()
+
+            // Dropdown rajoittaa näkyvien vaihtoehtojen määrän 100:aan. Jos
+            // haluttu arvo ei ole ensimmäisten joukossa, kirjoitetaan se
+            // suodatinkenttään, jolloin lista suodattuu ja valinta löytyy.
+            if (!result) {
+              var filterInput = S(input).find('.input-container input')
+              if (filterInput.length > 0) {
+                var domInput = filterInput[0]
+                Object.getOwnPropertyDescriptor(
+                  Object.getPrototypeOf(domInput),
+                  'value'
+                ).set.call(domInput, value)
+                triggerEvent(filterInput, 'input')()
+                result = findOption()
+              }
+            }
 
             if (result) {
               return triggerEvent(result, 'mousedown')()

--- a/web/test/spec/ammatillinenSpec_2.js
+++ b/web/test/spec/ammatillinenSpec_2.js
@@ -331,13 +331,14 @@ describe('Ammatillinen koulutus 2', function () {
               'Aikuisten perusopetus (0009)'
             ])
 
-            expect(osaamisalat.slice(-5)).to.deep.equal([
-              'Yritystoiminnan suunnittelun ja käynnistämisen osaamisala (2284)',
-              'Äänitekniikan osaamisala (2240)',
-              'Ääniteknikko (2128)',
-              'Äänitetuottaja (2127)',
-              'Äänityön osaamisala (2007)'
-            ])
+            // Dropdown näyttää enintään 100 ensimmäistä vaihtoehtoa ("Ei valintaa"
+            // + 99 osaamisalaa, aakkosjärjestyksessä) ja loppuun "tarkenna hakua"
+            // -vihjeen. Vihje todistaa, että koko osaamisalakoodisto (870 koodia)
+            // haettiin eikä vain perustekohtaiset.
+            expect(osaamisalat.length).to.equal(101)
+            expect(osaamisalat[osaamisalat.length - 1]).to.equal(
+              'Tarkenna hakua nähdäksesi lisää vaihtoehtoja'
+            )
           })
         })
       })


### PR DESCRIPTION
Cap the rendered option list to 100 items with a "refine search" hint,
replace per-option Bacon observables on itemClassName with a single
combineWith at the list level, and drop the O(N) findIndex in
handleMouseOver. With 5000+ option koodistos (e.g. opintokokonaisuudet
in Muu kuin säännelty koulutus), this eliminates ~10k subscriptions
and avoids full-list re-rendering on every hover.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
