### PR TITLE
TOR-2600: Collapse KIOS auditlog to one row per POST

### DIFF
--- a/src/main/scala/fi/oph/koski/kios/KiosServlet.scala
+++ b/src/main/scala/fi/oph/koski/kios/KiosServlet.scala
@@ -5,6 +5,7 @@ import fi.oph.koski.henkilo.{HenkilöOid, Hetu}
 import fi.oph.koski.http.{HttpStatus, JsonErrorMessage, KoskiErrorCategory}
 import fi.oph.koski.json.JsonSerializer
 import fi.oph.koski.koskiuser.{KoskiSpecificSession, RequiresKios}
+import fi.oph.koski.log.AuditLogMessage.ExtraFields
 import fi.oph.koski.log.{AuditLog, KoskiAuditLogMessage, KoskiAuditLogMessageField, KoskiOperation}
 import fi.oph.koski.servlet.{KoskiSpecificApiServlet, NoCache}
 import org.json4s.JValue
@@ -17,10 +18,7 @@ class KiosServlet(implicit val application: KoskiApplication) extends KoskiSpeci
     val ophKatselijaUser = KoskiSpecificSession.ophKatselijaUser(request)
     withJsonBody { json =>
       val oppija = extractAndValidateOid(json).flatMap(oid => application.kiosService.findOppija(oid)(ophKatselijaUser))
-      oppija.map(o => o.opiskeluoikeudet.foreach {
-        case x: KiosKoskeenTallennettavaOpiskeluoikeus if x.oid.isDefined => auditLog(o.henkilö.oid, opiskeluoikeusOid = x.oid.get)
-        case _ => auditLog(o.henkilö.oid)
-      })
+      oppija.foreach(auditLog)
       renderEither(oppija)
     }()
   }
@@ -29,10 +27,7 @@ class KiosServlet(implicit val application: KoskiApplication) extends KoskiSpeci
     val ophKatselijaUser = KoskiSpecificSession.ophKatselijaUser(request)
     withJsonBody { json =>
       val oppija = extractAndValidateHetu(json).flatMap(hetu => application.kiosService.findOppijaByHetu(hetu)(ophKatselijaUser))
-      oppija.map(o => o.opiskeluoikeudet.foreach {
-        case x: KiosKoskeenTallennettavaOpiskeluoikeus if x.oid.isDefined => auditLog(o.henkilö.oid, opiskeluoikeusOid = x.oid.get)
-        case _ => auditLog(o.henkilö.oid)
-      })
+      oppija.foreach(auditLog)
       renderEither(oppija)
     }()
   }
@@ -47,28 +42,14 @@ class KiosServlet(implicit val application: KoskiApplication) extends KoskiSpeci
       .left.map(errors => KoskiErrorCategory.badRequest.validation.jsonSchema(JsonErrorMessage(errors)))
       .flatMap(req => Hetu.validFormat(req.hetu))
 
-  private def auditLog(oppijaOid: String, opiskeluoikeusOid: String)(implicit user: KoskiSpecificSession): Unit =
-    AuditLog
-      .log(
-        KoskiAuditLogMessage(
-          KoskiOperation.KIOS_OPISKELUOIKEUS_HAKU,
-          user,
-          Map(
-            KoskiAuditLogMessageField.oppijaHenkiloOid -> oppijaOid,
-            KoskiAuditLogMessageField.opiskeluoikeusOid -> opiskeluoikeusOid,
-          )
-        )
-      )
-
-  private def auditLog(oppijaOid: String)(implicit user: KoskiSpecificSession): Unit =
-    AuditLog
-      .log(
-        KoskiAuditLogMessage(
-          KoskiOperation.KIOS_OPISKELUOIKEUS_HAKU,
-          user,
-          Map(
-            KoskiAuditLogMessageField.oppijaHenkiloOid -> oppijaOid,
-          )
-        )
-      )
+  private def auditLog(oppija: KiosOppija)(implicit user: KoskiSpecificSession): Unit = {
+    val oidit = oppija.opiskeluoikeudet.collect {
+      case x: KiosKoskeenTallennettavaOpiskeluoikeus if x.oid.isDefined => x.oid.get
+    }
+    val base: ExtraFields = Map(KoskiAuditLogMessageField.oppijaHenkiloOid -> oppija.henkilö.oid)
+    val fields =
+      if (oidit.nonEmpty) base + (KoskiAuditLogMessageField.opiskeluoikeusOid -> oidit.mkString(","))
+      else base
+    AuditLog.log(KoskiAuditLogMessage(KoskiOperation.KIOS_OPISKELUOIKEUS_HAKU, user, fields))
+  }
 }

--- a/src/test/scala/fi/oph/koski/kios/KiosServiceSpec.scala
+++ b/src/test/scala/fi/oph/koski/kios/KiosServiceSpec.scala
@@ -56,9 +56,10 @@ class KiosServiceSpec
   }
 
   "Access control toimii oikein" in {
+    AuditLogTester.clearMessages()
     post("/api/kios/oid", JsonSerializer.writeWithRoot(OidRequest(oid = KoskiSpecificMockOppijat.dippainssi.oid)), headers = authHeaders(kiosKäyttäjä) ++ jsonContent){
       verifyResponseStatusOk()
-      AuditLogTester.verifyLastAuditLogMessageForOperation(Map("operation" -> "KIOS_OPISKELUOIKEUS_HAKU"))
+      AuditLogTester.verifyOnlyAuditLogMessageForOperation(Map("operation" -> "KIOS_OPISKELUOIKEUS_HAKU"))
     }
 
     post("/api/kios/oid", JsonSerializer.writeWithRoot(OidRequest(oid = KoskiSpecificMockOppijat.dippainssi.oid)), headers = authHeaders(hakemuspalveluKäyttäjä) ++ jsonContent){
@@ -66,11 +67,26 @@ class KiosServiceSpec
     }
   }
 
-  "Hetu-haku kirjoittaa auditlogin" in {
+  "Hetu-haku kirjoittaa yhden auditlog-rivin per POST" in {
     AuditLogTester.clearMessages()
     post("/api/kios/hetu", JsonSerializer.writeWithRoot(HetuRequest(hetu = KoskiSpecificMockOppijat.dippainssi.hetu.get)), headers = authHeaders(kiosKäyttäjä) ++ jsonContent) {
       verifyResponseStatusOk()
-      AuditLogTester.verifyLastAuditLogMessageForOperation(Map("operation" -> "KIOS_OPISKELUOIKEUS_HAKU"))
+      AuditLogTester.verifyOnlyAuditLogMessageForOperation(Map(
+        "operation" -> "KIOS_OPISKELUOIKEUS_HAKU",
+        "target" -> Map("oppijaHenkiloOid" -> KoskiSpecificMockOppijat.dippainssi.oid),
+      ))
+    }
+  }
+
+  "Auditlogiin kirjoitetaan oppijan oid myös kun palautettavia opiskeluoikeuksia ei ole" in {
+    AuditLogTester.clearMessages()
+    val oppija = KoskiSpecificMockOppijat.ylioppilasEiValmistunut
+    post("/api/kios/oid", JsonSerializer.writeWithRoot(OidRequest(oid = oppija.oid)), headers = authHeaders(kiosKäyttäjä) ++ jsonContent) {
+      verifyResponseStatusOk()
+      AuditLogTester.verifyOnlyAuditLogMessageForOperation(Map(
+        "operation" -> "KIOS_OPISKELUOIKEUS_HAKU",
+        "target" -> Map("oppijaHenkiloOid" -> oppija.oid),
+      ))
     }
   }
 


### PR DESCRIPTION
KiosServlet previously wrote one audit row per opiskeluoikeus, producing eg.
6x rows at the same millisecond for oppija with several opiskeluoikeus.
Now writes a single KIOS_OPISKELUOIKEUS_HAKU row per successful POST with
a comma-separated list of opiskeluoikeusOids, and always logs the
oppijaHenkiloOid even when no opiskeluoikeudet are returned.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
