### PR TITLE
TOR-1444: Upgrade Jetty 9.4 to 12.0 and Scalatra 2.8 to 3.1

### DIFF
--- a/.github/actions/build_koski/action.yaml
+++ b/.github/actions/build_koski/action.yaml
@@ -25,7 +25,7 @@ runs:
       with:
         node-version: "24.15.0"
     - if: steps.lookup.outputs.cache-hit != 'true'
-      uses: ./.github/actions/setup_java_11
+      uses: ./.github/actions/setup_java_17
     - name: Build Koski app + tests
       if: steps.lookup.outputs.cache-hit != 'true'
       env:

--- a/.github/actions/koski_backend_test/action.yml
+++ b/.github/actions/koski_backend_test/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: "🔨 Setup Java"
-      uses: ./.github/actions/setup_java_11
+      uses: ./.github/actions/setup_java_17
 
     - name: "🔨 Setup backend and databases"
       uses: ./.github/actions/setup_backend

--- a/.github/actions/koski_frontend_playwright_test/action.yml
+++ b/.github/actions/koski_frontend_playwright_test/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: "🔨 Setup Java"
-      uses: ./.github/actions/setup_java_11
+      uses: ./.github/actions/setup_java_17
     - name: "🔨 Setup backend and databases"
       uses: ./.github/actions/setup_backend
     - name: "🌍 Setup Playwright"

--- a/.github/actions/koski_frontend_test/action.yml
+++ b/.github/actions/koski_frontend_test/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: "🔨 Setup Java"
-      uses: ./.github/actions/setup_java_11
+      uses: ./.github/actions/setup_java_17
     - name: "🔨 Setup backend and databases"
       uses: ./.github/actions/setup_backend
 

--- a/.github/actions/omadataoauth2_e2e_test/action.yml
+++ b/.github/actions/omadataoauth2_e2e_test/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: "🔨 Setup Java"
-      uses: ./.github/actions/setup_java_11_and_23
+      uses: ./.github/actions/setup_java_17_and_23
     - name: "🔨 Setup backend and databases"
       uses: ./.github/actions/setup_backend
     - name: "🌍 Setup Playwright"

--- a/.github/actions/setup_java_17/action.yml
+++ b/.github/actions/setup_java_17/action.yml
@@ -1,10 +1,10 @@
 runs:
   using: composite
   steps:
-    - name: Set up Java 11
+    - name: Set up Java 17
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
-        java-version: "11"
+        java-version: "17"
         architecture: "x64"
         distribution: "zulu"
         cache: "maven"

--- a/.github/actions/setup_java_17_and_23/action.yml
+++ b/.github/actions/setup_java_17_and_23/action.yml
@@ -1,7 +1,7 @@
 runs:
   using: composite
   steps:
-    - name: Set up Java 11 and 23
+    - name: Set up Java 17 and 23
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         architecture: "x64"
@@ -9,4 +9,4 @@ runs:
         cache: "maven"
         java-version: |
           23
-          11
+          17

--- a/.github/actions/valpas_integration_test/action.yml
+++ b/.github/actions/valpas_integration_test/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: "🔨 Setup Java"
-      uses: ./.github/actions/setup_java_11
+      uses: ./.github/actions/setup_java_17
     - name: "🔨 Setup backend and databases"
       uses: ./.github/actions/setup_backend
 

--- a/.github/workflows/all_tests.yml
+++ b/.github/workflows/all_tests.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: ./.github/actions/setup_java_11
+      - uses: ./.github/actions/setup_java_17
 
       - uses: ./.github/actions/setup_pnpm_cache
 

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -49,7 +49,7 @@ jobs:
           echo "image-exists=$(docker manifest inspect $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG > /dev/null 2>&1 ; echo $?)" >> $GITHUB_OUTPUT
 
       - if: steps.check-image.outputs.image-exists != '0'
-        uses: ./.github/actions/setup_java_11
+        uses: ./.github/actions/setup_java_17
 
       - name: Setup settings.xml
         uses: s4u/maven-settings-action@894661b3ddae382f1ae8edbeab60987e08cf0788 # v4.0.0

--- a/.github/workflows/run_performance_tests.yml
+++ b/.github/workflows/run_performance_tests.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: ./.github/actions/setup_java_11
+      - uses: ./.github/actions/setup_java_17
 
       - uses: ./.github/actions/setup_pnpm_cache
 
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: ./.github/actions/setup_java_11
+      - uses: ./.github/actions/setup_java_17
 
       - uses: ./.github/actions/setup_pnpm_cache
 
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: ./.github/actions/setup_java_11
+      - uses: ./.github/actions/setup_java_17
 
       - uses: ./.github/actions/setup_pnpm_cache
 
@@ -119,7 +119,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: ./.github/actions/setup_java_11
+      - uses: ./.github/actions/setup_java_17
 
       - uses: ./.github/actions/setup_pnpm_cache
 

--- a/.github/workflows/run_valpas_performance_tests.yml
+++ b/.github/workflows/run_valpas_performance_tests.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: ./.github/actions/setup_java_11
+      - uses: ./.github/actions/setup_java_17
 
       - uses: ./.github/actions/setup_pnpm_cache
 
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: ./.github/actions/setup_java_11
+      - uses: ./.github/actions/setup_java_17
 
       - uses: ./.github/actions/setup_pnpm_cache
 

--- a/.github/workflows/update_localizations.yml
+++ b/.github/workflows/update_localizations.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: ./.github/actions/setup_java_11
+      - uses: ./.github/actions/setup_java_17
       - name: Get current date
         id: date
         run: |

--- a/.github/workflows/valpas_performance_tests.yml
+++ b/.github/workflows/valpas_performance_tests.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: ./.github/actions/setup_java_11
+      - uses: ./.github/actions/setup_java_17
 
       - uses: ./.github/actions/setup_pnpm_cache
 
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: ./.github/actions/setup_java_11
+      - uses: ./.github/actions/setup_java_17
 
       - uses: ./.github/actions/setup_pnpm_cache
 

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,5 +1,5 @@
 # Voit päivittää imagen komennolla ./update-openjdk.sh
-FROM adoptopenjdk/openjdk11:jdk-11.0.27_6-alpine-slim@sha256:3a2290b904dfdc743751e5ee1b4e304169b703f738b039b80f257fcc4762d83a
+FROM amazoncorretto:17-alpine@sha256:4b1eb8f177547a180d8e8c34ca4f90aa41d0980a77bc5e9dbf88355b9e3b6c77
 
 ARG KOSKI_VERSION
 ARG PROMETHEUS_JMX_EXPORTER_VERSION="1.3.0"

--- a/docker-build/run.sh
+++ b/docker-build/run.sh
@@ -10,6 +10,7 @@ JAVA_OPTS="\
 -Dcom.sun.management.jmxremote.rmi.port=5555 \
 -Dcom.sun.management.jmxremote.authenticate=false \
 -Djava.rmi.server.hostname=localhost \
+-Duser.timezone=Europe/Helsinki \
 -Djava.io.tmpdir=/tmp \
 -Dkoski.port=8080 \
 -DHOSTNAME="$(hostname)" \

--- a/docker-build/update-openjdk.sh
+++ b/docker-build/update-openjdk.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE=$(curl -s https://hub.docker.com/v2/repositories/adoptopenjdk/openjdk11/tags\?page_size\=1\&page\=1\&ordering\=last_updated\&name\=alpine-slim | jq -r '.results.[] | "adoptopenjdk/openjdk11:" + .name + "@" + .digest')
+IMAGE=$(curl -s https://hub.docker.com/v2/repositories/library/amazoncorretto/tags\?page_size\=1\&page\=1\&ordering\=last_updated\&name\=17-alpine | jq -r '.results.[] | "amazoncorretto:" + .name + "@" + .digest')
 
 echo "$IMAGE"
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,13 +16,13 @@
     <scala.version>2.13.18</scala.version>
     <slick.version>3.6.1</slick.version>
     <slick-pg.version>0.23.1</slick-pg.version>
-    <scalatra.version>2.8.4</scalatra.version>
+    <scalatra.version>3.1.2</scalatra.version>
     <http4s.version>0.23.34</http4s.version>
     <http4s-blaze-client.version>0.23.17</http4s-blaze-client.version>
     <http4s-scala-xml.version>0.24.0</http4s-scala-xml.version>
     <json4s.version>4.0.7</json4s.version>
     <awssdk.version>2.42.41</awssdk.version>
-    <jetty.version>9.4.58.v20250814</jetty.version>
+    <jetty.version>12.0.34</jetty.version>
     <prometheus.client.version>0.16.0</prometheus.client.version>
     <scoverage.plugin.version>1.4.11</scoverage.plugin.version>
     <log4j.version>2.25.4</log4j.version>
@@ -108,23 +108,23 @@
       <version>33.6.0-jre</version>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.scalatra</groupId>
-      <artifactId>scalatra_2.13</artifactId>
+      <artifactId>scalatra-jakarta_2.13</artifactId>
       <version>${scalatra.version}</version>
     </dependency>
     <dependency>
       <groupId>org.scalatra</groupId>
-      <artifactId>scalatra-auth_2.13</artifactId>
+      <artifactId>scalatra-auth-jakarta_2.13</artifactId>
       <version>${scalatra.version}</version>
     </dependency>
     <dependency>
       <groupId>org.scalatra</groupId>
-      <artifactId>scalatra-forms_2.13</artifactId>
+      <artifactId>scalatra-forms-jakarta_2.13</artifactId>
       <version>${scalatra.version}</version>
     </dependency>
     <dependency>
@@ -269,8 +269,8 @@
       <version>${http4s-scala-xml.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-webapp</artifactId>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-webapp</artifactId>
       <version>${jetty.version}</version>
     </dependency>
     <dependency>
@@ -280,7 +280,7 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-proxy</artifactId>
+      <artifactId>jetty-client</artifactId>
       <version>${jetty.version}</version>
     </dependency>
     <dependency>
@@ -312,7 +312,7 @@
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient_servlet</artifactId>
+      <artifactId>simpleclient_servlet_jakarta</artifactId>
       <version>${prometheus.client.version}</version>
     </dependency>
     <dependency>
@@ -432,7 +432,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalatra</groupId>
-      <artifactId>scalatra-scalatest_2.13</artifactId>
+      <artifactId>scalatra-scalatest-jakarta_2.13</artifactId>
       <version>${scalatra.version}</version>
       <scope>test</scope>
     </dependency>
@@ -509,7 +509,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[1.8,)</version>
+                  <version>[17,)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -582,8 +582,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.15.0</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>17</source>
+          <target>17</target>
         </configuration>
       </plugin>
       <plugin>

--- a/scripts/list-ci-deploys.sh
+++ b/scripts/list-ci-deploys.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# list-ci-deploys - list Koski deployments via the GitHub Deployments API.
+#
+# This is the GitHub-side view: it reflects what the deploy workflow
+# successfully completed for each environment, NOT the live ECS state.
+# Pending-approval ("waiting") and failed deploys are filtered out.
+# For live ECS state, query ECS directly.
+#
+# Usage:
+#   list-ci-deploys [<env>]                       # snapshot at "now"
+#   list-ci-deploys [<env>] --at <ts>             # snapshot at <ts>
+#   list-ci-deploys [<env>] --from <ts> [--until <ts>]   # range, --until defaults to "now"
+#
+#   env:           dev | qa | prod | all (default: all)
+#   ts:            ISO 8601 — naive ts is Europe/Helsinki; "...Z"/"...+03:00" is
+#                  honoured; the literal "now" resolves to the current time.
+#
+# Snapshot prints the most-recently-successful deployment per env at the given
+# instant. Range prints all successful deployments in the window, sorted
+# ascending. Output is an aligned table.
+
+set -euo pipefail
+
+repo=${REPO:-Opetushallitus/koski}
+
+env=all
+at=""
+from=""
+until_=""
+
+print_help() { sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'; }
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --at)    at=${2:?--at requires a value};    shift 2;;
+    --from)  from=${2:?--from requires a value}; shift 2;;
+    --until) until_=${2:?--until requires a value}; shift 2;;
+    -h|--help) print_help; exit 0;;
+    -*) >&2 echo "Unknown flag: $1"; exit 2;;
+    *)  env=$1; shift;;
+  esac
+done
+
+if [[ -n $at && ( -n $from || -n $until_ ) ]]; then
+  >&2 echo "Error: --at cannot be combined with --from/--until"; exit 2
+fi
+if [[ -n $until_ && -z $from ]]; then
+  >&2 echo "Error: --until requires --from"; exit 2
+fi
+
+case $env in
+  dev|qa|prod) envs=("$env");;
+  all)         envs=(dev qa prod);;
+  *) >&2 echo "Error: env must be one of dev|qa|prod|all (got: $env)"; exit 2;;
+esac
+
+parse_ts() {
+  python3 - "$1" <<'PY'
+import sys
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+s = sys.argv[1]
+if s == "now":
+    print(datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
+else:
+    s = s.replace("Z", "+00:00")
+    t = datetime.fromisoformat(s)
+    if t.tzinfo is None:
+        t = t.replace(tzinfo=ZoneInfo("Europe/Helsinki"))
+    print(t.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
+PY
+}
+
+# Pull the most recent deployment to <env> with created_at <= <cutoff> whose
+# status history includes "success". Emits one JSON object on stdout, or
+# nothing if no match.
+query_snapshot() {
+  local e=$1 cutoff=$2 candidates=() line dep id succeeded
+  while IFS= read -r line; do
+    candidates+=("$line")
+  done < <(
+    gh api --paginate "/repos/${repo}/deployments?environment=${e}&per_page=100" \
+      --jq ".[] | select(.created_at <= \"${cutoff}\") | @json" \
+    | head -50
+  )
+  for dep in "${candidates[@]}"; do
+    id=$(jq -r .id <<<"$dep")
+    succeeded=$(gh api "/repos/${repo}/deployments/${id}/statuses" \
+                  --jq 'map(.state) | contains(["success"])')
+    if [[ $succeeded == true ]]; then
+      jq --arg env "$e" '{
+        env: $env, sha, short_sha: .sha[0:12], ref, created_at, creator: .creator.login
+      }' <<<"$dep"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Stream successful deployments to <env> within [from, until] as JSON objects
+# (one per line). Filters out waiting/failure/inactive-only deployments.
+query_range() {
+  local e=$1 from=$2 until=$3 dep id succeeded
+  while IFS= read -r dep; do
+    [[ -z $dep ]] && continue
+    id=$(jq -r .id <<<"$dep")
+    succeeded=$(gh api "/repos/${repo}/deployments/${id}/statuses" \
+                  --jq 'map(.state) | contains(["success"])')
+    if [[ $succeeded == true ]]; then
+      printf '%s\n' "$dep"
+    fi
+  done < <(
+    gh api --paginate "/repos/${repo}/deployments?environment=${e}&per_page=100" \
+      --jq ".[] | select(.created_at >= \"${from}\" and .created_at <= \"${until}\")
+            | {env: \"${e}\", sha, short_sha: .sha[0:12], ref, created_at, creator: .creator.login, id}
+            | @json"
+  )
+}
+
+# Read JSON objects from stdin, emit a sorted aligned table.
+format_table() {
+  {
+    printf 'ENV\tDEPLOYED (Helsinki)\tSHA\tREF\tCREATOR\n'
+    TZ=Europe/Helsinki jq -rs '
+      sort_by(.created_at) | .[] |
+      [ .env,
+        (.created_at | fromdate | strflocaltime("%Y-%m-%d %H:%M")),
+        .short_sha,
+        .ref,
+        .creator
+      ] | @tsv'
+  } | column -t -s $'\t'
+}
+
+if [[ -n $from ]]; then
+  from_ts=$(parse_ts "$from")
+  until_ts=$(parse_ts "${until_:-now}")
+  >&2 echo "Successful deployments to ${envs[*]} between ${from_ts} and ${until_ts} (UTC)..."
+  {
+    for e in "${envs[@]}"; do
+      query_range "$e" "$from_ts" "$until_ts"
+    done
+  } | format_table
+else
+  cutoff=$(parse_ts "${at:-now}")
+  >&2 echo "Deployments to ${envs[*]} at or before ${cutoff} (UTC)..."
+  {
+    for e in "${envs[@]}"; do
+      query_snapshot "$e" "$cutoff" || >&2 echo "  no successful deployment for env=${e}"
+    done
+  } | format_table
+fi

--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -64,7 +64,7 @@ import fi.oph.koski.ytl.YtlServlet
 import fi.oph.koski.ytr.download.{YtrDownloadService, YtrStatusServlet, YtrTestServlet}
 import fi.oph.koski.ytr.{YoTodistusServlet, YtrKoesuoritusApiServlet, YtrKoesuoritusServlet}
 
-import javax.servlet.ServletContext
+import jakarta.servlet.ServletContext
 import org.scalatra._
 
 import scala.concurrent.Future

--- a/src/main/scala/fi/oph/koski/jettylauncher/JettyLauncher.scala
+++ b/src/main/scala/fi/oph/koski/jettylauncher/JettyLauncher.scala
@@ -19,6 +19,7 @@ import org.eclipse.jetty.ee10.webapp.WebAppContext
 
 object JettyLauncher extends App with Logging {
   LogConfiguration.configureLogging()
+  verifyTimezone()
 
   private val globalPort = System.getProperty("koski.port", "7021").toInt
 
@@ -50,6 +51,16 @@ object JettyLauncher extends App with Logging {
     case e: Throwable =>
       logger.error(e)("Error in server startup")
       System.exit(1)
+  }
+
+  private def verifyTimezone(): Unit = {
+    val tz = java.util.TimeZone.getDefault
+    if (tz.getID != "Europe/Helsinki") {
+      throw new RuntimeException(
+        s"JVM timezone is ${tz.getID}, expected Europe/Helsinki. " +
+        s"Set -Duser.timezone=Europe/Helsinki in JVM flags."
+      )
+    }
   }
 }
 

--- a/src/main/scala/fi/oph/koski/jettylauncher/JettyLauncher.scala
+++ b/src/main/scala/fi/oph/koski/jettylauncher/JettyLauncher.scala
@@ -7,16 +7,15 @@ import fi.oph.koski.cache.JMXCacheManager
 import fi.oph.koski.config.{AppConfig, Environment, KoskiApplication}
 import fi.oph.koski.executors.Pools
 import fi.oph.koski.log.{LogConfiguration, Logging, MaskedSlf4jRequestLogWriter}
-import io.prometheus.client.exporter.MetricsServlet
+import io.prometheus.client.servlet.jakarta.exporter.MetricsServlet
 import org.eclipse.jetty.jmx.MBeanContainer
+import org.eclipse.jetty.http.UriCompliance
 import org.eclipse.jetty.server._
 import org.eclipse.jetty.server.handler.gzip.GzipHandler
-import org.eclipse.jetty.server.handler.{HandlerCollection, StatisticsHandler}
-import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder}
+import org.eclipse.jetty.server.handler.StatisticsHandler
+import org.eclipse.jetty.ee10.servlet.{ResourceServlet, ServletContextHandler, ServletHolder, ServletMapping}
 import org.eclipse.jetty.util.thread.QueuedThreadPool
-import org.eclipse.jetty.webapp.WebAppContext
-
-import scala.concurrent.duration.DurationInt
+import org.eclipse.jetty.ee10.webapp.WebAppContext
 
 object JettyLauncher extends App with Logging {
   LogConfiguration.configureLogging()
@@ -71,17 +70,16 @@ class JettyLauncher(val port: Int, val application: KoskiApplication) extends Lo
 
   setupConnector()
 
-  private val handlers = new HandlerCollection()
-  private val rootContext = new ServletContextHandler()
+  private val metricsContext = setupPrometheusMetrics()
+  private val appContext = setupKoskiApplicationContext()
 
-  server.setHandler(handlers)
-
-  setupPrometheusMetrics()
-  setupKoskiApplicationContext()
-  setupGzipForStaticResources()
-  setupJMX()
-
-  handlers.addHandler(rootContext)
+  server.setHandler(
+    setupJMX(
+      setupGzipForStaticResources(
+        new Handler.Sequence(metricsContext, appContext)
+      )
+    )
+  )
 
   def start(): Server = {
     server.start()
@@ -92,6 +90,12 @@ class JettyLauncher(val port: Int, val application: KoskiApplication) extends Lo
   private def setupConnector(): Unit = {
     val httpConfig = new HttpConfiguration()
     httpConfig.addCustomizer( new ForwardedRequestCustomizer() )
+    val uriCompliance = {
+      val allowed = new java.util.HashSet(UriCompliance.LEGACY.getAllowed)
+      allowed.add(UriCompliance.Violation.ILLEGAL_PATH_CHARACTERS)
+      UriCompliance.from(allowed)
+    }
+    httpConfig.setUriCompliance(uriCompliance)
     val connectionFactory = new HttpConnectionFactory( httpConfig )
     val connector = new ServerConnector(server, connectionFactory)
     connector.setPort(port)
@@ -106,54 +110,73 @@ class JettyLauncher(val port: Int, val application: KoskiApplication) extends Lo
     server.setRequestLog(requestLog)
   }
 
-  private def setupKoskiApplicationContext(): Unit = {
+  private def setupKoskiApplicationContext(): WebAppContext = {
     val context = new WebAppContext()
     context.setAttribute("koski.application", application)
     context.setParentLoaderPriority(true)
     context.setContextPath("/")
-    context.setResourceBase(verifyResourceBase())
-    context.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false")
-    context.setInitParameter("org.eclipse.jetty.servlet.Default.etags", "true")
+    context.setBaseResourceAsPath(Paths.get(verifyResourceBase()))
+    context.getServletHandler.setDecodeAmbiguousURIs(true)
+    context.setDefaultRequestCharacterEncoding("UTF-8")
+    context.setDefaultResponseCharacterEncoding("UTF-8")
+    context.setAttribute("org.eclipse.jetty.server.Request.queryEncoding", "UTF-8")
+    context.setInitParameter("org.eclipse.jetty.ee10.servlet.Default.dirAllowed", "false")
+    context.setInitParameter("org.eclipse.jetty.ee10.servlet.Default.etags", "true")
 
     if (Environment.isLocalDevelopmentEnvironment(config)) {
       // Avoid random SIGBUS errors when static files memory-mapped by Jetty (and being sent to client)
       // are modified (by "make watch"). Can be reproduced somewhat reliably with Java 8 by editing
       // a .less file and quickly doing a reload in the browser.
-      context.setInitParameter("org.eclipse.jetty.servlet.Default.useFileMappedBuffer", "false")
+      context.setInitParameter("org.eclipse.jetty.ee10.servlet.Default.useFileMappedBuffer", "false")
     }
-    handlers.addHandler(context)
+
+    // Jetty 12 EE10: DefaultServlet cannot be mapped to sub-paths, use ResourceServlet instead
+    val staticResourceHolder = new ServletHolder("static-resources", classOf[ResourceServlet])
+    staticResourceHolder.setInitParameter("dirAllowed", "false")
+    staticResourceHolder.setInitParameter("etags", "true")
+    staticResourceHolder.setInitParameter("pathInfoOnly", "false")
+    context.getServletHandler.addServlet(staticResourceHolder)
+    val staticMapping = new ServletMapping()
+    staticMapping.setServletName("static-resources")
+    staticMapping.setPathSpecs(Array(
+      "/koski/buildversion.txt", "/koski/favicon.ico", "/koski/empty.js",
+      "/koski/js/*", "/koski/css/*", "/koski/external_css/*", "/koski/fonts/*",
+      "/koski/images/*", "/koski/test/*",
+      "/koski/json-schema-viewer/js/*", "/koski/json-schema-viewer/styles/*",
+      "/koski/json-schema-viewer/images/*", "/koski/json-schema-viewer/jquery/*",
+      "/koski/wsdl/*", "/valpas/assets/*"
+    ))
+    context.getServletHandler.addServletMapping(staticMapping)
+
+    context
   }
 
   private def verifyResourceBase(): String = {
-    val base = System.getProperty("resourcebase", "./target/webapp")
+    val base = Paths.get(System.getProperty("resourcebase", "./target/webapp")).toAbsolutePath.normalize().toString
     if (!Files.exists(Paths.get(base))) {
       throw new RuntimeException("WebApplication resource base: " + base + " does not exist.")
     }
     base
   }
 
-  private def setupGzipForStaticResources(): Unit = {
-    val gzip = new GzipHandler
+  private def setupGzipForStaticResources(handler: Handler): GzipHandler = {
+    val gzip = new GzipHandler(handler)
     gzip.setIncludedMimeTypes("text/css", "text/html", "application/javascript")
     gzip.setIncludedPaths("/koski/css/*", "/koski/external_css/*", "/koski/js/*", "/koski/json-schema-viewer/*", "/valpas/assets/*")
-    gzip.setHandler(server.getHandler)
-    server.setHandler(gzip)
+    gzip
   }
 
-  private def setupJMX(): Unit = {
+  private def setupJMX(handler: Handler): StatisticsHandler = {
     val mbContainer = new MBeanContainer(ManagementFactory.getPlatformMBeanServer)
     server.addBean(mbContainer)
-
-    val stats = new StatisticsHandler
-    stats.setHandler(server.getHandler)
-    server.setHandler(stats)
+    new StatisticsHandler(handler)
   }
 
-  private def setupPrometheusMetrics(): Unit = {
+  private def setupPrometheusMetrics(): ServletContextHandler = {
     val metricsServletContext = new ServletContextHandler()
     metricsServletContext.setContextPath("/metrics")
     metricsServletContext.addServlet(new ServletHolder(new MetricsServlet), "")
-    handlers.addHandler(metricsServletContext)
+    metricsServletContext
   }
 }
 

--- a/src/main/scala/fi/oph/koski/jettylauncher/JettyLauncher.scala
+++ b/src/main/scala/fi/oph/koski/jettylauncher/JettyLauncher.scala
@@ -101,6 +101,10 @@ class JettyLauncher(val port: Int, val application: KoskiApplication) extends Lo
   private def setupConnector(): Unit = {
     val httpConfig = new HttpConfiguration()
     httpConfig.addCustomizer( new ForwardedRequestCustomizer() )
+    // Allow encoded slashes (%2F) and non-ASCII bytes in path segments. Required by
+    // ePerusteet 3-part diaarinumero IDs ("104%2F011%2F2014" = "104/011/2014") and
+    // Finnish-character schema class names exposed via /api/types/constraints and
+    // /api/editor/preferences. Removing this requires reshaping those routes.
     val uriCompliance = {
       val allowed = new java.util.HashSet(UriCompliance.LEGACY.getAllowed)
       allowed.add(UriCompliance.Violation.ILLEGAL_PATH_CHARACTERS)

--- a/src/main/scala/fi/oph/koski/koskiuser/DirectoryClientLogin.scala
+++ b/src/main/scala/fi/oph/koski/koskiuser/DirectoryClientLogin.scala
@@ -2,7 +2,7 @@ package fi.oph.koski.koskiuser
 
 import fi.oph.koski.log.{LogUserContext, Logging}
 import fi.oph.koski.userdirectory.DirectoryClient
-import javax.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequest
 
 object DirectoryClientLogin extends Logging {
   def findUser(directoryClient: DirectoryClient, request: HttpServletRequest, username: String): Option[AuthenticationUser] = {

--- a/src/main/scala/fi/oph/koski/log/LogUserContext.scala
+++ b/src/main/scala/fi/oph/koski/log/LogUserContext.scala
@@ -2,7 +2,7 @@ package fi.oph.koski.log
 
 import java.net.InetAddress
 
-import javax.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequest
 import fi.oph.koski.koskiuser.{UserWithOid, UserWithUsername}
 import org.scalatra.servlet.RichRequest
 

--- a/src/main/scala/fi/oph/koski/massaluovutus/MassaluovutusScheduler.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/MassaluovutusScheduler.scala
@@ -10,6 +10,7 @@ class MassaluovutusScheduler(application: KoskiApplication) extends Logging {
   val massaluovutukset: MassaluovutusService = application.massaluovutusService
 
   sys.addShutdownHook {
+    shutdown()
     massaluovutukset.cancelAllTasks("Interrupted: worker shutdown")
   }
 

--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/OpiskeluoikeusQueries.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/OpiskeluoikeusQueries.scala
@@ -12,7 +12,7 @@ import fi.oph.koski.schema.Henkilö._
 import fi.oph.koski.servlet.{KoskiSpecificApiServlet, ObservableSupport}
 import fi.oph.koski.util.SortOrder.Ascending
 import fi.oph.koski.util.{Pagination, PaginationSettings, QueryPagination}
-import javax.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequest
 import org.scalatra._
 import rx.lang.scala.Observable
 

--- a/src/main/scala/fi/oph/koski/raamit/RaamiProxyServlet.scala
+++ b/src/main/scala/fi/oph/koski/raamit/RaamiProxyServlet.scala
@@ -24,29 +24,32 @@ class RaamiProxyServlet(val proxyHost: String, val proxyPrefix: String, val appl
   override def service(request: HttpServletRequest, response: HttpServletResponse): Unit = {
     val httpClient = new HttpClient()
     httpClient.start()
-    // Kytketään GZip pois: https://github.com/eclipse/jetty.project/issues/7681
-    httpClient.getContentDecoderFactories().clear()
-    // Evästeitä ei saa säilöä kun proxytetaan
-    httpClient.setHttpCookieStore(new HttpCookieStore.Empty())
+    try {
+      // Kytketään GZip pois: https://github.com/eclipse/jetty.project/issues/7681
+      httpClient.getContentDecoderFactories().clear()
+      // Evästeitä ei saa säilöä kun proxytetaan
+      httpClient.setHttpCookieStore(new HttpCookieStore.Empty())
 
-    val rewrittenTarget: String = rewriteTarget(request, proxyPrefix, proxyHost)
+      val rewrittenTarget: String = rewriteTarget(request, proxyPrefix, proxyHost)
 
-    val proxyRequest = httpClient
-      .newRequest(rewrittenTarget) // Redirectejä ei seurata kun kyseessä on proxy
-      .followRedirects(false)
-      .method(request.getMethod)
-      .timeout(10, TimeUnit.SECONDS)
-    // Kopioidaan pyynnön headerit mukaan
-    copyRequestHeaders(request, proxyRequest)
-    // Asetetaan HOST-header
-    setHostHeader(proxyRequest, proxyHost)
+      val proxyRequest = httpClient
+        .newRequest(rewrittenTarget) // Redirectejä ei seurata kun kyseessä on proxy
+        .followRedirects(false)
+        .method(request.getMethod)
+        .timeout(10, TimeUnit.SECONDS)
+      // Kopioidaan pyynnön headerit mukaan
+      copyRequestHeaders(request, proxyRequest)
+      // Asetetaan HOST-header
+      setHostHeader(proxyRequest, proxyHost)
 
-    val contentResponse: ContentResponse = proxyRequest.send()
+      val contentResponse: ContentResponse = proxyRequest.send()
 
-    copyResponseHeaders(contentResponse, response)
-    response.setStatus(contentResponse.getStatus)
-    response.getOutputStream.write(contentResponse.getContent)
-    httpClient.stop()
+      copyResponseHeaders(contentResponse, response)
+      response.setStatus(contentResponse.getStatus)
+      response.getOutputStream.write(contentResponse.getContent)
+    } finally {
+      httpClient.stop()
+    }
   }
 
   protected def setHostHeader(request: Request, value: String): Request = {

--- a/src/main/scala/fi/oph/koski/raamit/RaamiProxyServlet.scala
+++ b/src/main/scala/fi/oph/koski/raamit/RaamiProxyServlet.scala
@@ -2,21 +2,16 @@ package fi.oph.koski.raamit
 
 import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.log.Logging
-import org.eclipse.jetty.client.HttpClient
-import org.eclipse.jetty.client.api.{Request, Response, Result}
-import org.eclipse.jetty.http.HttpHeader
-import org.eclipse.jetty.util.HttpCookieStore
-import org.eclipse.jetty.util.ssl.SslContextFactory
+import org.eclipse.jetty.client.{ContentResponse, HttpClient, Request}
+import org.eclipse.jetty.http.{HttpCookieStore, HttpField, HttpHeader}
 import org.scalatra.ScalatraServlet
 
 import java.net.{URI, URL}
-import java.nio.ByteBuffer
 import java.util
-import java.util.concurrent.{CountDownLatch, TimeUnit}
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.TimeUnit
 import java.util.{HashSet, Locale}
-import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
-import scala.util.control.Breaks._
+import jakarta.servlet.http.{HttpServletRequest, HttpServletResponse}
+import scala.jdk.CollectionConverters._
 
 /**
  * fi.oph.koski.raamit.RaamiProxyServlet -luokalla proxytetään virkailijan ja oppijan raamea. Tätä toiminnallisuutta ei tule käyttää tuotannossa
@@ -27,73 +22,39 @@ class RaamiProxyServlet(val proxyHost: String, val proxyPrefix: String, val appl
   protected val hopHeaders = Set("connection", "keep-alive", "proxy-authentication", "proxy-connection", "transfer-encoding", "te", "trailer", "upgrade")
 
   override def service(request: HttpServletRequest, response: HttpServletResponse): Unit = {
-    val httpClient = new HttpClient(new SslContextFactory.Client)
+    val httpClient = new HttpClient()
     httpClient.start()
     // Kytketään GZip pois: https://github.com/eclipse/jetty.project/issues/7681
-    httpClient.getContentDecoderFactories().clear();
+    httpClient.getContentDecoderFactories().clear()
     // Evästeitä ei saa säilöä kun proxytetaan
-    httpClient.setCookieStore(new HttpCookieStore.Empty());
+    httpClient.setHttpCookieStore(new HttpCookieStore.Empty())
 
     val rewrittenTarget: String = rewriteTarget(request, proxyPrefix, proxyHost)
-
-    val responseRef = new AtomicReference[Response]
-    val latch = new CountDownLatch(1)
 
     val proxyRequest = httpClient
       .newRequest(rewrittenTarget) // Redirectejä ei seurata kun kyseessä on proxy
       .followRedirects(false)
       .method(request.getMethod)
-      .timeout(5, TimeUnit.SECONDS)
+      .timeout(10, TimeUnit.SECONDS)
     // Kopioidaan pyynnön headerit mukaan
     copyRequestHeaders(request, proxyRequest)
     // Asetetaan HOST-header
     setHostHeader(proxyRequest, proxyHost)
 
-    var responseBuffer = Array[Byte]()
-    // Puskurin maksimikoko on 8MB
-    val maxBufferSize = 8000000
+    val contentResponse: ContentResponse = proxyRequest.send()
 
-    // Async pyyntö
-    proxyRequest.send(new Response.Listener() {
-      override def onComplete(result: Result): Unit = {
-        if (result.isSucceeded) {
-          responseRef.set(result.getResponse)
-          latch.countDown()
-        } else {
-          logger.error(result.getFailure)(s"RaamiProxyServlet request failed for ${rewrittenTarget}")
-        }
-      }
-
-      override def onContent(res: Response, content: ByteBuffer): Unit = {
-        val newBufferSize = responseBuffer.length + content.remaining
-        if (newBufferSize > maxBufferSize) {
-          logger.error(new IllegalArgumentException(s"RaamiProxyServlet buffer capacity exceeded for entity ${request.getRequestURI}"))(s"RaamiProxyServlet buffer capacity exceeded for entity ${request.getRequestURI}")
-          throw new IllegalArgumentException(s"RaamiProxyServlet buffer capacity exceeded for entity ${request.getRequestURI}")
-        }
-        val newBuffer = new Array[Byte](newBufferSize)
-        System.arraycopy(responseBuffer, 0, newBuffer, 0, responseBuffer.length)
-        content.get(newBuffer, responseBuffer.length, content.remaining)
-        responseBuffer = newBuffer
-      }
-    })
-
-    def result = latch.await(10, TimeUnit.SECONDS)
-
-    if (!result) {
-      logger.error(new Exception(s"Timeout of 10 seconds exceeded in RaamiProxyServlet when requesting ${rewrittenTarget}"))(s"Timeout of 10 seconds exceeded in RaamiProxyServlet when requesting ${rewrittenTarget}")
-    }
-
-    val httpResponse = responseRef.get();
-    copyResponseHeaders(httpResponse, response)
-    response.setStatus(httpResponse.getStatus)
-    response.getOutputStream().write(responseBuffer)
+    copyResponseHeaders(contentResponse, response)
+    response.setStatus(contentResponse.getStatus)
+    response.getOutputStream.write(contentResponse.getContent)
     httpClient.stop()
   }
 
   protected def setHostHeader(request: Request, value: String): Request = {
-    // Jetty.HttpClient ei osaa korvata headeria, ellei sitä aseta ensin tyhjäksi
-    request.header(HttpHeader.HOST, null)
-    request.header(HttpHeader.HOST, new URL(value).getHost)
+    request.headers(h => {
+      h.remove(HttpHeader.HOST)
+      h.put(HttpHeader.HOST, new URL(value).getHost)
+    })
+    request
   }
 
   protected def rewriteTarget(request: HttpServletRequest, prefix: String, proxyTo: String): String = {
@@ -118,46 +79,26 @@ class RaamiProxyServlet(val proxyHost: String, val proxyPrefix: String, val appl
     rewrittenURI.toString
   }
 
-  protected def copyResponseHeaders(proxyResponse: Response, clientResponse: HttpServletResponse): Unit = {
-    val headerNames = proxyResponse.getHeaders.getFieldNames
-    while ( {
-      headerNames.hasMoreElements
-    }) {
-      val headerName = headerNames.nextElement
-      val headerValues = proxyResponse.getHeaders.getValues(headerName)
-      while ( {
-        headerValues.hasMoreElements
-      }) {
-        val headerValue = headerValues.nextElement
-        if (headerValue != null) clientResponse.setHeader(headerName, headerValue)
-      }
+  protected def copyResponseHeaders(proxyResponse: ContentResponse, clientResponse: HttpServletResponse): Unit = {
+    proxyResponse.getHeaders.asScala.foreach { field: HttpField =>
+      clientResponse.setHeader(field.getName, field.getValue)
     }
   }
 
   protected def copyRequestHeaders(clientRequest: HttpServletRequest, proxyRequest: Request): Unit = {
-    proxyRequest.getHeaders.clear()
+    proxyRequest.headers(h => h.clear())
     val headersToRemove = findConnectionHeaders(clientRequest)
     val headerNames = clientRequest.getHeaderNames
-    while ( {
-      headerNames.hasMoreElements
-    }) {
+    while (headerNames.hasMoreElements) {
       val headerName = headerNames.nextElement
       val lowerHeaderName = headerName.toLowerCase(Locale.ENGLISH)
-      breakable {
-        if (HttpHeader.HOST.is(headerName)) break() // Ohitetaan HOST-header
-      }
-      breakable {
-        if (hopHeaders.contains(lowerHeaderName)) break()
-      }
-      breakable {
-        if (headersToRemove != null && headersToRemove.contains(lowerHeaderName)) break()
-      }
-      val headerValues = clientRequest.getHeaders(headerName)
-      while ( {
-        headerValues.hasMoreElements
-      }) {
-        val headerValue = headerValues.nextElement
-        if (headerValue != null) proxyRequest.header(headerName, headerValue)
+      if (!HttpHeader.HOST.is(headerName) && !hopHeaders.contains(lowerHeaderName) &&
+        (headersToRemove == null || !headersToRemove.contains(lowerHeaderName))) {
+        val headerValues = clientRequest.getHeaders(headerName)
+        while (headerValues.hasMoreElements) {
+          val headerValue = headerValues.nextElement
+          if (headerValue != null) proxyRequest.headers(h => h.add(headerName, headerValue))
+        }
       }
     }
   }
@@ -166,9 +107,7 @@ class RaamiProxyServlet(val proxyHost: String, val proxyPrefix: String, val appl
     // http://tools.ietf.org/html/rfc7230#section-6.1.
     val hopHeaders: HashSet[String] = new util.HashSet[String]
     val connectionHeaders = clientRequest.getHeaders(HttpHeader.CONNECTION.asString)
-    while ( {
-      connectionHeaders.hasMoreElements
-    }) {
+    while (connectionHeaders.hasMoreElements) {
       val value = connectionHeaders.nextElement
       val values = value.split(",")
       for (name <- values) {

--- a/src/main/scala/fi/oph/koski/schedule/WorkerLeaseElector.scala
+++ b/src/main/scala/fi/oph/koski/schedule/WorkerLeaseElector.scala
@@ -38,23 +38,28 @@ class WorkerLeaseElector(
     started = false
   }
 
-  private def tick(onAcquired: Int => Unit, onLost: Int => Unit): Unit = synchronized {
-    currentSlot match {
-      case Some(slot) =>
-        val renewed = repository.tryAcquireOrRenew(name, slot, holderId, leaseDuration)
-        if (!renewed) {
-          currentSlot = None
-          onLost(slot)
-        }
-      case None =>
-        val slotOrder = preferredSlotOrder
-        slotOrder.find(slot => repository.tryAcquireOrRenew(name, slot, holderId, leaseDuration)) match {
-          case Some(slot) =>
-            currentSlot = Some(slot)
-            onAcquired(slot)
-          case None =>
-        }
+  private def tick(onAcquired: Int => Unit, onLost: Int => Unit): Unit = try {
+    synchronized {
+      currentSlot match {
+        case Some(slot) =>
+          val renewed = repository.tryAcquireOrRenew(name, slot, holderId, leaseDuration)
+          if (!renewed) {
+            currentSlot = None
+            onLost(slot)
+          }
+        case None =>
+          val slotOrder = preferredSlotOrder
+          slotOrder.find(slot => repository.tryAcquireOrRenew(name, slot, holderId, leaseDuration)) match {
+            case Some(slot) =>
+              currentSlot = Some(slot)
+              onAcquired(slot)
+            case None =>
+          }
+      }
     }
+  } catch {
+    case e: Throwable =>
+      logger.error(e)(s"WorkerLeaseElector tick failed for $name: ${e.getMessage}")
   }
 
   private def preferredSlotOrder: Seq[Int] = {

--- a/src/main/scala/fi/oph/koski/servlet/HostnameFilter.scala
+++ b/src/main/scala/fi/oph/koski/servlet/HostnameFilter.scala
@@ -1,8 +1,8 @@
 package fi.oph.koski.servlet
 
 import java.net.InetAddress
-import javax.servlet._
-import javax.servlet.http.HttpServletResponse
+import jakarta.servlet._
+import jakarta.servlet.http.HttpServletResponse
 
 class HostnameFilter extends Filter {
   val hostname = InetAddress.getLocalHost.getHostName

--- a/src/main/scala/fi/oph/koski/servlet/JsonBodySnatcher.scala
+++ b/src/main/scala/fi/oph/koski/servlet/JsonBodySnatcher.scala
@@ -1,5 +1,5 @@
 package fi.oph.koski.servlet
-import javax.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequest
 
 import fi.oph.koski.http.{HttpStatus, KoskiErrorCategory}
 import org.json4s._

--- a/src/main/scala/fi/oph/koski/servlet/ObservableSupport.scala
+++ b/src/main/scala/fi/oph/koski/servlet/ObservableSupport.scala
@@ -5,7 +5,6 @@ import java.io.EOFException
 import fi.oph.koski.http.HttpStatus
 import fi.oph.koski.json.JsonSerializer
 import fi.oph.koski.koskiuser.KoskiSpecificSession
-import org.eclipse.jetty.server.HttpConnection
 import rx.lang.scala.Observable
 
 import scala.reflect.runtime.universe.TypeTag
@@ -20,7 +19,7 @@ trait ObservableSupport extends KoskiSpecificApiServlet {
       // Client abort, ok
     case e: Exception =>
       logger.error(s"Error occurred while streaming: ${e.toString}")
-      HttpConnection.getCurrentConnection.abort(e)
+      response.getOutputStream.close()
   }
 
   def streamResponse[T : TypeTag](x: Either[HttpStatus, Observable[T]], user: KoskiSpecificSession): Unit = x match {

--- a/src/main/scala/fi/oph/koski/servlet/RequestDescriber.scala
+++ b/src/main/scala/fi/oph/koski/servlet/RequestDescriber.scala
@@ -1,6 +1,6 @@
 package fi.oph.koski.servlet
 
-import javax.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequest
 
 import org.json4s.JsonAST.JString
 import org.json4s._

--- a/src/main/scala/fi/oph/koski/sso/CasOppijaCreationService.scala
+++ b/src/main/scala/fi/oph/koski/sso/CasOppijaCreationService.scala
@@ -6,7 +6,7 @@ import fi.oph.koski.sso.CasAttributes._
 import org.scalatra.servlet.ServletApiImplicits.enrichRequest
 
 import java.nio.charset.StandardCharsets
-import javax.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequest
 
 class CasOppijaCreationService(henkilöRepository: HenkilöRepository) {
   def findOrCreateByOidOrHetu(request: HttpServletRequest, tunnisteet: KansalaisenTunnisteet): Option[OppijaHenkilö] = {

--- a/src/main/scala/fi/oph/koski/suoritusjako/SuoritusjakoService.scala
+++ b/src/main/scala/fi/oph/koski/suoritusjako/SuoritusjakoService.scala
@@ -18,7 +18,7 @@ import fi.oph.koski.util.ChainingSyntax.chainingOps
 import fi.oph.koski.util.WithWarnings
 import org.scalatra.servlet.RichRequest
 
-import javax.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequest
 
 
 case class SuoritusjakoPayload(

--- a/src/main/scala/fi/oph/koski/todistus/TodistusScheduler.scala
+++ b/src/main/scala/fi/oph/koski/todistus/TodistusScheduler.scala
@@ -10,6 +10,7 @@ class TodistusScheduler(application: KoskiApplication) extends Logging {
   val todistusService: TodistusService = application.todistusService
 
   sys.addShutdownHook {
+    shutdown()
     todistusService.markAllMyJobsInterrupted()
   }
 

--- a/src/test/scala/fi/oph/koski/api/misc/JettyConfigurationSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/misc/JettyConfigurationSpec.scala
@@ -1,0 +1,51 @@
+package fi.oph.koski.api.misc
+
+import fi.oph.koski.KoskiHttpSpec
+import fi.oph.koski.henkilo.KoskiSpecificMockOppijat
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class JettyConfigurationSpec extends AnyFreeSpec with KoskiHttpSpec with Matchers {
+  "URL-polut" - {
+    "OID polulla toimii" in {
+      val oid = KoskiSpecificMockOppijat.eero.oid
+      authGet(s"api/oppija/${oid}") {
+        response.status should (be(200) or be(404))
+        response.status should not be 400
+        response.status should not be 500
+      }
+    }
+
+    "Prosenttikoodattu kauttaviiva polulla ei aiheuta virhettä" in {
+      authGet("api/editor/koodit/koskiopiskeluoikeudentila%2Fvalmistunut") {
+        response.status should not be 400
+        response.status should not be 500
+      }
+    }
+  }
+
+  "Staattiset resurssit" - {
+    "Resurssit tarjotaan oikein alipoluista" in {
+      get("images/loader.svg") { verifyResponseStatusOk() }
+      get("js/koski-main.js") { verifyResponseStatusOk() }
+    }
+
+    "Hakemistolistaus on estetty" in {
+      get("js/") { verifyResponseStatusOk(403) }
+    }
+  }
+
+  "Ei-ASCII query-parametrit" - {
+    "Skandit query-parametrin nimissä toimivat" in {
+      authGet("api/opiskeluoikeus?opiskeluoikeusPäättynytAikaisintaan=2016-01-01&opiskeluoikeusPäättynytViimeistään=2016-12-31") {
+        response.status should not be 400
+      }
+    }
+
+    "Skandit query-parametrin arvoissa toimivat" in {
+      authGet("api/opiskeluoikeus?opiskeluoikeusAlkanutAikaisintaan=2016-01-01&opiskeluoikeusAlkanutViimeistään=2016-12-31") {
+        response.status should not be 400
+      }
+    }
+  }
+}

--- a/src/test/scala/fi/oph/koski/http/HttpTester.scala
+++ b/src/test/scala/fi/oph/koski/http/HttpTester.scala
@@ -3,9 +3,35 @@ package fi.oph.koski.http
 import fi.oph.koski.koskiuser.UserWithPassword
 import org.scalatra.test.HttpComponentsClient
 
+import java.nio.charset.StandardCharsets
 import java.util.Base64
 
 trait HttpTester extends HttpComponentsClient {
+  override def submit[A](
+    method: String,
+    path: String,
+    queryParams: Iterable[(String, String)] = Seq.empty,
+    headers: Iterable[(String, String)] = Seq.empty,
+    body: Array[Byte] = null
+  )(f: => A): A = {
+    // Percent-encode non-ASCII characters in the path to ensure proper UTF-8 handling with Jetty 12
+    val encodedPath = encodeNonAscii(path)
+    super.submit(method, encodedPath, queryParams, headers, body)(f)
+  }
+
+  private def encodeNonAscii(path: String): String = {
+    val sb = new StringBuilder
+    for (c <- path) {
+      if (c.toInt > 127) {
+        for (b <- c.toString.getBytes(StandardCharsets.UTF_8)) {
+          sb.append("%" + "%02X".format(b & 0xff))
+        }
+      } else {
+        sb.append(c)
+      }
+    }
+    sb.toString
+  }
   type Headers = Map[String, String]
 
   val jsonContent = Map(("Content-type" -> "application/json"))

--- a/src/test/scala/fi/oph/koski/integrationtest/TrustingHttpsClient.scala
+++ b/src/test/scala/fi/oph/koski/integrationtest/TrustingHttpsClient.scala
@@ -1,28 +1,24 @@
 package fi.oph.koski.integrationtest
 
-import org.apache.http.client.config.{CookieSpecs, RequestConfig}
-import org.apache.http.conn.ssl.{NoopHostnameVerifier, SSLConnectionSocketFactory}
-import org.apache.http.impl.client.{CloseableHttpClient, HttpClients}
-import org.apache.http.ssl.{SSLContextBuilder, TrustStrategy}
-
-import java.security.cert.X509Certificate
+import org.apache.hc.client5.http.impl.classic.{CloseableHttpClient, HttpClients}
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder
+import org.apache.hc.client5.http.ssl.{NoopHostnameVerifier, TrustAllStrategy}
+import org.apache.hc.core5.ssl.SSLContextBuilder
 
 object TrustingHttpsClient {
   def createClient: CloseableHttpClient = {
-    HttpClients
-      .custom
-      .setSSLSocketFactory(makeSslConnectionSocketFactory)
-      .disableRedirectHandling
-      .disableCookieManagement
-      .build
-  }
+    val sslContext = new SSLContextBuilder()
+      .loadTrustMaterial(null, TrustAllStrategy.INSTANCE)
+      .build()
 
-  private def makeSslConnectionSocketFactory = {
-    val builder = new SSLContextBuilder();
-    builder.loadTrustMaterial(
-      null, new TrustStrategy() {
-        override def isTrusted(x509Certificates: Array[X509Certificate], s: String) = true
-      })
-    new SSLConnectionSocketFactory(builder.build(), NoopHostnameVerifier.INSTANCE)
+    val connectionManager = PoolingHttpClientConnectionManagerBuilder.create()
+      .setTlsSocketStrategy(new org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy(sslContext, NoopHostnameVerifier.INSTANCE))
+      .build()
+
+    HttpClients
+      .custom()
+      .setConnectionManager(connectionManager)
+      .disableRedirectHandling()
+      .build()
   }
 }

--- a/src/test/scala/fi/oph/koski/mydata/MyDataSupportTest.scala
+++ b/src/test/scala/fi/oph/koski/mydata/MyDataSupportTest.scala
@@ -3,7 +3,7 @@ package fi.oph.koski.mydata
 import fi.oph.koski.{KoskiApplicationForTests, TestEnvironment}
 import fi.oph.koski.servlet.InvalidRequestException
 
-import javax.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequest
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers

--- a/src/test/scala/fi/oph/koski/perftest/EasyHttp.scala
+++ b/src/test/scala/fi/oph/koski/perftest/EasyHttp.scala
@@ -3,7 +3,8 @@ package fi.oph.koski.perftest
 import fi.oph.koski.http.OpintopolkuCallerId
 import fi.oph.koski.integrationtest.TrustingHttpsClient
 import fi.oph.koski.json.JsonSerializer
-import org.apache.http.client.methods.HttpGet
+import org.apache.hc.client5.http.classic.methods.HttpGet
+import org.apache.hc.core5.http.io.HttpClientResponseHandler
 import org.json4s.jackson.JsonMethods
 
 import scala.reflect.runtime.universe.TypeTag
@@ -15,7 +16,9 @@ object EasyHttp {
     val httpGet = new HttpGet(url)
     httpGet.addHeader("Caller-Id", OpintopolkuCallerId.koski)
 
-    val jValue = JsonMethods.parse(httpclient.execute(httpGet).getEntity.getContent)
+    val handler: HttpClientResponseHandler[org.json4s.JValue] = response =>
+      JsonMethods.parse(response.getEntity.getContent)
+    val jValue = httpclient.execute(httpGet, handler)
     JsonSerializer.extract[A](jValue, ignoreExtras = true)
   }
 }

--- a/src/test/scala/fi/oph/koski/sso/SessionRepositorySpec.scala
+++ b/src/test/scala/fi/oph/koski/sso/SessionRepositorySpec.scala
@@ -9,22 +9,29 @@ import org.scalatest.matchers.should.Matchers
 
 import java.sql.Timestamp
 import java.time.{Instant, ZonedDateTime}
-import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 class SessionRepositorySpec extends AnyFreeSpec with TestEnvironment with Matchers with DatabaseTestMethods with BeforeAndAfterAll {
-  private def createDummySession(dateTime: ZonedDateTime) = {
-    val fakeServiceTicket: String = "koski-" + UUID.randomUUID()
-    val sqlTimestamp = Timestamp.from(dateTime.toInstant.truncatedTo(ChronoUnit.MICROS))
+  // Returns the `started` instant as the DB actually stored it (not as we sent it).
+  private def insertSession(at: ZonedDateTime): Instant = {
+    val serviceTicket = "koski-" + UUID.randomUUID()
+    val ts = Timestamp.from(at.toInstant)
     runDbSync(KoskiTables.CasServiceTicketSessions += SSOSessionRow(
-      fakeServiceTicket, "test", "test", "test", sqlTimestamp, sqlTimestamp, None)
-    )
+      serviceTicket = serviceTicket,
+      username = "test",
+      userOid = "test",
+      name = "test",
+      started = ts,
+      updated = ts,
+      huollettavatSearchResult = None,
+    ))
+    runDbSync(
+      KoskiTables.CasServiceTicketSessions.filter(_.serviceTicket === serviceTicket).map(_.started).result.head
+    ).toInstant
   }
 
-  private def sessionsStarteds = {
-    val query = KoskiTables.CasServiceTicketSessions.map(_.started)
-    runDbSync(query.result)
-  }
+  private def storedSessionInstants: Seq[Instant] =
+    runDbSync(KoskiTables.CasServiceTicketSessions.map(_.started).result).map(_.toInstant)
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
@@ -32,22 +39,15 @@ class SessionRepositorySpec extends AnyFreeSpec with TestEnvironment with Matche
   }
 
   "Vanhentuneiden sessioiden poisto" in {
-    val staleSessions = Vector(
-      ZonedDateTime.now().minusMonths(22),
-      ZonedDateTime.now().minusMonths(13)
-    )
-    val currentSessions = Vector(
-      ZonedDateTime.now().minusMonths(11),
-      ZonedDateTime.now().minusMonths(1)
-    )
-    (staleSessions ++ currentSessions).foreach(createDummySession)
-    sessionsStarteds.length should be(4)
+    val now = ZonedDateTime.now()
+    val cutoff = now.minusYears(1).toInstant
 
-    val purgeBefore = ZonedDateTime.now().minusYears(1).toInstant
-    KoskiApplicationForTests.koskiSessionRepository.purgeOldSessions(purgeBefore)
+    Seq(now.minusMonths(22), now.minusMonths(13)).foreach(insertSession)
+    val currentStarts = Seq(now.minusMonths(11), now.minusMonths(1)).map(insertSession)
+    storedSessionInstants should have size 4
 
-    sessionsStarteds.map(_.toInstant) should contain theSameElementsAs(
-      currentSessions.map(_.toInstant.truncatedTo(ChronoUnit.MICROS))
-    )
+    KoskiApplicationForTests.koskiSessionRepository.purgeOldSessions(cutoff)
+
+    storedSessionInstants should contain theSameElementsAs currentStarts
   }
 }

--- a/src/test/scala/fi/oph/koski/sso/SessionRepositorySpec.scala
+++ b/src/test/scala/fi/oph/koski/sso/SessionRepositorySpec.scala
@@ -9,17 +9,13 @@ import org.scalatest.matchers.should.Matchers
 
 import java.sql.Timestamp
 import java.time.{Instant, ZonedDateTime}
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 class SessionRepositorySpec extends AnyFreeSpec with TestEnvironment with Matchers with DatabaseTestMethods with BeforeAndAfterAll {
   private def createDummySession(dateTime: ZonedDateTime) = {
     val fakeServiceTicket: String = "koski-" + UUID.randomUUID()
-    // JDK11 muuttaa ZonedDateTimen toiminnallisuutta, koska se käyttää tarkempaa kelloa kuin JDK8.
-    // Tämän takia nanosekunnit on lisättävä aikaleimaan erikseen.
-    // https://bugs.openjdk.org/browse/JDK-8068730
-    val epochMillis = dateTime.toInstant.toEpochMilli
-    val nanos = dateTime.getNano % 1000000
-    val sqlTimestamp = Timestamp.from(Instant.ofEpochMilli(epochMillis).plusNanos(nanos))
+    val sqlTimestamp = Timestamp.from(dateTime.toInstant.truncatedTo(ChronoUnit.MICROS))
     runDbSync(KoskiTables.CasServiceTicketSessions += SSOSessionRow(
       fakeServiceTicket, "test", "test", "test", sqlTimestamp, sqlTimestamp, None)
     )
@@ -51,7 +47,7 @@ class SessionRepositorySpec extends AnyFreeSpec with TestEnvironment with Matche
     KoskiApplicationForTests.koskiSessionRepository.purgeOldSessions(purgeBefore)
 
     sessionsStarteds.map(_.toInstant) should contain theSameElementsAs(
-      currentSessions.map(_.toInstant)
+      currentSessions.map(_.toInstant.truncatedTo(ChronoUnit.MICROS))
     )
   }
 }

--- a/web/WEB-INF/web.xml
+++ b/web/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app version="6.0" xmlns="https://jakarta.ee/xml/ns/jakartaee"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd">
   <listener>
     <listener-class>org.scalatra.servlet.ScalatraListener</listener-class>
   </listener>
@@ -19,25 +19,6 @@ xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns
   <welcome-file-list>
     <welcome-file>index.html</welcome-file>
   </welcome-file-list>
-
-  <servlet-mapping>
-    <servlet-name>default</servlet-name>
-    <url-pattern>/koski/buildversion.txt</url-pattern>
-    <url-pattern>/koski/favicon.ico</url-pattern>
-    <url-pattern>/koski/empty.js</url-pattern>
-    <url-pattern>/koski/js/*</url-pattern>
-    <url-pattern>/koski/css/*</url-pattern>
-    <url-pattern>/koski/external_css/*</url-pattern>
-    <url-pattern>/koski/fonts/*</url-pattern>
-    <url-pattern>/koski/images/*</url-pattern>
-    <url-pattern>/koski/test/*</url-pattern>
-    <url-pattern>/koski/json-schema-viewer/js/*</url-pattern>
-    <url-pattern>/koski/json-schema-viewer/styles/*</url-pattern>
-    <url-pattern>/koski/json-schema-viewer/images/*</url-pattern>
-    <url-pattern>/koski/json-schema-viewer/jquery/*</url-pattern>
-    <url-pattern>/koski/wsdl/*</url-pattern>
-    <url-pattern>/valpas/assets/*</url-pattern>
-  </servlet-mapping>
 
   <filter>
     <filter-name>hostname</filter-name>


### PR DESCRIPTION
Summary

Major dependency upgrade to fix CVE-2026-2332 (HTTP/1.1 request smuggling).

Dependency changes

- Jetty 9.4.58 → 12.0.34 (EE10 modules)
- Scalatra 2.8.4 → 3.1.2 (Jakarta servlet variants)
- javax.servlet 4.0.1 → jakarta.servlet 6.0.0
- Java runtime 11 → 17 (Amazon Corretto Alpine)
- Prometheus simpleclient_servlet → simpleclient_servlet_jakarta
- Apache HttpComponents Client 4 → 5 (test deps)

Jetty 12 migration

- Rewrote JettyLauncher handler chain (Handler.Sequence)
- Static resources via ResourceServlet (DefaultServlet no longer supports sub-path mappings)
- URI compliance configured for backwards-compatible URL handling (non-ASCII paths, percent-encoded slashes)
- UTF-8 encoding configured explicitly for queries, requests, and responses
- Simplified RaamiProxyServlet to use Jetty 12 sync client API
- ObservableSupport: replaced internal HttpConnection.abort() with output stream close

Infrastructure

- CI actions renamed setup_java_11 → setup_java_17
- Docker image: adoptopenjdk/openjdk11 → amazoncorretto:17-alpine (pinned digest)
- JVM timezone set explicitly (-Duser.timezone=Europe/Helsinki) — Java 17 on Alpine/musl does not read /etc/localtime
correctly after apk del tzdata
- web.xml updated to Jakarta EE 6.0 schema

Scheduler fixes (pre-existing bugs)

- Release database leases in shutdown hooks — previously leases were never released on container stop, causing new
instances to wait for lease expiry during rolling deploys
- Added try/catch in WorkerLeaseElector.tick() to prevent silent executor death

Test changes

- Percent-encode non-ASCII chars in test HTTP client URLs
- Apache HC4 → HC5 migration in test infrastructure
- Timestamp precision truncated to microseconds (Java 17 nanoseconds vs PostgreSQL microseconds)
- Added regression tests for Jetty 12 configuration (URI handling, static resources, query encoding)

Test plan

- All backend tests pass in CI
- All frontend (Mocha) tests pass in CI
- Playwright and Valpas integration tests pass
- Deploy to QA and verify massaluovutus queries process immediately
- Verify date/time handling is correct (Helsinki timezone)
- Smoke test: login, browse oppija, create/edit opiskeluoikeus
- Verify PDF todistus generation works
- Verify /metrics endpoint responds