### PR TITLE
TOR-2606 Korjaa SDG lukio2019 osasuoritukset

### DIFF
--- a/src/main/scala/fi/oph/koski/sdg/SdgLukioSchema.scala
+++ b/src/main/scala/fi/oph/koski/sdg/SdgLukioSchema.scala
@@ -120,6 +120,8 @@ trait LukionOppimääränOsasuoritus2019 extends Osasuoritus
 case class SdgLukionOppiaineenSuoritus2019(
   koulutusmoduuli: schema.LukionOppiaine2019,
   arviointi: Option[List[SdgLukionArviointi]],
+  @SkipSerialization
+  suoritettuErityisenäTutkintona: Option[Boolean] = None,
   suorituskieli: Option[schema.Koodistokoodiviite],
   osasuoritukset: Option[List[LukionOppiaineenOsasuoritus2019]],
   @KoodistoKoodiarvo("lukionoppiaine")

--- a/src/test/scala/fi/oph/koski/sdg/KehaSDGSpec.scala
+++ b/src/test/scala/fi/oph/koski/sdg/KehaSDGSpec.scala
@@ -100,6 +100,27 @@ class KehaSDGSpec
     }
   }
 
+  "Lukio 2015 osasuoritukset tulevat läpi" in {
+    val hetu = KoskiSpecificMockOppijat.lukiolainen.hetu.get
+    postHetu(hetu) {
+      verifyResponseStatusOk()
+      val response = JsonSerializer.parse[SdgOppija](body)
+
+      val suoritus = response.opiskeluoikeudet
+        .flatMap(_.suoritukset)
+        .find(_.isInstanceOf[SdgLukionOppimääränSuoritus2015])
+        .getOrElse(fail("Suoritusta SdgLukionOppimääränSuoritus2015 ei löydy"))
+
+      val osasuoritukset = suoritus.osasuoritukset.getOrElse(fail("Osasuorituksia ei löydy"))
+      osasuoritukset should not be empty
+
+      val oppiaineet = osasuoritukset.collect { case o: SdgLukionOppiaineenSuoritus2015 => o }
+      withClue("Oppiaineet (SdgLukionOppiaineenSuoritus2015) puuttuvat osasuorituksista") {
+        oppiaineet should not be empty
+      }
+    }
+  }
+
   "Rajapinnan parametrit" in {
     val hetu = KoskiSpecificMockOppijat.ammattilainen.hetu.get
 

--- a/src/test/scala/fi/oph/koski/sdg/KehaSDGSpec.scala
+++ b/src/test/scala/fi/oph/koski/sdg/KehaSDGSpec.scala
@@ -77,6 +77,29 @@ class KehaSDGSpec
     }
   }
 
+  "Lukion osasuoritukset tulevat läpi" in {
+    val hetu = KoskiSpecificMockOppijat.uusiLukio.hetu.get
+    postHetu(hetu) {
+      verifyResponseStatusOk()
+      val response = JsonSerializer.parse[SdgOppija](body)
+
+      val suoritus = response.opiskeluoikeudet
+        .flatMap(_.suoritukset)
+        .find(_.tyyppi.koodiarvo == "lukionoppimaara")
+        .getOrElse(fail("Suoritusta tyyppiä lukionoppimaara ei löydy"))
+
+      val osasuoritukset = suoritus.osasuoritukset.getOrElse(fail("Osasuorituksia ei löydy"))
+      osasuoritukset should not be empty
+
+      val oppiaineet = osasuoritukset.collect { case o: SdgLukionOppiaineenSuoritus2019 => o }
+      withClue("Oppiaineet (SdgLukionOppiaineenSuoritus2019) puuttuvat osasuorituksista") {
+        oppiaineet should not be empty
+      }
+
+      body should not include ("\"suoritettuErityisenäTutkintona\"")
+    }
+  }
+
   "Rajapinnan parametrit" in {
     val hetu = KoskiSpecificMockOppijat.ammattilainen.hetu.get
 

--- a/src/test/scala/fi/oph/koski/sdg/KehaSDGSpec.scala
+++ b/src/test/scala/fi/oph/koski/sdg/KehaSDGSpec.scala
@@ -100,6 +100,40 @@ class KehaSDGSpec
     }
   }
 
+  "Lukio 2019: kaikki tuetut osasuoritustyypit tulevat läpi" in {
+    val hetu = KoskiSpecificMockOppijat.uusiLukio.hetu.get
+    postHetu(hetu) {
+      verifyResponseStatusOk()
+      val response = JsonSerializer.parse[SdgOppija](body)
+
+      val suoritus = response.opiskeluoikeudet
+        .flatMap(_.suoritukset)
+        .collect { case s: SdgLukionOppimääränSuoritus2019 => s }
+        .headOption
+        .getOrElse(fail("Suoritusta SdgLukionOppimääränSuoritus2019 ei löydy"))
+
+      val outer = suoritus.osasuoritukset.getOrElse(Nil)
+      val oppiaineet = outer.collect { case o: SdgLukionOppiaineenSuoritus2019 => o }
+      val muutOpinnot = outer.collect { case o: SdgMuidenLukioOpintojenSuoritus2019 => o }
+
+      withClue("SdgLukionOppiaineenSuoritus2019 puuttuu") { oppiaineet should not be empty }
+      withClue("SdgMuidenLukioOpintojenSuoritus2019 puuttuu") { muutOpinnot should not be empty }
+
+      val oppiaineInner = oppiaineet.flatMap(_.osasuoritukset.getOrElse(Nil))
+      withClue("SdgLukionModuulinSuoritusOppiaineissa2019 puuttuu oppiaineen alta") {
+        oppiaineInner.collect { case o: SdgLukionModuulinSuoritusOppiaineissa2019 => o } should not be empty
+      }
+
+      val muuInner = muutOpinnot.flatMap(_.osasuoritukset.getOrElse(Nil))
+      withClue("SdgLukionModuulinSuoritusMuissaOpinnoissa2019 puuttuu muun opinnon alta") {
+        muuInner.collect { case o: SdgLukionModuulinSuoritusMuissaOpinnoissa2019 => o } should not be empty
+      }
+      withClue("SdgLukionPaikallisenOpintojaksonSuoritus2019 puuttuu muun opinnon alta") {
+        muuInner.collect { case o: SdgLukionPaikallisenOpintojaksonSuoritus2019 => o } should not be empty
+      }
+    }
+  }
+
   "Lukio 2015 osasuoritukset tulevat läpi" in {
     val hetu = KoskiSpecificMockOppijat.lukiolainen.hetu.get
     postHetu(hetu) {


### PR DESCRIPTION
SdgLukionOppiaineenSuoritus2019 was missing the suoritettuErityisenäTutkintona
field that Koski's LukionOppiaineenSuoritus2019 always serializes to the DB. During
AnyOf discrimination for the LukionOppimääränOsasuoritus2019 trait the candidate
case class was rejected because of the unexpected property, and
ignoreNonValidatingListItems=true then silently dropped every oppiaine — leaving
osasuoritukset as an empty list in the SDG response.

Add the field as Option[Boolean] with @SkipSerialization so it is accepted on
input but kept out of both the response JSON and the published schema.

Also strengthen the existing "Lukion osasuoritukset tulevat läpi" test to assert
that SdgLukionOppiaineenSuoritus2019 items are actually present (the earlier
assertion passed on lukionmuuopinto items alone) and that
suoritettuErityisenäTutkintona does not leak into the body.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
