### PR TITLE
TOR-2585: Enable frozen-lockfile in all npm subprojects

### DIFF
--- a/omadata-oauth2-sample/server/.npmrc
+++ b/omadata-oauth2-sample/server/.npmrc
@@ -1,4 +1,4 @@
-frozen-lockfile=false
+frozen-lockfile=true
 
 # Avoid too-fresh packages (minutes since released)
 minimum-release-age=4320

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,9 @@
     ":preserveSemverRanges"
   ],
   "osvVulnerabilityAlerts": true,
+  "env": {
+    "npm_config_frozen_lockfile": "false"
+  },
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": [

--- a/smoketests/.npmrc
+++ b/smoketests/.npmrc
@@ -1,4 +1,4 @@
-frozen-lockfile=false
+frozen-lockfile=true
 
 # Avoid too-fresh packages (stability)
 minimum-release-age=4320

--- a/valpas-web/.npmrc
+++ b/valpas-web/.npmrc
@@ -1,6 +1,6 @@
 engine-strict=false
 
-frozen-lockfile=false
+frozen-lockfile=true
 
 # Avoid too-fresh packages (minutes since released)
 minimum-release-age=4320

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,6 +1,6 @@
 engine-strict=false
 
-frozen-lockfile=false
+frozen-lockfile=true
 
 # Avoid too-fresh packages (minutes since released)
 minimum-release-age=4320


### PR DESCRIPTION
Set frozen-lockfile=true in every subproject's .npmrc so that local
pnpm install cannot silently drift the lockfile. CI already passes
the flag explicitly via PNPM_FROZEN_FLAG, so its behaviour is
unchanged.

Renovate needs to refresh lockfiles for its lockFileMaintenance PRs,
so override the setting via npm_config_frozen_lockfile=false in
renovate.json's env config (env vars beat .npmrc).

This reverses commit df10c35f, which had disabled frozen-lockfile in
.npmrc to unblock Renovate. The env override is the cleaner way to
give Renovate that bypass without weakening dev defaults.

Caveat: Mend-hosted Renovate restricts which env vars can be set via
the env option (allowedEnv allowlist). If Renovate's lockFileMaintenance
PRs still fail with ERR_PNPM_NO_LOCKFILE after this change, the
npm_config_frozen_lockfile variable likely needs to be allowlisted on
the Mend side - contact Mend support or revisit the approach.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
