### PR TITLE
TOR-2585: Revert frozen-lockfile to false in subprojects

### DIFF
--- a/omadata-oauth2-sample/server/.npmrc
+++ b/omadata-oauth2-sample/server/.npmrc
@@ -1,4 +1,4 @@
-frozen-lockfile=true
+frozen-lockfile=false
 
 # Avoid too-fresh packages (minutes since released)
 minimum-release-age=4320

--- a/radiator/.npmrc
+++ b/radiator/.npmrc
@@ -1,5 +1,5 @@
 # Deterministic installs
-frozen-lockfile=true
+frozen-lockfile=false
 
 # Avoid too-fresh packages (minutes since released)
 minimum-release-age=4320

--- a/renovate.json
+++ b/renovate.json
@@ -5,9 +5,6 @@
     ":preserveSemverRanges"
   ],
   "osvVulnerabilityAlerts": true,
-  "env": {
-    "npm_config_frozen_lockfile": "false"
-  },
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": [

--- a/scripts/opiskeluoikeushistoria-debug/.npmrc
+++ b/scripts/opiskeluoikeushistoria-debug/.npmrc
@@ -1,5 +1,5 @@
 # Deterministic installs
-frozen-lockfile=true
+frozen-lockfile=false
 
 # Avoid too-fresh packages (minutes since released)
 minimum-release-age=4320

--- a/smoketests/.npmrc
+++ b/smoketests/.npmrc
@@ -1,4 +1,4 @@
-frozen-lockfile=true
+frozen-lockfile=false
 
 # Avoid too-fresh packages (stability)
 minimum-release-age=4320

--- a/valpas-web/.npmrc
+++ b/valpas-web/.npmrc
@@ -1,6 +1,6 @@
 engine-strict=false
 
-frozen-lockfile=true
+frozen-lockfile=false
 
 # Avoid too-fresh packages (minutes since released)
 minimum-release-age=4320

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,6 +1,6 @@
 engine-strict=false
 
-frozen-lockfile=true
+frozen-lockfile=false
 
 # Avoid too-fresh packages (minutes since released)
 minimum-release-age=4320


### PR DESCRIPTION
Mend-hosted Renovate rejects the env block from the previous commit
because npm_config_frozen_lockfile is not in its allowedEnv allowlist.
The invalid config caused Renovate to stop processing all PRs and
opened issue #4099.

Revert to the original approach: set frozen-lockfile=false in every
subproject .npmrc and remove the env block. This restores the policy
established by df10c35f and additionally aligns the two stragglers
(radiator, scripts/opiskeluoikeushistoria-debug) that were missed
back then, which was the original artifact failure on PR #4096.

Lockfile integrity in CI continues to be enforced by the explicit
--frozen-lockfile CLI flag in the GitHub Actions workflows (see
PNPM_FROZEN_FLAG), which conditionally switches to --no-frozen-lockfile
only for renovate[bot] PRs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
