### PR TITLE
TOR-2600 Korjaa supa audilogitusta

### DIFF
--- a/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/SuorituspalveluQuery.scala
+++ b/src/main/scala/fi/oph/koski/massaluovutus/suorituspalvelu/SuorituspalveluQuery.scala
@@ -37,13 +37,8 @@ trait SuorituspalveluQuery extends OpetushallituksenMassaluovutusQueryParameters
           val responseOpiskeluoikeudet = response.collect { case Right(oo) => oo }
           val responseVirheellisetOpiskeluoikeudet = response.collect { case Left(virheellinenOo) => virheellinenOo }
 
-          responseOpiskeluoikeudet.foreach { oo =>
-            SuorituspalveluQuery.auditLog(oppija_oid, oo.oid, None)
-          }
-
-          responseVirheellisetOpiskeluoikeudet.foreach { virheellinenOo =>
-            SuorituspalveluQuery.auditLog(oppija_oid, virheellinenOo.oid, None)
-          }
+          val auditLogOidit = responseOpiskeluoikeudet.map(_.oid) ++ responseVirheellisetOpiskeluoikeudet.map(_.oid)
+          SuorituspalveluQuery.auditLog(oppija_oid, auditLogOidit)
 
           Some(
             SupaResponse(
@@ -148,20 +143,20 @@ object SuorituspalveluQuery {
     "perusopetukseenvalmistavaopetus",
   )
 
-  def auditLog(oppijaOid: String, opiskeluoikeusOid: String, versionumero: Option[Int])(implicit user: Session): Unit =
-    AuditLog
-      .log(
-        KoskiAuditLogMessage(
-          KoskiOperation.SUORITUSPALVELU_OPISKELUOIKEUS_HAKU,
-          user,
-          (
-            Map(
-              KoskiAuditLogMessageField.oppijaHenkiloOid -> oppijaOid,
-              KoskiAuditLogMessageField.opiskeluoikeusOid -> opiskeluoikeusOid,
-            ) ++ versionumero.map(v => Map(
-              KoskiAuditLogMessageField.opiskeluoikeusVersio -> v.toString
-            )).getOrElse(Map.empty[AuditLogMessageField, String])
-          ).toMap
-        )
+  def auditLog(oppijaOid: String, opiskeluoikeusOidit: Seq[String], versionumero: Option[Int] = None)(implicit user: Session): Unit = {
+    val base: AuditLogMessage.ExtraFields = Map(KoskiAuditLogMessageField.oppijaHenkiloOid -> oppijaOid)
+    val withOidit =
+      if (opiskeluoikeusOidit.nonEmpty) base + (KoskiAuditLogMessageField.opiskeluoikeusOid -> opiskeluoikeusOidit.mkString(","))
+      else base
+    val fields = withOidit ++ versionumero.map(v =>
+      Map(KoskiAuditLogMessageField.opiskeluoikeusVersio -> v.toString)
+    ).getOrElse(Map.empty[AuditLogMessageField, String])
+    AuditLog.log(
+      KoskiAuditLogMessage(
+        KoskiOperation.SUORITUSPALVELU_OPISKELUOIKEUS_HAKU,
+        user,
+        fields
       )
+    )
+  }
 }

--- a/src/main/scala/fi/oph/koski/supa/SupaServlet.scala
+++ b/src/main/scala/fi/oph/koski/supa/SupaServlet.scala
@@ -60,7 +60,7 @@ class SupaServlet(implicit val application: KoskiApplication)
       ))
 
     supaVersioResponse.foreach { response =>
-      SuorituspalveluQuery.auditLog(response.oppijaOid, response.opiskeluoikeus.oid, response.opiskeluoikeus.versionumero)
+      SuorituspalveluQuery.auditLog(response.oppijaOid, List(response.opiskeluoikeus.oid), response.opiskeluoikeus.versionumero)
     }
 
     renderEither[SupaOpiskeluoikeudenVersioResponse](supaVersioResponse)

--- a/src/test/scala/fi/oph/koski/massaluovutus/MassaluovutusSpec.scala
+++ b/src/test/scala/fi/oph/koski/massaluovutus/MassaluovutusSpec.scala
@@ -601,19 +601,17 @@ class MassaluovutusSpec extends AnyFreeSpec with MassaluovutusTestMethods with M
           verifyResultAndContent(complete.files.last, user) {
             val json = JsonMethods.parse(body)
             val oos = json.asInstanceOf[JArray]
-            oos.arr.map(v =>
-              (
-                (v \ "oppijaOid").extract[String],
-                (v \ "opiskeluoikeudet").extract[List[JObject]].lastOption.map(oo => (oo \ "oid").extract[String])
-                  .orElse((v \ "virheellisetOpiskeluoikeudet").extract[List[JObject]].lastOption.map(oo => (oo \ "oid").extract[String]))
-                  .get
-              )
-            ).last match {
-              case (oppijaOid, opiskeluoikeusOid) => AuditLogTester.verifyLastAuditLogMessageForOperation(Map(
+            oos.arr.map { v =>
+              val oppijaOid = (v \ "oppijaOid").extract[String]
+              val ooOidit = (v \ "opiskeluoikeudet").extract[List[JObject]].map(oo => (oo \ "oid").extract[String])
+              val virheellisetOidit = (v \ "virheellisetOpiskeluoikeudet").extractOpt[List[JObject]].getOrElse(Nil).map(oo => (oo \ "oid").extract[String])
+              (oppijaOid, (ooOidit ++ virheellisetOidit).mkString(","))
+            }.last match {
+              case (oppijaOid, opiskeluoikeusOidit) => AuditLogTester.verifyLastAuditLogMessageForOperation(Map(
                 "operation" -> "SUORITUSPALVELU_OPISKELUOIKEUS_HAKU",
                 "target" -> Map(
                   "oppijaHenkiloOid" -> oppijaOid,
-                  "opiskeluoikeusOid" -> opiskeluoikeusOid,
+                  "opiskeluoikeusOid" -> opiskeluoikeusOidit,
                 ),
               ))
             }
@@ -1043,17 +1041,17 @@ class MassaluovutusSpec extends AnyFreeSpec with MassaluovutusTestMethods with M
           verifyResultAndContent(complete.files.last, user) {
             val json = JsonMethods.parse(body)
             val oos = json.asInstanceOf[JArray]
-            oos.arr.map(v =>
-              (
-                (v \ "oppijaOid").extract[String],
-                (v \ "opiskeluoikeudet").extract[List[JObject]].lastOption.map(oo => (oo \ "oid").extract[String]).getOrElse("")
-              )
-            ).last match {
-              case (oppijaOid, opiskeluoikeusOid) => AuditLogTester.verifyLastAuditLogMessageForOperation(Map(
+            oos.arr.map { v =>
+              val oppijaOid = (v \ "oppijaOid").extract[String]
+              val ooOidit = (v \ "opiskeluoikeudet").extract[List[JObject]].map(oo => (oo \ "oid").extract[String])
+              val virheellisetOidit = (v \ "virheellisetOpiskeluoikeudet").extractOpt[List[JObject]].getOrElse(Nil).map(oo => (oo \ "oid").extract[String])
+              (oppijaOid, (ooOidit ++ virheellisetOidit).mkString(","))
+            }.last match {
+              case (oppijaOid, opiskeluoikeusOidit) => AuditLogTester.verifyLastAuditLogMessageForOperation(Map(
                 "operation" -> "SUORITUSPALVELU_OPISKELUOIKEUS_HAKU",
                 "target" -> Map(
                   "oppijaHenkiloOid" -> oppijaOid,
-                  "opiskeluoikeusOid" -> opiskeluoikeusOid,
+                  "opiskeluoikeusOid" -> opiskeluoikeusOidit,
                 ),
               ))
             }


### PR DESCRIPTION
Previously SuorituspalveluQuery.run wrote one audit row per opiskeluoikeus
per oppija. Refactor SuorituspalveluQuery.auditLog to take a Seq of
opiskeluoikeus-OIDs and log a single row per oppija with the OIDs joined
by comma in the existing opiskeluoikeusOid field, matching the pattern
used by KIOS_OPISKELUOIKEUS_HAKU in KiosServlet.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
