### PR TITLE
TOR-2610 Korjaa flaky auditlog testi

### DIFF
--- a/src/test/scala/fi/oph/koski/log/AuditLogTester.scala
+++ b/src/test/scala/fi/oph/koski/log/AuditLogTester.scala
@@ -62,6 +62,13 @@ object AuditLogTester extends Matchers with LogTester {
       throw new IllegalStateException("Audit log message found, expected none")
     }
 
+  def verifyNoAuditLogMessagesForOperation(operation: String): Unit = {
+    val matching = filteredMessagesByOperation(Map("operation" -> operation))
+    if (matching.nonEmpty) {
+      throw new IllegalStateException(s"Expected no audit log messages for operation '$operation' but found: ${matching.mkString(", ")}")
+    }
+  }
+
   private def verifyAuditLogObject(msg: JObject, params: Map[String, Any]): Unit = {
     implicit val formats: Formats = GenericJsonFormats.genericFormats
     withClue(s"Audit log message: $msg | Expected: $params") {

--- a/src/test/scala/fi/oph/koski/todistus/TodistusAuditLogSpec.scala
+++ b/src/test/scala/fi/oph/koski/todistus/TodistusAuditLogSpec.scala
@@ -220,9 +220,8 @@ class TodistusAuditLogSpec extends TodistusSpecHelpers {
         }
 
         // Vain KANSALAINEN_LOGIN-loki pitäisi löytyä, ei TODISTUKSEN_LATAAMINEN-lokia
-        val logMessages = AuditLogTester.getLogMessages
-        logMessages.length should equal(1)
-        AuditLogTester.verifyLastAuditLogMessageForOperation(Map(
+        AuditLogTester.verifyNoAuditLogMessagesForOperation(KoskiOperation.TODISTUKSEN_LATAAMINEN.toString)
+        AuditLogTester.verifyOnlyAuditLogMessageForOperation(Map(
           "operation" -> KoskiOperation.KANSALAINEN_LOGIN.toString
         ))
       }


### PR DESCRIPTION
The assertion `getLogMessages.length should equal(1)` counted ALL audit
log messages, so the background `KielitutkintotodistusTiedoteScheduler`
(runs every 5s in tests, emits TIEDOTE_LAHETETTY) intermittently pushed
the count to 2.

`withoutRunningSchedulers` only suspends the todistus and cleanup
schedulers, not the tiedote scheduler. Commit 054eb05caa fixed the same
flakiness class for sibling tests by switching to operation-filtered
helpers, but missed this raw length check.

Replace with two filtered assertions that capture the test's actual
intent: no TODISTUKSEN_LATAAMINEN was emitted, and exactly one
KANSALAINEN_LOGIN was logged. Adds a `verifyNoAuditLogMessagesForOperation`
helper to AuditLogTester for the negative check.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
