### PR TITLE
TOR-2566 RDS IAM auth via AWS Advanced JDBC Wrapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
     <dependency>
       <groupId>com.typesafe</groupId>
       <artifactId>config</artifactId>
-      <version>1.4.8</version>
+      <version>1.4.7</version>
     </dependency>
     <dependency>
       <groupId>org.http4s</groupId>
@@ -399,7 +399,7 @@
     <dependency>
       <groupId>com.amazonaws.secretsmanager</groupId>
       <artifactId>aws-secretsmanager-jdbc</artifactId>
-      <version>2.1.1</version>
+      <version>2.1.0</version>
     </dependency>
     <!-- PDF generation deps -->
     <dependency>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -12,7 +12,13 @@ db = {
   registerMbeans = true
   initializationFailFast = true
   driverClassName=org.postgresql.Driver
-  // Properties to be passed to the PostgreSQL JDBC driver
+  // Properties to be passed to the PostgreSQL JDBC driver.
+  //
+  // socketTimeout is in SECONDS in all dbs.* properties blocks. This matches
+  // what plain postgres JDBC expects (used in local dev). The AWS Advanced
+  // JDBC Wrapper used in server environments expects MILLISECONDS — the
+  // conversion is done in code (DatabaseConfig.configForSlick) when
+  // useIamAuth=true, so the value here stays in human-friendly seconds.
   properties = {
     socketTimeout = 60
   }

--- a/src/main/scala/fi/oph/koski/config/SecretsManager.scala
+++ b/src/main/scala/fi/oph/koski/config/SecretsManager.scala
@@ -11,13 +11,6 @@ import java.time.{Duration, Instant}
 import java.util.concurrent.ConcurrentHashMap
 import scala.reflect.runtime.universe._
 
-case class DatabaseConnectionConfig(
-  host: String,
-  port: Int,
-  username: String,
-  password: String
-) extends NotLoggable
-
 object SecretsManager extends Logging {
   private val ttl: Duration = Duration.ofHours(1)
 
@@ -44,9 +37,6 @@ object SecretsManager extends Logging {
 }
 
 class SecretsManager extends Logging {
-  def getDatabaseSecret(secretId: String): DatabaseConnectionConfig =
-    getStructuredSecret[DatabaseConnectionConfig](secretId)
-
   def getStructuredSecret[T: TypeTag](secretId: String): T = {
     logger.debug(s"Searching for secret $secretId")
     JsonSerializer.extract[T](parse(getSecretString(secretId)), ignoreExtras = true)

--- a/src/main/scala/fi/oph/koski/db/DatabaseConfig.scala
+++ b/src/main/scala/fi/oph/koski/db/DatabaseConfig.scala
@@ -109,9 +109,16 @@ trait DatabaseConfig extends NotLoggable with Logging {
 
   private final def configForSlick(): Config = {
     if (useIamAuth) {
+      // The AWS Advanced JDBC Wrapper expects socketTimeout in milliseconds
+      // (it does TimeUnit.toSeconds(value) before forwarding to postgres
+      // JDBC's setSocketTimeout). Our reference.conf has socketTimeout in
+      // seconds — the natural unit for plain postgres JDBC used in local
+      // dev. Convert here, only on the IAM-auth path.
+      val socketTimeoutMs = config.getInt("properties.socketTimeout") * 1000
       config
         .withValue("driverClassName", fromAnyRef("software.amazon.jdbc.Driver"))
         .withValue("password", fromAnyRef(""))
+        .withValue("properties.socketTimeout", fromAnyRef(socketTimeoutMs))
         .withValue("url", fromAnyRef(url(useIamProtocol = true)))
     } else {
       config.withValue("url", fromAnyRef(url(useIamProtocol = false)))

--- a/src/main/scala/fi/oph/koski/db/DatabaseConfig.scala
+++ b/src/main/scala/fi/oph/koski/db/DatabaseConfig.scala
@@ -2,41 +2,23 @@ package fi.oph.koski.db
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigValueFactory._
-import fi.oph.koski.config.{Environment, FluentConfig, SecretsManager}
+import fi.oph.koski.config.{Environment, FluentConfig}
 import fi.oph.koski.log.{Logging, NotLoggable}
 import fi.oph.koski.raportointikanta.Schema
 import slick.jdbc.PostgresProfile
 
-
-object DatabaseConfig {
-  val EnvVarForKoskiDbSecret = "DB_KOSKI_SECRET_ID"
-  val EnvVarForRaportointiDbSecret = "DB_RAPORTOINTI_SECRET_ID"
-}
-
 class KoskiDatabaseConfig(val rootConfig: Config) extends DatabaseConfig {
-  override val envVarForSecretId: String = DatabaseConfig.EnvVarForKoskiDbSecret
-
   override protected def databaseSpecificConfig: Config = rootConfig.getConfig("dbs.koski")
+
+  override protected def iamHostEnvVar: Option[String] = Some("DB_KOSKI_HOST")
 
   override def migrationLocations: Option[String] = Some("db.migration")
 }
 
 class KoskiReplicaConfig(val rootConfig: Config) extends DatabaseConfig {
-  override val envVarForSecretId: String = DatabaseConfig.EnvVarForKoskiDbSecret
-
   override protected def databaseSpecificConfig: Config = rootConfig.getConfig("dbs.replica")
 
-  override protected def makeConfig(): Config = {
-    if (useSecretsManager) {
-      val host = sys.env.getOrElse(
-        "DB_KOSKI_REPLICA_HOST",
-        throw new RuntimeException("Secrets manager enabled for DB secrets but environment variable DB_KOSKI_REPLICA_HOST not set")
-      )
-      super.makeConfig().withValue("host", fromAnyRef(host))
-    } else {
-      super.makeConfig()
-    }
-  }
+  override protected def iamHostEnvVar: Option[String] = Some("DB_KOSKI_REPLICA_HOST")
 }
 
 trait RaportointiDatabaseConfigBase extends DatabaseConfig {
@@ -47,29 +29,29 @@ trait RaportointiDatabaseConfigBase extends DatabaseConfig {
 }
 
 class RaportointiDatabaseConfig(val rootConfig: Config, val schema: Schema) extends RaportointiDatabaseConfigBase {
-  override val envVarForSecretId: String = DatabaseConfig.EnvVarForRaportointiDbSecret
-
   override protected def databaseSpecificConfig: Config =
     rootConfig.getConfig("dbs.raportointi")
       .withValue("poolName", fromAnyRef(s"koskiRaportointiPool-${schema.name}"))
+
+  override protected def iamHostEnvVar: Option[String] = Some("DB_RAPORTOINTI_HOST")
 
   def withSchema(schema: Schema): RaportointiDatabaseConfig = new RaportointiDatabaseConfig(rootConfig, schema)
 }
 
 class RaportointiGenerointiDatabaseConfig(val rootConfig: Config, val schema: Schema) extends RaportointiDatabaseConfigBase {
-  override val envVarForSecretId: String = DatabaseConfig.EnvVarForRaportointiDbSecret
-
   override protected def databaseSpecificConfig: Config =
     rootConfig.getConfig("dbs.raportointiGenerointi")
       .withValue("poolName", fromAnyRef(s"koskiRaportointiGenerointiPool-${schema.name}"))
+
+  override protected def iamHostEnvVar: Option[String] = Some("DB_RAPORTOINTI_HOST")  // same RDS instance as raportointi
 
   def withSchema(schema: Schema): RaportointiGenerointiDatabaseConfig = new RaportointiGenerointiDatabaseConfig(rootConfig, schema)
 }
 
 class ValpasDatabaseConfig(val rootConfig: Config) extends DatabaseConfig {
-  override val envVarForSecretId: String = DatabaseConfig.EnvVarForKoskiDbSecret // Samalla instanssilla kuin pääkanta
-
   override protected def databaseSpecificConfig: Config = rootConfig.getConfig("dbs.valpas")
+
+  override protected def iamHostEnvVar: Option[String] = Some("DB_KOSKI_HOST")  // same RDS instance as koski master
 
   override def migrationLocations: Option[String] = Some("valpas.migration")
 }
@@ -77,29 +59,17 @@ class ValpasDatabaseConfig(val rootConfig: Config) extends DatabaseConfig {
 trait DatabaseConfig extends NotLoggable with Logging {
   val rootConfig: Config
 
-  protected val envVarForSecretId: String
-
-  protected final val useSecretsManager: Boolean = Environment.usesAwsSecretsManager
+  // Reads USE_SECRETS_MANAGER env var (kept for infra compat, also gates non-DB callers).
+  final val useIamAuth: Boolean = Environment.usesAwsSecretsManager
 
   protected def databaseSpecificConfig: Config
 
-  private final def sharedConfig: Config = rootConfig.getConfig("db")
+  // Env var that overrides the host when IAM auth is on. CDK populates these in server
+  // environments (it knows the RDS endpoints). None means "no override" — local dev keeps
+  // host = "localhost" from reference.conf since useIamAuth is false there anyway.
+  protected def iamHostEnvVar: Option[String] = None
 
-  private final def configWithSecrets(config: Config): Config = {
-    if (useSecretsManager) {
-      val secretsClient = new SecretsManager()
-      val secretId = secretsClient.getSecretId("Koski DB secrets", envVarForSecretId)
-      val secretConfig = secretsClient.getDatabaseSecret(secretId)
-      config
-        .withValue("host", fromAnyRef(secretConfig.host))
-        .withValue("port", fromAnyRef(secretConfig.port))
-        .withValue("user", fromAnyRef(secretConfig.username))
-        .withValue("password", fromAnyRef(secretConfig.password))
-        .withValue("secretId", fromAnyRef(secretId))
-    } else {
-      config
-    }
-  }
+  private final def sharedConfig: Config = rootConfig.getConfig("db")
 
   private final def configWithTestDb(config: Config): Config = {
     if (Environment.isUnitTestEnvironment(rootConfig)) {
@@ -110,24 +80,33 @@ trait DatabaseConfig extends NotLoggable with Logging {
     }
   }
 
+  private final def configForIamAuth(config: Config): Config = {
+    if (useIamAuth) {
+      val host = iamHostEnvVar.flatMap(sys.env.get).getOrElse(config.getString("host"))
+      config
+        .withValue("host", fromAnyRef(host))
+        .withValue("user", fromAnyRef("koski_iam"))
+    } else {
+      config
+    }
+  }
+
   protected def makeConfig(): Config = {
     databaseSpecificConfig
       .withFallback(sharedConfig)
-      .andThen(configWithSecrets)
+      .andThen(configForIamAuth)
       .andThen(configWithTestDb)
   }
 
   private final def configForSlick(): Config = {
-    (if (useSecretsManager) {
-      // Secrets Manager JDBC-ajuri haluaa käyttäjänimenä secret ID:n. Korvataan
-      // konfiguraation käyttäjänimi vasta tässä vaiheessa, jotta konfiguraatio
-      // toimii myös Flywayn käyttämän tavallisen JDBC-ajurin kanssa.
+    if (useIamAuth) {
       config
-        .withValue("user", config.getValue("secretId"))
-        .withValue("driverClassName", fromAnyRef("com.amazonaws.secretsmanager.sql.AWSSecretsManagerPostgreSQLDriver"))
+        .withValue("driverClassName", fromAnyRef("software.amazon.jdbc.Driver"))
+        .withValue("password", fromAnyRef(""))
+        .withValue("url", fromAnyRef(url(useIamProtocol = true)))
     } else {
-      config
-    }).withValue("url", fromAnyRef(url(useSecretsManagerProtocol = useSecretsManager)))
+      config.withValue("url", fromAnyRef(url(useIamProtocol = false)))
+    }
   }
 
   private final lazy val config: Config = makeConfig()
@@ -142,18 +121,20 @@ trait DatabaseConfig extends NotLoggable with Logging {
 
   final def user: String = config.getString("user")
 
-  final def password: String = config.getString("password")
+  final def password: String = if (useIamAuth) "" else config.getString("password")
 
-  final def url(useSecretsManagerProtocol: Boolean): String = {
-    val protocol = if (useSecretsManagerProtocol) {
-      "jdbc-secretsmanager:postgresql"
+  final def url(useIamProtocol: Boolean): String = {
+    if (useIamProtocol) {
+      // Pair IAM auth with SSL in the URL so both Slick and Flyway see the params
+      // (Flyway's setDataSource(url, user, password) overload doesn't accept Properties).
+      // RDS IAM requires TLS; ssl=true&sslmode=require enforces it for any consumer of this URL.
+      s"jdbc:aws-wrapper:postgresql://${host}:${port}/${dbname}?wrapperPlugins=iam&ssl=true&sslmode=require"
     } else {
-      "jdbc:postgresql"
+      s"jdbc:postgresql://${host}:${port}/${dbname}"
     }
-    s"$protocol://${host}:${port}/${dbname}"
   }
 
-  final def isLocal: Boolean = host == "localhost" && !useSecretsManager
+  final def isLocal: Boolean = host == "localhost" && !useIamAuth
 
   final def toSlickDatabase: DB = {
     logger.info(s"Using database $dbname")

--- a/src/main/scala/fi/oph/koski/db/DatabaseConfig.scala
+++ b/src/main/scala/fi/oph/koski/db/DatabaseConfig.scala
@@ -82,7 +82,16 @@ trait DatabaseConfig extends NotLoggable with Logging {
 
   private final def configForIamAuth(config: Config): Config = {
     if (useIamAuth) {
-      val host = iamHostEnvVar.flatMap(sys.env.get).getOrElse(config.getString("host"))
+      val host = iamHostEnvVar match {
+        case Some(envVarName) =>
+          sys.env.getOrElse(envVarName,
+            throw new RuntimeException(
+              s"IAM auth is enabled but env var $envVarName is not set"
+            )
+          )
+        case None =>
+          config.getString("host")
+      }
       config
         .withValue("host", fromAnyRef(host))
         .withValue("user", fromAnyRef("koski_iam"))

--- a/src/main/scala/fi/oph/koski/db/Migration.scala
+++ b/src/main/scala/fi/oph/koski/db/Migration.scala
@@ -2,6 +2,7 @@ package fi.oph.koski.db
 
 import fi.oph.koski.log.Logging
 import org.flywaydb.core.Flyway
+import org.flywaydb.core.internal.util.jdbc.DriverDataSource
 
 object Migration extends Logging {
   def migrateSchema(config: DatabaseConfig): Unit = {
@@ -19,9 +20,21 @@ object Migration extends Logging {
   private def createFlyway(config: DatabaseConfig, locations: String) = {
     val flyway = new Flyway
     flyway.setLocations(locations)
-    flyway.setDataSource(config.url(useSecretsManagerProtocol = false), config.user, config.password)
+    // Flyway's 3-arg setDataSource autodetects the driver from the URL prefix
+    // using a hardcoded list, which doesn't include the AWS Wrapper's
+    // jdbc:aws-wrapper:postgresql:// scheme. Provide the driver class explicitly.
+    flyway.setDataSource(new DriverDataSource(
+      Thread.currentThread.getContextClassLoader,
+      driverClassFor(config),
+      config.url(useIamProtocol = config.useIamAuth),
+      config.user,
+      config.password
+    ))
     flyway.setSchemas(config.schemaName)
     flyway.setValidateOnMigrate(false)
     flyway
   }
+
+  private def driverClassFor(config: DatabaseConfig): String =
+    if (config.useIamAuth) "software.amazon.jdbc.Driver" else "org.postgresql.Driver"
 }


### PR DESCRIPTION
Migrates Koski's DB connections off AWS SDK v1 (`aws-secretsmanager-jdbc`) to RDS IAM authentication via the [AWS Advanced JDBC Wrapper](https://github.com/awslabs/aws-advanced-jdbc-wrapper). Server environments now authenticate as a dedicated DB user with short-lived AWS-signed tokens instead of a rotated password fetched from Secrets Manager. Local dev path is unchanged.