### PR TITLE
TOR-2620 Konfiguroi ytr s3 client eksplisiittisesti

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -348,6 +348,11 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
+      <artifactId>apache-client</artifactId>
+      <version>${awssdk.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
       <artifactId>eventbridge</artifactId>
       <version>${awssdk.version}</version>
     </dependency>

--- a/src/main/scala/fi/oph/koski/ytr/YoTodistusService.scala
+++ b/src/main/scala/fi/oph/koski/ytr/YoTodistusService.scala
@@ -5,6 +5,7 @@ import fi.oph.koski.http.{HttpStatus, KoskiErrorCategory}
 import fi.oph.koski.log.Logging
 import fi.oph.koski.util.Streams
 import fi.oph.koski.ytr.MockYtrClient.yoTodistusResource
+import software.amazon.awssdk.core.exception.SdkClientException
 import software.amazon.awssdk.core.sync.ResponseTransformer
 import software.amazon.awssdk.services.s3.{S3Client, S3Utilities}
 import software.amazon.awssdk.services.s3.model.{GetObjectRequest, GetObjectResponse}
@@ -64,6 +65,9 @@ class RemoteYoTodistusService(application: KoskiApplication, config: YtrS3Config
         objectRequest(req.certificateUrl),
         ResponseTransformer.toOutputStream[GetObjectResponse](output),
       )
+    } catch {
+      case e: SdkClientException if e.getMessage != null && e.getMessage.contains("Broken pipe") =>
+        logger.warn(s"getCertificate: client disconnected during download of $req")
     } finally {
       logger.info(s"getCertificate end $req")
       output.flush()

--- a/src/main/scala/fi/oph/koski/ytr/YtrS3.scala
+++ b/src/main/scala/fi/oph/koski/ytr/YtrS3.scala
@@ -4,11 +4,13 @@ import com.typesafe.config.Config
 import fi.oph.koski.config.{Environment, KoskiApplication, SecretsManager}
 import fi.oph.koski.log.NotLoggable
 import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+import software.amazon.awssdk.http.apache.ApacheHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sts.StsClient
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
+
 
 case class YtrS3Config(accessKeyId: String, secretAccessKey: String, roleArn: String, externalId: String, bucket: String) extends NotLoggable
 
@@ -22,7 +24,20 @@ class YtrS3(config: YtrS3Config) {
     .roleSessionName("koski-ytr-role")
     .build
 
-  private val stsClient: StsClient = StsClient.builder.region(Region.EU_WEST_1).credentialsProvider(credentials).build
+  private val httpClient = ApacheHttpClient.builder()
+    .maxConnections(150)
+    .build()
+
+  // Separate pool so STS token refresh doesn't compete with S3 downloads
+  private val stsHttpClient = ApacheHttpClient.builder()
+    .maxConnections(10)
+    .build()
+
+  private val stsClient: StsClient = StsClient.builder
+    .region(Region.EU_WEST_1)
+    .credentialsProvider(credentials)
+    .httpClient(stsHttpClient)
+    .build
 
   private val assumeRole = StsAssumeRoleCredentialsProvider.builder
     .stsClient(stsClient)
@@ -31,7 +46,11 @@ class YtrS3(config: YtrS3Config) {
 
   val bucket: String = ytrS3Bucket
 
-  val client: S3Client = S3Client.builder.region(Region.EU_NORTH_1).credentialsProvider(assumeRole).build
+  val client: S3Client = S3Client.builder
+    .region(Region.EU_NORTH_1)
+    .credentialsProvider(assumeRole)
+    .httpClient(httpClient)
+    .build
 }
 
 object YtrS3Config {


### PR DESCRIPTION
Investigated SdkClientException: Unable to unmarshall response (Broken pipe) errors appearing in CloudWatch during YO certificate downloads by citizens.

Root cause: The S3 SDK streams the PDF directly from YTR's S3 bucket to the citizen's HTTP response output stream (ResponseTransformer.toOutputStream). When a citizen's connection drops mid-download (mobile network loss, closing the browser), Jetty closes the output stream and the SDK throws SdkClientException wrapping the broken pipe. This is expected behaviour, not an S3 error, but was surfacing as an unhandled exception.

Changes:
  - Catch SdkClientException caused by broken pipe in RemoteYoTodistusService.download and log as WARN instead of letting it propagate as an error
  - Switch YtrS3 to use Apache HTTP client explicitly, with a pool of 150 connections for S3 and a separate 10-connection pool for STS — prevents token refresh operations from competing with active downloads under load

Not done / known limitation: The ideal fix would be presigned S3 URLs so the PDF is delivered directly from S3 to the citizen without proxying through our server, eliminating the broken pipe scenario entirely. This requires changes on the YTR side and is out of scope here.