### PR TITLE
TOR-2622: Lisää lukuvuosimaksu-rahoitusmuoto DIA- ja ISH-opiskeluoike…

### DIFF
--- a/src/main/scala/fi/oph/koski/schema/DIA.scala
+++ b/src/main/scala/fi/oph/koski/schema/DIA.scala
@@ -57,9 +57,10 @@ case class DIAOpiskeluoikeudenTila(
 case class DIAOpiskeluoikeusjakso(
   alku: LocalDate,
   tila: Koodistokoodiviite,
-  @Description("Opintojen rahoitus. Mikäli kyseessä on kaksoitutkintoa suorittava opiskelija, jonka rahoituksen saa ammatillinen oppilaitos, tulee käyttää arvoa 6: Muuta kautta rahoitettu. Muussa tapauksessa käytetään arvoa 1: Valtionosuusrahoitteinen koulutus.")
+  @Description("Opintojen rahoitus. Mikäli kyseessä on kaksoitutkintoa suorittava opiskelija, jonka rahoituksen saa ammatillinen oppilaitos, tulee käyttää arvoa 6: Muuta kautta rahoitettu. Muussa tapauksessa käytetään arvoa 1: Valtionosuusrahoitteinen koulutus. Lukuvuosimaksu 16 käytössä vain 1.8.2026 tai myöhemmin alkavissa DIA-opiskeluoikeuksissa.")
   @KoodistoKoodiarvo("1")
   @KoodistoKoodiarvo("6")
+  @KoodistoKoodiarvo("16")
   override val opintojenRahoitus: Option[Koodistokoodiviite] = None
 ) extends KoskiLaajaOpiskeluoikeusjakso
 

--- a/src/main/scala/fi/oph/koski/schema/InternationalSchool.scala
+++ b/src/main/scala/fi/oph/koski/schema/InternationalSchool.scala
@@ -103,9 +103,10 @@ case class InternationalSchoolOpiskeluoikeudenTila(
 case class InternationalSchoolOpiskeluoikeusjakso(
   alku: LocalDate,
   tila: Koodistokoodiviite,
-  @Description("Opintojen rahoitus. Mikäli kyseessä on kaksoitutkintoa suorittava opiskelija, jonka rahoituksen saa ammatillinen oppilaitos, tulee käyttää arvoa 6: Muuta kautta rahoitettu. Muussa tapauksessa käytetään arvoa 1: Valtionosuusrahoitteinen koulutus.")
+  @Description("Opintojen rahoitus. Mikäli kyseessä on kaksoitutkintoa suorittava opiskelija, jonka rahoituksen saa ammatillinen oppilaitos, tulee käyttää arvoa 6: Muuta kautta rahoitettu. Muussa tapauksessa käytetään arvoa 1: Valtionosuusrahoitteinen koulutus. Lukuvuosimaksu 16 käytössä vain 1.8.2026 tai myöhemmin alkavissa International School of Helsinki -opiskeluoikeuksissa.")
   @KoodistoKoodiarvo("1")
   @KoodistoKoodiarvo("6")
+  @KoodistoKoodiarvo("16")
   override val opintojenRahoitus: Option[Koodistokoodiviite] = None
 ) extends KoskiLaajaOpiskeluoikeusjakso
 

--- a/src/test/scala/fi/oph/koski/api/oppijavalidation/OppijaValidationDIASpec.scala
+++ b/src/test/scala/fi/oph/koski/api/oppijavalidation/OppijaValidationDIASpec.scala
@@ -178,5 +178,25 @@ class OppijaValidationDIASpec extends AnyFreeSpec with KoskiHttpSpec with Opiske
         opiskeluoikeusPeruutettu
       ).foreach(verifyRahoitusmuotoKielletty)
     }
+
+    "lukuvuosimaksurahoitusta ei voi käyttää ennen 1.8.2026 alkavassa opiskeluoikeudessa" in {
+      val oo = defaultOpiskeluoikeus.copy(tila = DIAOpiskeluoikeudenTila(List(
+        DIAOpiskeluoikeusjakso(LocalDate.of(2026, 7, 31), opiskeluoikeusLäsnä, Some(lukuvuosimaksuRahoitteinen))
+      )))
+      setupOppijaWithOpiskeluoikeus(oo) {
+        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.date.alkamispäivä(
+          "Lukuvuosimaksurahoitusta (opintojenRahoitus koodiarvo 16) ei voi käyttää opiskeluoikeudessa, jonka alkamispäivä on ennen 1.8.2026"
+        ))
+      }
+    }
+
+    "lukuvuosimaksurahoitusta voi käyttää 1.8.2026 tai myöhemmin alkavassa opiskeluoikeudessa" in {
+      val oo = defaultOpiskeluoikeus.copy(tila = DIAOpiskeluoikeudenTila(List(
+        DIAOpiskeluoikeusjakso(LocalDate.of(2026, 8, 1), opiskeluoikeusLäsnä, Some(lukuvuosimaksuRahoitteinen))
+      )))
+      setupOppijaWithOpiskeluoikeus(oo) {
+        verifyResponseStatusOk()
+      }
+    }
   }
 }

--- a/src/test/scala/fi/oph/koski/api/oppijavalidation/OppijaValidationInternationalSchoolSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/oppijavalidation/OppijaValidationInternationalSchoolSpec.scala
@@ -122,6 +122,34 @@ class OppijaValidationInternationalSchoolSpec extends AnyFreeSpec with KoskiHttp
     }
   }
 
+  "Opintojen rahoitus" - {
+    "lukuvuosimaksurahoitusta ei voi käyttää ennen 1.8.2026 alkavassa opiskeluoikeudessa" in {
+      val oo = defaultOpiskeluoikeus.copy(
+        tila = InternationalSchoolOpiskeluoikeudenTila(List(
+          InternationalSchoolOpiskeluoikeusjakso(date(2026, 7, 31), LukioExampleData.opiskeluoikeusAktiivinen, Some(ExampleData.lukuvuosimaksuRahoitteinen))
+        )),
+        suoritukset = List(InternationalSchoolExampleData.diplomaSuoritus(12, date(2026, 7, 31), None))
+      )
+      setupOppijaWithOpiskeluoikeus(oo) {
+        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.date.alkamispäivä(
+          "Lukuvuosimaksurahoitusta (opintojenRahoitus koodiarvo 16) ei voi käyttää opiskeluoikeudessa, jonka alkamispäivä on ennen 1.8.2026"
+        ))
+      }
+    }
+
+    "lukuvuosimaksurahoitusta voi käyttää 1.8.2026 tai myöhemmin alkavassa opiskeluoikeudessa" in {
+      val oo = defaultOpiskeluoikeus.copy(
+        tila = InternationalSchoolOpiskeluoikeudenTila(List(
+          InternationalSchoolOpiskeluoikeusjakso(date(2026, 8, 1), LukioExampleData.opiskeluoikeusAktiivinen, Some(ExampleData.lukuvuosimaksuRahoitteinen))
+        )),
+        suoritukset = List(InternationalSchoolExampleData.diplomaSuoritus(12, date(2026, 8, 1), None))
+      )
+      setupOppijaWithOpiskeluoikeus(oo) {
+        verifyResponseStatusOk()
+      }
+    }
+  }
+
   override def tag = implicitly[reflect.runtime.universe.TypeTag[InternationalSchoolOpiskeluoikeus]]
   def tutkintoSuoritus: DiplomaVuosiluokanSuoritus = InternationalSchoolExampleData.diplomaSuoritus(12, date(2019, 8, 15), None)
 

--- a/tiedonsiirtoprotokollan_muutoshistoria.md
+++ b/tiedonsiirtoprotokollan_muutoshistoria.md
@@ -1,3 +1,7 @@
+# 18.5.2026
+
+- Lisätty DIA-tutkinnon ja International School of Helsinki -opiskeluoikeuksiin uusi rahoitusmuoto 16, lukuvuosimaksu.
+
 # 7.5.2026
 
 - Ahvenanmaan perusopetuksen (TOR-2587) wiring: tyypin rekisteröinti, koodistofixturet, esimerkkioppija, ePerusteet-validoinnin ohitus. Tallennettavissa dev/QA-ympäristöissä; tuotannossa estetty `features.disabledPäätasonSuoritusLuokat`-konfiguraatiolla.

--- a/validaation_muutoshistoria.md
+++ b/validaation_muutoshistoria.md
@@ -1,5 +1,9 @@
 # Koskeen tallennettavien tietojen validaatiosäännöt
 
+## 18.5.2026
+
+- DIA-tutkinnon ja International School of Helsinki -opiskeluoikeuksissa sallitaan uusi rahoitusmuoto 16 (lukuvuosimaksu) 1.8.2026 tai myöhemmin alkaneissa opiskeluoikeuksissa
+
 ## 6.5.2026
 
 - Esi- ja perusopetuksen tuen muutoksen validaatiot on muutettu astumaan voimaan 1.9.2026 aiemman 1.8.2026 sijaan.

--- a/web/app/types/fi/oph/koski/schema/DIAOpiskeluoikeusjakso.ts
+++ b/web/app/types/fi/oph/koski/schema/DIAOpiskeluoikeusjakso.ts
@@ -19,7 +19,7 @@ export type DIAOpiskeluoikeusjakso = {
     | 'valiaikaisestikeskeytynyt'
     | 'valmistunut'
   >
-  opintojenRahoitus?: Koodistokoodiviite<'opintojenrahoitus', '1' | '6'>
+  opintojenRahoitus?: Koodistokoodiviite<'opintojenrahoitus', '1' | '6' | '16'>
 }
 
 export const DIAOpiskeluoikeusjakso = (o: {
@@ -34,7 +34,7 @@ export const DIAOpiskeluoikeusjakso = (o: {
     | 'valiaikaisestikeskeytynyt'
     | 'valmistunut'
   >
-  opintojenRahoitus?: Koodistokoodiviite<'opintojenrahoitus', '1' | '6'>
+  opintojenRahoitus?: Koodistokoodiviite<'opintojenrahoitus', '1' | '6' | '16'>
 }): DIAOpiskeluoikeusjakso => ({
   $class: 'fi.oph.koski.schema.DIAOpiskeluoikeusjakso',
   ...o

--- a/web/app/types/fi/oph/koski/schema/InternationalSchoolOpiskeluoikeusjakso.ts
+++ b/web/app/types/fi/oph/koski/schema/InternationalSchoolOpiskeluoikeusjakso.ts
@@ -19,7 +19,7 @@ export type InternationalSchoolOpiskeluoikeusjakso = {
     | 'valiaikaisestikeskeytynyt'
     | 'valmistunut'
   >
-  opintojenRahoitus?: Koodistokoodiviite<'opintojenrahoitus', '1' | '6'>
+  opintojenRahoitus?: Koodistokoodiviite<'opintojenrahoitus', '1' | '6' | '16'>
 }
 
 export const InternationalSchoolOpiskeluoikeusjakso = (o: {
@@ -34,7 +34,7 @@ export const InternationalSchoolOpiskeluoikeusjakso = (o: {
     | 'valiaikaisestikeskeytynyt'
     | 'valmistunut'
   >
-  opintojenRahoitus?: Koodistokoodiviite<'opintojenrahoitus', '1' | '6'>
+  opintojenRahoitus?: Koodistokoodiviite<'opintojenrahoitus', '1' | '6' | '16'>
 }): InternationalSchoolOpiskeluoikeusjakso => ({
   $class: 'fi.oph.koski.schema.InternationalSchoolOpiskeluoikeusjakso',
   ...o

--- a/web/test/spec/internationalschoolSpec.js
+++ b/web/test/spec/internationalschoolSpec.js
@@ -263,7 +263,8 @@ describe('International school', function () {
         it('Vaihtoehtoina on lukion opintojenRahoitus-vaihtoehdot', function () {
           expect(addOppija.opintojenRahoitukset()).to.deep.equal([
             'Valtionosuusrahoitteinen koulutus',
-            'Muuta kautta rahoitettu'
+            'Muuta kautta rahoitettu',
+            'Lukuvuosimaksu'
           ])
         })
 


### PR DESCRIPTION
…uksille

Mahdollistetaan opintojenrahoitus-koodiston arvon 16 (lukuvuosimaksu) käyttö DIA-tutkinnon ja International School of Helsinki -opiskeluoikeuksissa. Rahoitusmuotoa voi käyttää vasta 1.8.2026 tai myöhemmin alkavissa opiskeluoikeuksissa, samoin kuin lukio- ja ammatillisissa opiskeluoikeuksissa (TOR-2588). Rajapäivävalidaatio ja oppivelvollisuus-/maksuttomuuslogiikka toteutuvat jo aiempien muutosten kautta, koska ne pattern-matchaavat KoskiOpiskeluoikeusjakso-trait:iin, jota DIA- ja ISH-jaksot toteuttavat.