### PR TITLE
Korjaa flaky koulutuksenKoodiPoistettuEPerusteistaSpec

### DIFF
--- a/web/test/spec/koulutuksenKoodiPoistettuEPerusteistaSpec.js
+++ b/web/test/spec/koulutuksenKoodiPoistettuEPerusteistaSpec.js
@@ -32,7 +32,8 @@ describe('Koulutuksen koodi poistettu ePerusteista', function () {
     before(
       Authentication().login(),
       page.openPage,
-      page.oppijaHaku.searchAndSelect('161097-132N')
+      page.oppijaHaku.searchAndSelect('161097-132N'),
+      wait.forAjax
     )
 
     describe('Ennen muokkaamista', function () {
@@ -58,7 +59,8 @@ describe('Koulutuksen koodi poistettu ePerusteista', function () {
     before(
       Authentication().login(),
       page.openPage,
-      page.oppijaHaku.searchAndSelect('151099-036E')
+      page.oppijaHaku.searchAndSelect('151099-036E'),
+      wait.forAjax
     )
 
     describe('Katselutilassa', function () {


### PR DESCRIPTION
Lisää wait.forAjax kummankin describe-lohkon before-vaiheeseen, jotta TunnisteenKoodiarvoEditor ehtii hakea koulutukset diaarinumerolle ennen assertiota. searchAndSelect odottaa selauksen jälkeen vain 50 ms, mikä ei riittänyt: jos fetch viivästyi, .tunniste-koodiarvo renderöityi tyhjänä ja testi näki "Koulutus Puuteollisuuden perustutkinto OPH-2455-2017" ilman koodiarvoa 12345.