### PR TITLE
TOR-xxxx: Käytä samaa PostgreSQL-versiota kuin RDS:ssä

### DIFF
--- a/docker-compose-arm64.yaml
+++ b/docker-compose-arm64.yaml
@@ -2,7 +2,7 @@ version: "3"
 services:
 
   postgres:
-    image: "postgres:15.18@sha256:67dc02dae6e27fa8b4333df9bfdf15265b33ce04186cd7e65c0b8fe67ee37b97"
+    image: "postgres:15.17@sha256:32016c79bea24c14917660106bc23a03341d94b9983aeb41f4130b4f3fbd6dd0"
     command: "postgres -c max_connections=200 -c log_statement=all -c log_destination=stderr"
     environment:
       - "POSTGRES_USER=oph"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 services:
 
   postgres:
-    image: "postgres:15.18@sha256:67dc02dae6e27fa8b4333df9bfdf15265b33ce04186cd7e65c0b8fe67ee37b97"
+    image: "postgres:15.17@sha256:32016c79bea24c14917660106bc23a03341d94b9983aeb41f4130b4f3fbd6dd0"
     command: "postgres -c max_connections=200 -c log_statement=all -c log_destination=stderr"
     environment:
       - "POSTGRES_USER=oph"

--- a/renovate.json
+++ b/renovate.json
@@ -91,6 +91,12 @@
       "description": "Wait 3 days before updating Maven dependencies",
       "matchManagers": ["maven"],
       "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Pin postgres Docker image to match RDS version (RDS upgrades to 15.17 on 2026-06-03; auto-minor-version-upgrade is enabled in RDS). Bump this constraint when RDS is upgraded further.",
+      "matchManagers": ["docker-compose"],
+      "matchPackageNames": ["postgres"],
+      "allowedVersions": "<=15.17"
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
RDS Päivittää 15.17 2026-06-03 , joten jätetty valmiiksi versio 15.17 vähän etukäteen.