### PR TITLE
TOR-1466 Opensearch IAM auth

### DIFF
--- a/.github/workflows/all_tests.yml
+++ b/.github/workflows/all_tests.yml
@@ -240,6 +240,7 @@ jobs:
       - uses: ./.github/actions/koski_backend_test
         with:
           suites: |
+            fi.oph.koski.opensearch, \
             fi.oph.koski.oppivelvollisuustieto, \
             fi.oph.koski.ovara, \
             fi.oph.koski.valvira, \

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ backtest:
 	fi.oph.koski.integrationtest,fi.oph.koski.json,fi.oph.koski.kela,fi.oph.koski.koodisto,\
 	fi.oph.koski.koskiuser,fi.oph.koski.localization,fi.oph.koski.cas,fi.oph.koski.log,\
 	fi.oph.koski.luovutuspalvelu,fi.oph.koski.migration,fi.oph.koski.migri,\
-	fi.oph.koski.mocha,fi.oph.koski.mydata,fi.oph.koski.omaopintopolkuloki,\
+	fi.oph.koski.mocha,fi.oph.koski.mydata,fi.oph.koski.omaopintopolkuloki,fi.oph.koski.opensearch,\
 	fi.oph.koski.opiskeluoikeus,fi.oph.koski.oppilaitos,fi.oph.koski.oppivelvollisuustieto,\
 	fi.oph.koski.organisaatio,fi.oph.koski.perftest,fi.oph.koski.raportit,\
 	fi.oph.koski.raportointikanta,fi.oph.koski.schedule,fi.oph.koski.schema,\

--- a/pom.xml
+++ b/pom.xml
@@ -338,6 +338,16 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
+      <artifactId>auth</artifactId>
+      <version>${awssdk.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>http-auth-aws</artifactId>
+      <version>${awssdk.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
       <artifactId>s3</artifactId>
       <version>${awssdk.version}</version>
     </dependency>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -119,6 +119,11 @@ opensearch = {
   host = "localhost"
   port = 9200
   protocol = "http"
+  # TOR-1466: flip to true via AppConfig per env to activate SigV4 signing of
+  # outbound requests. Local dev keeps this false (no IAM creds, no FGAC on
+  # the docker container).
+  useIamAuth = false
+  region = "eu-west-1"
 }
 
 features = {

--- a/src/main/scala/fi/oph/koski/http/Http.scala
+++ b/src/main/scala/fi/oph/koski/http/Http.scala
@@ -172,7 +172,15 @@ object Http extends Logging {
 
 }
 
-case class Http(root: String, client: Client[IO]) extends Logging {
+/** Optional pre-send transformer for outgoing requests. Used to inject SigV4
+  * signatures for AWS-managed OpenSearch when the FGAC IAM-auth feature is on.
+  * Implementations should be idempotent and side-effect-free apart from
+  * resolving credentials. */
+trait RequestSigner {
+  def sign(request: Request[IO]): IO[Request[IO]]
+}
+
+case class Http(root: String, client: Client[IO], signer: Option[RequestSigner] = None) extends Logging {
   private val DefaultTimeout = 2.minutes
 
   private val rootUri = Http.uriFromString(root)
@@ -218,12 +226,17 @@ case class Http(root: String, client: Client[IO]) extends Logging {
     (request: Request[IO], uriTemplate: String, timeout: FiniteDuration)
     (decoder: Decode[ResultType])
   : IO[ResultType] = {
-    runRequest(uriTemplate, decoder, timeout)(
-      request
-        .withUri(addRoot(request.uri))
-        .withHeaders(request.headers ++ commonHeaders)
-        .addCookie(OpintopolkuCsrfToken.serviceCookie)
-    )
+    val prepared = request
+      .withUri(addRoot(request.uri))
+      .withHeaders(request.headers ++ commonHeaders)
+      .addCookie(OpintopolkuCsrfToken.serviceCookie)
+
+    val readyToSend: IO[Request[IO]] = signer match {
+      case Some(s) => s.sign(prepared)
+      case None    => IO.pure(prepared)
+    }
+
+    readyToSend.flatMap(runRequest(uriTemplate, decoder, timeout))
   }
 
   private def runRequest[ResultType]

--- a/src/main/scala/fi/oph/koski/opensearch/OpenSearch.scala
+++ b/src/main/scala/fi/oph/koski/opensearch/OpenSearch.scala
@@ -1,7 +1,7 @@
 package fi.oph.koski.opensearch
 
 import com.typesafe.config.Config
-import fi.oph.koski.http.Http
+import fi.oph.koski.http.{Http, RequestSigner}
 import fi.oph.koski.log.Logging
 import fi.oph.koski.util.PaginationSettings
 
@@ -15,7 +15,20 @@ case class OpenSearch(config: Config) extends Logging {
 
   private val url = s"$protocol://$host:$port"
 
-  val http: Http = Http(url, "opensearch")
+  // TOR-1466: SigV4 signing for AWS-managed OpenSearch under FGAC. Feature-flagged
+  // so the signer can ship in code with no behavior change, then be activated
+  // per env via AppConfig (opensearch.useIamAuth=true) before the irreversible
+  // FGAC enable step on the domain.
+  private val signer: Option[RequestSigner] =
+    if (config.getBoolean("opensearch.useIamAuth")) {
+      val region = config.getString("opensearch.region")
+      logger.info(s"OpenSearch IAM auth enabled, signing requests with SigV4 (region=$region)")
+      Some(new SigV4Signer(region))
+    } else {
+      None
+    }
+
+  val http: Http = Http(url, "opensearch").copy(signer = signer)
 }
 
 object OpenSearch {

--- a/src/main/scala/fi/oph/koski/opensearch/SigV4Signer.scala
+++ b/src/main/scala/fi/oph/koski/opensearch/SigV4Signer.scala
@@ -8,55 +8,99 @@ import org.http4s.{Headers, Request}
 import org.typelevel.ci.CIString
 import software.amazon.awssdk.auth.credentials.{AwsCredentialsProvider, DefaultCredentialsProvider}
 import software.amazon.awssdk.http.auth.aws.signer.{AwsV4FamilyHttpSigner, AwsV4HttpSigner}
-import software.amazon.awssdk.http.auth.spi.signer.SignRequest
+import software.amazon.awssdk.http.auth.spi.signer.{HttpSigner, SignRequest}
 import software.amazon.awssdk.http.{ContentStreamProvider, SdkHttpFullRequest, SdkHttpMethod}
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity
 
 import java.io.ByteArrayInputStream
 import java.net.URI
+import java.time.Clock
 import scala.jdk.CollectionConverters._
 
 /** Signs outbound http4s requests with AWS Signature V4 against the OpenSearch
   * service. Used when the domain has FGAC enabled and requires IAM-signed
   * requests. Credentials are resolved via the default AWS SDK chain (ECS task
-  * role in dev/qa/prod, SSO/env vars for local-against-cloud). */
+  * role in dev/qa/prod, SSO/env vars for local-against-cloud).
+  *
+  * Whole-body materialization: SigV4 requires the SHA-256 of the full payload
+  * to be in the signature, so streaming signing isn't an option (AWS-managed
+  * OpenSearch rejects the UNSIGNED-PAYLOAD escape hatch under FGAC). Buffering
+  * is fine for OS search/index traffic (KBs to low MBs). Don't use this signer
+  * for large bulk uploads or streaming payloads. */
 class SigV4Signer(
   region: String,
-  credentialsProvider: AwsCredentialsProvider = DefaultCredentialsProvider.builder().build()
+  credentialsProvider: AwsCredentialsProvider = DefaultCredentialsProvider.builder().build(),
+  clock: Clock = Clock.systemUTC()
 ) extends RequestSigner {
 
   private val signer = AwsV4HttpSigner.create()
   private val signingName = "es"
 
-  override def sign(request: Request[IO]): IO[Request[IO]] =
+  // Headers that are framing/transport concerns rather than content. Not
+  // included in signing input (SDK derives them) and not re-emitted to
+  // http4s after signing (http4s/blaze sets them itself at transport time).
+  private val FramingHeaders: Set[String] = Set(
+    "host",
+    "content-length",
+    "transfer-encoding",
+    "expect",
+    "connection"
+  )
+
+  override def sign(request: Request[IO]): IO[Request[IO]] = {
+    // Defensive: SigV4 needs an absolute URI to derive the canonical Host. In
+    // normal Koski usage Http.processRequest calls addRoot first, so this
+    // always holds — but cheap to guard against misuse.
+    require(
+      request.uri.host.isDefined,
+      s"SigV4Signer requires an absolute URI with host; got: ${request.uri}"
+    )
+
     request.body.compile.toVector.map(_.toArray).map { bodyBytes =>
       val sdkRequest = toSdkRequest(request, bodyBytes)
 
       val signRequestBuilder = SignRequest
+        // Type ascription is needed because SignRequest.builder is generic
+        // over the identity type — without it Scala can't pick the overload.
         .builder(credentialsProvider.resolveCredentials(): AwsCredentialsIdentity)
         .request(sdkRequest)
         .putProperty(AwsV4FamilyHttpSigner.SERVICE_SIGNING_NAME, signingName)
         .putProperty(AwsV4HttpSigner.REGION_NAME, region)
+        .putProperty(HttpSigner.SIGNING_CLOCK, clock)
       payloadProviderFor(bodyBytes).foreach(signRequestBuilder.payload)
       val signed = signer.sign(signRequestBuilder.build())
 
+      // Re-attach signed headers to the http4s request. Skip framing headers
+      // that http4s/blaze sets itself at send time — re-emitting them would
+      // duplicate or conflict with what the underlying transport injects, and
+      // for Host specifically the signed value must match what blaze actually
+      // sends or AWS rejects the signature.
       val signedHeaders: List[Raw] = signed.request().headers().asScala.toList.flatMap {
         case (name, values) =>
-          values.asScala.toList.map(value => Raw(CIString(name), value))
+          if (FramingHeaders.contains(name.toLowerCase)) Nil
+          else values.asScala.toList.map(value => Raw(CIString(name), value))
       }
 
       request
         .withBodyStream(Stream.emits(bodyBytes).covary[IO])
         .withHeaders(Headers(signedHeaders))
     }
+  }
 
   private def toSdkRequest(req: Request[IO], body: Array[Byte]): SdkHttpFullRequest = {
     val builder = SdkHttpFullRequest.builder()
       .method(SdkHttpMethod.fromValue(req.method.name))
       .uri(URI.create(req.uri.toString))
 
+    // Don't smuggle framing headers (Host, Content-Length, Transfer-Encoding,
+    // Expect, Connection) into the SDK request. The SDK derives Host from the
+    // URI, and Content-Length / Transfer-Encoding are computed by http4s/blaze
+    // at send time. Including them here can sign a value that doesn't match
+    // what gets sent.
     req.headers.headers.foreach { h =>
-      builder.appendHeader(h.name.toString, h.value)
+      if (!FramingHeaders.contains(h.name.toString.toLowerCase)) {
+        builder.appendHeader(h.name.toString, h.value)
+      }
     }
 
     payloadProviderFor(body).foreach(builder.contentStreamProvider)

--- a/src/main/scala/fi/oph/koski/opensearch/SigV4Signer.scala
+++ b/src/main/scala/fi/oph/koski/opensearch/SigV4Signer.scala
@@ -1,0 +1,69 @@
+package fi.oph.koski.opensearch
+
+import cats.effect.IO
+import fi.oph.koski.http.RequestSigner
+import fs2.Stream
+import org.http4s.Header.Raw
+import org.http4s.{Headers, Request}
+import org.typelevel.ci.CIString
+import software.amazon.awssdk.auth.credentials.{AwsCredentialsProvider, DefaultCredentialsProvider}
+import software.amazon.awssdk.http.auth.aws.signer.{AwsV4FamilyHttpSigner, AwsV4HttpSigner}
+import software.amazon.awssdk.http.auth.spi.signer.SignRequest
+import software.amazon.awssdk.http.{ContentStreamProvider, SdkHttpFullRequest, SdkHttpMethod}
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity
+
+import java.io.ByteArrayInputStream
+import java.net.URI
+import scala.jdk.CollectionConverters._
+
+/** Signs outbound http4s requests with AWS Signature V4 against the OpenSearch
+  * service. Used when the domain has FGAC enabled and requires IAM-signed
+  * requests. Credentials are resolved via the default AWS SDK chain (ECS task
+  * role in dev/qa/prod, SSO/env vars for local-against-cloud). */
+class SigV4Signer(
+  region: String,
+  credentialsProvider: AwsCredentialsProvider = DefaultCredentialsProvider.builder().build()
+) extends RequestSigner {
+
+  private val signer = AwsV4HttpSigner.create()
+  private val signingName = "es"
+
+  override def sign(request: Request[IO]): IO[Request[IO]] =
+    request.body.compile.toVector.map(_.toArray).map { bodyBytes =>
+      val sdkRequest = toSdkRequest(request, bodyBytes)
+
+      val signRequestBuilder = SignRequest
+        .builder(credentialsProvider.resolveCredentials(): AwsCredentialsIdentity)
+        .request(sdkRequest)
+        .putProperty(AwsV4FamilyHttpSigner.SERVICE_SIGNING_NAME, signingName)
+        .putProperty(AwsV4HttpSigner.REGION_NAME, region)
+      payloadProviderFor(bodyBytes).foreach(signRequestBuilder.payload)
+      val signed = signer.sign(signRequestBuilder.build())
+
+      val signedHeaders: List[Raw] = signed.request().headers().asScala.toList.flatMap {
+        case (name, values) =>
+          values.asScala.toList.map(value => Raw(CIString(name), value))
+      }
+
+      request
+        .withBodyStream(Stream.emits(bodyBytes).covary[IO])
+        .withHeaders(Headers(signedHeaders))
+    }
+
+  private def toSdkRequest(req: Request[IO], body: Array[Byte]): SdkHttpFullRequest = {
+    val builder = SdkHttpFullRequest.builder()
+      .method(SdkHttpMethod.fromValue(req.method.name))
+      .uri(URI.create(req.uri.toString))
+
+    req.headers.headers.foreach { h =>
+      builder.appendHeader(h.name.toString, h.value)
+    }
+
+    payloadProviderFor(body).foreach(builder.contentStreamProvider)
+
+    builder.build()
+  }
+
+  private def payloadProviderFor(body: Array[Byte]): Option[ContentStreamProvider] =
+    if (body.nonEmpty) Some(() => new ByteArrayInputStream(body)) else None
+}

--- a/src/test/scala/fi/oph/koski/opensearch/SigV4SignerSpec.scala
+++ b/src/test/scala/fi/oph/koski/opensearch/SigV4SignerSpec.scala
@@ -1,0 +1,59 @@
+package fi.oph.koski.opensearch
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import fs2.Stream
+import org.http4s.{Method, Request, Uri}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+
+class SigV4SignerSpec extends AnyFreeSpec with Matchers {
+
+  private val fakeCreds = StaticCredentialsProvider.create(
+    AwsBasicCredentials.create("AKIAFAKETESTKEY", "wJalrXUtnFEMI/K7MDENG/fakeSecretKey")
+  )
+  private val signer = new SigV4Signer("eu-west-1", fakeCreds)
+
+  "SigV4Signer" - {
+    "adds AWS4-HMAC-SHA256 Authorization header to a GET request" in {
+      val req = Request[IO](
+        method = Method.GET,
+        uri = Uri.unsafeFromString("https://vpc-koski-opensearch-xxxx.eu-west-1.es.amazonaws.com/_cluster/health")
+      )
+
+      val signed = signer.sign(req).unsafeRunSync()
+
+      val authHeader = signed.headers.get(org.typelevel.ci.CIString("Authorization"))
+      authHeader.isDefined shouldBe true
+      authHeader.get.head.value should startWith("AWS4-HMAC-SHA256 ")
+      authHeader.get.head.value should include("Credential=AKIAFAKETESTKEY/")
+      authHeader.get.head.value should include("es/aws4_request")
+    }
+
+    "includes x-amz-date and x-amz-content-sha256 headers" in {
+      val req = Request[IO](
+        method = Method.POST,
+        uri = Uri.unsafeFromString("https://vpc-koski-opensearch-xxxx.eu-west-1.es.amazonaws.com/perustiedot-v3/_search")
+      ).withBodyStream(Stream.emits("""{"query":{"match_all":{}}}""".getBytes("UTF-8")).covary[IO])
+
+      val signed = signer.sign(req).unsafeRunSync()
+
+      signed.headers.get(org.typelevel.ci.CIString("x-amz-date")).isDefined shouldBe true
+      signed.headers.get(org.typelevel.ci.CIString("x-amz-content-sha256")).isDefined shouldBe true
+    }
+
+    "preserves the request body bytes through signing" in {
+      val body = """{"query":{"match_all":{}}}"""
+      val req = Request[IO](
+        method = Method.POST,
+        uri = Uri.unsafeFromString("https://example.com/_search")
+      ).withBodyStream(Stream.emits(body.getBytes("UTF-8")).covary[IO])
+
+      val signed = signer.sign(req).unsafeRunSync()
+      val resultBody = signed.body.compile.toVector.map(_.toArray).map(new String(_, "UTF-8")).unsafeRunSync()
+
+      resultBody shouldBe body
+    }
+  }
+}

--- a/src/test/scala/fi/oph/koski/opensearch/SigV4SignerSpec.scala
+++ b/src/test/scala/fi/oph/koski/opensearch/SigV4SignerSpec.scala
@@ -8,12 +8,18 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
 
+import java.time.{Clock, Instant, ZoneOffset}
+
 class SigV4SignerSpec extends AnyFreeSpec with Matchers {
 
   private val fakeCreds = StaticCredentialsProvider.create(
     AwsBasicCredentials.create("AKIAFAKETESTKEY", "wJalrXUtnFEMI/K7MDENG/fakeSecretKey")
   )
   private val signer = new SigV4Signer("eu-west-1", fakeCreds)
+
+  // Fixed-clock signer for deterministic / regression tests.
+  private val fixedClock = Clock.fixed(Instant.parse("2026-01-01T12:00:00Z"), ZoneOffset.UTC)
+  private val deterministicSigner = new SigV4Signer("eu-west-1", fakeCreds, fixedClock)
 
   "SigV4Signer" - {
     "adds AWS4-HMAC-SHA256 Authorization header to a GET request" in {
@@ -54,6 +60,57 @@ class SigV4SignerSpec extends AnyFreeSpec with Matchers {
       val resultBody = signed.body.compile.toVector.map(_.toArray).map(new String(_, "UTF-8")).unsafeRunSync()
 
       resultBody shouldBe body
+    }
+
+    "differentiates signatures when the query string changes" in {
+      // Canonical query string handling is a common SigV4 footgun — make sure
+      // different query strings produce different signatures.
+      val r1 = Request[IO](
+        method = Method.GET,
+        uri = Uri.unsafeFromString("https://vpc-koski-opensearch-xxxx.eu-west-1.es.amazonaws.com/_search?scroll=1m&size=100")
+      )
+      val r2 = Request[IO](
+        method = Method.GET,
+        uri = Uri.unsafeFromString("https://vpc-koski-opensearch-xxxx.eu-west-1.es.amazonaws.com/_search?scroll=2m&size=100")
+      )
+
+      val sig1 = deterministicSigner.sign(r1).unsafeRunSync()
+        .headers.get(org.typelevel.ci.CIString("Authorization")).get.head.value
+      val sig2 = deterministicSigner.sign(r2).unsafeRunSync()
+        .headers.get(org.typelevel.ci.CIString("Authorization")).get.head.value
+
+      sig1 should not equal sig2
+    }
+
+    "signs deterministically with a fixed clock (regression guard)" in {
+      // Same request + same credentials + same clock should produce identical
+      // signatures. If this breaks, canonicalization (signed headers list,
+      // query-string ordering, payload hash, etc.) has changed and the
+      // surrounding behavior needs scrutiny.
+      val req = Request[IO](
+        method = Method.GET,
+        uri = Uri.unsafeFromString("https://vpc-koski-opensearch-xxxx.eu-west-1.es.amazonaws.com/perustiedot-v3/_search?size=10")
+      )
+
+      val sig1 = deterministicSigner.sign(req).unsafeRunSync()
+        .headers.get(org.typelevel.ci.CIString("Authorization")).get.head.value
+      val sig2 = deterministicSigner.sign(req).unsafeRunSync()
+        .headers.get(org.typelevel.ci.CIString("Authorization")).get.head.value
+
+      sig1 shouldBe sig2
+    }
+
+    "rejects a request without an absolute URI" in {
+      val req = Request[IO](
+        method = Method.GET,
+        uri = Uri.unsafeFromString("/perustiedot-v3/_search")  // no host
+      )
+
+      // Wrapped in IO, so we have to materialize to see the failure.
+      val ex = intercept[IllegalArgumentException] {
+        signer.sign(req).unsafeRunSync()
+      }
+      ex.getMessage should include("absolute URI")
     }
   }
 }


### PR DESCRIPTION
Wraps the http4s OpenSearch client with AWS Signature V4 signing when opensearch.useIamAuth=true in AppConfig (default false in reference.conf so local dev / tests are unaffected). The signer uses AwsV4HttpSigner
from software.amazon.awssdk:http-auth-aws and resolves credentials via ECS task role in dev/qa/prod.

Ship-flag-first design: deploy this code with the flag off, verify nothing breaks in any env, then flip the flag per env to start signing against the still-unsecured 1.3 domain (signed requests carry extra headers but are otherwise accepted), THEN enable FGAC on the domain (see TOR-1466 in koski-aws-infra). This decouples "the signing code
exists" from "the signing code is active" -- the irreversible FGAC step rides on top of an already-verified signer.

New files:
- src/main/scala/fi/oph/koski/opensearch/SigV4Signer.scala
- src/test/scala/fi/oph/koski/opensearch/SigV4SignerSpec.scala

Modified:
- src/main/scala/fi/oph/koski/http/Http.scala -- add RequestSigner trait and optional signer field on Http case class
- src/main/scala/fi/oph/koski/opensearch/OpenSearch.scala -- read useIamAuth flag, conditionally attach signer
- src/main/resources/reference.conf -- opensearch.useIamAuth + region
- pom.xml -- software.amazon.awssdk:auth and :http-auth-aws

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
