### PR TITLE
Lisää oppiaineen koodi perusopetuksen virheilmoituksiin

### DIFF
--- a/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
+++ b/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
@@ -1282,7 +1282,7 @@ class KoskiValidator(
         HttpStatus.fold(
           suoritus.osasuoritusLista.map {
             case os: RajattavaOppimäärä if os.rajattuOppimäärä =>
-              HttpStatus.validate(vainSallitutArvosanat(os, "5"))(KoskiErrorCategory.badRequest.validation.date(s"Rajatulle oppimäärälle sallitaan vain arvosana 5 kun kyseessä on perusopetuksen oppimäärän suoritus"))
+              HttpStatus.validate(vainSallitutArvosanat(os, "5"))(KoskiErrorCategory.badRequest.validation.date(s"Rajatulle oppimäärälle ${os.koulutusmoduuli.tunniste.koodiarvo} sallitaan vain arvosana 5 kun kyseessä on perusopetuksen oppimäärän suoritus"))
             case _ => HttpStatus.ok
           }
         )
@@ -1292,9 +1292,9 @@ class KoskiValidator(
             case os: RajattavaOppimäärä if os.rajattuOppimäärä =>
               suoritus.koulutusmoduuli.tunniste.koodiarvo match {
                 case "9" if s.jääLuokalle =>
-                  HttpStatus.validate(vainSallitutArvosanat(os, "S", "H"))(KoskiErrorCategory.badRequest.validation.date(s"Rajatulle oppimäärälle sallitaan arvosanat S ja H vain kun kyseessä on 9. lk ja oppilas jää luokalle"))
+                  HttpStatus.validate(vainSallitutArvosanat(os, "S", "H"))(KoskiErrorCategory.badRequest.validation.date(s"Rajatulle oppimäärälle ${os.koulutusmoduuli.tunniste.koodiarvo} sallitaan arvosanat S ja H vain kun kyseessä on 9. lk ja oppilas jää luokalle"))
                 case "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" =>
-                  HttpStatus.validate(vainSallitutArvosanat(os, "S", "H"))(KoskiErrorCategory.badRequest.validation.date(s"Rajatulle oppimäärälle sallitaan arvosanat S ja H vain kun kyseessä on 1. - 8. lk suoritus"))
+                  HttpStatus.validate(vainSallitutArvosanat(os, "S", "H"))(KoskiErrorCategory.badRequest.validation.date(s"Rajatulle oppimäärälle ${os.koulutusmoduuli.tunniste.koodiarvo} sallitaan arvosanat S ja H vain kun kyseessä on 1. - 8. lk suoritus"))
                 case _ => HttpStatus.ok
               }
             case _ => HttpStatus.ok
@@ -1729,7 +1729,7 @@ class KoskiValidator(
         if (väliaikainenValidaationLöystyttämienPoistettavaSyksyllä2020) {
           HttpStatus.ok
         } else {
-          KoskiErrorCategory.badRequest.validation.arviointi.sallittuVainValinnaiselle(s"Arviointi ${o.viimeisinArviointi.map(_.arvosana.koodiarvo).mkString} on sallittu vain jos oppimäärä on rajattu (yksilöllistetty) tai valinnaisille oppiaineille joiden laajuus on alle kaksi vuosiviikkotuntia")
+          KoskiErrorCategory.badRequest.validation.arviointi.sallittuVainValinnaiselle(s"Arviointi ${o.viimeisinArviointi.map(_.arvosana.koodiarvo).mkString} on sallittu vain jos oppiaineen ${o.koulutusmoduuli.tunniste.koodiarvo} oppimäärä on rajattu (yksilöllistetty) tai valinnaisille oppiaineille joiden laajuus on alle kaksi vuosiviikkotuntia")
         }
       } else if (eiArvioituSanallisesti && !o.yksilöllistettyOppimäärä && !o.rajattuOppimäärä && !o.koulutusmoduuli.pakollinen && o.koulutusmoduuli.laajuus.exists(_.arvo < 2)) {
         KoskiErrorCategory.badRequest.validation.arviointi.eiSallittuSuppealleValinnaiselle("Vain arvioinnit 'S' ja 'O' on sallittu valinnaiselle valtakunnalliselle oppiaineelle, jonka laajuus on alle kaksi vuosiviikkotuntia (" + suorituksenTunniste(o) + ")")

--- a/src/main/scala/fi/oph/koski/validation/PerusopetuksenOpiskeluoikeudenValidation.scala
+++ b/src/main/scala/fi/oph/koski/validation/PerusopetuksenOpiskeluoikeudenValidation.scala
@@ -91,7 +91,7 @@ object PerusopetuksenOpiskeluoikeusValidation extends Logging {
                 val tavoitekokonaisuusosuujaksolle = vahvistuspäivä.exists(d => tavoitekokonaisuuksittainOpiskeluVoimassa(oo, d))
                 if (vahvistuspäivä.isEmpty || (vsopOn && vahvistuspäivä.exists(p => !p.isAfter(cutoff)))) { None }
                 else if (!tavoitekokonaisuusosuujaksolle ) {
-                  Some(KoskiErrorCategory.badRequest.validation.date(s"Perusopetuksen oppiaineen suorituksella on tavoitekokonaisuuksittain opiskeluun liittyvä tieto luokkaAste (${la.koodiarvo}) mutta ei tavoitekokonaisuuksittain opiskelun aikajaksoa, joka kattaisi vuosiluokan vahvistuspäivän tai suorituksen arviointipäivän."))
+                  Some(KoskiErrorCategory.badRequest.validation.date(s"Perusopetuksen oppiaineen ${os.koulutusmoduuli.tunniste.koodiarvo} suorituksella on tavoitekokonaisuuksittain opiskeluun liittyvä tieto luokkaAste (${la.koodiarvo}) mutta ei tavoitekokonaisuuksittain opiskelun aikajaksoa, joka kattaisi vuosiluokan vahvistuspäivän tai suorituksen arviointipäivän."))
                 } else if (la == vuosiluokka) {
                   Some(KoskiErrorCategory.badRequest.validation.date(s"Perusopetuksen oppiaineen suorituksen tavoitekokonaisuuksittain opiskeluun liittyvä kenttä luokkaAste ei saa olla sama kuin vuosiluokka (${vuosiluokka.koodiarvo})"))
                 } else{ None }

--- a/src/test/scala/fi/oph/koski/api/oppijavalidation/OppijaValidationPerusopetusSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/oppijavalidation/OppijaValidationPerusopetusSpec.scala
@@ -386,7 +386,7 @@ class OppijaValidationPerusopetusSpec extends TutkinnonPerusteetTest[Perusopetuk
 
         "Kielletty pakollisten oppiaineiden suorituksilta" in {
           setupOppijaWithOpiskeluoikeus(defaultOpiskeluoikeus.copy(suoritukset = List(yhdeksännenLuokanSuoritus, päättötodistusSuoritus.copy(osasuoritukset = Some(List(pakollinenS)))))) {
-            verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.arviointi.sallittuVainValinnaiselle("Arviointi S on sallittu vain jos oppimäärä on rajattu (yksilöllistetty) tai valinnaisille oppiaineille joiden laajuus on alle kaksi vuosiviikkotuntia"))
+            verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.arviointi.sallittuVainValinnaiselle("Arviointi S on sallittu vain jos oppiaineen AI oppimäärä on rajattu (yksilöllistetty) tai valinnaisille oppiaineille joiden laajuus on alle kaksi vuosiviikkotuntia"))
           }
         }
 
@@ -437,7 +437,7 @@ class OppijaValidationPerusopetusSpec extends TutkinnonPerusteetTest[Perusopetuk
 
         "Kielletty pakollisten oppiaineiden suorituksilta" in {
           setupOppijaWithOpiskeluoikeus(defaultOpiskeluoikeus.copy(suoritukset = List(yhdeksännenLuokanSuoritus, päättötodistusSuoritus.copy(osasuoritukset = Some(List(pakollinenO)))))) {
-            verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.arviointi.sallittuVainValinnaiselle("Arviointi O on sallittu vain jos oppimäärä on rajattu (yksilöllistetty) tai valinnaisille oppiaineille joiden laajuus on alle kaksi vuosiviikkotuntia"))
+            verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.arviointi.sallittuVainValinnaiselle("Arviointi O on sallittu vain jos oppiaineen AI oppimäärä on rajattu (yksilöllistetty) tai valinnaisille oppiaineille joiden laajuus on alle kaksi vuosiviikkotuntia"))
           }
         }
 
@@ -449,14 +449,14 @@ class OppijaValidationPerusopetusSpec extends TutkinnonPerusteetTest[Perusopetuk
 
         "Kielletty valinnaisten oppiaineiden suorituksilta joiden laajuus on 2 vuosiviikkotuntia tai yli" in {
           setupOppijaWithOpiskeluoikeus(defaultOpiskeluoikeus.copy(suoritukset = List(yhdeksännenLuokanSuoritus, päättötodistusSuoritus.copy(osasuoritukset = Some(List(valinnainenO)))))) {
-            verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.arviointi.sallittuVainValinnaiselle("Arviointi O on sallittu vain jos oppimäärä on rajattu (yksilöllistetty) tai valinnaisille oppiaineille joiden laajuus on alle kaksi vuosiviikkotuntia"))
+            verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.arviointi.sallittuVainValinnaiselle("Arviointi O on sallittu vain jos oppiaineen AI oppimäärä on rajattu (yksilöllistetty) tai valinnaisille oppiaineille joiden laajuus on alle kaksi vuosiviikkotuntia"))
           }
         }
 
         "Kielletty valinnaisten kielioppiaineiden suorituksilta joiden laajuus on 2 vuosiviikkotuntia tai yli" in {
           val valinnainenKieliO = suoritus(kieli("B1", "SV").copy(pakollinen = false, laajuus = vuosiviikkotuntia(2))).copy(arviointi = osallistunut)
           setupOppijaWithOpiskeluoikeus(defaultOpiskeluoikeus.copy(suoritukset = List(yhdeksännenLuokanSuoritus, päättötodistusSuoritus.copy(osasuoritukset = Some(List(valinnainenKieliO)))))) {
-            verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.arviointi.sallittuVainValinnaiselle("Arviointi O on sallittu vain jos oppimäärä on rajattu (yksilöllistetty) tai valinnaisille oppiaineille joiden laajuus on alle kaksi vuosiviikkotuntia"))
+            verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.arviointi.sallittuVainValinnaiselle("Arviointi O on sallittu vain jos oppiaineen B1 oppimäärä on rajattu (yksilöllistetty) tai valinnaisille oppiaineille joiden laajuus on alle kaksi vuosiviikkotuntia"))
           }
         }
 
@@ -477,7 +477,7 @@ class OppijaValidationPerusopetusSpec extends TutkinnonPerusteetTest[Perusopetuk
         "Kielletty paikallisten oppiaineden suorituksilta joiden laajuus on 2 vuosiviikkotuntia tai yli" in {
           val paikallinenLaajuus2 = suoritus(paikallinenOppiaine("HI", "Historia", "Opiskellaan historiaa", vuosiviikkotuntia(2))).copy(arviointi = osallistunut)
           setupOppijaWithOpiskeluoikeus(defaultOpiskeluoikeus.copy(suoritukset = List(yhdeksännenLuokanSuoritus, päättötodistusSuoritus.copy(osasuoritukset = Some(List(paikallinenLaajuus2)))))) {
-            verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.arviointi.sallittuVainValinnaiselle("Arviointi O on sallittu vain jos oppimäärä on rajattu (yksilöllistetty) tai valinnaisille oppiaineille joiden laajuus on alle kaksi vuosiviikkotuntia"))
+            verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.arviointi.sallittuVainValinnaiselle("Arviointi O on sallittu vain jos oppiaineen HI oppimäärä on rajattu (yksilöllistetty) tai valinnaisille oppiaineille joiden laajuus on alle kaksi vuosiviikkotuntia"))
           }
         }
       }
@@ -806,7 +806,7 @@ class OppijaValidationPerusopetusSpec extends TutkinnonPerusteetTest[Perusopetuk
 
         setupOppijaWithOpiskeluoikeus(makeSeiskaluokanRajattuOppimäärä("5")) {
           verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.date(
-            "Rajatulle oppimäärälle sallitaan arvosanat S ja H vain kun kyseessä on 1. - 8. lk suoritus"
+            "Rajatulle oppimäärälle AI sallitaan arvosanat S ja H vain kun kyseessä on 1. - 8. lk suoritus"
           ))
         }
 
@@ -847,7 +847,7 @@ class OppijaValidationPerusopetusSpec extends TutkinnonPerusteetTest[Perusopetuk
 
         setupOppijaWithOpiskeluoikeus(makeYsiluokanLuokallejääntiRajattuOppimäärä("5")) {
           verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.date(
-            "Rajatulle oppimäärälle sallitaan arvosanat S ja H vain kun kyseessä on 9. lk ja oppilas jää luokalle"
+            "Rajatulle oppimäärälle AI sallitaan arvosanat S ja H vain kun kyseessä on 9. lk ja oppilas jää luokalle"
           ))
         }
 
@@ -879,7 +879,7 @@ class OppijaValidationPerusopetusSpec extends TutkinnonPerusteetTest[Perusopetuk
 
         setupOppijaWithOpiskeluoikeus(makeYsiluokanRajattuOppimäärä("S")) {
           verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.date(
-            "Rajatulle oppimäärälle sallitaan vain arvosana 5 kun kyseessä on perusopetuksen oppimäärän suoritus"
+            "Rajatulle oppimäärälle AI sallitaan vain arvosana 5 kun kyseessä on perusopetuksen oppimäärän suoritus"
           ))
         }
 
@@ -1026,7 +1026,7 @@ class OppijaValidationPerusopetusSpec extends TutkinnonPerusteetTest[Perusopetuk
           setupOppijaWithOpiskeluoikeus(withLuokkaAste.build) {
             verifyResponseStatus(400,
               KoskiErrorCategory.badRequest.validation.date(
-                "Perusopetuksen oppiaineen suorituksella on tavoitekokonaisuuksittain opiskeluun liittyvä tieto luokkaAste (8) mutta ei tavoitekokonaisuuksittain opiskelun aikajaksoa, joka kattaisi vuosiluokan vahvistuspäivän tai suorituksen arviointipäivän."
+                "Perusopetuksen oppiaineen HI suorituksella on tavoitekokonaisuuksittain opiskeluun liittyvä tieto luokkaAste (8) mutta ei tavoitekokonaisuuksittain opiskelun aikajaksoa, joka kattaisi vuosiluokan vahvistuspäivän tai suorituksen arviointipäivän."
               )
             )
           }


### PR DESCRIPTION
TOR-2632: Virheviesteissä olisi hyvä olla oppiaine, jotta opetuksen järjestäjien olisi helppo löytää virhe eikä olla meihin yhteydessä.
Lisättiin oppiaineen koodi virheilmoituksiin