### PR TITLE
TOR-2587 Ahvenanmaa koodistot

### DIFF
--- a/src/main/resources/mockdata/koodisto/koodit/ahvenanmaankoskioppiaineetyleissivistava.json
+++ b/src/main/resources/mockdata/koodisto/koodit/ahvenanmaankoskioppiaineetyleissivistava.json
@@ -223,9 +223,9 @@
     "withinCodeElements": [],
     "includesCodeElements": [],
     "levelsWithCodeElements": [],
-    "koodiUri": "ahvenanmaankoskioppiaineetyleissivistava_li",
+    "koodiUri": "ahvenanmaankoskioppiaineetyleissivistava_id",
     "versio": 1,
-    "koodiArvo": "LI"
+    "koodiArvo": "ID"
   },
   {
     "metadata": [
@@ -247,9 +247,9 @@
     "withinCodeElements": [],
     "includesCodeElements": [],
     "levelsWithCodeElements": [],
-    "koodiUri": "ahvenanmaankoskioppiaineetyleissivistava_op",
+    "koodiUri": "ahvenanmaankoskioppiaineetyleissivistava_eh",
     "versio": 1,
-    "koodiArvo": "OP"
+    "koodiArvo": "EH"
   },
   {
     "metadata": [

--- a/src/main/scala/fi/oph/koski/documentation/ExamplesAhvenanmaanPerusopetus.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesAhvenanmaanPerusopetus.scala
@@ -59,9 +59,9 @@ object AhvenanmaanPerusopetusExampleData {
     oppiaineenSuoritus(oppiaine("MU", "Musik"), 9),
     oppiaineenSuoritus(oppiaine("KU", "Bildkonst"), 8),
     oppiaineenSuoritus(oppiaine("KS", "Slöjd"), 7),
-    oppiaineenSuoritus(oppiaine("LI", "Idrott"), 9),
+    oppiaineenSuoritus(oppiaine("ID", "Idrott"), 9),
     oppiaineenSuoritus(oppiaine("HEKO", "Hem- och konsumentkunskap"), 8),
-    oppiaineenSuoritus(oppiaine("OP", "Elevhandledning"), 8),
+    oppiaineenSuoritus(oppiaine("EH", "Elevhandledning"), 8),
     oppiaineenSuoritus(vierasKieli("A1", "EN"), 9),
     oppiaineenSuoritus(vierasKieli("B1", "FI"), 7),
   )

--- a/src/main/scala/fi/oph/koski/schema/AhvenanmaanPerusopetus.scala
+++ b/src/main/scala/fi/oph/koski/schema/AhvenanmaanPerusopetus.scala
@@ -398,7 +398,7 @@ case class AhvenanmaanPerusopetuksenVierasKieli(
   @KoodistoKoodiarvo("A1")
   @KoodistoKoodiarvo("A2")
   @KoodistoKoodiarvo("B1")
-  @KoodistoKoodiarvo("B3")
+  @KoodistoKoodiarvo("B2")
   tunniste: Koodistokoodiviite,
   @Description("Mikä kieli on kyseessä")
   @KoodistoUri("kielivalikoima")

--- a/src/main/scala/fi/oph/koski/schema/AhvenanmaanPerusopetus.scala
+++ b/src/main/scala/fi/oph/koski/schema/AhvenanmaanPerusopetus.scala
@@ -381,9 +381,9 @@ case class AhvenanmaanPerusopetuksenMuuOppiaine(
   @KoodistoKoodiarvo("KS")
   @KoodistoKoodiarvo("TX")
   @KoodistoKoodiarvo("TN")
-  @KoodistoKoodiarvo("LI")
+  @KoodistoKoodiarvo("ID")
   @KoodistoKoodiarvo("HEKO")
-  @KoodistoKoodiarvo("OP")
+  @KoodistoKoodiarvo("EH")
   tunniste: Koodistokoodiviite,
   pakollinen: Boolean = true,
   perusteenDiaarinumero: Option[String] = None,

--- a/src/test/resources/backwardcompatibility/ahvenanmaanperusopetus-9.luokkalainen_2026-06-02.json
+++ b/src/test/resources/backwardcompatibility/ahvenanmaanperusopetus-9.luokkalainen_2026-06-02.json
@@ -458,7 +458,7 @@
       }, {
         "koulutusmoduuli" : {
           "tunniste" : {
-            "koodiarvo" : "LI",
+            "koodiarvo" : "ID",
             "koodistoUri" : "ahvenanmaankoskioppiaineetyleissivistava"
           },
           "pakollinen" : true
@@ -500,7 +500,7 @@
       }, {
         "koulutusmoduuli" : {
           "tunniste" : {
-            "koodiarvo" : "OP",
+            "koodiarvo" : "EH",
             "koodistoUri" : "ahvenanmaankoskioppiaineetyleissivistava"
           },
           "pakollinen" : true
@@ -974,7 +974,7 @@
       }, {
         "koulutusmoduuli" : {
           "tunniste" : {
-            "koodiarvo" : "LI",
+            "koodiarvo" : "ID",
             "koodistoUri" : "ahvenanmaankoskioppiaineetyleissivistava"
           },
           "pakollinen" : true
@@ -1016,7 +1016,7 @@
       }, {
         "koulutusmoduuli" : {
           "tunniste" : {
-            "koodiarvo" : "OP",
+            "koodiarvo" : "EH",
             "koodistoUri" : "ahvenanmaankoskioppiaineetyleissivistava"
           },
           "pakollinen" : true

--- a/web/app/types/fi/oph/koski/schema/AhvenanmaanPerusopetuksenMuuOppiaine.ts
+++ b/web/app/types/fi/oph/koski/schema/AhvenanmaanPerusopetuksenMuuOppiaine.ts
@@ -33,9 +33,9 @@ export type AhvenanmaanPerusopetuksenMuuOppiaine = {
     | 'KS'
     | 'TX'
     | 'TN'
-    | 'LI'
+    | 'ID'
     | 'HEKO'
-    | 'OP'
+    | 'EH'
   >
 }
 
@@ -64,9 +64,9 @@ export const AhvenanmaanPerusopetuksenMuuOppiaine = (o: {
     | 'KS'
     | 'TX'
     | 'TN'
-    | 'LI'
+    | 'ID'
     | 'HEKO'
-    | 'OP'
+    | 'EH'
   >
 }): AhvenanmaanPerusopetuksenMuuOppiaine => ({
   $class: 'fi.oph.koski.schema.AhvenanmaanPerusopetuksenMuuOppiaine',

--- a/web/app/types/fi/oph/koski/schema/AhvenanmaanPerusopetuksenVierasKieli.ts
+++ b/web/app/types/fi/oph/koski/schema/AhvenanmaanPerusopetuksenVierasKieli.ts
@@ -16,7 +16,7 @@ export type AhvenanmaanPerusopetuksenVierasKieli = {
   perusteenDiaarinumero?: string
   tunniste: Koodistokoodiviite<
     'ahvenanmaankoskioppiaineetyleissivistava',
-    'A1' | 'A2' | 'B1' | 'B3'
+    'A1' | 'A2' | 'B1' | 'B2'
   >
 }
 
@@ -28,7 +28,7 @@ export const AhvenanmaanPerusopetuksenVierasKieli = (o: {
   perusteenDiaarinumero?: string
   tunniste: Koodistokoodiviite<
     'ahvenanmaankoskioppiaineetyleissivistava',
-    'A1' | 'A2' | 'B1' | 'B3'
+    'A1' | 'A2' | 'B1' | 'B2'
   >
 }): AhvenanmaanPerusopetuksenVierasKieli => ({
   $class: 'fi.oph.koski.schema.AhvenanmaanPerusopetuksenVierasKieli',


### PR DESCRIPTION
TOR-2587: Viilaa Ahvenanmaan oppiainekoodistoa
TOR-2587: Korjaa Ahvenanmaan vieraan kielen sallitut koodit