### PR TITLE
Revert pnpm 11 bump to unblock trivy CI

### DIFF
--- a/.github/actions/setup_pnpm_cache/action.yml
+++ b/.github/actions/setup_pnpm_cache/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Setup pnpm
       uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
       with:
-        version: 11.5.0
+        version: 10.34.1
 
     - name: Get pnpm store path
       id: pnpm-store


### PR DESCRIPTION
## Summary
- Reverts #4129, which bumped the pnpm action from `10.34.1` to `11.5.0`.
- pnpm v11 fails the frozen-lockfile check on `pnpm.overrides` in workspaces whose `pnpm-lock.yaml` was generated by v10, breaking the trivy CI job at *Install JS deps* with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` (first failure surfaced in `smoketests/`).
- Staying on pnpm 10 until the per-workspace lockfiles are regenerated and the `packageManager` / `engines.pnpm` pins are bumped in each workspace.

## Test plan
- [ ] CI passes on this branch (trivy *Install JS deps* step in particular)
- [ ] Confirm renovate keeps the pnpm 11 PR open / reopens it so we can retry once lockfiles are migrated

🤖 Generated with [Claude Code](https://claude.com/claude-code)