### PR TITLE
Pin smoketests Node.js to 24.15.0

### DIFF
--- a/.github/workflows/run_smoketests.yml
+++ b/.github/workflows/run_smoketests.yml
@@ -17,7 +17,10 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: "24.16.0"
+          # Pinned to 24.15.0 because 24.16.0 has a bug in extract-zip
+          # that silently truncates Chrome extraction, breaking
+          # `puppeteer browsers install chrome`. See nodejs/node#63487.
+          node-version: "24.15.0"
 
       - uses: ./.github/actions/setup_pnpm_cache
 


### PR DESCRIPTION
## Summary

- Pin Node version in `run_smoketests.yml` to `24.15.0`
- Node 24.16.0 has a bug in `extract-zip` that silently truncates Chrome extraction during `puppeteer browsers install chrome`, leaving an empty cache directory and causing every smoketest run to fail with `Could not find Chrome (ver. 148.0.7778.97)`
- Upstream issue: [nodejs/node#63487](https://github.com/nodejs/node/issues/63487)

## Background

Smoketests have failed on every scheduled run since 2026-06-05. Reproduced locally on `node:24.16.0` linux/amd64 in Docker: the install command exits 0 with no output and only the `.zip` plus a couple of extracted manifest files remain. Switching the same setup to `node:24.15.0` produces a fully extracted Chrome binary and the expected `chrome@148.0.7778.97 …/chrome` output.

## Test plan

- [ ] Trigger `Run smoketests` workflow manually on this branch and confirm the suomi.fi and eIDAS login tests succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)