### PR TITLE
TOR-2654 Opensearch viilauksia

### DIFF
--- a/src/main/scala/fi/oph/koski/perustiedot/OpiskeluoikeudenPerustiedot.scala
+++ b/src/main/scala/fi/oph/koski/perustiedot/OpiskeluoikeudenPerustiedot.scala
@@ -1,6 +1,6 @@
 package fi.oph.koski.perustiedot
 
-import java.time.LocalDate
+import java.time.{LocalDate, LocalDateTime}
 
 import fi.oph.koski.db.{HenkilöRow, KoskiOpiskeluoikeusRow}
 import fi.oph.koski.henkilo.{OppijaHenkilö, OppijaHenkilöWithMasterInfo}
@@ -37,7 +37,9 @@ case class OpiskeluoikeudenPerustiedot(
   @KoodistoUri("koskiopiskeluoikeudentila")
   tilat: Option[List[OpiskeluoikeusJaksonPerustiedot]], // Optionality can be removed after re-indexing
   @Description("Luokan tai ryhmän tunniste, esimerkiksi 9C")
-  luokka: Option[String]
+  luokka: Option[String],
+  @Description("Opiskeluoikeuden tietokantarivin viimeisin muokkausaikaleima. Käytetään mm. inkrementaalisten OpenSearch-migraatioiden lähteenä (--aikaleima-from).")
+  aikaleima: Option[LocalDateTime]
 ) extends OpiskeluoikeudenOsittaisetTiedot
 
 case class NimitiedotJaOid(oid: String, etunimet: String, kutsumanimi: String, sukunimi: String)
@@ -119,7 +121,8 @@ object OpiskeluoikeudenPerustiedot {
       extract[Koodistokoodiviite](data \ "tyyppi"),
       suoritukset,
       Some(fixTilat(extract[List[OpiskeluoikeusJaksonPerustiedot]](data \ "tila" \ "opiskeluoikeusjaksot", ignoreExtras = true))),
-      luokka)
+      luokka,
+      extract[Option[LocalDateTime]](data \ "aikaleima"))
   }
 
   private def getLuokka(oo: Opiskeluoikeus): Option[String] = oo match {

--- a/src/main/scala/fi/oph/koski/perustiedot/OpiskeluoikeudenPerustiedotIndexer.scala
+++ b/src/main/scala/fi/oph/koski/perustiedot/OpiskeluoikeudenPerustiedotIndexer.scala
@@ -23,7 +23,7 @@ object OpiskeluoikeudenPerustiedotIndexer {
       "filter" -> Map(
         "finnish_folding" -> Map(
           "type" -> "icu_folding",
-          "unicodeSetFilter" -> "[^åäöÅÄÖ]"
+          "unicode_set_filter" -> "[^åäöÅÄÖ]"
         )
       ),
       "analyzer" -> Map(
@@ -74,7 +74,8 @@ object OpiskeluoikeudenPerustiedotIndexer {
         )
       ),
       "tilat" -> Map("type" -> "nested"),
-      "suoritukset" -> Map("type" -> "nested")
+      "suoritukset" -> Map("type" -> "nested"),
+      "aikaleima" -> Map("type" -> "date")
     )
   )
 }


### PR DESCRIPTION
Add Option[LocalDateTime] aikaleima to OpiskeluoikeudenPerustiedot,
populated from Opiskeluoikeus.aikaleima (i.e. the DB row's
last-modified timestamp). Enables future incremental OpenSearch
migrations to use --aikaleima-from.

Add explicit `date` mapping for the field in the perustiedot index.
mappingVersion left at 3; the existing perustiedot-v3 index needs a
one-time PUT /_mapping to register the field type before the next
deploy.

Also fix icu_folding filter parameter name: unicodeSetFilter →
unicode_set_filter (the correct OpenSearch settings key).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
