### PR TITLE
TOR-2569: Tarkenna SDG ammatillisen osasuoritusten koulutusmoduulit

### DIFF
--- a/src/main/scala/fi/oph/koski/sdg/SdgAmmatillinenSchema.scala
+++ b/src/main/scala/fi/oph/koski/sdg/SdgAmmatillinenSchema.scala
@@ -100,7 +100,7 @@ trait OsittaisenAmmatillisenTutkinnonOsanUseastaTutkinnostaSuoritus extends Osas
 
 @Title("Yhteisen tutkinnon osan suoritus")
 case class SdgYhteisenTutkinnonOsanSuoritus(
-  koulutusmoduuli: schema.AmmatillisenTutkinnonOsa,
+  koulutusmoduuli: schema.YhteinenTutkinnonOsa,
   tutkinto: Option[schema.AmmatillinenTutkintoKoulutus],
   @KoodistoKoodiarvo("2") // Yhteiset tutkinnon osat
   tutkinnonOsanRyhmä: Option[schema.Koodistokoodiviite],
@@ -116,7 +116,7 @@ case class SdgYhteisenTutkinnonOsanSuoritus(
 
 @Title("Muun tutkinnon osan suoritus")
 case class SdgMuunTutkinnonOsanSuoritus(
-  koulutusmoduuli: schema.AmmatillisenTutkinnonOsa,
+  koulutusmoduuli: schema.MuuKuinYhteinenTutkinnonOsa,
   tutkinto: Option[schema.AmmatillinenTutkintoKoulutus],
   @KoodistoKoodiarvo("1") // Ammatilliset tutkinnon osat
   @KoodistoKoodiarvo("3") // Vapaavalintaiset tutkinnon osat
@@ -132,7 +132,7 @@ case class SdgMuunTutkinnonOsanSuoritus(
 @Title("Korkeakouluopintoja")
 @OnlyWhen("../../suoritustapa/koodiarvo", "reformi")
 case class SdgAmmatillinenKorkeakouluopintoja(
-  koulutusmoduuli: schema.AmmatillisenTutkinnonOsa,
+  koulutusmoduuli: schema.KorkeakouluopinnotTutkinnonOsa,
   @KoodistoKoodiarvo("1") // Ammatilliset tutkinnon osat
   tutkinnonOsanRyhmä: Option[schema.Koodistokoodiviite],
   osasuoritukset: Option[List[SdgAmmatillinenKorkeakouluopintojenSuoritus]],
@@ -141,7 +141,7 @@ case class SdgAmmatillinenKorkeakouluopintoja(
 
 @Title("Yhteisten tutkinnon osien osa-alueita, lukio-opintoja tai muita jatko-opintovalmiuksia tukevia opintoja")
 case class SdgAmmatillisenTutkinnonOsanJatkoOpintovalmiuksiaTukevienOpintojenSuoritus(
-  koulutusmoduuli: schema.AmmatillisenTutkinnonOsa,
+  koulutusmoduuli: schema.JatkoOpintovalmiuksiaTukeviaOpintojaTutkinnonOsa,
   tutkinnonOsanRyhmä: Option[schema.Koodistokoodiviite],
   osasuoritukset: Option[List[YhteistenTutkinnonOsienOsaAlueidenTaiLukioOpintojenTaiMuidenOpintovalmiuksiaTukevienOpintojenOsasuoritus]] = None,
   tyyppi: schema.Koodistokoodiviite


### PR DESCRIPTION
## Summary

- The four ammatillinen osasuoritus case classes in `SdgAmmatillinenSchema` (`SdgYhteisenTutkinnonOsanSuoritus`, `SdgMuunTutkinnonOsanSuoritus`, `SdgAmmatillinenKorkeakouluopintoja`, `SdgAmmatillisenTutkinnonOsanJatkoOpintovalmiuksiaTukevienOpintojenSuoritus`) declared `koulutusmoduuli` as the sealed trait `schema.AmmatillisenTutkinnonOsa`, which exposes all five subtypes in the generated SDG schema.
- Narrowed each to the specific subtype used by the corresponding Koski osasuoritus class (`YhteinenTutkinnonOsa`, `MuuKuinYhteinenTutkinnonOsa`, `KorkeakouluopinnotTutkinnonOsa`, `JatkoOpintovalmiuksiaTukeviaOpintojaTutkinnonOsa`), matching the Koski schema's per-suoritus typing.
- Audited the remaining SDG schemas (DIA, EB, European School of Helsinki, IB, International School, Korkeakoulu, Lukio, Ylioppilastutkinto); all other `koulutusmoduuli` declarations already match their Koski equivalents.

## Test plan

- [ ] `mvn scala:compile` passes
- [ ] Regenerate `SdgSchemaSpec` snapshot (the generated SDG JSON schema for these four suoritustyypit changes)
- [ ] `BackwardCompatibilitySpec` and related SDG tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)