### PR TITLE
TOR-2651 Poista varhennetun oppivelvollisuuden tukijaksojen validaatio

### DIFF
--- a/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
+++ b/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
@@ -744,24 +744,15 @@ class KoskiValidator(
     val varhennettuOppivelvollisuusVoimaan = LocalDate.parse(config.getString("validaatiot.varhennettuOppivelvollisuusVoimaan"))
     lisätiedot match {
       case Some(lt: VarhennettuOppivelvollisuus) =>
-        val sisältymättömätJaksot = sisältymättömätAikajaksot(lt.varhennetunOppivelvollisuudenJaksot, lt)
-
         val aikaisinAlkamispäivä = findEnsimmäinenAlkamispäivä(lt.varhennetunOppivelvollisuudenJaksot)
 
         val varhennettuAlkaaLiianAikaisin = aikaisinAlkamispäivä match {
           case Some(x) => x.isBefore(varhennettuOppivelvollisuusVoimaan)
           case _ => false
         }
-        HttpStatus.fold(
-          HttpStatus.validate(!varhennettuAlkaaLiianAikaisin)(
-            KoskiErrorCategory.badRequest.validation.date(
-              s"Varhennetun oppivelvollisuuden jaksot -lisätiedon varhaisin sallittu voimassaolopäivä on $varhennettuOppivelvollisuusVoimaan"
-            )
-          ),
-          HttpStatus.validate(sisältymättömätJaksot.isEmpty)(
-            KoskiErrorCategory.badRequest.validation.date(
-              s"Varhennetun oppivelvollisuuden jaksoissa (${sisältymättömätJaksot.get.mkString(",")}) on päiviä, joille ei ole tuen päätöksen jaksoa"
-            )
+        HttpStatus.validate(!varhennettuAlkaaLiianAikaisin)(
+          KoskiErrorCategory.badRequest.validation.date(
+            s"Varhennetun oppivelvollisuuden jaksot -lisätiedon varhaisin sallittu voimassaolopäivä on $varhennettuOppivelvollisuusVoimaan"
           )
         )
       case _ => HttpStatus.ok

--- a/src/test/scala/fi/oph/koski/api/oppijavalidation/OppijaValidationEsiopetusSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/oppijavalidation/OppijaValidationEsiopetusSpec.scala
@@ -884,12 +884,11 @@ class OppijaValidationEsiopetusSpec extends TutkinnonPerusteetTest[EsiopetuksenO
         defaultOpiskeluoikeus.copy(
           tila = NuortenPerusopetuksenOpiskeluoikeudenTila(List(NuortenPerusopetuksenOpiskeluoikeusjakso(date(2026, 7, 31), opiskeluoikeusLäsnä))),
           lisätiedot = Some(EsiopetuksenOpiskeluoikeudenLisätiedot(
-            varhennetunOppivelvollisuudenJaksot = Some(List(Aikajakso(alku = Some(alku), loppu = None))),
-            tuenPäätöksenJaksot = Some(List(Tukijakso(alku = Some(alku), loppu = None))),
+            varhennetunOppivelvollisuudenJaksot = Some(List(Aikajakso(alku = Some(alku), loppu = None)))
           ))
         )
       }
-      "Varhennettu oppivelvollisuus ei saa alkaa ennen voimaantuloa ja vaatii tukijakson" in {
+      "Varhennettu oppivelvollisuus ei saa alkaa ennen voimaantuloa" in {
         val oo = makeOpiskeluoikeus(päätöksetSallittuAlkaen)
         setupOppijaWithOpiskeluoikeus(oo) {
           verifyResponseStatusOk()
@@ -899,13 +898,6 @@ class OppijaValidationEsiopetusSpec extends TutkinnonPerusteetTest[EsiopetuksenO
         setupOppijaWithOpiskeluoikeus(ooLiianAikaisin) {
           verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.date(
             "Varhennetun oppivelvollisuuden jaksot -lisätiedon varhaisin sallittu voimassaolopäivä on 2026-08-01"
-          ))
-        }
-
-        val ooIlmanTukijaksoja = oo.copy(lisätiedot = oo.lisätiedot.map(_.copy(tuenPäätöksenJaksot = None)))
-        setupOppijaWithOpiskeluoikeus(ooIlmanTukijaksoja) {
-          verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.date(
-            "Varhennetun oppivelvollisuuden jaksoissa (2026-08-01 – ) on päiviä, joille ei ole tuen päätöksen jaksoa"
           ))
         }
       }

--- a/validaation_muutoshistoria.md
+++ b/validaation_muutoshistoria.md
@@ -1,5 +1,10 @@
 # Koskeen tallennettavien tietojen validaatiosäännöt
 
+## 17.6.2026
+
+- Poistettiin validaatio, joka vaati varhennetun oppivelvollisuuden jaksolle voimassa olevan tuen päätöksen jakson.
+  - Varhennetun oppivelvollisuuden jakson saa siis siirtää ilman yhtäkään tuen päätöksen jaksoa.
+
 ## 3.6.2026
 
 - Ammatillisen opiskeluoikeuden uudelle rahoitusmuodolle tilauskoulutus (koodiarvo 17) on lisätty seuraavat validaatiot:


### PR DESCRIPTION
Poistetaan validaatio, joka vaatii varhennetun oppivelvollisuuden jaksolle voimassa olevan tuen päätöksen jakson. Varhennetun oppivelvollisuuden jakson saa siis siirtää ilman yhtäkään tuen päätöksen jaksoa.