### PR TITLE
TOR-2631 Virta tietomallin lisaykset kelaa varten

### DIFF
--- a/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
+++ b/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
@@ -105,6 +105,8 @@ case class KorkeakoulututkinnonSuoritus(
   override val osasuoritukset: Option[List[KorkeakoulunOpintojaksonSuoritus]],
   @Description("Päivämäärä, jolloin suoritus on hyväksiluettu")
   hyväksilukupäivä: Option[LocalDate] = None,
+  @Description("Virrasta saatu julkinen lisätieto suorituksesta")
+  lisätieto: Option[LocalizedString] = None,
   @KoodistoKoodiarvo("korkeakoulututkinto")
   tyyppi: Koodistokoodiviite = Koodistokoodiviite("korkeakoulututkinto", koodistoUri = "suorituksentyyppi")
 ) extends KorkeakouluSuoritus {
@@ -125,6 +127,10 @@ case class KorkeakoulunOpintojaksonSuoritus(
   override val osasuoritukset: Option[List[KorkeakoulunOpintojaksonSuoritus]] = None,
   @Description("Päivämäärä, jolloin suoritus on hyväksiluettu")
   hyväksilukupäivä: Option[LocalDate] = None,
+  @Description("Virrasta saatu julkinen lisätieto suorituksesta")
+  lisätieto: Option[LocalizedString] = None,
+  @Description("Onko suoritus opinnäytetyö")
+  opinnäytetyö: Option[Boolean] = None,
   @KoodistoKoodiarvo("korkeakoulunopintojakso")
   tyyppi: Koodistokoodiviite = Koodistokoodiviite("korkeakoulunopintojakso", koodistoUri = "suorituksentyyppi")
 ) extends KorkeakouluSuoritus {
@@ -140,6 +146,8 @@ case class MuuKorkeakoulunSuoritus (
    vahvistus: Option[Päivämäärävahvistus],
    suorituskieli: Option[Koodistokoodiviite],
    override val osasuoritukset: Option[List[KorkeakoulunOpintojaksonSuoritus]],
+   @Description("Virrasta saatu julkinen lisätieto suorituksesta")
+   lisätieto: Option[LocalizedString] = None,
    @KoodistoKoodiarvo("muukorkeakoulunsuoritus")
    tyyppi: Koodistokoodiviite = Koodistokoodiviite("muukorkeakoulunsuoritus", koodistoUri = "suorituksentyyppi")
  ) extends KorkeakouluSuoritus with Arvioinniton {

--- a/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
+++ b/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
@@ -283,7 +283,8 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
             suorituskieli = (suoritus \\ "Kieli").headOption.flatMap(kieli => koodistoViitePalvelu.validate(Koodistokoodiviite(kieli.text.toUpperCase, "kieli"))),
             toimipiste = oppilaitos(suoritus, päivämääräVahvistus.map(_.päivä)),
             osasuoritukset = optionalList(osasuoritukset),
-            hyväksilukupäivä = hyväksilukuPäivämäärä(suoritus)
+            hyväksilukupäivä = hyväksilukuPäivämäärä(suoritus),
+            lisätieto = julkinenLisätieto(suoritus)
           )
         }
         if (tutkinnonSuoritus.isEmpty) {
@@ -375,7 +376,9 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
       toimipiste = oppilaitos(suoritus, päivämääräVahvistus.map(_.päivä)),
       osasuoritukset = optionalList(osasuoritukset),
       luokittelu = noneIfEmpty(parseLuokittelu(suoritus, "virtaopsuorluokittelu")),
-      hyväksilukupäivä = hyväksilukuPäivämäärä(suoritus)
+      hyväksilukupäivä = hyväksilukuPäivämäärä(suoritus),
+      lisätieto = julkinenLisätieto(suoritus),
+      opinnäytetyö = opinnäytetyö(suoritus)
     )
   }
 
@@ -507,6 +510,17 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
 
   private def nimi(node: Node): Option[LocalizedString] = {
     sanitize((node \ "Nimi" map { nimi => (nimi \ "@kieli").text -> nimi.text }).toMap)
+  }
+
+  private def julkinenLisätieto(node: Node): Option[LocalizedString] = {
+    sanitize((node \ "JulkinenLisatieto" map { lisätieto => (lisätieto \ "@kieli").text -> lisätieto.text }).toMap)
+  }
+
+  private def opinnäytetyö(node: Node): Option[Boolean] = {
+    (node \ "Opinnaytetyo").headOption.map(_.text.trim).collect {
+      case "1" | "true"  => true
+      case "0" | "false" => false
+    }
   }
 
   private def suorituksenNimi(suoritus: Node): LocalizedString = {

--- a/src/test/scala/fi/oph/koski/virta/VirtaXMLConverterSpec.scala
+++ b/src/test/scala/fi/oph/koski/virta/VirtaXMLConverterSpec.scala
@@ -415,6 +415,84 @@ class VirtaXMLConverterSpec extends AnyFreeSpec with TestEnvironment with Matche
       }
     }
 
+    "JulkinenLisätieto" - {
+      def opintojaksoWithLisätieto(lisätiedot: scala.xml.NodeSeq): Elem =
+        <virta:Opintosuoritus opiskeluoikeusAvain="avopH1O1" opiskelijaAvain="avopH1" koulutusmoduulitunniste="K-123" avain="lisatieto-oj-1">
+          <virta:SuoritusPvm>2017-12-04</virta:SuoritusPvm>
+          <virta:Laajuus><virta:Opintopiste>5</virta:Opintopiste></virta:Laajuus>
+          <virta:Arvosana><virta:Viisiportainen>5</virta:Viisiportainen></virta:Arvosana>
+          <virta:Myontaja>10076</virta:Myontaja>
+          <virta:Laji>2</virta:Laji>
+          <virta:Nimi kieli="fi">Opintojakso</virta:Nimi>
+          <virta:Kieli>fi</virta:Kieli>
+          {lisätiedot}
+        </virta:Opintosuoritus>
+
+      def tutkintoWithLisätieto(lisätiedot: scala.xml.NodeSeq): Elem =
+        <virta:Opintosuoritus opiskeluoikeusAvain="avopH1O1" opiskelijaAvain="avopH1" koulutusmoduulitunniste="tutkinto-123" avain="lisatieto-tutkinto-1">
+          <virta:SuoritusPvm>2017-12-04</virta:SuoritusPvm>
+          <virta:Laajuus><virta:Opintopiste>180</virta:Opintopiste></virta:Laajuus>
+          <virta:Arvosana><virta:Hyvaksytty>HYV</virta:Hyvaksytty></virta:Arvosana>
+          <virta:Myontaja>10076</virta:Myontaja>
+          <virta:Laji>1</virta:Laji>
+          <virta:Nimi kieli="fi">Tutkinto</virta:Nimi>
+          <virta:Kieli>fi</virta:Kieli>
+          <virta:Koulutuskoodi>612103</virta:Koulutuskoodi>
+          {lisätiedot}
+        </virta:Opintosuoritus>
+
+      "parsitaan opintojakson suoritukselta" in {
+        val suoritus = convertSuoritus(opintojaksoWithLisätieto(<virta:JulkinenLisatieto kieli="fi">Talouskriisit (ECOK-256)</virta:JulkinenLisatieto>))
+        suoritus.get shouldBe a[KorkeakoulunOpintojaksonSuoritus]
+        suoritus.get.asInstanceOf[KorkeakoulunOpintojaksonSuoritus].lisätieto.map(_.get("fi")) shouldBe Some("Talouskriisit (ECOK-256)")
+      }
+
+      "parsitaan tutkinnon suoritukselta" in {
+        val suoritus = convertSuoritus(tutkintoWithLisätieto(<virta:JulkinenLisatieto>Theory of Elasticity</virta:JulkinenLisatieto>))
+        suoritus.get shouldBe a[KorkeakoulututkinnonSuoritus]
+        suoritus.get.asInstanceOf[KorkeakoulututkinnonSuoritus].lisätieto.map(_.get("fi")) shouldBe Some("Theory of Elasticity")
+      }
+
+      "tukee monikielisyyttä" in {
+        val suoritus = convertSuoritus(opintojaksoWithLisätieto(
+          <virta:JulkinenLisatieto kieli="fi">Suomeksi</virta:JulkinenLisatieto>
+          <virta:JulkinenLisatieto kieli="sv">På svenska</virta:JulkinenLisatieto>
+          <virta:JulkinenLisatieto kieli="en">In English</virta:JulkinenLisatieto>
+        ))
+        val lisätieto = suoritus.get.asInstanceOf[KorkeakoulunOpintojaksonSuoritus].lisätieto.value
+        lisätieto.get("fi") shouldBe "Suomeksi"
+        lisätieto.get("sv") shouldBe "På svenska"
+        lisätieto.get("en") shouldBe "In English"
+      }
+
+      "on None jos JulkinenLisatieto puuttuu" in {
+        val suoritus = convertSuoritus(opintojaksoWithLisätieto(scala.xml.NodeSeq.Empty))
+        suoritus.get.asInstanceOf[KorkeakoulunOpintojaksonSuoritus].lisätieto shouldBe None
+      }
+    }
+
+    "Opinnäytetyö" - {
+      def opintojaksoWithOpinnäytetyö(opinnäytetyö: Option[String]): Elem =
+        <virta:Opintosuoritus opiskeluoikeusAvain="avopH1O1" opiskelijaAvain="avopH1" koulutusmoduulitunniste="K-123" avain="opinnaytetyo-1">
+          <virta:SuoritusPvm>2017-12-04</virta:SuoritusPvm>
+          <virta:Laajuus><virta:Opintopiste>5</virta:Opintopiste></virta:Laajuus>
+          <virta:Arvosana><virta:Viisiportainen>5</virta:Viisiportainen></virta:Arvosana>
+          <virta:Myontaja>10076</virta:Myontaja>
+          <virta:Laji>2</virta:Laji>
+          <virta:Nimi kieli="fi">Opinnäytetyö</virta:Nimi>
+          <virta:Kieli>fi</virta:Kieli>
+          {opinnäytetyö.map(arvo => <virta:Opinnaytetyo>{arvo}</virta:Opinnaytetyo>).getOrElse(scala.xml.NodeSeq.Empty)}
+        </virta:Opintosuoritus>
+
+      def opinnäytetyö(arvo: Option[String]): Option[Boolean] =
+        convertSuoritus(opintojaksoWithOpinnäytetyö(arvo)).get.asInstanceOf[KorkeakoulunOpintojaksonSuoritus].opinnäytetyö
+
+      "parsitaan kun arvo on 1" in { opinnäytetyö(Some("1")) shouldBe Some(true) }
+      "parsitaan kun arvo on true" in { opinnäytetyö(Some("true")) shouldBe Some(true) }
+      "parsitaan kun arvo on 0" in { opinnäytetyö(Some("0")) shouldBe Some(false) }
+      "on None jos Opinnaytetyo puuttuu" in { opinnäytetyö(None) shouldBe None }
+    }
+
     "Luokittelu" - {
       "parsitaan koodistoviitteeksi" in {
         val luokittelut = convertSuoritus(suoritusWithOrganisaatio(None, luokittelu=Some(1)))

--- a/web/app/types/fi/oph/koski/schema/KorkeakoulunOpintojaksonSuoritus.ts
+++ b/web/app/types/fi/oph/koski/schema/KorkeakoulunOpintojaksonSuoritus.ts
@@ -17,6 +17,8 @@ export type KorkeakoulunOpintojaksonSuoritus = {
   tila?: Koodistokoodiviite<'suorituksentila', string>
   hyväksilukupäivä?: string
   suorituskieli?: Koodistokoodiviite<'kieli', string>
+  lisätieto?: LocalizedString
+  opinnäytetyö?: boolean
   luokittelu?: Array<Koodistokoodiviite<'virtaopsuorluokittelu', string>>
   koulutusmoduuli: KorkeakoulunOpintojakso
   toimipiste: Oppilaitos
@@ -30,6 +32,8 @@ export const KorkeakoulunOpintojaksonSuoritus = (o: {
   tila?: Koodistokoodiviite<'suorituksentila', string>
   hyväksilukupäivä?: string
   suorituskieli?: Koodistokoodiviite<'kieli', string>
+  lisätieto?: LocalizedString
+  opinnäytetyö?: boolean
   luokittelu?: Array<Koodistokoodiviite<'virtaopsuorluokittelu', string>>
   koulutusmoduuli: KorkeakoulunOpintojakso
   toimipiste: Oppilaitos

--- a/web/app/types/fi/oph/koski/schema/KorkeakoulututkinnonSuoritus.ts
+++ b/web/app/types/fi/oph/koski/schema/KorkeakoulututkinnonSuoritus.ts
@@ -18,6 +18,7 @@ export type KorkeakoulututkinnonSuoritus = {
   tila?: Koodistokoodiviite<'suorituksentila', string>
   hyväksilukupäivä?: string
   suorituskieli?: Koodistokoodiviite<'kieli', string>
+  lisätieto?: LocalizedString
   koulutusmoduuli: Korkeakoulututkinto
   toimipiste: Oppilaitos
   osasuoritukset?: Array<KorkeakoulunOpintojaksonSuoritus>
@@ -30,6 +31,7 @@ export const KorkeakoulututkinnonSuoritus = (o: {
   tila?: Koodistokoodiviite<'suorituksentila', string>
   hyväksilukupäivä?: string
   suorituskieli?: Koodistokoodiviite<'kieli', string>
+  lisätieto?: LocalizedString
   koulutusmoduuli: Korkeakoulututkinto
   toimipiste: Oppilaitos
   osasuoritukset?: Array<KorkeakoulunOpintojaksonSuoritus>

--- a/web/app/types/fi/oph/koski/schema/MuuKorkeakoulunSuoritus.ts
+++ b/web/app/types/fi/oph/koski/schema/MuuKorkeakoulunSuoritus.ts
@@ -15,6 +15,7 @@ export type MuuKorkeakoulunSuoritus = {
   tyyppi: Koodistokoodiviite<'suorituksentyyppi', 'muukorkeakoulunsuoritus'>
   tila?: Koodistokoodiviite<'suorituksentila', string>
   suorituskieli?: Koodistokoodiviite<'kieli', string>
+  lisätieto?: LocalizedString
   koulutusmoduuli: MuuKorkeakoulunOpinto
   toimipiste: Oppilaitos
   osasuoritukset?: Array<KorkeakoulunOpintojaksonSuoritus>
@@ -25,6 +26,7 @@ export const MuuKorkeakoulunSuoritus = (o: {
   tyyppi?: Koodistokoodiviite<'suorituksentyyppi', 'muukorkeakoulunsuoritus'>
   tila?: Koodistokoodiviite<'suorituksentila', string>
   suorituskieli?: Koodistokoodiviite<'kieli', string>
+  lisätieto?: LocalizedString
   koulutusmoduuli: MuuKorkeakoulunOpinto
   toimipiste: Oppilaitos
   osasuoritukset?: Array<KorkeakoulunOpintojaksonSuoritus>


### PR DESCRIPTION
Add two pieces of data to higher-education suoritukset that arrived from
Virta but were previously dropped during conversion:

- lisätieto (Option[LocalizedString]): from Opintosuoritus.JulkinenLisatieto,
  multilingual like Nimi. Added to the tutkinto, opintojakso and
  MuuKorkeakoulunSuoritus suoritus types.
- opinnäytetyö (Option[Boolean]): from Opintosuoritus.Opinnaytetyo, on the
  opintojakso suoritus only. Virta sends the value both as 0/1 and
  true/false; both forms are supported.

Synthetically built suoritukset (MuuKorkeakoulunSuoritus and the degree of a
terminated opiskeluoikeus) do not get these values, as they have no source
Opintosuoritus node.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
