### PR TITLE
Bump ws to >=8.21.0 in smoketests to fix CVE-2026-48779

### DIFF
--- a/smoketests/package.json
+++ b/smoketests/package.json
@@ -24,7 +24,8 @@
   "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800",
   "pnpm": {
     "overrides": {
-      "basic-ftp": ">=5.2.1"
+      "basic-ftp": ">=5.2.1",
+      "ws": ">=8.21.0"
     }
   },
   "devDependencies": {

--- a/smoketests/pnpm-lock.yaml
+++ b/smoketests/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   basic-ftp: '>=5.2.1'
+  ws: '>=8.21.0'
 
 importers:
 
@@ -473,8 +474,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -847,7 +848,7 @@ snapshots:
       devtools-protocol: 0.0.1608973
       typed-query-selector: 2.12.2
       webdriver-bidi-protocol: 0.4.1
-      ws: 8.20.1
+      ws: 8.21.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -990,7 +991,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.20.1: {}
+  ws@8.21.0: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
Trivy flagged ws@8.20.1 (HIGH, memory-exhaustion DoS from tiny
fragments/data chunks). In smoketests, ws is a production transitive
dependency of puppeteer, so it is in scope for the scan. Added a pnpm
override forcing ws>=8.21.0 (puppeteer-core accepts ws@^8.x, so this is
a drop-in security bump). web/ and valpas-web/ are unaffected: they only
pull ws through devDependencies, which Trivy does not scan by default.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
