### PR TITLE
TOR-2400 Salli lyhyt jarjestajan nimi

### DIFF
--- a/src/main/scala/fi/oph/koski/todistus/TodistusDataValidation.scala
+++ b/src/main/scala/fi/oph/koski/todistus/TodistusDataValidation.scala
@@ -79,7 +79,7 @@ object TodistusDataValidation {
     validateNonEmptyNonWhitespace(järjestäjäNimi, "Järjestäjän nimi", todistusId)
       .flatMap(_ => validateNotLocalizationKey(järjestäjäNimi, "Järjestäjän nimi", todistusId))
       .flatMap(_ => validateNotMissingString(järjestäjäNimi, "Järjestäjän nimi", todistusId))
-      .flatMap(_ => validateReasonableLength(järjestäjäNimi, "Järjestäjän nimi", todistusId, minLength = 5, maxLength = 200))
+      .flatMap(_ => validateReasonableLength(järjestäjäNimi, "Järjestäjän nimi", todistusId, minLength = 2, maxLength = 200))
   }
 
   private def validateAllekirjoitusPäivämäärä(päivämäärä: String, todistusId: String): Either[HttpStatus, Unit] = {

--- a/src/test/scala/fi/oph/koski/todistus/TodistusDataValidationSpec.scala
+++ b/src/test/scala/fi/oph/koski/todistus/TodistusDataValidationSpec.scala
@@ -198,6 +198,12 @@ class TodistusDataValidationSpec extends AnyFreeSpec with Matchers {
       }
 
       "Järjestäjän nimi" - {
+        "hyväksyy lyhyen mutta validin nimen (esim. 'OSAO')" in {
+          val data = createValidTodistusData().copy(järjestäjäNimi = "OSAO")
+          val result = TodistusDataValidation.validateYleinenKielitutkintoData(data, "test-id")
+          result shouldBe Right(())
+        }
+
         "hylkää tyhjän nimen" in {
           val data = createValidTodistusData().copy(järjestäjäNimi = "")
           val result = TodistusDataValidation.validateYleinenKielitutkintoData(data, "test-id")


### PR DESCRIPTION
Todistus generation failed with a 500 for legitimate organizers whose
name is shorter than 5 characters (e.g. "OSAO", Oulun seudun
ammattiopisto). The minimum-length check in TodistusDataValidation is
only a sanity floor — the real garbage detection is the empty/whitespace,
localization-key and "???"-missing-string checks — so the value of 5 was
arbitrarily too high. Lowered it to 2 so real short abbreviations pass
while single-character garbage is still rejected.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
