### PR TITLE
TOR-2400 Korjaa todistus-servletin turha 500

### DIFF
--- a/src/main/scala/fi/oph/koski/todistus/TodistusApiServlet.scala
+++ b/src/main/scala/fi/oph/koski/todistus/TodistusApiServlet.scala
@@ -16,8 +16,10 @@ class TodistusApiServlet(implicit val application: KoskiApplication)
   implicit def session: KoskiSpecificSession = koskiSessionOption.get
 
   before() {
-    requireTodistusEnabled
+    // Tunnistautuminen ensin: requireKansalainenOr... käsittelee sessiottoman pyynnön (401),
+    // requireTodistusEnabled taas lukee session, joten se ei saa ajaa ennen tunnistautumista.
     requireKansalainenOrTodistuksiaLataavaOphKäyttäjä
+    requireTodistusEnabled
   }
 
   get("/status/:id") {

--- a/src/main/scala/fi/oph/koski/todistus/TodistusDownloadServlet.scala
+++ b/src/main/scala/fi/oph/koski/todistus/TodistusDownloadServlet.scala
@@ -23,8 +23,10 @@ class TodistusDownloadServlet(implicit val application: KoskiApplication)
   val frontendValvontaMode: FrontendValvontaMode.FrontendValvontaMode = FrontendValvontaMode.ENABLED
 
   before() {
-    requireTodistusEnabled
+    // Tunnistautuminen ensin: requireKansalainenOr... käsittelee sessiottoman pyynnön (401),
+    // requireTodistusEnabled taas lukee session, joten se ei saa ajaa ennen tunnistautumista.
     requireKansalainenOrTodistuksiaLataavaOphKäyttäjä
+    requireTodistusEnabled
   }
 
   get("/:id") { nonce =>

--- a/src/main/scala/fi/oph/koski/todistus/TodistusPreviewServlet.scala
+++ b/src/main/scala/fi/oph/koski/todistus/TodistusPreviewServlet.scala
@@ -22,8 +22,10 @@ class TodistusPreviewServlet(implicit val application: KoskiApplication)
   val frontendValvontaMode: FrontendValvontaMode.FrontendValvontaMode = FrontendValvontaMode.ENABLED
 
   before() {
-    requireTodistusEnabled
+    // Tunnistautuminen ensin: requireOphPääkäyttäjä käsittelee sessiottoman pyynnön (401),
+    // requireTodistusEnabled taas lukee session, joten se ei saa ajaa ennen tunnistautumista.
     requireOphPääkäyttäjä
+    requireTodistusEnabled
   }
 
   get("/:templateVariant/:opiskeluoikeusOid")(nonce => {

--- a/src/main/scala/fi/oph/koski/todistus/TodistusServlet.scala
+++ b/src/main/scala/fi/oph/koski/todistus/TodistusServlet.scala
@@ -20,7 +20,9 @@ trait TodistusServlet extends ScalatraServlet with HasKoskiSpecificSession with 
   private val featureFlags: TodistusFeatureFlags = application.todistusFeatureFlags
 
   protected def requireTodistusEnabled: Unit = {
-    if (!featureFlags.isEnabledForUser(session)) {
+    // koskiSessionOption.exists eikä session, jottei tunnistautumaton pyyntö kaadu None.get:iin.
+    // Tunnistautuminen tarkistetaan ennen tätä, joten ilman sessiota tänne ei normaalisti päädytä.
+    if (!koskiSessionOption.exists(featureFlags.isEnabledForUser)) {
       haltWithStatus(KoskiErrorCategory.notImplemented("Todistuspalvelu ei ole käytössä"))
     }
   }
@@ -34,8 +36,11 @@ trait TodistusServlet extends ScalatraServlet with HasKoskiSpecificSession with 
   }
 
   protected def requireOphPääkäyttäjä: Unit = {
-    if (!session.hasRole(OPHPAAKAYTTAJA)) {
-      haltWithStatus(KoskiErrorCategory.forbidden("Sallittu vain OPH-pääkäyttäjälle"))
+    getUser match {
+      case Left(error) => haltWithStatus(error)
+      case Right(_) if !session.hasRole(OPHPAAKAYTTAJA) =>
+        haltWithStatus(KoskiErrorCategory.forbidden("Sallittu vain OPH-pääkäyttäjälle"))
+      case Right(_) =>
     }
   }
 

--- a/src/main/scala/fi/oph/koski/todistus/tiedote/TiedoteApiServlet.scala
+++ b/src/main/scala/fi/oph/koski/todistus/tiedote/TiedoteApiServlet.scala
@@ -17,8 +17,12 @@ class TiedoteApiServlet(implicit val application: KoskiApplication)
   implicit def session: KoskiSpecificSession = koskiSessionOption.get
 
   before() {
-    if (!session.hasRole(OPHPAAKAYTTAJA)) {
-      haltWithStatus(KoskiErrorCategory.forbidden("Sallittu vain OPH-pääkäyttäjälle"))
+    // Tunnistautuminen getUserilla ennen sessionin lukemista, jottei sessioton pyyntö kaadu None.get:iin.
+    getUser match {
+      case Left(error) => haltWithStatus(error)
+      case Right(_) if !session.hasRole(OPHPAAKAYTTAJA) =>
+        haltWithStatus(KoskiErrorCategory.forbidden("Sallittu vain OPH-pääkäyttäjälle"))
+      case Right(_) =>
     }
   }
 

--- a/src/test/scala/fi/oph/koski/todistus/TodistusKayttoOikeudetSpec.scala
+++ b/src/test/scala/fi/oph/koski/todistus/TodistusKayttoOikeudetSpec.scala
@@ -766,4 +766,34 @@ class TodistusKayttoOikeudetSpec extends TodistusSpecHelpers {
     }
   }
 
+  "Tunnistautumaton pyyntö ei kaadu 500:aan" - {
+    val oid = "1.2.246.562.15.12345678901"
+    val id = "123e4567-e89b-42d3-a456-426614174000"
+
+    // API-endpointit palauttavat 401, selainendpointit (KoskiHtmlServlet) ohjaavat kirjautumiseen (302).
+    "generate-endpoint palauttaa 401" in {
+      get(s"api/todistus/generate/fi/$oid", headers = jsonContent) {
+        verifyResponseStatus(401)
+      }
+    }
+
+    "status-endpoint palauttaa 401" in {
+      get(s"api/todistus/status/$id", headers = jsonContent) {
+        verifyResponseStatus(401)
+      }
+    }
+
+    "download-endpoint ohjaa kirjautumiseen (302)" in {
+      get(s"todistus/download/$id", headers = jsonContent) {
+        verifyResponseStatus(302)
+      }
+    }
+
+    "preview-endpoint ohjaa kirjautumiseen (302)" in {
+      get(s"todistus/preview/fi/$oid", headers = jsonContent) {
+        verifyResponseStatus(302)
+      }
+    }
+  }
+
 }

--- a/src/test/scala/fi/oph/koski/todistus/tiedote/TiedoteApiSpec.scala
+++ b/src/test/scala/fi/oph/koski/todistus/tiedote/TiedoteApiSpec.scala
@@ -36,6 +36,12 @@ class TiedoteApiSpec extends TodistusSpecHelpers {
         }
       }
 
+      "Tunnistautumaton pyyntö palauttaa 401 (eikä kaadu 500:aan)" in {
+        get("api/tiedote/jobs", headers = jsonContent) {
+          verifyResponseStatus(401)
+        }
+      }
+
       "Tukee state-suodatusta" in {
         withoutRunningTiedoteScheduler {
           app.kielitutkintotodistusTiedoteService.processAll()


### PR DESCRIPTION
Todistus-servlettien before()-filtterit lukivat sessionin (koskiSessionOption.get) ennen kuin tunnistautuminen oli tarkistettu mikä kaatui None.get:iin (NoSuchElementException -> 500) siistin 401:n sijaan. 

Korjaus: tunnistautuminen getUserilla (joka palauttaa Left -> halt 401) ennen sessionin lukemista kuten muualla koodissa.

- requireTodistusEnabled: koskiSessionOption.exists, ei session.get
- requireOphPääkäyttäjä: getUser ensin (401), sitten rooli (403)
- Api/Download/Preview: tunnistautumisgate ennen requireTodistusEnabled
- TiedoteApiServlet: getUser-pohjainen tarkistus suoran session.hasRolen tilalle

API-endpointit palauttavat nyt 401, selainendpointit (KoskiHtmlServlet) ohjaavat kirjautumiseen (302). Lisätty testit kummallekin tapaukselle.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
