### PR TITLE
Korjaa tunnistautumattoman todistuskutsun 500-virhe

### DIFF
--- a/src/main/scala/fi/oph/koski/todistus/TodistusApiServlet.scala
+++ b/src/main/scala/fi/oph/koski/todistus/TodistusApiServlet.scala
@@ -1,7 +1,6 @@
 package fi.oph.koski.todistus
 
 import fi.oph.koski.config.KoskiApplication
-import fi.oph.koski.koskiuser.{KoskiCookieAndBasicAuthenticationSupport, KoskiSpecificSession}
 import fi.oph.koski.log.KoskiOperation.TODISTUKSEN_LUONTI
 import fi.oph.koski.log.KoskiAuditLogMessageField
 import fi.oph.koski.servlet.{KoskiSpecificApiServlet, NoCache}
@@ -11,10 +10,7 @@ class TodistusApiServlet(implicit val application: KoskiApplication)
   extends KoskiSpecificApiServlet
     with TodistusServlet
     with NoCache
-    with KoskiCookieAndBasicAuthenticationSupport
 {
-  implicit def session: KoskiSpecificSession = koskiSessionOption.get
-
   before() {
     requireTodistusEnabled
     requireKansalainenOrTodistuksiaLataavaOphKäyttäjä

--- a/src/main/scala/fi/oph/koski/todistus/TodistusDownloadServlet.scala
+++ b/src/main/scala/fi/oph/koski/todistus/TodistusDownloadServlet.scala
@@ -3,7 +3,6 @@ package fi.oph.koski.todistus
 import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.frontendvalvonta.FrontendValvontaMode
 import fi.oph.koski.html.{EiRaameja, Raamit}
-import fi.oph.koski.koskiuser.{KoskiCookieAndBasicAuthenticationSupport, KoskiSpecificSession}
 import fi.oph.koski.servlet.{KoskiHtmlServlet, NoCache}
 
 import scala.util.Using
@@ -12,10 +11,7 @@ class TodistusDownloadServlet(implicit val application: KoskiApplication)
   extends KoskiHtmlServlet
     with TodistusServlet
     with NoCache
-    with KoskiCookieAndBasicAuthenticationSupport
 {
-  implicit def session: KoskiSpecificSession = koskiSessionOption.get
-
   protected val virkailijaRaamitSet: Boolean = false
   protected def virkailijaRaamit: Raamit = EiRaameja
 

--- a/src/main/scala/fi/oph/koski/todistus/TodistusPreviewServlet.scala
+++ b/src/main/scala/fi/oph/koski/todistus/TodistusPreviewServlet.scala
@@ -3,17 +3,13 @@ package fi.oph.koski.todistus
 import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.frontendvalvonta.FrontendValvontaMode
 import fi.oph.koski.html.{EiRaameja, Raamit}
-import fi.oph.koski.koskiuser.{KoskiCookieAndBasicAuthenticationSupport, KoskiSpecificSession}
 import fi.oph.koski.servlet.{KoskiHtmlServlet, NoCache}
 
 class TodistusPreviewServlet(implicit val application: KoskiApplication)
   extends KoskiHtmlServlet
     with TodistusServlet
     with NoCache
-    with KoskiCookieAndBasicAuthenticationSupport
 {
-  implicit def session: KoskiSpecificSession = koskiSessionOption.get
-
   protected val virkailijaRaamitSet: Boolean = false
   protected def virkailijaRaamit: Raamit = EiRaameja
 

--- a/src/main/scala/fi/oph/koski/todistus/TodistusServlet.scala
+++ b/src/main/scala/fi/oph/koski/todistus/TodistusServlet.scala
@@ -3,18 +3,17 @@ package fi.oph.koski.todistus
 import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.http.{HttpStatus, KoskiErrorCategory}
 import fi.oph.koski.koskiuser.Rooli.OPHPAAKAYTTAJA
-import fi.oph.koski.koskiuser.{HasKoskiSpecificSession, KoskiCookieAndBasicAuthenticationSupport, KoskiSpecificSession, Rooli, UserLanguage}
+import fi.oph.koski.koskiuser._
 import fi.oph.koski.log.KoskiOperation.{KoskiOperation, TODISTUKSEN_ESIKATSELU, TODISTUKSEN_LATAAMINEN}
-import fi.oph.koski.log.{AuditLog, AuditLogMessage, KoskiAuditLogMessage, KoskiAuditLogMessageField, Logging}
+import fi.oph.koski.log._
 import fi.oph.koski.schema.Opiskeluoikeus
 import org.scalatra.ScalatraServlet
 
 import java.util.UUID
 import scala.util.Try
 
-trait TodistusServlet extends ScalatraServlet with HasKoskiSpecificSession with KoskiCookieAndBasicAuthenticationSupport with Logging {
+trait TodistusServlet extends ScalatraServlet with RequiresSession with Logging {
   def application: KoskiApplication
-  implicit def session: KoskiSpecificSession
 
   val service: TodistusService = application.todistusService
   private val featureFlags: TodistusFeatureFlags = application.todistusFeatureFlags

--- a/src/main/scala/fi/oph/koski/todistus/tiedote/TiedoteApiServlet.scala
+++ b/src/main/scala/fi/oph/koski/todistus/tiedote/TiedoteApiServlet.scala
@@ -2,7 +2,7 @@ package fi.oph.koski.todistus.tiedote
 
 import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.http.KoskiErrorCategory
-import fi.oph.koski.koskiuser.{KoskiCookieAndBasicAuthenticationSupport, KoskiSpecificSession}
+import fi.oph.koski.koskiuser.RequiresSession
 import fi.oph.koski.koskiuser.Rooli.OPHPAAKAYTTAJA
 import fi.oph.koski.log.KoskiAuditLogMessageField.{opiskeluoikeusOid => opiskeluoikeusOidField, oppijaHenkiloOid}
 import fi.oph.koski.log.KoskiOperation.TIEDOTE_RESETOITU
@@ -12,10 +12,8 @@ import fi.oph.koski.servlet.{KoskiSpecificApiServlet, NoCache}
 class TiedoteApiServlet(implicit val application: KoskiApplication)
   extends KoskiSpecificApiServlet
     with NoCache
-    with KoskiCookieAndBasicAuthenticationSupport
+    with RequiresSession
 {
-  implicit def session: KoskiSpecificSession = koskiSessionOption.get
-
   before() {
     if (!session.hasRole(OPHPAAKAYTTAJA)) {
       haltWithStatus(KoskiErrorCategory.forbidden("Sallittu vain OPH-pääkäyttäjälle"))

--- a/src/test/scala/fi/oph/koski/todistus/TodistusKayttoOikeudetSpec.scala
+++ b/src/test/scala/fi/oph/koski/todistus/TodistusKayttoOikeudetSpec.scala
@@ -1,6 +1,7 @@
 package fi.oph.koski.todistus
 
 import fi.oph.koski.henkilo.KoskiSpecificMockOppijat
+import fi.oph.koski.http.KoskiErrorCategory
 import fi.oph.koski.koskiuser.MockUsers
 import fi.oph.koski.schema.KielitutkinnonOpiskeluoikeus
 
@@ -177,6 +178,33 @@ class TodistusKayttoOikeudetSpec extends TodistusSpecHelpers {
         get(s"api/todistus/generate/${req.toPathParams}", headers = authHeaders(MockUsers.kalle) ++ jsonContent) {
           verifyResponseStatus(403)
         }
+      }
+    }
+  }
+
+  "Tunnistautumaton kutsu" - {
+    // Regressiotesti: aiemmin tunnistautumaton kutsu kaatui 500-virheeseen (None.get),
+    // koska requireTodistusEnabled pakotti session-arvon ennen kuin tunnistautuminen oli
+    // tarkistettu. Nyt vastauksena tulee 401.
+    val oppijaOid = KoskiSpecificMockOppijat.kielitutkinnonSuorittaja.oid
+
+    "statuspyyntö parametreilla palauttaa 401:n eikä 500:aa" in {
+      val opiskeluoikeusOid = getVahvistettuKielitutkinnonOpiskeluoikeus(oppijaOid).flatMap(_.oid).get
+      get(s"api/todistus/status/fi/$opiskeluoikeusOid", headers = jsonContent) {
+        verifyResponseStatus(401, KoskiErrorCategory.unauthorized.notAuthenticated())
+      }
+    }
+
+    "statuspyyntö id:llä palauttaa 401:n eikä 500:aa" in {
+      get(s"api/todistus/status/${java.util.UUID.randomUUID()}", headers = jsonContent) {
+        verifyResponseStatus(401, KoskiErrorCategory.unauthorized.notAuthenticated())
+      }
+    }
+
+    "generointipyyntö palauttaa 401:n eikä 500:aa" in {
+      val opiskeluoikeusOid = getVahvistettuKielitutkinnonOpiskeluoikeus(oppijaOid).flatMap(_.oid).get
+      get(s"api/todistus/generate/fi/$opiskeluoikeusOid", headers = jsonContent) {
+        verifyResponseStatus(401, KoskiErrorCategory.unauthorized.notAuthenticated())
       }
     }
   }

--- a/src/test/scala/fi/oph/koski/todistus/tiedote/TiedoteApiSpec.scala
+++ b/src/test/scala/fi/oph/koski/todistus/tiedote/TiedoteApiSpec.scala
@@ -1,6 +1,7 @@
 package fi.oph.koski.todistus.tiedote
 
 import fi.oph.koski.henkilo.KoskiSpecificMockOppijat
+import fi.oph.koski.http.KoskiErrorCategory
 import fi.oph.koski.koskiuser.MockUsers
 import fi.oph.koski.todistus.TodistusSpecHelpers
 import fi.oph.koski.util.Wait
@@ -33,6 +34,14 @@ class TiedoteApiSpec extends TodistusSpecHelpers {
       "Tavallinen käyttäjä saa 403" in {
         get("api/tiedote/jobs", headers = authHeaders(MockUsers.stadinAmmattiopistoKatselija) ++ jsonContent) {
           verifyResponseStatus(403)
+        }
+      }
+
+      "Tunnistautumaton kutsu palauttaa 401:n eikä kaadu 500:aan" in {
+        // Regressiotesti: aiemmin tunnistautumaton kutsu kaatui 500-virheeseen (None.get),
+        // koska before() luki session-arvon ennen tunnistautumistarkistusta. Nyt vastauksena tulee 401.
+        get("api/tiedote/jobs", headers = jsonContent) {
+          verifyResponseStatus(401, KoskiErrorCategory.unauthorized.notAuthenticated())
         }
       }
 


### PR DESCRIPTION
TOR-2468

Tunnistautumaton kutsu todistusrajapintoihin (esim. GET /api/todistus/status/:templateVariant/:opiskeluoikeusOid) kaatui 500-virheeseen (NoSuchElementException: None.get) sen sijaan, että se olisi palauttanut 401:n.

Syy: requireTodistusEnabled on jokaisen todistusservletin before()-lohkon ensimmäinen tarkistus, ja se luki session-arvon (= koskiSessionOption.get) ennen kuin yksikään tunnistautumistarkistus ehti palauttaa 401:tä. Tunnistautumattomalla kutsulla koskiSessionOption on None, joten .get heitti poikkeuksen.

Korjaus: TodistusServlet mixaa nyt RequiresSession-traitin, jonka before()- suodatin ajetaan ennen servlettien omia before()-lohkoja ja keskeyttää tunnistautumattomat pyynnöt 401:een. Näin requireTodistusEnabled ja roolitarkistukset voivat turvallisesti lukea session-arvon. Samalla poistettiin servleteistä päällekkäinen implicit def session ja turhat mixinit, jotka RequiresSession tuo.

Lisätty regressiotestit TodistusKayttoOikeudetSpec-luokkaan: ne palauttivat ilman korjausta täsmälleen tuotannon oireen (500 internalError).