### PR TITLE
TOR-2587: näytä paikallisen oppiaineen lisäys sinisenä plus-ikonilla

### DIFF
--- a/web/app/ahvenanmaan-perusopetus/AhvenanmaanPerusopetuksenOppiaineet.tsx
+++ b/web/app/ahvenanmaan-perusopetus/AhvenanmaanPerusopetuksenOppiaineet.tsx
@@ -44,7 +44,11 @@ import {
   OsasuoritusTable,
   OsasuoritusTableColumn
 } from '../components-v2/opiskeluoikeus/OsasuoritusTable'
-import { CHARCODE_REMOVE } from '../components-v2/texts/Icon'
+import {
+  CHARCODE_ADD,
+  CHARCODE_REMOVE,
+  Icon
+} from '../components-v2/texts/Icon'
 import { FootnoteDescriptions } from '../components/footnote'
 import { finnish, t } from '../i18n/i18n'
 import { shouldShowLaajuusColumn } from '../perusopetus-v2/oppiaineLaajuus'
@@ -706,16 +710,17 @@ const UusiAhvenanmaanOppiaine: React.FC<UusiAhvenanmaanOppiaineProps> = ({
           k.koodiviite as Koodistokoodiviite<'ahvenanmaankoskioppiaineetyleissivistava'>
       }))
 
-    const uusiPaikallinenLabel = t('Lisää')
+    const uusiPaikallinenLabel = t('Lisää') + '...'
     const uusiPaikallinen = {
       key: UUSI_PAIKALLINEN_OPPIAINE_KEY,
       label: uusiPaikallinenLabel,
       display: (
         <>
-          <span className="plus">{''}</span>
+          <Icon charCode={CHARCODE_ADD} />
           {uusiPaikallinenLabel}
         </>
       ),
+      isAddNew: true,
       value: undefined as any
     }
 

--- a/web/app/components-v2/controls/Select.less
+++ b/web/app/components-v2/controls/Select.less
@@ -101,6 +101,17 @@
         &.Select__optionLabel--hover {
           background: #f0f0f0;
         }
+
+        // "Lisää uusi" -toiminto näytetään sinisenä ja plus-ikonilla (vrt. vanhan
+        // UI:n new-item). Plus-ikoni perii saman sinisen kuin teksti.
+        &.Select__optionLabel--addNew {
+          color: @color-link-blue;
+
+          .Icon {
+            color: inherit;
+            margin-right: 6px;
+          }
+        }
       }
     }
 

--- a/web/app/components-v2/controls/Select.tsx
+++ b/web/app/components-v2/controls/Select.tsx
@@ -66,6 +66,8 @@ export type FlatOption<T> = {
   isGroup?: boolean
   // Jos tosi, näytetään poistosymboli nimen vieressä, jonka klikkaaminen kutsuu Selectin callbackia onRemove
   removable?: boolean
+  // Jos tosi, vaihtoehto tyylitellään "lisää uusi" -toiminnoksi (sininen teksti, vrt. vanhan UI:n new-item)
+  isAddNew?: boolean
 }
 
 export const LoadingOptions: OptionList<any> = []
@@ -244,7 +246,8 @@ const OptionList = <T,>(props: OptionListProps<T>): React.ReactElement => {
                   'Select__optionLabel',
                   props.hoveredOption?.key === opt.key &&
                     'Select__optionLabel--hover',
-                  opt.isGroup && 'Select__optionGroup'
+                  opt.isGroup && 'Select__optionGroup',
+                  opt.isAddNew && 'Select__optionLabel--addNew'
                 )}
                 onMouseOver={
                   opt.isGroup

--- a/web/app/perusopetus-v2/PerusopetuksenOppiaineet.tsx
+++ b/web/app/perusopetus-v2/PerusopetuksenOppiaineet.tsx
@@ -81,7 +81,11 @@ import {
   KeyValueTable
 } from '../components-v2/containers/KeyValueTable'
 import { IconButton } from '../components-v2/controls/IconButton'
-import { CHARCODE_REMOVE } from '../components-v2/texts/Icon'
+import {
+  CHARCODE_ADD,
+  CHARCODE_REMOVE,
+  Icon
+} from '../components-v2/texts/Icon'
 import { FlatButton } from '../components-v2/controls/FlatButton'
 import { NumberField } from '../components-v2/controls/NumberField'
 import { LaajuusVuosiviikkotunneissa } from '../types/fi/oph/koski/schema/LaajuusVuosiviikkotunneissa'
@@ -807,16 +811,17 @@ const UusiPerusopetuksenOppiaine: React.FC<UusiPerusopetuksenOppiaineProps> = ({
       removable: true
     }))
 
-    const uusiPaikallinenLabel = t('Lisää')
+    const uusiPaikallinenLabel = t('Lisää') + '...'
     const uusiPaikallinen = {
       key: UUSI_PAIKALLINEN_OPPIAINE_KEY,
       label: uusiPaikallinenLabel,
       display: (
         <>
-          <span className="plus">{''}</span>
+          <Icon charCode={CHARCODE_ADD} />
           {uusiPaikallinenLabel}
         </>
       ),
+      isAddNew: true,
       value: undefined as any
     }
 


### PR DESCRIPTION
Tyylittele perusopetus-v2:n ja Ahvenanmaan oppiainetaulukoiden "Lisää..."-pudotusvalikon vaihtoehto vanhan käyttöliittymän new-item-tyyliin: sininen teksti ja plus-ikoni.

- Lisää Select-komponentin vaihtoehdolle isAddNew-lippu, joka liittää Select__optionLabel--addNew-modifierin (sininen @color-link-blue).
- Renderöi plus-ikoni jaetulla Icon-komponentilla (CHARCODE_ADD) raa'an FontAwesome-merkin sijaan; ikoni perii saman sinisen kuin teksti. Tämä korjaa myös Ahvenanmaan puuttuneen ikonin (tyhjä merkki lähdekoodissa).
- Lisää kolme pistettä label-tekstin perään vanhan kälin tapaan.