### PR TITLE
Update amazon-ecs-deploy-task-definition to v2.6.2

### DIFF
--- a/.github/workflows/deploy_koski.yml
+++ b/.github/workflows/deploy_koski.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Deploy using ECS
         id: ecs-deploy
-        uses: aws-actions/amazon-ecs-deploy-task-definition@cbf54ec46642b86ff78c2f5793da6746954cf8ff # v2
+        uses: aws-actions/amazon-ecs-deploy-task-definition@a310a830f5c14e583e35d84e4e1ec7dd177c3c9c # v2.6.2
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: koski-v2
@@ -96,7 +96,7 @@ jobs:
 
       - name: Deploy Amazon ECS task definition
         id: raportointikanta-loader-taskdef-deploy
-        uses: aws-actions/amazon-ecs-deploy-task-definition@cbf54ec46642b86ff78c2f5793da6746954cf8ff # v2
+        uses: aws-actions/amazon-ecs-deploy-task-definition@a310a830f5c14e583e35d84e4e1ec7dd177c3c9c # v2.6.2
         with:
           task-definition: ${{ steps.raportointikanta-loader-task-def.outputs.task-definition }}
           cluster: koski-cluster
@@ -125,7 +125,7 @@ jobs:
 
       - name: Deploy Amazon ECS task definition
         id: ytr-data-loader-taskdef-deploy
-        uses: aws-actions/amazon-ecs-deploy-task-definition@cbf54ec46642b86ff78c2f5793da6746954cf8ff # v2
+        uses: aws-actions/amazon-ecs-deploy-task-definition@a310a830f5c14e583e35d84e4e1ec7dd177c3c9c # v2.6.2
         with:
           task-definition: ${{ steps.ytr-data-loader-task-def.outputs.task-definition }}
           cluster: koski-cluster

--- a/.github/workflows/omadataoauth2sample_deploy.yml
+++ b/.github/workflows/omadataoauth2sample_deploy.yml
@@ -117,7 +117,7 @@ jobs:
           image: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ inputs.commithash }}
 
       - name: Deploy to Amazon ECS service
-        uses: aws-actions/amazon-ecs-deploy-task-definition@cbf54ec46642b86ff78c2f5793da6746954cf8ff # v2
+        uses: aws-actions/amazon-ecs-deploy-task-definition@a310a830f5c14e583e35d84e4e1ec7dd177c3c9c # v2.6.2
         with:
           task-definition: ${{ steps.render-task-def.outputs.task-definition }}
           service: ${{ env.TASK_FAMILY }}


### PR DESCRIPTION
Bump the pinned action SHA from v2 (cbf54ec) to v2.6.2 (a310a83)
across all ECS deploy jobs.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
