### PR TITLE
Korjaa checkdoc-skriptien vertailualue kahden pisteen muotoon

### DIFF
--- a/scripts/checkdoc_schema.sh
+++ b/scripts/checkdoc_schema.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 function has_schema_changes() {
-  git log --name-only --pretty=format: HEAD...origin/master | grep -E "src/main/scala/fi/oph/koski/schema" > /dev/null
+  git log --name-only --pretty=format: origin/master..HEAD | grep -E "src/main/scala/fi/oph/koski/schema" > /dev/null
 }
 
 function has_tiedonsiirtoprotokollan_muutoshistoria_changes() {
-  git log --name-only --pretty=format: HEAD...origin/master | grep -E "tiedonsiirtoprotokollan_muutoshistoria" > /dev/null
+  git log --name-only --pretty=format: origin/master..HEAD | grep -E "tiedonsiirtoprotokollan_muutoshistoria" > /dev/null
 }
 
 function check_changes() {
@@ -15,7 +15,7 @@ function check_changes() {
       echo "ERROR! Branch has schema changes but no changes to tiedonsiirtoprotokollan_muutoshistoria.md."
       echo "It is possible the changes are cosmetic or not visible to API users, but needs to be checked."
       echo
-      git log --name-only HEAD...origin/master
+      git log --name-only origin/master..HEAD
       exit 1
     fi
   fi

--- a/scripts/checkdoc_validation.sh
+++ b/scripts/checkdoc_validation.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 function has_validation_changes() {
-  git log --name-only --pretty=format: HEAD...origin/master | grep -E "koski/validation|koski/eperusteetvalidation|api/OppijaValidation" > /dev/null
+  git log --name-only --pretty=format: origin/master..HEAD | grep -E "koski/validation|koski/eperusteetvalidation|api/OppijaValidation" > /dev/null
 }
 
 function has_validaation_muustohistoria_changes() {
-  git log --name-only --pretty=format: HEAD...origin/master | grep -E "validaation_muutoshistoria" > /dev/null
+  git log --name-only --pretty=format: origin/master..HEAD | grep -E "validaation_muutoshistoria" > /dev/null
 }
 
 function check_changes() {
@@ -14,7 +14,7 @@ function check_changes() {
     if ! has_validaation_muustohistoria_changes; then
       echo "ERROR! Branch has validation changes but no changes to validaation_muutoshistoria.md:"
       echo
-      git log --name-only HEAD...origin/master
+      git log --name-only origin/master..HEAD
       exit 1
     fi
   fi


### PR DESCRIPTION
checkdoc_validation.sh ja checkdoc_schema.sh vertasivat haaraa masteriin kolmen pisteen symmetrisellä alueella (HEAD...origin/master), johon kuuluivat myös masterin omat commitit. Tämä aiheutti vääriä virheitä: kun master eteni dokumentoimattomalla validaatio- tai skeemamuutoksella (esim. TOR-2632), jokainen masterista jäljessä oleva haara hylättiin – myös sellaiset, jotka eivät koskeneet validaatio- tai skeemakoodiin lainkaan.

Vaihda kahden pisteen alueeseen (origin/master..HEAD), jolloin tarkastellaan vain haaran omia committeja. Tämä korjaa väärät virheet ja estää myös väärän hyväksynnän, jossa masterin muutoshistoriamerkintä peittäisi haaralta puuttuvan merkinnän.