### PR TITLE
TOR-2669: Ohita poistetut opiskeluoikeudet perustietojen manuaalisynkronoinnissa

### DIFF
--- a/.github/workflows/all_tests.yml
+++ b/.github/workflows/all_tests.yml
@@ -162,6 +162,7 @@ jobs:
             fi.oph.koski.opiskeluoikeus, \
             fi.oph.koski.oppilaitos, \
             fi.oph.koski.organisaatio, \
+            fi.oph.koski.perustiedot, \
             fi.oph.koski.typemodel, \
             fi.oph.koski.omadataoauth2.unit, \
             fi.oph.koski.kielitutkinto, \

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ backtest:
 	fi.oph.koski.luovutuspalvelu,fi.oph.koski.migration,fi.oph.koski.migri,\
 	fi.oph.koski.mocha,fi.oph.koski.mydata,fi.oph.koski.omaopintopolkuloki,fi.oph.koski.opensearch,\
 	fi.oph.koski.opiskeluoikeus,fi.oph.koski.oppilaitos,fi.oph.koski.oppivelvollisuustieto,\
-	fi.oph.koski.organisaatio,fi.oph.koski.perftest,fi.oph.koski.raportit,\
+	fi.oph.koski.organisaatio,fi.oph.koski.perftest,fi.oph.koski.perustiedot,fi.oph.koski.raportit,\
 	fi.oph.koski.raportointikanta,fi.oph.koski.schedule,fi.oph.koski.schema,\
 	fi.oph.koski.sso,fi.oph.koski.sure,fi.oph.koski.supa,fi.oph.koski.tools,fi.oph.koski.turvakielto,fi.oph.koski.userdirectory,fi.oph.koski.util,\
 	fi.oph.koski.valpas,fi.oph.koski.valpas.hakeutumisvalvonta,fi.oph.koski.valpas.kuntailmoitus,\

--- a/src/main/scala/fi/oph/koski/perustiedot/OpiskeluoikeudenPerustiedotIndexer.scala
+++ b/src/main/scala/fi/oph/koski/perustiedot/OpiskeluoikeudenPerustiedotIndexer.scala
@@ -139,10 +139,18 @@ class OpiskeluoikeudenPerustiedotIndexer(
       .toSeq
     if (itemsToSync.nonEmpty) {
       logger.debug(s"Manually syncing ${itemsToSync.length} rows")
-      itemsToSync.groupBy(_._2.upsert) foreach { case (upsert, syncRows) =>
+      // Poistetuilla opiskeluoikeuksilla (mitätöity/suostumus peruttu) data-sarake on tyhjä, eikä niitä voi
+      // deserialisoida. Käsitellään ne indeksistä poistoina samaan tapaan kuin tavallisessa synkronoinnissa,
+      // jottei manuaalisynkronointi jää jumiin deserialisointivirheeseen.
+      val (poistetut, voimassaolevat) = itemsToSync.partition(_._1._1.poistettu)
+
+      voimassaolevat.groupBy(_._2.upsert) foreach { case (upsert, syncRows) =>
         perustiedotSyncRepository.addToSyncQueueRaw(syncRows.map({
           case ((ooRow, henkRow), _) => perustiedotManualSyncRepository.makeSyncRow(ooRow, henkRow)
         }).flatten, upsert)
+      }
+      if (poistetut.nonEmpty) {
+        perustiedotSyncRepository.addDeletesToSyncQueue(poistetut.map(_._1._1.id).toList)
       }
       perustiedotManualSyncRepository.deleteFromQueue(allRows.map(_._2.id))
       logger.debug(s"Done manually syncing ${allRows.length} rows")

--- a/src/test/scala/fi/oph/koski/perustiedot/PerustiedotManualSyncSpec.scala
+++ b/src/test/scala/fi/oph/koski/perustiedot/PerustiedotManualSyncSpec.scala
@@ -1,0 +1,54 @@
+package fi.oph.koski.perustiedot
+
+import fi.oph.koski.api.misc.{OpiskeluoikeudenMitätöintiJaPoistoTestMethods, PutOpiskeluoikeusTestMethods, SearchTestMethods}
+import fi.oph.koski.db.KoskiTables.{KoskiOpiskeluOikeudet, PerustiedotManualSync, PerustiedotSync}
+import fi.oph.koski.db.PerustiedotManualSyncRow
+import fi.oph.koski.db.PostgresDriverWithJsonSupport.api._
+import fi.oph.koski.documentation.VapaaSivistystyöExample
+import fi.oph.koski.documentation.VapaaSivistystyöExample.opiskeluoikeusVapaatavoitteinen
+import fi.oph.koski.henkilo.KoskiSpecificMockOppijat
+import fi.oph.koski.schema.VapaanSivistystyönOpiskeluoikeus
+import fi.oph.koski.{DirtiesFixtures, KoskiApplicationForTests, KoskiHttpSpec}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class PerustiedotManualSyncSpec
+  extends AnyFreeSpec
+    with Matchers
+    with KoskiHttpSpec
+    with DirtiesFixtures
+    with PutOpiskeluoikeusTestMethods[VapaanSivistystyönOpiskeluoikeus]
+    with OpiskeluoikeudenMitätöintiJaPoistoTestMethods
+    with SearchTestMethods {
+
+  def tag = implicitly[reflect.runtime.universe.TypeTag[VapaanSivistystyönOpiskeluoikeus]]
+  override def defaultOpiskeluoikeus: VapaanSivistystyönOpiskeluoikeus = opiskeluoikeusVapaatavoitteinen
+
+  private val oppija = KoskiSpecificMockOppijat.vapaaSivistystyöVapaatavoitteinenKoulutus
+
+  "Perustietojen manuaalisynkronointi" - {
+    "ei jää jumiin poistettuun (tyhjä data) opiskeluoikeuteen vaan poistaa sen indeksistä" in {
+      val ooOid = setupOppijaWithAndGetOpiskeluoikeus(
+        oo = VapaaSivistystyöExample.opiskeluoikeusVapaatavoitteinen,
+        henkilö = oppija
+      ).oid.get
+      val ooId = runDbSync(KoskiOpiskeluOikeudet.filter(_.oid === ooOid).map(_.id).result).head
+
+      // Poiston jälkeen opiskeluoikeuden data-sarake on tyhjä eikä sitä voi deserialisoida
+      poistaOpiskeluoikeus(oppija.oid, ooOid)
+      runDbSync(KoskiOpiskeluOikeudet.filter(_.oid === ooOid).map(_.poistettu).result).head should be(true)
+
+      // Lisätään poistettu opiskeluoikeus manuaalisynkronointijonoon (kuten ylläpito tekisi käsin)
+      runDbSync(PerustiedotManualSync += PerustiedotManualSyncRow(opiskeluoikeusOid = ooOid, upsert = true))
+
+      // Aiemmin tämä heitti MappingExceptionin ja jätti jonon jumiin
+      KoskiApplicationForTests.perustiedotIndexer.manualSync(refresh = true)
+
+      // Jonon pitää tyhjentyä
+      runDbSync(PerustiedotManualSync.filter(_.opiskeluoikeusOid === ooOid).result) should be(empty)
+
+      // Poistettu opiskeluoikeus on lisätty tavalliseen synkronointijonoon indeksistä poistona
+      runDbSync(PerustiedotSync.filter(_.opiskeluoikeusId === ooId).map(_.upsert).result) should contain(false)
+    }
+  }
+}


### PR DESCRIPTION
## Ongelma

Perustietojen manuaalisynkronointi (`OpiskeluoikeudenPerustiedotIndexer.manualSync`, ajetaan 5 min välein) deserialisoi jokaisen jonossa olevan opiskeluoikeuden `toOpiskeluoikeusUnsafe`-kutsulla. Poistetulla opiskeluoikeudella (mitätöity / suostumus peruttu) `data`-sarake on tyhjä `{}`-objekti (asetetaan `OpiskeluoikeusPoistoUtils`-luokassa), joten deserialisointi heitti `MappingException`in.

Koska jono tyhjennetään vasta koko erän onnistuttua, ajastin yritti samaa epäonnistuvaa erää uudelleen viiden minuutin välein loputtomiin — tämä jumitti kaiken manuaalisynkronoinnin.

## Korjaus

Erotellaan poistetut rivit ennen deserialisointia ja ohjataan ne `addDeletesToSyncQueue`-jonoon, jolloin indeksimerkintä poistetaan — samaan tapaan kuin tavallinen synkronointi käsittelee tyhjän datan rivit. Loput rivit synkronoidaan kuten ennenkin, ja koko jono tyhjenee joka tapauksessa.

## Testit

Uusi `PerustiedotManualSyncSpec` luo VST-vapaatavoitteisen opiskeluoikeuden, poistaa sen, lisää sen manuaalisynkronointijonoon ja varmistaa että `manualSync` ei jää jumiin: jono tyhjenee ja opiskeluoikeus lisätään tavalliseen synkronointijonoon indeksistä poistona.

🤖 Generated with [Claude Code](https://claude.com/claude-code)