### PR TITLE
TOR-2667: Valpas security audit fixes

### DIFF
--- a/src/main/scala/fi/oph/koski/frontendvalvonta/FrontendValvottuServlet.scala
+++ b/src/main/scala/fi/oph/koski/frontendvalvonta/FrontendValvottuServlet.scala
@@ -25,6 +25,8 @@ trait FrontendValvottuServlet extends ScalatraBase {
     FrontendValvontaHeaders.headers(allowFrameAncestors, allowFrameSrcSelf, frontendValvontaMode, unsafeAllowInlineStyles, unsafeAllowBaseUri, nonce, formActionSources).foreach {
       case (h, v) => response.setHeader(h, v)
     }
+    response.setHeader("Cache-Control", "no-store, no-cache, must-revalidate")
+    response.setHeader("Pragma", "no-cache")
     nonce
   }
 }

--- a/src/main/scala/fi/oph/koski/jettylauncher/JettyLauncher.scala
+++ b/src/main/scala/fi/oph/koski/jettylauncher/JettyLauncher.scala
@@ -102,6 +102,8 @@ class JettyLauncher(val port: Int, val application: KoskiApplication) extends Lo
   private def setupConnector(): Unit = {
     val httpConfig = new HttpConfiguration()
     httpConfig.addCustomizer( new ForwardedRequestCustomizer() )
+    httpConfig.setSendServerVersion(false)
+    httpConfig.setSendXPoweredBy(false)
     // Allow encoded slashes (%2F) and non-ASCII bytes in path segments. Required by
     // ePerusteet 3-part diaarinumero IDs ("104%2F011%2F2014" = "104/011/2014") and
     // Finnish-character schema class names exposed via /api/types/constraints and

--- a/src/main/scala/fi/oph/koski/valpas/valpasrepository/ValpasKuntailmoitus.scala
+++ b/src/main/scala/fi/oph/koski/valpas/valpasrepository/ValpasKuntailmoitus.scala
@@ -2,6 +2,7 @@ package fi.oph.koski.valpas.valpasrepository
 
 import fi.oph.koski.schema.annotation.{KoodistoKoodiarvo, KoodistoUri}
 import fi.oph.koski.schema.{Koodistokoodiviite, OrganisaatioWithOid}
+import fi.oph.scalaschema.annotation.RegularExpression
 import fi.oph.koski.valpas.yhteystiedot.ValpasYhteystietojenAlkuperä
 
 import java.time.LocalDateTime
@@ -53,10 +54,15 @@ case class ValpasKuntailmoituksenTekijäLaajatTiedot(
 
 case class ValpasKuntailmoituksenTekijäHenkilö(
   oid: Option[ValpasKuntailmoituksenTekijäHenkilö.Oid], // Option, koska create-operaatiossa bäkkäri lukee tekijän oidin sessiosta
+  @RegularExpression("""^[^<>\r\n\t]{0,255}$""")
   etunimet: Option[String], // Option, koska kuntailmoitusta tehdessä tieto täytetään käyttäjän tiedoista
+  @RegularExpression("""^[^<>\r\n\t]{0,255}$""")
   sukunimi: Option[String], // Option, koska kuntailmoitusta tehdessä tieto täytetään käyttäjän tiedoista
+  @RegularExpression("""^[^<>\r\n\t]{0,255}$""")
   kutsumanimi: Option[String],
+  @RegularExpression("""^[^<>\r\n\t]{0,255}$""")
   email: Option[String],
+  @RegularExpression("""^[^<>\r\n\t]{0,255}$""")
   puhelinnumero: Option[String]
 )
 
@@ -65,10 +71,15 @@ object ValpasKuntailmoituksenTekijäHenkilö {
 }
 
 case class ValpasKuntailmoituksenOppijanYhteystiedot(
+  @RegularExpression("""^[^<>\r\n\t]{0,255}$""")
   puhelinnumero: Option[String] = None,
+  @RegularExpression("""^[^<>\r\n\t]{0,255}$""")
   email: Option[String] = None,
+  @RegularExpression("""^[^<>\r\n\t]{0,255}$""")
   lähiosoite: Option[String] = None,
+  @RegularExpression("""^[A-Za-z0-9 -]{0,10}$""")
   postinumero: Option[String] = None,
+  @RegularExpression("""^[^<>\r\n\t]{0,255}$""")
   postitoimipaikka: Option[String] = None,
   @KoodistoUri("maatjavaltiot2")
   maa: Option[Koodistokoodiviite] = None

--- a/src/test/scala/fi/oph/koski/valpas/kuntailmoitus/ValpasKuntailmoitusApiServletSpec.scala
+++ b/src/test/scala/fi/oph/koski/valpas/kuntailmoitus/ValpasKuntailmoitusApiServletSpec.scala
@@ -420,6 +420,51 @@ class ValpasKuntailmoitusApiServletSpec extends ValpasTestBase with BeforeAndAft
     }
   }
 
+  "Kuntailmoituksen tekijän yhteystiedoissa kulmasulkeet (esim. skriptitagi) palauttaa schema-virheen" in {
+    val ilmoitus = teeKuntailmoitusInputTekijänYhteystiedoilla(kutsumanimi = "<script>alert(0)</script>")
+
+    post("/valpas/api/kuntailmoitus", body = ilmoitus, headers = authHeaders() ++ jsonContent) {
+      verifyResponseStatus(
+        400,
+        ErrorMatcher.regex(
+          KoskiErrorCategory.badRequest.validation.jsonSchema,
+          ".*kutsumanimi.*regularExpressionMismatch.*".r
+        )
+      )
+    }
+  }
+
+  "Kuntailmoituksen oppijan yhteystiedoissa epäkelpo postinumero palauttaa schema-virheen" in {
+    val ilmoitus =
+      s"""
+         |{
+         |  "oppijaOid": "${ValpasMockOppijat.oppivelvollinenYsiluokkaKeskenKeväällä2021.oid}",
+         |  "tekijä" : {
+         |    "organisaatio" : {
+         |      "oid" : "${MockOrganisaatiot.jyväskylänNormaalikoulu}"
+         |    }
+         |  },
+         |  "kunta" : {
+         |    "oid" : "${MockOrganisaatiot.helsinginKaupunki}"
+         |  },
+         |  "oppijanYhteystiedot" : {
+         |    "postinumero" : "00100!<script>"
+         |  },
+         |  "hakenutMuualle" : false
+         |}
+         |""".stripMargin
+
+    post("/valpas/api/kuntailmoitus", body = ilmoitus, headers = authHeaders() ++ jsonContent) {
+      verifyResponseStatus(
+        400,
+        ErrorMatcher.regex(
+          KoskiErrorCategory.badRequest.validation.jsonSchema,
+          ".*postinumero.*regularExpressionMismatch.*".r
+        )
+      )
+    }
+  }
+
   "Kuntailmoituksen tekeminen ilman oikeuksia tekijäorganisaatioon palauttaa virheen" in {
     val minimikuntailmoitus = teeMinimiKuntailmoitusInput()
 


### PR DESCRIPTION
Security hardening for Valpas (TOR-2667).

- **Input validation:** constrain kuntailmoitus free-text contact/address fields — length cap, reject `<`/`>`;
  `postinumero` restricted to postal-code characters.
- **Server header:** disable Jetty `Server` / `X-Powered-By` version disclosure.
- **Caching:** add `no-store` / `no-cache` to frontend HTML shell responses (API responses were already `NoCache`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)