### PR TITLE
TOR-2464: Näytä käännökset JSON Schema Viewerissä

### DIFF
--- a/.github/workflows/all_tests.yml
+++ b/.github/workflows/all_tests.yml
@@ -140,6 +140,7 @@ jobs:
         with:
           suites: |
             fi.oph.koski.cache, \
+            fi.oph.koski.documentation, \
             fi.oph.koski.editor, \
             fi.oph.koski.environment, \
             fi.oph.koski.etk, \

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ js-unit-test-watch:
 .PHONY: backtest
 backtest:
 	mvn $(mvn_opts) -DargLine="$(mvn_argline)" test -DmembersOnlySuites="\
-	fi.oph.koski.cache,fi.oph.koski.editor,fi.oph.koski.environment,\
+	fi.oph.koski.cache,fi.oph.koski.documentation,fi.oph.koski.editor,fi.oph.koski.environment,\
 	fi.oph.koski.etk,fi.oph.koski.hakemuspalvelu,fi.oph.koski.henkilo,fi.oph.koski.html,fi.oph.koski.http,\
 	fi.oph.koski.integrationtest,fi.oph.koski.json,fi.oph.koski.kela,fi.oph.koski.koodisto,\
 	fi.oph.koski.koskiuser,fi.oph.koski.localization,fi.oph.koski.cas,fi.oph.koski.log,\

--- a/documentation/json-schema-viewer.md
+++ b/documentation/json-schema-viewer.md
@@ -45,11 +45,49 @@ re-apply them**:
   from the label length, since the tree font is monospace) shown only on the
   focused node as a rounded green outline around the label. Replaces the plain
   bold, which was hard to see.
+- **Translation panel rendering** (TOR-2464) — the info panel's "Translation"
+  tab reads `node.translation` and renders one block per language (quiet
+  language label, bold title, plain description), using `.text()` so the
+  strings are escaped. See "Translation tab" below for how the data is
+  produced.
 
 The `deprecated` / `redundantData` / `sensitive` booleans the viewer reads come
 from the schema JSON, emitted by the matching annotations in
 `src/main/scala/fi/oph/koski/schema/annotation/` (`Deprecated`, `RedundantData`,
 `Annotations.scala` → `SensitiveData`).
+
+## Translation tab (TOR-2464)
+
+The info panel's "Translation" tab is populated server-side. Each viewer
+schema is served through `LocalizedSchemas` (`fi.oph.koski.documentation`),
+which:
+
+- builds the same `ClassSchema` as the corresponding `*Schema` object
+  (`KoskiSchema.createSchema`),
+- runs `SchemaLocalizationEnricher` (`fi.oph.koski.localization`) to attach a
+  `translation` field to each property and class node, resolved from
+  `koskiLocalizationRepository` using the same keys as
+  `KoskiSpecificSchemaLocalization` — **title + description only**,
+- caches the enriched JSON ~1 min (matching the localization cache refresh),
+  so translation edits appear without a restart.
+
+The emitted shape is language-keyed and **excludes Finnish** (the Finnish
+title is the node name and the Finnish description is already in the
+Definition box):
+
+```json
+"translation": { "sv": { "title": "…", "description": "…" }, "en": { … } }
+```
+
+Notes:
+
+- Tooltip/info-link annotations aren't emitted into the schema JSON, so they
+  aren't shown; missing keys/languages are skipped, and a node with no sv/en
+  translation gets no `translation` field.
+- The `translation` keyword is non-standard and ignored by JSON Schema
+  validators, so it is a safe additive change to the documentation schemas
+  (which external integrators may also consume).
+- To cover a new schema, register it in `LocalizedSchemas`.
 
 ## Editing / build
 

--- a/src/main/scala/fi/oph/koski/documentation/DocumentationApiServlet.scala
+++ b/src/main/scala/fi/oph/koski/documentation/DocumentationApiServlet.scala
@@ -1,35 +1,25 @@
 package fi.oph.koski.documentation
 
 import fi.oph.koski.config.KoskiApplication
-import fi.oph.koski.hakemuspalvelu.HakemuspalveluSchema
 import fi.oph.koski.http.KoskiErrorCategory
 import fi.oph.koski.json.JsonSerializer
-import fi.oph.koski.kela.KelaSchema
 import fi.oph.koski.koodisto.Koodistot
 import fi.oph.koski.koskiuser.Unauthenticated
-import fi.oph.koski.luovutuspalvelu.HslResponse
 import fi.oph.koski.massaluovutus.luokallejaaneet.MassaluovutusQueryLuokalleJaaneetResult
 import fi.oph.koski.massaluovutus.suorituspalvelu.SupaResponse
 import fi.oph.koski.massaluovutus.valintalaskenta.ValintalaskentaResult
-import fi.oph.koski.migri.MigriSchema
 import fi.oph.koski.massaluovutus.{QueryDocumentation, QueryResponse}
-import fi.oph.koski.omadataoauth2.{OmaDataOAuth2AktiivisetJaPäättyneetOpiskeluoikeudet, OmaDataOAuth2Documentation, OmaDataOAuth2KaikkiOpiskeluoikeudet, OmaDataOAuth2KaikkiOpiskeluoikeudetJaValintatiedot, OmaDataOAuth2SuoritetutTutkinnot}
-import fi.oph.koski.schema.KoskiSchema
-import fi.oph.koski.sdg.SdgSchema
+import fi.oph.koski.omadataoauth2.OmaDataOAuth2Documentation
 import fi.oph.koski.servlet.{KoskiSpecificApiServlet, NoCache}
-import fi.oph.koski.suoritusjako.{AktiivisetJaPäättyneetOpinnotOppijaJakolinkillä, SuoritetutTutkinnotOppijaJakolinkillä}
 import fi.oph.koski.supa.SupaOpiskeluoikeudenVersioResponse
-import fi.oph.koski.valpas.kela.ValpasKelaSchema
 import fi.oph.koski.valpas.massaluovutus.{ValpasEiOppivelvollisuuttaSuorittavatMassaluovutusResult, ValpasOppivelvollisetMassaluovutusResult}
-import fi.oph.koski.valpas.oppija.ValpasInternalSchema
-import fi.oph.koski.valpas.ytl.ValpasYtlSchema
-import fi.oph.koski.valvira.ValviraSchema
-import fi.oph.koski.kios.KiosSchema
-import fi.oph.koski.ytl.YtlSchema
 
 import scala.reflect.runtime.{universe => ru}
 
 class DocumentationApiServlet(application: KoskiApplication) extends KoskiSpecificApiServlet with Unauthenticated with NoCache {
+  private lazy val localizedSchemas =
+    new LocalizedSchemas(application.koskiLocalizationRepository)(application.cacheManager)
+
   get("/categoryNames.json") {
     KoskiTiedonSiirtoHtml.categoryNames
   }
@@ -54,75 +44,75 @@ class DocumentationApiServlet(application: KoskiApplication) extends KoskiSpecif
     renderOption(KoskiErrorCategory.notFound)(Examples.oppijaExamples.find(_.name == params("name")).map(_.data))
   }
   get("/koski-oppija-schema.json") {
-    KoskiSchema.schemaJson
+    localizedSchemas("koski-oppija-schema.json")
   }
 
   get("/valvira-oppija-schema.json") {
-    ValviraSchema.schemaJson
+    localizedSchemas("valvira-oppija-schema.json")
   }
 
   get("/hakemuspalvelu-oppija-schema.json") {
-    HakemuspalveluSchema.schemaJson
+    localizedSchemas("hakemuspalvelu-oppija-schema.json")
   }
 
   get("/hsl-oppija-schema.json") {
-    HslResponse.schemaJson
+    localizedSchemas("hsl-oppija-schema.json")
   }
 
   get("/kela-oppija-schema.json") {
-    KelaSchema.schemaJson
+    localizedSchemas("kela-oppija-schema.json")
   }
 
   get("/suoritetut-tutkinnot-oppija-schema.json") {
-    SuoritetutTutkinnotOppijaJakolinkillä.schemaJson
+    localizedSchemas("suoritetut-tutkinnot-oppija-schema.json")
   }
 
   get("/aktiiviset-ja-paattyneet-opinnot-oppija-schema.json") {
-    AktiivisetJaPäättyneetOpinnotOppijaJakolinkillä.schemaJson
+    localizedSchemas("aktiiviset-ja-paattyneet-opinnot-oppija-schema.json")
   }
 
   get("/kios-oppija-schema.json") {
-    KiosSchema.schemaJson
+    localizedSchemas("kios-oppija-schema.json")
   }
 
   get("/sdg-oppija-schema.json") {
-    SdgSchema.schemaJson
+    localizedSchemas("sdg-oppija-schema.json")
   }
 
   get("/ytl-oppija-schema.json") {
-    YtlSchema.schemaJson
+    localizedSchemas("ytl-oppija-schema.json")
   }
 
   get("/ytl-valpas-oppija-schema.json") {
-    ValpasYtlSchema.schemaJson
+    localizedSchemas("ytl-valpas-oppija-schema.json")
   }
 
   get("/valpas-kela-oppija-schema.json") {
-    ValpasKelaSchema.schemaJson
+    localizedSchemas("valpas-kela-oppija-schema.json")
   }
 
   get("/valpas-internal-laaja-schema.json") {
-    ValpasInternalSchema.laajaSchemaJson
+    localizedSchemas("valpas-internal-laaja-schema.json")
   }
 
   get("/valpas-internal-suppea-schema.json") {
-    ValpasInternalSchema.suppeaSchemaJson
+    localizedSchemas("valpas-internal-suppea-schema.json")
   }
 
   get("/valpas-internal-kunta-suppea-schema.json") {
-    ValpasInternalSchema.kuntaSuppeaSchemaJson
+    localizedSchemas("valpas-internal-kunta-suppea-schema.json")
   }
 
   get("/valpas-internal-heturouhinta-schema.json") {
-    ValpasInternalSchema.heturouhintaSchemaJson
+    localizedSchemas("valpas-internal-heturouhinta-schema.json")
   }
 
   get("/valpas-internal-kuntarouhinta-schema.json") {
-    ValpasInternalSchema.kuntarouhintaSchemaJson
+    localizedSchemas("valpas-internal-kuntarouhinta-schema.json")
   }
 
   get("/migri-oppija-schema.json") {
-    MigriSchema.schemaJson
+    localizedSchemas("migri-oppija-schema.json")
   }
 
   get("/koodistot.json") {
@@ -170,19 +160,19 @@ class DocumentationApiServlet(application: KoskiApplication) extends KoskiSpecif
   }
 
   get("/omadata-oauth2-suoritetut-tutkinnot-oppija-schema.json") {
-    OmaDataOAuth2SuoritetutTutkinnot.schemaJson
+    localizedSchemas("omadata-oauth2-suoritetut-tutkinnot-oppija-schema.json")
   }
 
   get("/omadata-oauth2-aktiiviset-ja-paattyneet-opinnot-oppija-schema.json") {
-    OmaDataOAuth2AktiivisetJaPäättyneetOpiskeluoikeudet.schemaJson
+    localizedSchemas("omadata-oauth2-aktiiviset-ja-paattyneet-opinnot-oppija-schema.json")
   }
 
   get("/omadata-oauth2-kaikki-tiedot-oppija-schema.json") {
-    OmaDataOAuth2KaikkiOpiskeluoikeudet.schemaJson
+    localizedSchemas("omadata-oauth2-kaikki-tiedot-oppija-schema.json")
   }
 
   get("/omadata-oauth2-kaikki-tiedot-ja-valintatiedot-oppija-schema.json") {
-    OmaDataOAuth2KaikkiOpiskeluoikeudetJaValintatiedot.schemaJson
+    localizedSchemas("omadata-oauth2-kaikki-tiedot-ja-valintatiedot-oppija-schema.json")
   }
 
   override def toJsonString[T: ru.TypeTag](x: T): String = JsonSerializer.writeWithRoot(x)

--- a/src/main/scala/fi/oph/koski/documentation/LocalizedSchemas.scala
+++ b/src/main/scala/fi/oph/koski/documentation/LocalizedSchemas.scala
@@ -1,0 +1,66 @@
+package fi.oph.koski.documentation
+
+import fi.oph.koski.cache.{CacheManager, KeyValueCache, RefreshingCache}
+import fi.oph.koski.hakemuspalvelu.HakemuspalveluOppija
+import fi.oph.koski.kela.KelaOppija
+import fi.oph.koski.kios.KiosOppija
+import fi.oph.koski.localization.{LocalizationRepository, SchemaLocalizationEnricher}
+import fi.oph.koski.luovutuspalvelu.HslResponse
+import fi.oph.koski.migri.MigriOppija
+import fi.oph.koski.omadataoauth2.{OmaDataOAuth2AktiivisetJaPäättyneetOpiskeluoikeudet, OmaDataOAuth2KaikkiOpiskeluoikeudet, OmaDataOAuth2KaikkiOpiskeluoikeudetJaValintatiedot, OmaDataOAuth2SuoritetutTutkinnot}
+import fi.oph.koski.schema.KoskiSchema
+import fi.oph.koski.sdg.SdgOppija
+import fi.oph.koski.suoritusjako.{AktiivisetJaPäättyneetOpinnotOppijaJakolinkillä, SuoritetutTutkinnotOppijaJakolinkillä}
+import fi.oph.koski.valpas.kela.ValpasKelaOppija
+import fi.oph.koski.valpas.oppija.{OppijaHakutilanteillaLaajatTiedot, OppijaHakutilanteillaSuppeatTiedot, OppijaKuntailmoituksillaSuppeatTiedot}
+import fi.oph.koski.valpas.rouhinta.{HeturouhinnanTulos, KuntarouhinnanTulos}
+import fi.oph.koski.valpas.ytl.YtlMaksuttomuustieto
+import fi.oph.koski.valvira.ValviraOppija
+import fi.oph.koski.ytl.YtlOppija
+import fi.oph.scalaschema.{ClassSchema, SchemaToJson}
+import org.json4s.JValue
+
+import scala.concurrent.duration.DurationInt
+
+class LocalizedSchemas(localizationRepository: LocalizationRepository)(implicit cacheManager: CacheManager) {
+  private def build(clazz: Class[_]): () => ClassSchema =
+    () => KoskiSchema.createSchema(clazz).asInstanceOf[ClassSchema]
+
+  private val schemasByName: Map[String, () => ClassSchema] = Map(
+    "koski-oppija-schema.json" -> (() => KoskiSchema.schema),
+    "valvira-oppija-schema.json" -> build(classOf[ValviraOppija]),
+    "hakemuspalvelu-oppija-schema.json" -> build(classOf[HakemuspalveluOppija]),
+    "hsl-oppija-schema.json" -> build(classOf[HslResponse]),
+    "kela-oppija-schema.json" -> build(classOf[KelaOppija]),
+    "suoritetut-tutkinnot-oppija-schema.json" -> build(classOf[SuoritetutTutkinnotOppijaJakolinkillä]),
+    "aktiiviset-ja-paattyneet-opinnot-oppija-schema.json" -> build(classOf[AktiivisetJaPäättyneetOpinnotOppijaJakolinkillä]),
+    "kios-oppija-schema.json" -> build(classOf[KiosOppija]),
+    "sdg-oppija-schema.json" -> build(classOf[SdgOppija]),
+    "ytl-oppija-schema.json" -> build(classOf[YtlOppija]),
+    "ytl-valpas-oppija-schema.json" -> build(classOf[YtlMaksuttomuustieto]),
+    "valpas-kela-oppija-schema.json" -> build(classOf[ValpasKelaOppija]),
+    "valpas-internal-laaja-schema.json" -> build(classOf[OppijaHakutilanteillaLaajatTiedot]),
+    "valpas-internal-suppea-schema.json" -> build(classOf[OppijaHakutilanteillaSuppeatTiedot]),
+    "valpas-internal-kunta-suppea-schema.json" -> build(classOf[OppijaKuntailmoituksillaSuppeatTiedot]),
+    "valpas-internal-heturouhinta-schema.json" -> build(classOf[HeturouhinnanTulos]),
+    "valpas-internal-kuntarouhinta-schema.json" -> build(classOf[KuntarouhinnanTulos]),
+    "migri-oppija-schema.json" -> build(classOf[MigriOppija]),
+    "omadata-oauth2-suoritetut-tutkinnot-oppija-schema.json" -> build(classOf[OmaDataOAuth2SuoritetutTutkinnot]),
+    "omadata-oauth2-aktiiviset-ja-paattyneet-opinnot-oppija-schema.json" -> build(classOf[OmaDataOAuth2AktiivisetJaPäättyneetOpiskeluoikeudet]),
+    "omadata-oauth2-kaikki-tiedot-oppija-schema.json" -> build(classOf[OmaDataOAuth2KaikkiOpiskeluoikeudet]),
+    "omadata-oauth2-kaikki-tiedot-ja-valintatiedot-oppija-schema.json" -> build(classOf[OmaDataOAuth2KaikkiOpiskeluoikeudetJaValintatiedot])
+  )
+
+  private val cache = KeyValueCache[String, JValue](
+    new RefreshingCache("LocalizedSchemas", RefreshingCache.Params(1.minute, maxSize = 50)),
+    (name: String) => localize(schemasByName(name)())
+  )
+
+  def contains(name: String): Boolean = schemasByName.contains(name)
+
+  def apply(name: String): JValue = cache(name)
+
+  private def localize(schema: ClassSchema): JValue =
+    new SchemaLocalizationEnricher(localizationRepository.localizations)
+      .enrich(schema, SchemaToJson.toJsonSchema(schema))
+}

--- a/src/main/scala/fi/oph/koski/localization/SchemaLocalizationEnricher.scala
+++ b/src/main/scala/fi/oph/koski/localization/SchemaLocalizationEnricher.scala
@@ -1,10 +1,45 @@
 package fi.oph.koski.localization
 
 import fi.oph.koski.schema.LocalizedString
-import org.json4s.JsonAST.{JArray, JObject, JString}
+import fi.oph.scalaschema.ClassSchema
+import org.json4s.JsonAST.{JArray, JObject, JString, JValue}
 
 class SchemaLocalizationEnricher(localizations: Map[String, LocalizedString]) {
   import SchemaLocalizationEnricher.KeyAndText
+
+  def enrich(schema: ClassSchema, json: JObject): JObject = {
+    val definitionsBySimpleName = schema.definitions.collect { case c: ClassSchema => c.simpleName -> c }.toMap
+    val withDefinitions = JObject(json.obj.map {
+      case ("definitions", JObject(defs)) =>
+        "definitions" -> JObject(defs.map {
+          case (name, defJson: JObject) =>
+            name -> definitionsBySimpleName.get(name).fold(defJson: JValue)(injectClassBody(_, defJson))
+          case other => other
+        })
+      case other => other
+    })
+    injectClassBody(schema, withDefinitions)
+  }
+
+  private def injectClassBody(schema: ClassSchema, classJson: JObject): JObject = {
+    val propertiesByKey = schema.properties.map(p => p.key -> p).toMap
+    val withProperties = JObject(classJson.obj.map {
+      case ("properties", JObject(props)) =>
+        "properties" -> JObject(props.map {
+          case (key, node: JObject) =>
+            val translation = propertiesByKey.get(key)
+              .flatMap(p => translationFor(List(KoskiSpecificSchemaLocalization.title(p)), KoskiSpecificSchemaLocalization.description(p)))
+            key -> translation.fold(node: JValue)(withTranslation(node, _))
+          case other => other
+        })
+      case other => other
+    })
+    translationFor(Nil, KoskiSpecificSchemaLocalization.description(schema))
+      .fold(withProperties)(withTranslation(withProperties, _))
+  }
+
+  private def withTranslation(node: JObject, translation: JObject): JObject =
+    JObject(node.obj :+ ("translation", translation: JValue))
 
   def translationFor(titleParts: List[KeyAndText], descriptionParts: List[KeyAndText]): Option[JObject] = {
     val entries = List(

--- a/src/main/scala/fi/oph/koski/localization/SchemaLocalizationEnricher.scala
+++ b/src/main/scala/fi/oph/koski/localization/SchemaLocalizationEnricher.scala
@@ -2,7 +2,7 @@ package fi.oph.koski.localization
 
 import fi.oph.koski.schema.LocalizedString
 import fi.oph.scalaschema.ClassSchema
-import org.json4s.JsonAST.{JArray, JObject, JString, JValue}
+import org.json4s.JsonAST.{JObject, JString, JValue}
 
 class SchemaLocalizationEnricher(localizations: Map[String, LocalizedString]) {
   import SchemaLocalizationEnricher.KeyAndText
@@ -42,21 +42,22 @@ class SchemaLocalizationEnricher(localizations: Map[String, LocalizedString]) {
     JObject(node.obj :+ ("translation", translation: JValue))
 
   def translationFor(titleParts: List[KeyAndText], descriptionParts: List[KeyAndText]): Option[JObject] = {
-    val entries = List(
-      "Otsikko" -> lines(titleParts),
-      "Kuvaus" -> lines(descriptionParts)
-    ).collect { case (label, ls) if ls.nonEmpty => label -> JArray(ls.map(JString)) }
-    if (entries.isEmpty) None else Some(JObject(entries: _*))
+    val byLanguage = SchemaLocalizationEnricher.translatedLanguages.flatMap { lang =>
+      val fields = List(
+        "title" -> textFor(titleParts, lang),
+        "description" -> textFor(descriptionParts, lang)
+      ).collect { case (key, Some(text)) => key -> (JString(text): JValue) }
+      if (fields.isEmpty) None else Some(lang -> (JObject(fields: _*): JValue))
+    }
+    if (byLanguage.isEmpty) None else Some(JObject(byLanguage: _*))
   }
 
-  private def lines(parts: List[KeyAndText]): List[String] =
-    parts.flatMap { case (key, _) =>
-      localizations.get(key).toList.flatMap { localized =>
-        LocalizedString.languages.flatMap(lang => localized.getOptional(lang).map(text => s"$lang: $text"))
-      }
-    }
+  private def textFor(parts: List[KeyAndText], lang: String): Option[String] =
+    parts.flatMap { case (key, _) => localizations.get(key).flatMap(_.getOptional(lang)) }.headOption
 }
 
 object SchemaLocalizationEnricher {
   type KeyAndText = (String, String)
+
+  val translatedLanguages: List[String] = List("sv", "en")
 }

--- a/src/main/scala/fi/oph/koski/localization/SchemaLocalizationEnricher.scala
+++ b/src/main/scala/fi/oph/koski/localization/SchemaLocalizationEnricher.scala
@@ -1,0 +1,27 @@
+package fi.oph.koski.localization
+
+import fi.oph.koski.schema.LocalizedString
+import org.json4s.JsonAST.{JArray, JObject, JString}
+
+class SchemaLocalizationEnricher(localizations: Map[String, LocalizedString]) {
+  import SchemaLocalizationEnricher.KeyAndText
+
+  def translationFor(titleParts: List[KeyAndText], descriptionParts: List[KeyAndText]): Option[JObject] = {
+    val entries = List(
+      "Otsikko" -> lines(titleParts),
+      "Kuvaus" -> lines(descriptionParts)
+    ).collect { case (label, ls) if ls.nonEmpty => label -> JArray(ls.map(JString)) }
+    if (entries.isEmpty) None else Some(JObject(entries: _*))
+  }
+
+  private def lines(parts: List[KeyAndText]): List[String] =
+    parts.flatMap { case (key, _) =>
+      localizations.get(key).toList.flatMap { localized =>
+        LocalizedString.languages.flatMap(lang => localized.getOptional(lang).map(text => s"$lang: $text"))
+      }
+    }
+}
+
+object SchemaLocalizationEnricher {
+  type KeyAndText = (String, String)
+}

--- a/src/test/scala/fi/oph/koski/documentation/LocalizedSchemasSpec.scala
+++ b/src/test/scala/fi/oph/koski/documentation/LocalizedSchemasSpec.scala
@@ -1,0 +1,51 @@
+package fi.oph.koski.documentation
+
+import fi.oph.koski.{KoskiApplicationForTests, TestEnvironment}
+import org.json4s.JValue
+import org.json4s.JsonAST.{JArray, JObject, JString}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class LocalizedSchemasSpec extends AnyFreeSpec with TestEnvironment with Matchers {
+  private val localizedSchemas =
+    new LocalizedSchemas(KoskiApplicationForTests.koskiLocalizationRepository)(KoskiApplicationForTests.cacheManager)
+
+  "koski-oppija-schema.json is enriched with fi/sv/en translations on many nodes" in {
+    val lines = translationLines(localizedSchemas("koski-oppija-schema.json"))
+    lines.count(_.startsWith("fi: ")) should be > 50
+    lines.exists(_.startsWith("sv: ")) shouldBe true
+    lines.exists(_.startsWith("en: ")) shouldBe true
+  }
+
+  "all registered viewer schemas are enriched with translations" - {
+    val schemaNames = List(
+      "kela-oppija-schema.json",
+      "migri-oppija-schema.json",
+      "valpas-internal-laaja-schema.json",
+      "omadata-oauth2-kaikki-tiedot-oppija-schema.json"
+    )
+    schemaNames.foreach { name =>
+      name in {
+        localizedSchemas.contains(name) shouldBe true
+        translationLines(localizedSchemas(name)).count(_.startsWith("fi: ")) should be > 10
+      }
+    }
+  }
+
+  private def translationLines(json: JValue): List[String] = json match {
+    case JObject(fields) =>
+      fields.flatMap {
+        case ("translation", t) => collectStrings(t)
+        case (_, v) => translationLines(v)
+      }
+    case JArray(items) => items.flatMap(translationLines)
+    case _ => Nil
+  }
+
+  private def collectStrings(json: JValue): List[String] = json match {
+    case JString(s) => List(s)
+    case JObject(fields) => fields.flatMap { case (_, v) => collectStrings(v) }
+    case JArray(items) => items.flatMap(collectStrings)
+    case _ => Nil
+  }
+}

--- a/src/test/scala/fi/oph/koski/documentation/LocalizedSchemasSpec.scala
+++ b/src/test/scala/fi/oph/koski/documentation/LocalizedSchemasSpec.scala
@@ -2,7 +2,7 @@ package fi.oph.koski.documentation
 
 import fi.oph.koski.{KoskiApplicationForTests, TestEnvironment}
 import org.json4s.JValue
-import org.json4s.JsonAST.{JArray, JObject, JString}
+import org.json4s.JsonAST.{JArray, JNothing, JObject}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -10,11 +10,12 @@ class LocalizedSchemasSpec extends AnyFreeSpec with TestEnvironment with Matcher
   private val localizedSchemas =
     new LocalizedSchemas(KoskiApplicationForTests.koskiLocalizationRepository)(KoskiApplicationForTests.cacheManager)
 
-  "koski-oppija-schema.json is enriched with fi/sv/en translations on many nodes" in {
-    val lines = translationLines(localizedSchemas("koski-oppija-schema.json"))
-    lines.count(_.startsWith("fi: ")) should be > 50
-    lines.exists(_.startsWith("sv: ")) shouldBe true
-    lines.exists(_.startsWith("en: ")) shouldBe true
+  "koski-oppija-schema.json is enriched with sv/en translations on many nodes, excluding fi" in {
+    val ts = translations(localizedSchemas("koski-oppija-schema.json"))
+    ts.size should be > 50
+    ts.exists(t => (t \ "sv" \ "title") != JNothing || (t \ "sv" \ "description") != JNothing) shouldBe true
+    ts.exists(t => (t \ "en" \ "title") != JNothing || (t \ "en" \ "description") != JNothing) shouldBe true
+    ts.forall(t => (t \ "fi") == JNothing) shouldBe true
   }
 
   "all registered viewer schemas are enriched with translations" - {
@@ -27,25 +28,18 @@ class LocalizedSchemasSpec extends AnyFreeSpec with TestEnvironment with Matcher
     schemaNames.foreach { name =>
       name in {
         localizedSchemas.contains(name) shouldBe true
-        translationLines(localizedSchemas(name)).count(_.startsWith("fi: ")) should be > 10
+        translations(localizedSchemas(name)).size should be > 10
       }
     }
   }
 
-  private def translationLines(json: JValue): List[String] = json match {
+  private def translations(json: JValue): List[JValue] = json match {
     case JObject(fields) =>
       fields.flatMap {
-        case ("translation", t) => collectStrings(t)
-        case (_, v) => translationLines(v)
+        case ("translation", t) => t :: translations(t)
+        case (_, v) => translations(v)
       }
-    case JArray(items) => items.flatMap(translationLines)
-    case _ => Nil
-  }
-
-  private def collectStrings(json: JValue): List[String] = json match {
-    case JString(s) => List(s)
-    case JObject(fields) => fields.flatMap { case (_, v) => collectStrings(v) }
-    case JArray(items) => items.flatMap(collectStrings)
+    case JArray(items) => items.flatMap(translations)
     case _ => Nil
   }
 }

--- a/src/test/scala/fi/oph/koski/localization/SchemaLocalizationEnricherSpec.scala
+++ b/src/test/scala/fi/oph/koski/localization/SchemaLocalizationEnricherSpec.scala
@@ -1,0 +1,37 @@
+package fi.oph.koski.localization
+
+import fi.oph.koski.schema.{Finnish, LocalizedString}
+import org.json4s.JsonAST.{JArray, JObject, JString}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class SchemaLocalizationEnricherSpec extends AnyFreeSpec with Matchers {
+  private val localizations: Map[String, LocalizedString] = Map(
+    "Tila" -> Finnish("Tila", Some("Status"), Some("State")),
+    "description:Opiskeluoikeuden voimassaolo" -> Finnish("Opiskeluoikeuden voimassaolo", Some("Studierättens giltighet"), None)
+  )
+  private val enricher = new SchemaLocalizationEnricher(localizations)
+
+  "translationFor" - {
+    "builds an Otsikko entry from a title key" in {
+      enricher.translationFor(List(("Tila", "Tila")), Nil) shouldBe Some(
+        JObject("Otsikko" -> JArray(List(JString("fi: Tila"), JString("sv: Status"), JString("en: State"))))
+      )
+    }
+
+    "omits missing languages and merges title + description" in {
+      val result = enricher.translationFor(
+        List(("Tila", "Tila")),
+        List(("description:Opiskeluoikeuden voimassaolo", "Opiskeluoikeuden voimassaolo"))
+      )
+      result shouldBe Some(JObject(
+        "Otsikko" -> JArray(List(JString("fi: Tila"), JString("sv: Status"), JString("en: State"))),
+        "Kuvaus" -> JArray(List(JString("fi: Opiskeluoikeuden voimassaolo"), JString("sv: Studierättens giltighet")))
+      ))
+    }
+
+    "returns None when nothing resolves" in {
+      enricher.translationFor(List(("Unknown", "Unknown")), Nil) shouldBe None
+    }
+  }
+}

--- a/src/test/scala/fi/oph/koski/localization/SchemaLocalizationEnricherSpec.scala
+++ b/src/test/scala/fi/oph/koski/localization/SchemaLocalizationEnricherSpec.scala
@@ -2,7 +2,7 @@ package fi.oph.koski.localization
 
 import fi.oph.koski.schema.{Finnish, KoskiSchema, LocalizedString}
 import fi.oph.scalaschema.{ClassSchema, SchemaToJson}
-import org.json4s.JsonAST.{JArray, JObject, JString}
+import org.json4s.JsonAST.{JNothing, JObject, JString}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -13,21 +13,21 @@ class SchemaLocalizationEnricherSpec extends AnyFreeSpec with Matchers {
   )
   private val enricher = new SchemaLocalizationEnricher(localizations)
 
-  "translationFor" - {
-    "builds an Otsikko entry from a title key" in {
-      enricher.translationFor(List(("Tila", "Tila")), Nil) shouldBe Some(
-        JObject("Otsikko" -> JArray(List(JString("fi: Tila"), JString("sv: Status"), JString("en: State"))))
-      )
+  "translationFor groups by language and excludes Finnish" - {
+    "builds a title entry for each non-Finnish language" in {
+      enricher.translationFor(List(("Tila", "Tila")), Nil) shouldBe Some(JObject(
+        "sv" -> JObject("title" -> JString("Status")),
+        "en" -> JObject("title" -> JString("State"))
+      ))
     }
 
-    "omits missing languages and merges title + description" in {
-      val result = enricher.translationFor(
+    "omits missing languages and includes title + description" in {
+      enricher.translationFor(
         List(("Tila", "Tila")),
         List(("description:Opiskeluoikeuden voimassaolo", "Opiskeluoikeuden voimassaolo"))
-      )
-      result shouldBe Some(JObject(
-        "Otsikko" -> JArray(List(JString("fi: Tila"), JString("sv: Status"), JString("en: State"))),
-        "Kuvaus" -> JArray(List(JString("fi: Opiskeluoikeuden voimassaolo"), JString("sv: Studierättens giltighet")))
+      ) shouldBe Some(JObject(
+        "sv" -> JObject("title" -> JString("Status"), "description" -> JString("Studierättens giltighet")),
+        "en" -> JObject("title" -> JString("State"))
       ))
     }
 
@@ -37,11 +37,12 @@ class SchemaLocalizationEnricherSpec extends AnyFreeSpec with Matchers {
   }
 
   "enrich" - {
-    "injects translation into matching property nodes" in {
+    "injects language-grouped translations into matching property nodes" in {
       val schema = KoskiSchema.createSchema(classOf[EnricherTestOppija]).asInstanceOf[ClassSchema]
       val enriched = enricher.enrich(schema, SchemaToJson.toJsonSchema(schema))
-      (enriched \ "properties" \ "tila" \ "translation" \ "Otsikko") shouldBe
-        JArray(List(JString("fi: Tila"), JString("sv: Status"), JString("en: State")))
+      (enriched \ "properties" \ "tila" \ "translation" \ "sv" \ "title") shouldBe JString("Status")
+      (enriched \ "properties" \ "tila" \ "translation" \ "en" \ "title") shouldBe JString("State")
+      (enriched \ "properties" \ "tila" \ "translation" \ "fi") shouldBe JNothing
     }
   }
 }

--- a/src/test/scala/fi/oph/koski/localization/SchemaLocalizationEnricherSpec.scala
+++ b/src/test/scala/fi/oph/koski/localization/SchemaLocalizationEnricherSpec.scala
@@ -1,6 +1,7 @@
 package fi.oph.koski.localization
 
-import fi.oph.koski.schema.{Finnish, LocalizedString}
+import fi.oph.koski.schema.{Finnish, KoskiSchema, LocalizedString}
+import fi.oph.scalaschema.{ClassSchema, SchemaToJson}
 import org.json4s.JsonAST.{JArray, JObject, JString}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -34,4 +35,15 @@ class SchemaLocalizationEnricherSpec extends AnyFreeSpec with Matchers {
       enricher.translationFor(List(("Unknown", "Unknown")), Nil) shouldBe None
     }
   }
+
+  "enrich" - {
+    "injects translation into matching property nodes" in {
+      val schema = KoskiSchema.createSchema(classOf[EnricherTestOppija]).asInstanceOf[ClassSchema]
+      val enriched = enricher.enrich(schema, SchemaToJson.toJsonSchema(schema))
+      (enriched \ "properties" \ "tila" \ "translation" \ "Otsikko") shouldBe
+        JArray(List(JString("fi: Tila"), JString("sv: Status"), JString("en: State")))
+    }
+  }
 }
+
+case class EnricherTestOppija(tila: String)

--- a/web/static/json-schema-viewer/js/json-schema-viewer.js
+++ b/web/static/json-schema-viewer/js/json-schema-viewer.js
@@ -14274,16 +14274,23 @@ if (typeof window.JSV === "undefined") {
             $("#info-definition").html((node.description || "No definition provided.").replace(/\. \(/g, ".<br>("));
             $("#info-type").html(node.displayType.toString());
             if (node.translation) {
-                var trans = $("<ul></ul>");
-                $.each(node.translation, function(p, v) {
-                    var li = $("<li>" + p + "</li>");
-                    var ul = $("<ul></ul>");
-                    $.each(v, function(i, e) {
-                        ul.append("<li>" + e + "</li>");
-                    });
-                    trans.append(li.append(ul));
+                var languageNames = { sv: "Ruotsi", en: "Englanti" };
+                var trans = $('<div class="translation-list"></div>');
+                $.each([ "sv", "en" ], function(i, lang) {
+                    var t = node.translation[lang];
+                    if (t) {
+                        var block = $('<div class="translation-lang-block"></div>');
+                        block.append($('<div class="translation-lang"></div>').text(languageNames[lang] || lang));
+                        if (t.title) {
+                            block.append($('<div class="translation-title"></div>').text(t.title));
+                        }
+                        if (t.description) {
+                            block.append($('<div class="translation-description"></div>').text(t.description));
+                        }
+                        trans.append(block);
+                    }
                 });
-                $("#info-translation").html(trans);
+                $("#info-translation").html(trans.children().length ? trans : "No translations available.");
             } else {
                 $("#info-translation").html("No translations available.");
             }

--- a/web/static/json-schema-viewer/styles/json-schema-viewer.css
+++ b/web/static/json-schema-viewer/styles/json-schema-viewer.css
@@ -154,6 +154,21 @@ div#info-tab-def.info-tab,
   color: green;
   font-weight: 900;
 }
+#info-translation .translation-lang-block {
+  margin-top: 0.8em;
+}
+#info-translation .translation-lang-block:first-child {
+  margin-top: 0;
+}
+#info-translation .translation-lang {
+  font-size: 0.8em;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #777;
+}
+#info-translation .translation-title {
+  font-weight: 700;
+}
 #textarea-json {
   height: auto !important;
   overflow-y: auto;


### PR DESCRIPTION
Kunkin skeeman kentän otsikko ja kuvaus näytetään ruotsiksi ja englanniksi lokalisointipalvelusta schema viewerin Translation-osiossa - ensimmäinen vedos.

> One-line mental model:
> localization service (keys+text) → KoskiSpecificSchemaLocalization (field → key) → enrich walks the flat 
> ClassSchema↔JSON and injects {sv,en} per node → LocalizedSchemas serves it cached → viewer shows it.

<img width="398" height="571" alt="Screenshot 2026-07-09 at 11 41 51" src="https://github.com/user-attachments/assets/8b696cb9-2595-4ee3-83ab-9dc5e629eb6d" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)