### PR TITLE
TOR-2464: Uudista schema viewerin infopaneeli

### DIFF
--- a/documentation/json-schema-viewer.md
+++ b/documentation/json-schema-viewer.md
@@ -45,48 +45,65 @@ re-apply them**:
   from the label length, since the tree font is monospace) shown only on the
   focused node as a rounded green outline around the label. Replaces the plain
   bold, which was hard to see.
-- **Translation panel rendering** (TOR-2464) — the info panel's "Translation"
-  tab reads `node.translation` and renders one block per language (quiet
-  language label, bold title, plain description), using `.text()` so the
-  strings are escaped. See "Translation tab" below for how the data is
-  produced.
+- **Info-panel Definition layout** (TOR-2464) — the info panel's Definition tab
+  is restructured (design direction "1a") into two sections: a **Technical**
+  definition-list table and a **Description** section. The Technical table emits
+  a row only when the fact is present, read from the schema's **structured** JSON
+  fields — `Type`, `Cardinality` (array/object only, from `minItems`/`maxItems`/
+  required), `Minimum`/`Maximum`, `Format` (`pattern`), `Allowed` (enum chips),
+  and an `Annotation` row of mono chips (`@SensitiveData`/`@RedundantData`/
+  `@Deprecated`). Behaviour-changing annotations also render an icon **badge**
+  (lock for sensitive, circle-slash for "not in use"). The Description section
+  shows one block per language (`fi`/`sv`/`en`: tag + bold term + prose) from
+  `node.translation`. The panel never parses the `description` string. The dark
+  header + tab row are styled over jQuery Mobile; the tab row is kept as the
+  current product. See "Localized definition panel" below.
 
 The `deprecated` / `redundantData` / `sensitive` booleans the viewer reads come
 from the schema JSON, emitted by the matching annotations in
 `src/main/scala/fi/oph/koski/schema/annotation/` (`Deprecated`, `RedundantData`,
 `Annotations.scala` → `SensitiveData`).
 
-## Translation tab (TOR-2464)
+## Localized definition panel (TOR-2464)
 
-The info panel's "Translation" tab is populated server-side. Each viewer
-schema is served through `LocalizedSchemas` (`fi.oph.koski.documentation`),
-which:
+The info panel shows each schema node's title and definition in fi/sv/en,
+populated server-side. Each viewer schema is served through `LocalizedSchemas`
+(`fi.oph.koski.documentation`), which:
 
 - builds the same `ClassSchema` as the corresponding `*Schema` object
   (`KoskiSchema.createSchema`),
 - runs `SchemaLocalizationEnricher` (`fi.oph.koski.localization`) to attach a
   `translation` field to each property and class node, resolved from
   `koskiLocalizationRepository` using the same keys as
-  `KoskiSpecificSchemaLocalization` — **title + description only**,
+  `KoskiSpecificSchemaLocalization` — **title + description only**. Class nodes
+  use the class title as the key, so class/object titles are translated too,
 - caches the enriched JSON ~1 min (matching the localization cache refresh),
   so translation edits appear without a restart.
 
-The emitted shape is language-keyed and **excludes Finnish** (the Finnish
-title is the node name and the Finnish description is already in the
-Definition box):
+The emitted shape is language-keyed and includes Finnish (shown as its own
+`fi` block):
 
 ```json
-"translation": { "sv": { "title": "…", "description": "…" }, "en": { … } }
+"translation": {
+  "fi": { "title": "…", "description": "…" },
+  "sv": { "title": "…", "description": "…" },
+  "en": { … }
+}
 ```
 
 Notes:
 
 - Tooltip/info-link annotations aren't emitted into the schema JSON, so they
-  aren't shown; missing keys/languages are skipped, and a node with no sv/en
+  aren't shown; missing keys/languages are skipped, and a node with no
   translation gets no `translation` field.
 - The `translation` keyword is non-standard and ignored by JSON Schema
   validators, so it is a safe additive change to the documentation schemas
   (which external integrators may also consume).
+- The technical block reads only structured JSON fields, so it does **not** show
+  facts that live only in the `description` string — e.g. the `@KoodistoUri`
+  reference (`(Koodisto: …)`), the `@Deprecated` message/date, `@DefaultValue`,
+  the `osaamispiste`-style unit, or Oksa links. Making those show would require
+  emitting them as structured fields.
 - To cover a new schema, register it in `LocalizedSchemas`.
 
 ## Editing / build

--- a/documentation/json-schema-viewer.md
+++ b/documentation/json-schema-viewer.md
@@ -99,11 +99,15 @@ Notes:
 - The `translation` keyword is non-standard and ignored by JSON Schema
   validators, so it is a safe additive change to the documentation schemas
   (which external integrators may also consume).
-- The technical block reads only structured JSON fields, so it does **not** show
-  facts that live only in the `description` string — e.g. the `@KoodistoUri`
-  reference (`(Koodisto: …)`), the `@Deprecated` message/date, `@DefaultValue`,
-  the `osaamispiste`-style unit, or Oksa links. Making those show would require
-  emitting them as structured fields.
+- The technical block reads only **structured** JSON fields, never the
+  `description` string. Several Koski annotations were given structured fields so
+  they can be shown as their own row/chip: `KoodistoUri` → `koodisto` (Koodisto
+  row, linked), `KoodistoKoodiarvo` → `koodiarvot` (Allowed row), `OksaUri` →
+  `oksa` (Oksa row, linked), `Deprecated` → `deprecatedMessage` (badge),
+  `UnitOfMeasure` → `unit` (Format row), `ReadOnly` → `readOnly`/`readOnlyText`
+  (Read-only row). These are additive keywords, ignored by JSON Schema validators.
+- Still **not** shown, because it only lives in the `description` string:
+  `@DefaultValue` (it's a scala-schema annotation, not Koski).
 - To cover a new schema, register it in `LocalizedSchemas`.
 
 ## Editing / build

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <artifactId>scala-schema</artifactId>
       <groupId>com.github.Opetushallitus</groupId>
-      <version>2.44.0_2.13</version>
+      <version>2.45.0_2.13</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/src/main/scala/fi/oph/koski/jsonschemaviewer/JsonSchemaViewerHtmlServlet.scala
+++ b/src/main/scala/fi/oph/koski/jsonschemaviewer/JsonSchemaViewerHtmlServlet.scala
@@ -126,20 +126,13 @@ class JsonSchemaViewerHtmlServlet(implicit val application: KoskiApplication) ex
                   </ul>
                 </div>
                 <div class="ui-body-d ui-content info-tab" id="info-tab-def">
-                  <h4>Type:</h4>
-                  <p id="info-type">
-                    Select a node to view the type.
-                  </p>
-                  <hr />
-                  <h4>Definition:</h4>
-                  <p id="info-definition">
+                  <div class="jsv-eyebrow" id="info-technical-header">Technical</div>
+                  <dl id="info-technical"></dl>
+                  <div id="info-badges"></div>
+                  <div class="jsv-eyebrow" id="info-description-header">Description</div>
+                  <div id="info-localized">
                     Select a node to view the definition.
-                  </p>
-                  <hr />
-                  <h4>Translation:</h4>
-                  <p id="info-translation">
-                    Select a node to view the translation.
-                  </p>
+                  </div>
                 </div>
                 <div class="ui-body-d ui-content info-tab"  id="info-tab-example">
                   <p>

--- a/src/main/scala/fi/oph/koski/localization/SchemaLocalizationEnricher.scala
+++ b/src/main/scala/fi/oph/koski/localization/SchemaLocalizationEnricher.scala
@@ -1,7 +1,7 @@
 package fi.oph.koski.localization
 
 import fi.oph.koski.schema.LocalizedString
-import fi.oph.scalaschema.ClassSchema
+import fi.oph.scalaschema.{ClassSchema, Property}
 import org.json4s.JsonAST.{JObject, JString, JValue}
 
 class SchemaLocalizationEnricher(localizations: Map[String, LocalizedString]) {
@@ -27,9 +27,14 @@ class SchemaLocalizationEnricher(localizations: Map[String, LocalizedString]) {
       case ("properties", JObject(props)) =>
         "properties" -> JObject(props.map {
           case (key, node: JObject) =>
-            val translation = propertiesByKey.get(key)
+            val property = propertiesByKey.get(key)
+            val translated = property
               .flatMap(p => translationFor(List(KoskiSpecificSchemaLocalization.title(p)), KoskiSpecificSchemaLocalization.description(p)))
-            key -> translation.fold(node: JValue)(withTranslation(node, _))
+              .fold(node)(withTranslation(node, _))
+            val enriched = property
+              .flatMap(deprecatedTextFor)
+              .fold(translated)(text => JObject(translated.obj :+ ("deprecatedText", JString(text): JValue)))
+            key -> (enriched: JValue)
           case other => other
         })
       case other => other
@@ -41,6 +46,11 @@ class SchemaLocalizationEnricher(localizations: Map[String, LocalizedString]) {
 
   private def withTranslation(node: JObject, translation: JObject): JObject =
     JObject(node.obj :+ ("translation", translation: JValue))
+
+  private def deprecatedTextFor(property: Property): Option[String] =
+    KoskiSpecificSchemaLocalization.deprecated(property).flatMap {
+      case (key, _) => localizations.get(key).flatMap(_.getOptional("fi"))
+    }
 
   def translationFor(titleParts: List[KeyAndText], descriptionParts: List[KeyAndText]): Option[JObject] = {
     val byLanguage = SchemaLocalizationEnricher.displayedLanguages.flatMap { lang =>

--- a/src/main/scala/fi/oph/koski/localization/SchemaLocalizationEnricher.scala
+++ b/src/main/scala/fi/oph/koski/localization/SchemaLocalizationEnricher.scala
@@ -34,7 +34,8 @@ class SchemaLocalizationEnricher(localizations: Map[String, LocalizedString]) {
         })
       case other => other
     })
-    translationFor(Nil, KoskiSpecificSchemaLocalization.description(schema))
+    val classTitle = List((schema.title, schema.title))
+    translationFor(classTitle, KoskiSpecificSchemaLocalization.description(schema))
       .fold(withProperties)(withTranslation(withProperties, _))
   }
 
@@ -42,7 +43,7 @@ class SchemaLocalizationEnricher(localizations: Map[String, LocalizedString]) {
     JObject(node.obj :+ ("translation", translation: JValue))
 
   def translationFor(titleParts: List[KeyAndText], descriptionParts: List[KeyAndText]): Option[JObject] = {
-    val byLanguage = SchemaLocalizationEnricher.translatedLanguages.flatMap { lang =>
+    val byLanguage = SchemaLocalizationEnricher.displayedLanguages.flatMap { lang =>
       val fields = List(
         "title" -> textFor(titleParts, lang),
         "description" -> textFor(descriptionParts, lang)
@@ -59,5 +60,5 @@ class SchemaLocalizationEnricher(localizations: Map[String, LocalizedString]) {
 object SchemaLocalizationEnricher {
   type KeyAndText = (String, String)
 
-  val translatedLanguages: List[String] = List("sv", "en")
+  val displayedLanguages: List[String] = List("fi", "sv", "en")
 }

--- a/src/main/scala/fi/oph/koski/schema/annotation/Annotations.scala
+++ b/src/main/scala/fi/oph/koski/schema/annotation/Annotations.scala
@@ -3,7 +3,7 @@ package fi.oph.koski.schema.annotation
 import fi.oph.koski.koskiuser.Rooli.Role
 import fi.oph.scalaschema._
 import org.json4s.JsonAST
-import org.json4s.JsonAST.{JBool, JObject}
+import org.json4s.JsonAST.{JBool, JObject, JString}
 
 /* This property can be used to represent the whole entity */
 case class Representative() extends RepresentationalMetadata
@@ -18,7 +18,8 @@ case class FlattenInUI() extends RepresentationalMetadata
 case class Tabular() extends RepresentationalMetadata
 
 case class ReadOnly(why: String) extends Metadata {
-  override def appendMetadataToJsonSchema(obj: JsonAST.JObject) = appendToDescription(obj, why)
+  override def appendMetadataToJsonSchema(obj: JsonAST.JObject) =
+    appendToDescription(obj.merge(JObject("readOnly" -> JBool(true), "readOnlyText" -> JString(why))), why)
 }
 
 case class ClassName(classname: String) extends RepresentationalMetadata
@@ -27,7 +28,9 @@ case class ClassName(classname: String) extends RepresentationalMetadata
 case class MultiLineString(lineCount: Int) extends RepresentationalMetadata
 
 /* Tags a numeric field with a unit of measure */
-case class UnitOfMeasure(unit: String) extends RepresentationalMetadata
+case class UnitOfMeasure(unit: String) extends RepresentationalMetadata {
+  override def appendMetadataToJsonSchema(obj: JObject): JObject = obj.merge(JObject("unit" -> JString(unit)))
+}
 
 /* An example of the data */
 case class Example(text: String) extends RepresentationalMetadata

--- a/src/main/scala/fi/oph/koski/schema/annotation/Deprecated.scala
+++ b/src/main/scala/fi/oph/koski/schema/annotation/Deprecated.scala
@@ -1,11 +1,11 @@
 package fi.oph.koski.schema.annotation
 
 import fi.oph.scalaschema.Metadata
-import org.json4s.JsonAST.{JBool, JObject}
+import org.json4s.JsonAST.{JBool, JObject, JString}
 
 // When field is deprecated it is hidden from the UI when it doesn't contain data
 case class Deprecated(msg: String) extends Metadata {
   def descriptionWithStyle: String = "<b>Vanhentunut kenttä: </b>" + msg
   def wrapInParentheses(description: String) = s"($description)"
-  override def appendMetadataToJsonSchema(obj: JObject) = appendToDescription(obj.merge(JObject("deprecated" -> JBool(true))), wrapInParentheses(descriptionWithStyle))
+  override def appendMetadataToJsonSchema(obj: JObject) = appendToDescription(obj.merge(JObject("deprecated" -> JBool(true), "deprecatedMessage" -> JString(msg))), wrapInParentheses(descriptionWithStyle))
 }

--- a/src/main/scala/fi/oph/koski/schema/annotation/KoodistoKoodiarvo.scala
+++ b/src/main/scala/fi/oph/koski/schema/annotation/KoodistoKoodiarvo.scala
@@ -16,7 +16,12 @@ case class KoodistoKoodiarvo(arvo: String) extends Metadata {
   )
 
   override def appendMetadataToJsonSchema(obj: JObject) = {
-    appendToDescription(obj, "(Hyväksytty koodiarvo: " + arvo + ")")
+    val existing = (obj \ "koodiarvot") match {
+      case JArray(arr) => arr
+      case _ => Nil
+    }
+    val withKoodiarvot = JObject(obj.obj.filterNot(_._1 == "koodiarvot") :+ ("koodiarvot" -> JArray(existing :+ JString(arvo))))
+    appendToDescription(withKoodiarvot, "(Hyväksytty koodiarvo: " + arvo + ")")
   }
 
   override def applyMetadata(x: ObjectWithMetadata[_], schemaFactory: SchemaFactory) = {

--- a/src/main/scala/fi/oph/koski/schema/annotation/KoodistoUri.scala
+++ b/src/main/scala/fi/oph/koski/schema/annotation/KoodistoUri.scala
@@ -9,7 +9,7 @@ case class KoodistoUri(koodistoUri: String) extends Metadata {
   def asLink = <a href={url} target="_blank">{koodistoUri}</a>
 
   override def appendMetadataToJsonSchema(obj: JsonAST.JObject) = {
-    appendToDescription(obj, s"(Koodisto: $asLink)")
+    appendToDescription(obj.merge(JsonAST.JObject("koodisto" -> JsonAST.JString(koodistoUri))), s"(Koodisto: $asLink)")
   }
 
   override def applyMetadata(x: ObjectWithMetadata[_], schemaFactory: SchemaFactory) = {

--- a/src/main/scala/fi/oph/koski/schema/annotation/OksaUri.scala
+++ b/src/main/scala/fi/oph/koski/schema/annotation/OksaUri.scala
@@ -1,11 +1,13 @@
 package fi.oph.koski.schema.annotation
 
 import fi.oph.scalaschema.Metadata
-import org.json4s.JsonAST.JObject
+import org.json4s.JsonAST.{JObject, JString}
 
 case class OksaUri(tunnus: String, käsite: String) extends Metadata {
   private val baseUrl = "https://wiki.eduuni.fi/display/ophoppija/Opetus+ja+koulutussanasto+-+OKSA"
-  def asLink = <a href={baseUrl + "#" + tunnus} target="_blank">{käsite}</a>
+  private val url = baseUrl + "#" + tunnus
+  def asLink = <a href={url} target="_blank">{käsite}</a>
 
-  override def appendMetadataToJsonSchema(obj: JObject) = appendToDescription(obj, s"(Oksa: $asLink)")
+  override def appendMetadataToJsonSchema(obj: JObject) =
+    appendToDescription(obj.merge(JObject("oksa" -> JObject("käsite" -> JString(käsite), "url" -> JString(url)))), s"(Oksa: $asLink)")
 }

--- a/src/test/scala/fi/oph/koski/documentation/LocalizedSchemasSpec.scala
+++ b/src/test/scala/fi/oph/koski/documentation/LocalizedSchemasSpec.scala
@@ -10,12 +10,12 @@ class LocalizedSchemasSpec extends AnyFreeSpec with TestEnvironment with Matcher
   private val localizedSchemas =
     new LocalizedSchemas(KoskiApplicationForTests.koskiLocalizationRepository)(KoskiApplicationForTests.cacheManager)
 
-  "koski-oppija-schema.json is enriched with sv/en translations on many nodes, excluding fi" in {
+  "koski-oppija-schema.json is enriched with fi/sv/en translations on many nodes" in {
     val ts = translations(localizedSchemas("koski-oppija-schema.json"))
     ts.size should be > 50
+    ts.exists(t => (t \ "fi" \ "title") != JNothing) shouldBe true
     ts.exists(t => (t \ "sv" \ "title") != JNothing || (t \ "sv" \ "description") != JNothing) shouldBe true
     ts.exists(t => (t \ "en" \ "title") != JNothing || (t \ "en" \ "description") != JNothing) shouldBe true
-    ts.forall(t => (t \ "fi") == JNothing) shouldBe true
   }
 
   "all registered viewer schemas are enriched with translations" - {

--- a/src/test/scala/fi/oph/koski/localization/SchemaLocalizationEnricherSpec.scala
+++ b/src/test/scala/fi/oph/koski/localization/SchemaLocalizationEnricherSpec.scala
@@ -1,8 +1,9 @@
 package fi.oph.koski.localization
 
 import fi.oph.koski.schema.{Finnish, KoskiSchema, LocalizedString}
+import fi.oph.scalaschema.annotation.Title
 import fi.oph.scalaschema.{ClassSchema, SchemaToJson}
-import org.json4s.JsonAST.{JNothing, JObject, JString}
+import org.json4s.JsonAST.{JObject, JString}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -13,9 +14,10 @@ class SchemaLocalizationEnricherSpec extends AnyFreeSpec with Matchers {
   )
   private val enricher = new SchemaLocalizationEnricher(localizations)
 
-  "translationFor groups by language and excludes Finnish" - {
-    "builds a title entry for each non-Finnish language" in {
+  "translationFor groups by language, fi included" - {
+    "builds a title entry for each language" in {
       enricher.translationFor(List(("Tila", "Tila")), Nil) shouldBe Some(JObject(
+        "fi" -> JObject("title" -> JString("Tila")),
         "sv" -> JObject("title" -> JString("Status")),
         "en" -> JObject("title" -> JString("State"))
       ))
@@ -26,6 +28,7 @@ class SchemaLocalizationEnricherSpec extends AnyFreeSpec with Matchers {
         List(("Tila", "Tila")),
         List(("description:Opiskeluoikeuden voimassaolo", "Opiskeluoikeuden voimassaolo"))
       ) shouldBe Some(JObject(
+        "fi" -> JObject("title" -> JString("Tila"), "description" -> JString("Opiskeluoikeuden voimassaolo")),
         "sv" -> JObject("title" -> JString("Status"), "description" -> JString("Studierättens giltighet")),
         "en" -> JObject("title" -> JString("State"))
       ))
@@ -38,13 +41,23 @@ class SchemaLocalizationEnricherSpec extends AnyFreeSpec with Matchers {
 
   "enrich" - {
     "injects language-grouped translations into matching property nodes" in {
-      val schema = KoskiSchema.createSchema(classOf[EnricherTestOppija]).asInstanceOf[ClassSchema]
-      val enriched = enricher.enrich(schema, SchemaToJson.toJsonSchema(schema))
+      val enriched = enrichedTestSchema
+      (enriched \ "properties" \ "tila" \ "translation" \ "fi" \ "title") shouldBe JString("Tila")
       (enriched \ "properties" \ "tila" \ "translation" \ "sv" \ "title") shouldBe JString("Status")
       (enriched \ "properties" \ "tila" \ "translation" \ "en" \ "title") shouldBe JString("State")
-      (enriched \ "properties" \ "tila" \ "translation" \ "fi") shouldBe JNothing
     }
+
+    "translates the class title on the class node" in {
+      val enriched = enrichedTestSchema
+      (enriched \ "translation" \ "fi" \ "title") shouldBe JString("Tila")
+      (enriched \ "translation" \ "sv" \ "title") shouldBe JString("Status")
+    }
+  }
+
+  private def enrichedTestSchema = {
+    val schema = KoskiSchema.createSchema(classOf[EnricherTestOppija]).asInstanceOf[ClassSchema]
+    enricher.enrich(schema, SchemaToJson.toJsonSchema(schema))
   }
 }
 
-case class EnricherTestOppija(tila: String)
+@Title("Tila") case class EnricherTestOppija(tila: String)

--- a/web/static/json-schema-viewer/js/json-schema-viewer.js
+++ b/web/static/json-schema-viewer/js/json-schema-viewer.js
@@ -14338,7 +14338,7 @@ if (typeof window.JSV === "undefined") {
             };
             if (node.sensitive) { addBadge(lockIcon, '<strong>Erityinen henkilötieto + salassa pidettävä tieto</strong>'); }
             if (node.redundantData) { addBadge(slashIcon, '<strong>Kenttä ei ole käytössä.</strong> Koski ei ota vastaan kentässä siirrettyä tietoa.'); }
-            if (node.deprecated) { addBadge(clockIcon, '<strong>Vanhentunut kenttä.</strong> ' + esc(node.deprecatedMessage)); }
+            if (node.deprecated) { addBadge(clockIcon, '<strong>Vanhentunut kenttä.</strong> ' + esc(node.deprecatedText || node.deprecatedMessage)); }
 
             // === Description: yksi lohko per kieli (FI ensin, sitten SV, EN) ===
             var fiTitle = node.translation && node.translation.fi && node.translation.fi.title;
@@ -14547,6 +14547,7 @@ if (typeof window.JSV === "undefined") {
                 koodisto: schema.koodisto || s.koodisto,
                 unit: schema.unit || s.unit,
                 deprecatedMessage: schema.deprecatedMessage || s.deprecatedMessage,
+                deprecatedText: schema.deprecatedText || s.deprecatedText,
                 readOnly: schema.readOnly || s.readOnly,
                 readOnlyText: schema.readOnlyText || s.readOnlyText,
                 koodiarvot: schema.koodiarvot || s.koodiarvot,

--- a/web/static/json-schema-viewer/js/json-schema-viewer.js
+++ b/web/static/json-schema-viewer/js/json-schema-viewer.js
@@ -14292,6 +14292,7 @@ if (typeof window.JSV === "undefined") {
             } else {
                 addRow("Cardinality", mono(node.require ? "1..1" : "0..1"));
             }
+            if (node["default"] != null) { addRow("Default", mono(node["default"])); }
             if (node.minimum != null) { addRow("Minimum", mono(node.minimum + (node.exclusiveMinimum ? " (exclusive)" : ""))); }
             if (node.maximum != null) { addRow("Maximum", mono(node.maximum + (node.exclusiveMaximum ? " (exclusive)" : ""))); }
             if (node.pattern) { addRow("Format", mono(node.pattern)); }
@@ -14311,6 +14312,12 @@ if (typeof window.JSV === "undefined") {
             var allowedValues = (node.enumValues || []).concat(node.koodiarvot || []);
             if (allowedValues.length) { addRow("Allowed", chips(allowedValues)); }
             if (node.readOnly) { addRow("Read-only", $('<span class="jsv-plain"></span>').text(node.readOnlyText || "Vain luettava kenttä.")); }
+            if (node.conditions && node.conditions.length) {
+                var condEl = $('<div class="jsv-plain"></div>');
+                $.each(node.conditions, function(i, c) { condEl.append($('<div></div>').text(c)); });
+                addRow("Condition", condEl);
+            }
+            if (node.acceptsSingleValue) { addRow("Input", $('<span class="jsv-plain"></span>').text("Accepts also a single value")); }
             var annotationTokens = [];
             if (node.sensitive) { annotationTokens.push("@SensitiveData"); }
             if (node.redundantData) { annotationTokens.push("@RedundantData"); }
@@ -14538,7 +14545,10 @@ if (typeof window.JSV === "undefined") {
                 readOnly: schema.readOnly || s.readOnly,
                 readOnlyText: schema.readOnlyText || s.readOnlyText,
                 koodiarvot: schema.koodiarvot || s.koodiarvot,
-                oksa: schema.oksa || s.oksa
+                oksa: schema.oksa || s.oksa,
+                "default": schema["default"] || s["default"],
+                conditions: schema.conditions || s.conditions,
+                acceptsSingleValue: schema.acceptsSingleValue || s.acceptsSingleValue
             };
             node.require = parent && parent.required ? parent.required.indexOf(node.name) > -1 : false;
             if (parent) {

--- a/web/static/json-schema-viewer/js/json-schema-viewer.js
+++ b/web/static/json-schema-viewer/js/json-schema-viewer.js
@@ -14271,29 +14271,64 @@ if (typeof window.JSV === "undefined") {
             $.each([ schema, def, ex ], function(i, e) {
                 e.height(height);
             });
-            $("#info-definition").html((node.description || "No definition provided.").replace(/\. \(/g, ".<br>("));
-            $("#info-type").html(node.displayType.toString());
-            if (node.translation) {
-                var languageNames = { sv: "Ruotsi", en: "Englanti" };
-                var trans = $('<div class="translation-list"></div>');
-                $.each([ "sv", "en" ], function(i, lang) {
-                    var t = node.translation[lang];
-                    if (t) {
-                        var block = $('<div class="translation-lang-block"></div>');
-                        block.append($('<div class="translation-lang"></div>').text(languageNames[lang] || lang));
-                        if (t.title) {
-                            block.append($('<div class="translation-title"></div>').text(t.title));
-                        }
-                        if (t.description) {
-                            block.append($('<div class="translation-description"></div>').text(t.description));
-                        }
-                        trans.append(block);
-                    }
-                });
-                $("#info-translation").html(trans.children().length ? trans : "No translations available.");
-            } else {
-                $("#info-translation").html("No translations available.");
+            // Technical: definition-list table from structured schema fields
+            var mono = function(text) { return $('<span class="jsv-mono"></span>').text(text); };
+            var chip = function(text) { return $('<span class="jsv-chip"></span>').text(text); };
+            var chips = function(values) {
+                var el = $('<div class="jsv-chips"></div>');
+                $.each(values, function(i, v) { el.append(chip(v)); });
+                return el;
+            };
+            var techTable = $("#info-technical").empty();
+            var addRow = function(label, valueEl) {
+                techTable.append($('<div class="jsv-tech-row"></div>')
+                    .append($('<dt class="jsv-tech-label"></dt>').text(label))
+                    .append($('<dd class="jsv-tech-value"></dd>').append(valueEl)));
+            };
+
+            addRow("Type", mono(node.displayType.toString()));
+            if (node.type === "array") {
+                addRow("Cardinality", mono((node.minItems || 0) + ".." + (node.maxItems != null ? node.maxItems : "*")));
+            } else if (node.type === "object") {
+                addRow("Cardinality", mono(node.require ? "1..1" : "0..1"));
             }
+            if (node.minimum != null) { addRow("Minimum", mono(node.minimum + (node.exclusiveMinimum ? " (exclusive)" : ""))); }
+            if (node.maximum != null) { addRow("Maximum", mono(node.maximum + (node.exclusiveMaximum ? " (exclusive)" : ""))); }
+            if (node.pattern) { addRow("Format", mono(node.pattern)); }
+            if (node.enumValues && node.enumValues.length) { addRow("Allowed", chips(node.enumValues)); }
+            var annotationTokens = [];
+            if (node.sensitive) { annotationTokens.push("@SensitiveData"); }
+            if (node.redundantData) { annotationTokens.push("@RedundantData"); }
+            if (node.deprecated) { annotationTokens.push("@Deprecated"); }
+            if (annotationTokens.length) { addRow("Annotation", chips(annotationTokens)); }
+
+            // Behaviour badges: annotations that change how the field behaves
+            var badges = $("#info-badges").empty();
+            var lockIcon = '<svg class="jsv-badge-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#2a2a2a" stroke-width="2"><rect x="4" y="10.5" width="16" height="10.5" rx="2"></rect><path d="M8 10.5V7a4 4 0 0 1 8 0v3.5"></path></svg>';
+            var slashIcon = '<svg class="jsv-badge-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#2a2a2a" stroke-width="2"><circle cx="12" cy="12" r="9"></circle><path d="M5.6 5.6l12.8 12.8"></path></svg>';
+            var addBadge = function(iconHtml, textHtml) {
+                badges.append($('<div class="jsv-badge"></div>').html(iconHtml + '<span class="jsv-badge-text">' + textHtml + '</span>'));
+            };
+            if (node.sensitive) { addBadge(lockIcon, '<strong>Erityinen henkilötieto + salassa pidettävä tieto</strong>'); }
+            if (node.redundantData) { addBadge(slashIcon, '<strong>Kenttä ei ole käytössä.</strong> Koski ei ota vastaan kentässä siirrettyä tietoa.'); }
+
+            // === Description: yksi lohko per kieli (FI ensin, sitten SV, EN) ===
+            var languageBlock = function(lang, title, description) {
+                var block = $('<div class="jsv-lang-block"></div>');
+                block.append($('<span class="jsv-lang-tag jsv-lang-' + lang + '"></span>').text(lang.toUpperCase()));
+                if (title) { block.append($('<div class="jsv-term"></div>').text(title)); }
+                if (description) { block.append($('<div class="jsv-prose"></div>').text(description)); }
+                return block;
+            };
+            var blocks = [];
+            $.each([ "fi", "sv", "en" ], function(i, lang) {
+                var t = node.translation && node.translation[lang];
+                if (t && (t.title || t.description)) { blocks.push(languageBlock(lang, t.title, t.description)); }
+            });
+            if (blocks.length === 0 && node.title) { blocks.push(languageBlock("fi", node.title, "")); }
+            var localized = $("#info-localized").empty();
+            $.each(blocks, function(i, block) { localized.append(block); });
+            $("#info-description-header").toggle(blocks.length > 0);
             JSV.createPre(schema, tv4.getSchema(node.schema), false, node.plainName);
             var example = !node.example && node.parent && node.parent.example && node.parent.type === "object" ? node.parent.example : node.example;
             if (example) {
@@ -14470,7 +14505,15 @@ if (typeof window.JSV === "undefined") {
                 parentSchema: parent,
                 deprecated: schema.deprecated || s.deprecated,
                 redundantData: schema.redundantData || s.redundantData,
-                sensitive: schema.sensitive || s.sensitive
+                sensitive: schema.sensitive || s.sensitive,
+                minItems: s.minItems,
+                maxItems: s.maxItems,
+                minimum: s.minimum,
+                maximum: s.maximum,
+                exclusiveMinimum: s.exclusiveMinimum,
+                exclusiveMaximum: s.exclusiveMaximum,
+                pattern: s.pattern,
+                enumValues: s["enum"]
             };
             node.require = parent && parent.required ? parent.required.indexOf(node.name) > -1 : false;
             if (parent) {
@@ -14488,6 +14531,7 @@ if (typeof window.JSV === "undefined") {
             } else {
                 JSV.treeData = node;
             }
+            node.title = node.name;
             if (node.type === "array") {
                 node.name += "[" + (s.minItems || " ") + "]";
                 node.minItems = s.minItems;

--- a/web/static/json-schema-viewer/js/json-schema-viewer.js
+++ b/web/static/json-schema-viewer/js/json-schema-viewer.js
@@ -14289,13 +14289,28 @@ if (typeof window.JSV === "undefined") {
             addRow("Type", mono(node.displayType.toString()));
             if (node.type === "array") {
                 addRow("Cardinality", mono((node.minItems || 0) + ".." + (node.maxItems != null ? node.maxItems : "*")));
-            } else if (node.type === "object") {
+            } else {
                 addRow("Cardinality", mono(node.require ? "1..1" : "0..1"));
             }
             if (node.minimum != null) { addRow("Minimum", mono(node.minimum + (node.exclusiveMinimum ? " (exclusive)" : ""))); }
             if (node.maximum != null) { addRow("Maximum", mono(node.maximum + (node.exclusiveMaximum ? " (exclusive)" : ""))); }
             if (node.pattern) { addRow("Format", mono(node.pattern)); }
-            if (node.enumValues && node.enumValues.length) { addRow("Allowed", chips(node.enumValues)); }
+            if (node.unit) { addRow("Format", mono(node.unit)); }
+            if (node.koodisto) {
+                var koodistoLink = $('<a class="jsv-mono jsv-koodisto-link" target="_blank"></a>')
+                    .attr("href", "/koski/dokumentaatio/koodisto/" + node.koodisto + "/latest")
+                    .text(node.koodisto);
+                addRow("Koodisto", koodistoLink);
+            }
+            if (node.oksa) {
+                var oksaLink = $('<a class="jsv-mono jsv-oksa-link" target="_blank"></a>')
+                    .attr("href", node.oksa.url)
+                    .text(node.oksa["käsite"] || node.oksa.url);
+                addRow("Oksa", oksaLink);
+            }
+            var allowedValues = (node.enumValues || []).concat(node.koodiarvot || []);
+            if (allowedValues.length) { addRow("Allowed", chips(allowedValues)); }
+            if (node.readOnly) { addRow("Read-only", $('<span class="jsv-plain"></span>').text(node.readOnlyText || "Vain luettava kenttä.")); }
             var annotationTokens = [];
             if (node.sensitive) { annotationTokens.push("@SensitiveData"); }
             if (node.redundantData) { annotationTokens.push("@RedundantData"); }
@@ -14303,14 +14318,17 @@ if (typeof window.JSV === "undefined") {
             if (annotationTokens.length) { addRow("Annotation", chips(annotationTokens)); }
 
             // Behaviour badges: annotations that change how the field behaves
+            var esc = function(s) { return $("<div></div>").text(s || "").html(); };
             var badges = $("#info-badges").empty();
             var lockIcon = '<svg class="jsv-badge-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#2a2a2a" stroke-width="2"><rect x="4" y="10.5" width="16" height="10.5" rx="2"></rect><path d="M8 10.5V7a4 4 0 0 1 8 0v3.5"></path></svg>';
             var slashIcon = '<svg class="jsv-badge-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#2a2a2a" stroke-width="2"><circle cx="12" cy="12" r="9"></circle><path d="M5.6 5.6l12.8 12.8"></path></svg>';
+            var clockIcon = '<svg class="jsv-badge-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#2a2a2a" stroke-width="2"><circle cx="12" cy="12" r="9"></circle><path d="M12 7v5l3 2"></path></svg>';
             var addBadge = function(iconHtml, textHtml) {
                 badges.append($('<div class="jsv-badge"></div>').html(iconHtml + '<span class="jsv-badge-text">' + textHtml + '</span>'));
             };
             if (node.sensitive) { addBadge(lockIcon, '<strong>Erityinen henkilötieto + salassa pidettävä tieto</strong>'); }
             if (node.redundantData) { addBadge(slashIcon, '<strong>Kenttä ei ole käytössä.</strong> Koski ei ota vastaan kentässä siirrettyä tietoa.'); }
+            if (node.deprecated) { addBadge(clockIcon, '<strong>Vanhentunut kenttä.</strong> ' + esc(node.deprecatedMessage)); }
 
             // === Description: yksi lohko per kieli (FI ensin, sitten SV, EN) ===
             var languageBlock = function(lang, title, description) {
@@ -14513,7 +14531,14 @@ if (typeof window.JSV === "undefined") {
                 exclusiveMinimum: s.exclusiveMinimum,
                 exclusiveMaximum: s.exclusiveMaximum,
                 pattern: s.pattern,
-                enumValues: s["enum"]
+                enumValues: s["enum"],
+                koodisto: schema.koodisto || s.koodisto,
+                unit: schema.unit || s.unit,
+                deprecatedMessage: schema.deprecatedMessage || s.deprecatedMessage,
+                readOnly: schema.readOnly || s.readOnly,
+                readOnlyText: schema.readOnlyText || s.readOnlyText,
+                koodiarvot: schema.koodiarvot || s.koodiarvot,
+                oksa: schema.oksa || s.oksa
             };
             node.require = parent && parent.required ? parent.required.indexOf(node.name) > -1 : false;
             if (parent) {
@@ -14673,7 +14698,10 @@ if (typeof window.JSV === "undefined") {
                 d3.select("#n-" + d.id).classed("focus", true);
                 if (!JSV.plain) {
                     JSV.setPermalink(d);
-                    $("#info-title").text("Info: " + d.name);
+                    var titleText = "Info: " + d.name;
+                    // Shrink the font for long field names so the whole name stays visible.
+                    var titleSize = Math.max(10, 15 - Math.max(0, titleText.length - 24) * 0.15);
+                    $("#info-title").text(titleText).css("font-size", titleSize + "px");
                     JSV.setInfo(d);
                     panel.panel("open");
                 }

--- a/web/static/json-schema-viewer/js/json-schema-viewer.js
+++ b/web/static/json-schema-viewer/js/json-schema-viewer.js
@@ -14338,10 +14338,12 @@ if (typeof window.JSV === "undefined") {
             if (node.deprecated) { addBadge(clockIcon, '<strong>Vanhentunut kenttä.</strong> ' + esc(node.deprecatedMessage)); }
 
             // === Description: yksi lohko per kieli (FI ensin, sitten SV, EN) ===
+            var fiTitle = node.translation && node.translation.fi && node.translation.fi.title;
             var languageBlock = function(lang, title, description) {
                 var block = $('<div class="jsv-lang-block"></div>');
                 block.append($('<span class="jsv-lang-tag jsv-lang-' + lang + '"></span>').text(lang.toUpperCase()));
-                if (title) { block.append($('<div class="jsv-term"></div>').text(title)); }
+                var term = title || fiTitle || node.plainName || node.title || node.name;
+                if (term) { block.append($('<div class="jsv-term"></div>').text(term)); }
                 if (description) { block.append($('<div class="jsv-prose"></div>').text(description)); }
                 return block;
             };

--- a/web/static/json-schema-viewer/js/json-schema-viewer.js
+++ b/web/static/json-schema-viewer/js/json-schema-viewer.js
@@ -14162,6 +14162,8 @@ if (typeof window.JSV === "undefined") {
             $("#sharelink").on("click", function() {
                 $(this).select();
             });
+            $(document).on("keydown", JSV.keyNav);
+            $(window).on("throttledresize", JSV.pinPanel);
             JSV.viewerInit = true;
         },
         contentHeight: function() {
@@ -14311,6 +14313,7 @@ if (typeof window.JSV === "undefined") {
             }
             var allowedValues = (node.enumValues || []).concat(node.koodiarvot || []);
             if (allowedValues.length) { addRow("Allowed", chips(allowedValues)); }
+            if (node.synthetic) { addRow("Computed", $('<span class="jsv-plain"></span>').text("Derived value, not set on input")); }
             if (node.readOnly) { addRow("Read-only", $('<span class="jsv-plain"></span>').text(node.readOnlyText || "Vain luettava kenttä.")); }
             if (node.conditions && node.conditions.length) {
                 var condEl = $('<div class="jsv-plain"></div>');
@@ -14550,7 +14553,8 @@ if (typeof window.JSV === "undefined") {
                 oksa: schema.oksa || s.oksa,
                 "default": schema["default"] || s["default"],
                 conditions: schema.conditions || s.conditions,
-                acceptsSingleValue: schema.acceptsSingleValue || s.acceptsSingleValue
+                acceptsSingleValue: schema.acceptsSingleValue || s.acceptsSingleValue,
+                synthetic: schema.synthetic || s.synthetic
             };
             node.require = parent && parent.required ? parent.required.indexOf(node.name) > -1 : false;
             if (parent) {
@@ -14719,6 +14723,95 @@ if (typeof window.JSV === "undefined") {
                 }
             }
         },
+        visibleNodes: function() {
+            var out = [];
+            (function walk(node) {
+                if (!node) {
+                    return;
+                }
+                if (!JSV.labels[node.name]) {
+                    out.push(node);
+                }
+                if (node.children) {
+                    node.children.forEach(walk);
+                }
+            })(JSV.treeData);
+            return out;
+        },
+        firstSelectableChild: function(d) {
+            var kids = d.children || [], i, deep;
+            for (i = 0; i < kids.length; i++) {
+                if (!JSV.labels[kids[i].name]) {
+                    return kids[i];
+                }
+                deep = JSV.firstSelectableChild(kids[i]);
+                if (deep) {
+                    return deep;
+                }
+            }
+            return null;
+        },
+        keyNav: function(e) {
+            var keys = {
+                ArrowUp: 1,
+                ArrowDown: 1,
+                ArrowLeft: 1,
+                ArrowRight: 1,
+                Enter: 1
+            };
+            if (!keys[e.key]) {
+                return;
+            }
+            var tag = document.activeElement && document.activeElement.tagName;
+            if (tag === "INPUT" || tag === "TEXTAREA") {
+                return;
+            }
+            if (!$.mobile.activePage || $.mobile.activePage.attr("id") !== "viewer-page") {
+                return;
+            }
+            if (!JSV.treeData) {
+                return;
+            }
+            e.preventDefault();
+            var current = JSV.focusNode || JSV.treeData;
+            if (e.key === "Enter") {
+                JSV.clickTitle(current);
+            } else if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+                var list = JSV.visibleNodes(), i = list.indexOf(current);
+                if (i < 0) {
+                    JSV.clickTitle(list[0]);
+                } else {
+                    var next = e.key === "ArrowDown" ? list[Math.min(i + 1, list.length - 1)] : list[Math.max(i - 1, 0)];
+                    JSV.clickTitle(next);
+                }
+            } else if (e.key === "ArrowRight") {
+                if (current._children) {
+                    JSV.click(current);
+                } else if (current.children && current.children.length) {
+                    var child = JSV.firstSelectableChild(current);
+                    if (child) {
+                        JSV.clickTitle(child);
+                    }
+                }
+            } else if (e.key === "ArrowLeft") {
+                if (current.children && current.children.length) {
+                    JSV.click(current);
+                } else if (current.parent) {
+                    JSV.clickTitle(current.parent);
+                }
+            }
+        },
+        pinPanel: function() {
+            if (JSV.plain) {
+                return;
+            }
+            if (!$.mobile.activePage || $.mobile.activePage.attr("id") !== "viewer-page") {
+                return;
+            }
+            if (window.matchMedia && window.matchMedia("(min-width: 48em)").matches) {
+                $("#info-panel").panel("open");
+            }
+        },
         zoom: function() {
             JSV.svgGroup.attr("transform", "translate(" + JSV.zoomListener.translate() + ")" + "scale(" + JSV.zoomListener.scale() + ")");
         },
@@ -14882,6 +14975,7 @@ if (typeof window.JSV === "undefined") {
                 JSV.svgGroup = JSV.baseSvg.append("g").attr("id", "node-group");
                 JSV.resetViewer();
                 JSV.centerNode(JSV.treeData, 4);
+                JSV.pinPanel();
                 var legendData = [ {
                     text: "Expanded",
                     y: 20

--- a/web/static/json-schema-viewer/styles/json-schema-viewer.css
+++ b/web/static/json-schema-viewer/styles/json-schema-viewer.css
@@ -154,20 +154,153 @@ div#info-tab-def.info-tab,
   color: green;
   font-weight: 900;
 }
-#info-translation .translation-lang-block {
-  margin-top: 0.8em;
+/* === TOR-2464 info-panel redesign (design direction 1a) === */
+/* Remove jQuery Mobile panel/tab insets so the header + tabs span full width
+   and the body controls its own padding (keeps left edges aligned). */
+#info-panel .ui-panel-inner {
+  padding: 0;
 }
-#info-translation .translation-lang-block:first-child {
-  margin-top: 0;
+#info-panel #info-tabs {
+  padding: 0;
+  margin: 0;
 }
-#info-translation .translation-lang {
-  font-size: 0.8em;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: #777;
+/* Dark header bar */
+#info-panel .ui-header {
+  background: #1c1c1c;
+  border: none;
+  margin: 0;
 }
-#info-translation .translation-title {
+#info-panel #info-title {
+  color: #fff;
   font-weight: 700;
+  font-size: 15px;
+  text-align: center;
+  text-shadow: none;
+}
+/* Body */
+#info-tab-def {
+  padding: 20px 22px 24px;
+  font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+}
+/* Section eyebrows */
+#info-tab-def .jsv-eyebrow {
+  font: 600 10.5px ui-monospace, Menlo, monospace;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: #9a9a9a;
+}
+#info-tab-def #info-technical-header {
+  margin-bottom: 11px;
+}
+#info-tab-def #info-description-header {
+  margin-bottom: 14px;
+}
+/* Technical definition-list table */
+#info-technical {
+  margin: 0 0 14px;
+  border: 1px solid #e6e6e6;
+  border-radius: 5px;
+  overflow: hidden;
+}
+#info-technical .jsv-tech-row {
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  border-bottom: 1px solid #eee;
+}
+#info-technical .jsv-tech-row:last-child {
+  border-bottom: none;
+}
+#info-technical .jsv-tech-label {
+  margin: 0;
+  padding: 9px 12px;
+  background: #fafafa;
+  font-size: 12.5px;
+  color: #6a6a6a;
+  border-right: 1px solid #eee;
+}
+#info-technical .jsv-tech-value {
+  margin: 0;
+  padding: 9px 12px;
+}
+#info-technical .jsv-mono {
+  font: 13px ui-monospace, Menlo, monospace;
+  color: #1a1a1a;
+}
+/* Chips */
+.jsv-chip {
+  display: inline-block;
+  font: 12px ui-monospace, Menlo, monospace;
+  background: #f0f0f0;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  padding: 2px 6px;
+  color: #1a1a1a;
+}
+.jsv-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+.jsv-chips .jsv-chip {
+  font-size: 11.5px;
+}
+/* Behavior badges */
+#info-badges:empty {
+  margin-bottom: 8px;
+}
+#info-badges .jsv-badge {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  padding: 10px 12px;
+  border: 1px solid #cdcdcd;
+  background: #f4f4f4;
+  border-radius: 6px;
+  margin-bottom: 22px;
+}
+#info-badges .jsv-badge-icon {
+  flex: none;
+  margin-top: 1px;
+}
+#info-badges .jsv-badge-text {
+  font-size: 12.5px;
+  line-height: 1.4;
+  color: #2a2a2a;
+}
+#info-badges .jsv-badge-text strong {
+  font-weight: 600;
+}
+/* Description language blocks */
+#info-localized .jsv-lang-block {
+  margin-bottom: 18px;
+}
+#info-localized .jsv-lang-block:last-child {
+  margin-bottom: 0;
+}
+#info-localized .jsv-lang-tag {
+  display: inline-block;
+  font: 600 10px ui-monospace, Menlo, monospace;
+  letter-spacing: 0.06em;
+  border-radius: 3px;
+  padding: 2px 6px;
+  margin-bottom: 7px;
+  color: #8a8a8a;
+  background: #f2f2f2;
+}
+#info-localized .jsv-lang-fi {
+  color: #5a5a5a;
+  background: #ececec;
+}
+#info-localized .jsv-term {
+  font-weight: 700;
+  font-size: 15px;
+  color: #1a1a1a;
+  margin-bottom: 4px;
+}
+#info-localized .jsv-prose {
+  font-size: 14px;
+  line-height: 1.5;
+  color: #333;
 }
 #textarea-json {
   height: auto !important;

--- a/web/static/json-schema-viewer/styles/json-schema-viewer.css
+++ b/web/static/json-schema-viewer/styles/json-schema-viewer.css
@@ -176,6 +176,7 @@ div#info-tab-def.info-tab,
   font-size: 15px;
   text-align: center;
   text-shadow: none;
+  overflow-wrap: anywhere;
 }
 /* Body */
 #info-tab-def {
@@ -225,6 +226,15 @@ div#info-tab-def.info-tab,
 #info-technical .jsv-mono {
   font: 13px ui-monospace, Menlo, monospace;
   color: #1a1a1a;
+}
+#info-technical .jsv-koodisto-link,
+#info-technical .jsv-oksa-link {
+  text-decoration: underline;
+}
+#info-technical .jsv-plain {
+  font-size: 12.5px;
+  line-height: 1.4;
+  color: #333;
 }
 /* Chips */
 .jsv-chip {

--- a/web/test/e2e/schema-viewer.spec.ts
+++ b/web/test/e2e/schema-viewer.spec.ts
@@ -1,25 +1,93 @@
 import { expect, test } from './base'
+import { Page } from '@playwright/test'
+
+// The `v=` permalink values are tree-index paths, so they depend on the schema's
+// property/union ordering — each test also asserts the node name, so a shifted path
+// fails clearly. Nodes below are stable design-example fields.
+const openNode = async (page: Page, v: string, expectedName: string) => {
+  // Force a full load: the viewer reads `v=` from the hash only on load, and a
+  // hash-only change (opening a second node in the same test) does not reload the
+  // SPA. about:blank guarantees the next goto navigates fresh to the wanted node.
+  await page.goto('about:blank')
+  await page.goto(`/koski/json-schema-viewer#viewer-page?v=${v}`)
+  await page.locator('svg#jsv-tree').waitFor({ state: 'visible', timeout: 30000 })
+  await page.locator('a[href="#info-panel"]').click()
+  await expect(page.locator('#info-technical')).toBeVisible({ timeout: 10000 })
+  await expect(page.locator('#info-title')).toContainText(expectedName)
+}
 
 test.describe('Schema viewer', () => {
   test.setTimeout(60000)
 
-  test('OksaUri-linkit näkyvät klikattavina ja sisältävät #-fragmentin', async ({
+  test('Koodisto, Oksa, Allowed ja käännökset (opiskeluoikeuden tyyppi)', async ({
     page
   }) => {
-    await page.goto(
-      '/koski/json-schema-viewer#viewer-page?v=1-0-18-10' //Vapaan sivistystyön opiskeluoikeus / tyyppi
+    await openNode(page, '1-0-18-10', 'tyyppi')
+    const tech = page.locator('#info-technical')
+    // Koodisto row (linked)
+    await expect(
+      tech.locator('a[href*="/koodisto/opiskeluoikeudentyyppi/"]')
+    ).toBeVisible()
+    // Oksa row (linked, with #-fragment)
+    const oksaLink = tech.locator('a[href*="wiki.eduuni.fi"]')
+    await expect(oksaLink).toBeVisible()
+    expect(await oksaLink.getAttribute('href')).toContain('#tmpOKSAID')
+    // Allowed koodiarvo chip
+    await expect(tech.locator('.jsv-chip', { hasText: 'tuva' })).toBeVisible()
+    // fi + sv description blocks
+    await expect(
+      page.locator('#info-localized .jsv-lang-tag', { hasText: 'FI' })
+    ).toBeVisible()
+    await expect(
+      page.locator('#info-localized .jsv-lang-tag', { hasText: 'SV' })
+    ).toBeVisible()
+  })
+
+  test('@SensitiveData: chip, lock-badge ja taulukon kardinaliteetti', async ({
+    page
+  }) => {
+    await openNode(page, '1-0-2-11-2', 'sisäoppilaitosmainenMajoitus')
+    await expect(page.locator('#info-technical')).toContainText('0..*')
+    await expect(
+      page.locator('#info-technical .jsv-chip', { hasText: '@SensitiveData' })
+    ).toBeVisible()
+    await expect(page.locator('#info-badges')).toContainText(
+      'Erityinen henkilötieto'
     )
+  })
 
-    await page.locator('svg#jsv-tree').waitFor({
-      state: 'visible',
-      timeout: 30000
-    })
+  test('@RedundantData: chip ja "ei käytössä" -badge', async ({ page }) => {
+    await openNode(page, '1-0-2-11-0', 'oikeusMaksuttomaanAsuntolapaikkaan')
+    await expect(
+      page.locator('#info-technical .jsv-chip', { hasText: '@RedundantData' })
+    ).toBeVisible()
+    await expect(page.locator('#info-badges')).toContainText(
+      'Kenttä ei ole käytössä'
+    )
+  })
 
-    await page.locator('a[href="#info-panel"]').click()
+  test('@Deprecated, Koodisto ja Read-only (suorituksen tila)', async ({
+    page
+  }) => {
+    await openNode(page, '1-0-16-9-0-2-13-0-0-9', 'tila')
+    const tech = page.locator('#info-technical')
+    await expect(tech).toContainText('Koodisto')
+    await expect(tech).toContainText('Read-only')
+    await expect(
+      tech.locator('.jsv-chip', { hasText: '@Deprecated' })
+    ).toBeVisible()
+    await expect(page.locator('#info-badges')).toContainText('Vanhentunut')
+  })
 
-    const oksaLink = page.locator('#info-technical a[href*="wiki.eduuni.fi"]')
-    await expect(oksaLink).toBeVisible({ timeout: 10000 })
-    const oksaHref = await oksaLink.getAttribute('href')
-    expect(oksaHref).toContain('#tmpOKSAID')
+  // Default/Computed rows come from the scala-schema change (DefaultValue emitting a
+  // `default` field, SyntheticProperty emitting `synthetic`). Enable once scala-schema
+  // is released and the Koski dependency bumped past 2.40.0.
+  test.skip('Default- ja Computed-rivit (odottaa scala-schema-julkaisua)', async ({
+    page
+  }) => {
+    await openNode(page, '1-0-2-11-0', 'oikeusMaksuttomaanAsuntolapaikkaan')
+    await expect(page.locator('#info-technical')).toContainText('Default')
+    await openNode(page, '1-0-16-9-0-2-13-0-0-9', 'tila')
+    await expect(page.locator('#info-technical')).toContainText('Computed')
   })
 })

--- a/web/test/e2e/schema-viewer.spec.ts
+++ b/web/test/e2e/schema-viewer.spec.ts
@@ -17,10 +17,7 @@ test.describe('Schema viewer', () => {
 
     await page.locator('a[href="#info-panel"]').click()
 
-    const infoDefinition = page.locator('#info-definition')
-    await expect(infoDefinition).toBeVisible({ timeout: 10000 })
-
-    const oksaLink = infoDefinition.locator('a[href*="wiki.eduuni.fi"]')
+    const oksaLink = page.locator('#info-technical a[href*="wiki.eduuni.fi"]')
     await expect(oksaLink).toBeVisible({ timeout: 10000 })
     const oksaHref = await oksaLink.getAttribute('href')
     expect(oksaHref).toContain('#tmpOKSAID')

--- a/web/test/e2e/schema-viewer.spec.ts
+++ b/web/test/e2e/schema-viewer.spec.ts
@@ -79,12 +79,9 @@ test.describe('Schema viewer', () => {
     await expect(page.locator('#info-badges')).toContainText('Vanhentunut')
   })
 
-  // Default/Computed rows come from the scala-schema change (DefaultValue emitting a
-  // `default` field, SyntheticProperty emitting `synthetic`). Enable once scala-schema
-  // is released and the Koski dependency bumped past 2.40.0.
-  test.skip('Default- ja Computed-rivit (odottaa scala-schema-julkaisua)', async ({
-    page
-  }) => {
+  // Default/Computed rows come from the scala-schema structured fields (DefaultValue
+  // emitting `default`, SyntheticProperty emitting `synthetic`), available since 2.45.0_2.13.
+  test('Default- ja Computed-rivit', async ({ page }) => {
     await openNode(page, '1-0-2-11-0', 'oikeusMaksuttomaanAsuntolapaikkaan')
     await expect(page.locator('#info-technical')).toContainText('Default')
     await openNode(page, '1-0-16-9-0-2-13-0-0-9', 'tila')


### PR DESCRIPTION
Uusi versio Schema Viewerin infopanelista. 

- Näyttää proosan ja tekniset yksityiskohdat omissa osioissaan 
- Käsittelee annotaatiot melkein kattavasti (tarvitaan myös https://github.com/Opetushallitus/scala-schema/pull/69)
- Uudet tyylit by Claude Design
- Lisätty tuki nuolinäppäimillä navigoimiseen

<img width="4080" height="4084" alt="panel-collage" src="https://github.com/user-attachments/assets/4575e150-7dad-4e74-94da-a5f089aa7e0f" />
