### PR TITLE
TOR-2340: DIA opintopiste-laajuusyksikkö ja tunnustettu tutkintovaiheen osasuoritus

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -361,6 +361,7 @@ validaatiot = {
     duplikaatinSallivatAmmatillisenKoulutuksenPerusteenDiaarinumerot = ["OPH-1161-2018", "OPH-2487-2018", "OPH-2142-2025"]
     ammatillinenViestintäJaVuorovaikutusKoodit26Rajapäivä = "2026-08-01"
     lukuvuosimaksuRahoitusVoimassaAlkaen = "2026-08-01"
+    diaLaajuudetOpintopisteinäAlkaen = "2026-08-01"
     tilauskoulutusRahoitusVoimassaAlkaen = "2026-08-01"
 }
 

--- a/src/main/scala/fi/oph/koski/documentation/DIAExampleData.scala
+++ b/src/main/scala/fi/oph/koski/documentation/DIAExampleData.scala
@@ -12,6 +12,8 @@ object DIAExampleData {
 
   def laajuus(laajuus: Float, yksikkö: String = "3"): Some[LaajuusVuosiviikkotunneissa] = Some(LaajuusVuosiviikkotunneissa(laajuus, Koodistokoodiviite(koodistoUri = "opintojenlaajuusyksikko", koodiarvo = yksikkö)))
 
+  def laajuusOpintopisteinä(laajuus: Float): Some[LaajuusOpintopisteissä] = Some(LaajuusOpintopisteissä(laajuus))
+
   def diaValmistavaVaiheAineSuoritus(oppiaine: DIAOppiaine, lukukaudet: Option[List[(DIAOppiaineenValmistavanVaiheenLukukausi, String)]] = None) = DIAOppiaineenValmistavanVaiheenSuoritus(
     koulutusmoduuli = oppiaine,
     osasuoritukset = lukukaudet.map(_.map { case (lukukausi, arvosana) =>
@@ -40,30 +42,30 @@ object DIAExampleData {
       })
     )
 
-  def diaOppiaineMuu(aine: String, osaAlue: String, laajuus: Option[LaajuusVuosiviikkotunneissa] = None) = DIAOppiaineMuu(
+  def diaOppiaineMuu(aine: String, osaAlue: String, laajuus: Option[LaajuusVuosiviikkotunneissaTaiOpintopisteissä] = None) = DIAOppiaineMuu(
     tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = aine),
     laajuus = laajuus,
     osaAlue = Koodistokoodiviite(koodiarvo = osaAlue, koodistoUri = "diaosaalue")
   )
 
-  def diaOppiaineKieliaine(taso: String, kieli: String, laajuus: Option[LaajuusVuosiviikkotunneissa] = None) = DIAOppiaineKieli(
+  def diaOppiaineKieliaine(taso: String, kieli: String, laajuus: Option[LaajuusVuosiviikkotunneissaTaiOpintopisteissä] = None) = DIAOppiaineKieli(
     tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = taso),
     kieli = Koodistokoodiviite(koodistoUri = "kielivalikoima", koodiarvo = kieli),
     laajuus = laajuus
   )
 
-  def diaOppiaineÄidinkieli(kieli: String, laajuus: Option[LaajuusVuosiviikkotunneissa] = None) = DIAOppiaineÄidinkieli(
+  def diaOppiaineÄidinkieli(kieli: String, laajuus: Option[LaajuusVuosiviikkotunneissaTaiOpintopisteissä] = None) = DIAOppiaineÄidinkieli(
     tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = "AI"),
     kieli = Koodistokoodiviite(koodistoUri = "oppiainediaaidinkieli", koodiarvo = kieli),
     laajuus = laajuus
   )
 
-  def diaOppiaineLisäaine(aine: String, laajuus: Option[LaajuusVuosiviikkotunneissa] = None) = DIAOppiaineLisäaine(
+  def diaOppiaineLisäaine(aine: String, laajuus: Option[LaajuusVuosiviikkotunneissaTaiOpintopisteissä] = None) = DIAOppiaineLisäaine(
     tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = aine),
     laajuus = laajuus
   )
 
-  def diaOppiaineLisäaineKieli(taso: String, kieli: String, laajuus: Option[LaajuusVuosiviikkotunneissa] = None) = DIAOppiaineLisäaineKieli(
+  def diaOppiaineLisäaineKieli(taso: String, kieli: String, laajuus: Option[LaajuusVuosiviikkotunneissaTaiOpintopisteissä] = None) = DIAOppiaineLisäaineKieli(
     tunniste = Koodistokoodiviite(koodistoUri = "oppiaineetdia", koodiarvo = taso),
     kieli = Koodistokoodiviite(koodistoUri = "kielivalikoima", koodiarvo = kieli),
     laajuus = laajuus
@@ -77,12 +79,12 @@ object DIAExampleData {
     Some(List(DIAOppiaineenValmistavanVaiheenLukukaudenArviointi(arvosana = Koodistokoodiviite(koodiarvo = arvosana, koodistoUri = "arviointiasteikkodiavalmistava"), päivä = Some(päivä))))
   }
 
-  def diaValmistavaLukukausi(lukukausi: String = "1", laajuus: Option[LaajuusVuosiviikkotunneissa] = None) = DIAOppiaineenValmistavanVaiheenLukukausi(
+  def diaValmistavaLukukausi(lukukausi: String = "1", laajuus: Option[LaajuusVuosiviikkotunneissaTaiOpintopisteissä] = None) = DIAOppiaineenValmistavanVaiheenLukukausi(
     tunniste = Koodistokoodiviite(koodiarvo = lukukausi, koodistoUri = "dialukukausi"),
     laajuus = laajuus
   )
 
-  def diaTutkintoLukukausi(lukukausi: String = "3", laajuus: Option[LaajuusVuosiviikkotunneissa] = None) = DIAOppiaineenTutkintovaiheenLukukausi(
+  def diaTutkintoLukukausi(lukukausi: String = "3", laajuus: Option[LaajuusVuosiviikkotunneissaTaiOpintopisteissä] = None) = DIAOppiaineenTutkintovaiheenLukukausi(
     tunniste = Koodistokoodiviite(koodiarvo = lukukausi, koodistoUri = "dialukukausi"),
     laajuus = laajuus
   )

--- a/src/main/scala/fi/oph/koski/editor/EditorModelBuilder.scala
+++ b/src/main/scala/fi/oph/koski/editor/EditorModelBuilder.scala
@@ -244,9 +244,25 @@ case class OneOfModelBuilder(t: AnyOfSchema)(implicit context: ModelBuilderConte
     if (clazz == classOf[LocalizedString]) {
       buildModelForObject(LocalizedString.finnish(""), metadata)
     } else {
-      buildModel(modelBuilderForClass(t.alternatives.head).buildPrototype(metadata), metadata)
+      buildModel(modelBuilderForClass(oletusvaihtoehto).buildPrototype(metadata), metadata)
     }
   }
+
+  // Unionin oletusvaihtoehto on aakkosjärjestyksessä ensimmäinen. DIA-tutkinnon
+  // laajuusyksikkö on unioni (vuosiviikkotunti/opintopiste), jossa oletukseksi
+  // haluamme vuosiviikkotunnin: ennen 1.8.2026 alkaneet DIA-opiskeluoikeudet
+  // ilmoitetaan vuosiviikkotunteina, ja niitä on valtaosa. 1.8.2026 tai myöhemmin
+  // alkaneille validointi vaatii opintopisteen, jonka käyttäjä valitsee itse.
+  // Prototyypit rakennetaan globaalisti ilman opiskeluoikeuskohtaista tietoa, joten
+  // oletus on kiinteä.
+  private def oletusvaihtoehto: SchemaWithClassName =
+    if (sanitizeName(t.simpleName) == "laajuusvuosiviikkotunneissataiopintopisteissa") {
+      t.alternatives
+        .find(a => sanitizeName(a.simpleName) == "laajuusvuosiviikkotunneissa")
+        .getOrElse(t.alternatives.head)
+    } else {
+      t.alternatives.head
+    }
 }
 
 case class ObjectModelBuilder(schema: ClassSchema)(implicit context: ModelBuilderContext) extends ModelBuilderForClass {

--- a/src/main/scala/fi/oph/koski/schema/DIA.scala
+++ b/src/main/scala/fi/oph/koski/schema/DIA.scala
@@ -186,9 +186,10 @@ case class DIAOppiaineenValmistavanVaiheenLukukaudenSuoritus(
 case class DIAOppiaineenTutkintovaiheenOsasuorituksenSuoritus(
   koulutusmoduuli: DIAOppiaineenTutkintovaiheenOsasuoritus,
   arviointi: Option[List[DIATutkintovaiheenArviointi]] = None,
+  tunnustettu: Option[OsaamisenTunnustaminen] = None,
   @KoodistoKoodiarvo("diaoppiaineentutkintovaiheenosasuorituksensuoritus")
   tyyppi: Koodistokoodiviite = Koodistokoodiviite(koodiarvo = "diaoppiaineentutkintovaiheenosasuorituksensuoritus", koodistoUri = "suorituksentyyppi")
-) extends DIASuoritus
+) extends DIASuoritus with MahdollisestiTunnustettu
 
 trait DIAOppiaineenOsasuoritus extends KoodistostaLöytyväKoulutusmoduuli
 
@@ -205,7 +206,7 @@ case class DIAOppiaineenValmistavanVaiheenLukukausi(
   @KoodistoKoodiarvo("1")
   @KoodistoKoodiarvo("2")
   tunniste: Koodistokoodiviite,
-  laajuus: Option[LaajuusVuosiviikkotunneissa]
+  laajuus: Option[LaajuusVuosiviikkotunneissaTaiOpintopisteissä]
 ) extends DIAOppiaineenLukukausi
 
 @Title("DIA-oppiaineen tutkintovaiheen lukukausi")
@@ -216,7 +217,7 @@ case class DIAOppiaineenTutkintovaiheenLukukausi(
   @KoodistoKoodiarvo("5")
   @KoodistoKoodiarvo("6")
   tunniste: Koodistokoodiviite,
-  laajuus: Option[LaajuusVuosiviikkotunneissa]
+  laajuus: Option[LaajuusVuosiviikkotunneissaTaiOpintopisteissä]
 ) extends DIAOppiaineenLukukausi with DIAOppiaineenTutkintovaiheenOsasuoritus
 
 @Title("DIA-tutkinnon päättökoe")
@@ -303,7 +304,7 @@ trait DIAOppiaine extends KoodistostaLöytyväKoulutusmoduuliValinnainenLaajuus 
   @KoodistoUri("oppiaineetdia")
   @OksaUri("tmpOKSAID256", "oppiaine")
   def tunniste: Koodistokoodiviite
-  def laajuus: Option[LaajuusVuosiviikkotunneissa]
+  def laajuus: Option[LaajuusVuosiviikkotunneissaTaiOpintopisteissä]
 }
 
 trait DIAOsaAlueOppiaine extends DIAOppiaine {
@@ -330,7 +331,7 @@ case class DIAOppiaineMuu(
   @KoodistoKoodiarvo("FI")
   @KoodistoKoodiarvo("ET")
   tunniste: Koodistokoodiviite,
-  laajuus: Option[LaajuusVuosiviikkotunneissa],
+  laajuus: Option[LaajuusVuosiviikkotunneissaTaiOpintopisteissä],
   @Description("Oppiaineen osa-alue (1-3)")
   osaAlue: Koodistokoodiviite,
   pakollinen: Boolean = true
@@ -343,7 +344,7 @@ case class DIAOppiaineKieli(
   @KoodistoKoodiarvo("B1")
   @KoodistoKoodiarvo("B3")
   tunniste: Koodistokoodiviite,
-  laajuus: Option[LaajuusVuosiviikkotunneissa],
+  laajuus: Option[LaajuusVuosiviikkotunneissaTaiOpintopisteissä],
   @KoodistoUri("kielivalikoima")
   @KoodistoKoodiarvo("EN")
   @KoodistoKoodiarvo("FR")
@@ -364,7 +365,7 @@ case class DIAOppiaineKieli(
 case class DIAOppiaineÄidinkieli(
   @KoodistoKoodiarvo("AI")
   tunniste: Koodistokoodiviite,
-  laajuus: Option[LaajuusVuosiviikkotunneissa],
+  laajuus: Option[LaajuusVuosiviikkotunneissaTaiOpintopisteissä],
   @KoodistoUri("oppiainediaaidinkieli")
   @KoodistoKoodiarvo("FI")
   @KoodistoKoodiarvo("S2")
@@ -391,13 +392,13 @@ case class DIAOppiaineLisäaine(
   @KoodistoKoodiarvo("RALI")
   @KoodistoKoodiarvo("VT")
   tunniste: Koodistokoodiviite,
-  laajuus: Option[LaajuusVuosiviikkotunneissa]
+  laajuus: Option[LaajuusVuosiviikkotunneissaTaiOpintopisteissä]
 ) extends DIAOppiaine
 
 case class DIAOppiaineLisäaineKieli(
   @KoodistoKoodiarvo("B2")
   tunniste: Koodistokoodiviite,
-  laajuus: Option[LaajuusVuosiviikkotunneissa],
+  laajuus: Option[LaajuusVuosiviikkotunneissaTaiOpintopisteissä],
   @KoodistoUri("kielivalikoima")
   @KoodistoKoodiarvo("LA")
   @Discriminator

--- a/src/main/scala/fi/oph/koski/schema/Laajuus.scala
+++ b/src/main/scala/fi/oph/koski/schema/Laajuus.scala
@@ -30,13 +30,13 @@ case class LaajuusOpintopisteissä(
   arvo: Double,
   @KoodistoKoodiarvo("2")
   yksikkö: Koodistokoodiviite = laajuusOpintopisteissä
-) extends LaajuusOpintopisteissäTaiKursseissa with LaajuusOpintopisteissäTaiTunneissa
+) extends LaajuusOpintopisteissäTaiKursseissa with LaajuusOpintopisteissäTaiTunneissa with LaajuusVuosiviikkotunneissaTaiOpintopisteissä
 
 case class LaajuusVuosiviikkotunneissa(
   arvo: Double,
   @KoodistoKoodiarvo("3")
   yksikkö: Koodistokoodiviite = laajuusVuosiviikkotunneissa
-) extends LaajuusVuosiviikkotunneissaTaiKursseissa with LaajuusVuosiviikkotunneissaTaiTunneissa
+) extends LaajuusVuosiviikkotunneissaTaiKursseissa with LaajuusVuosiviikkotunneissaTaiTunneissa with LaajuusVuosiviikkotunneissaTaiOpintopisteissä
 
 case class LaajuusKursseissa(
   arvo: Double,
@@ -52,6 +52,8 @@ trait LaajuusVuosiviikkotunneissaTaiKursseissa extends Laajuus
 trait LaajuusVuosiviikkotunneissaTaiTunneissa extends Laajuus
 
 trait LaajuusOpintopisteissäTaiTunneissa extends Laajuus
+
+trait LaajuusVuosiviikkotunneissaTaiOpintopisteissä extends Laajuus
 
 case class LaajuusTunneissa(
   arvo: Double,

--- a/src/main/scala/fi/oph/koski/validation/DIAValidation.scala
+++ b/src/main/scala/fi/oph/koski/validation/DIAValidation.scala
@@ -1,0 +1,43 @@
+package fi.oph.koski.validation
+
+import com.typesafe.config.Config
+import fi.oph.koski.http.{HttpStatus, KoskiErrorCategory}
+import fi.oph.koski.schema._
+import fi.oph.koski.util.ChainingSyntax._
+import fi.oph.koski.util.FinnishDateFormat
+
+import java.time.LocalDate
+
+object DIAValidation {
+  def validateOpiskeluoikeus(config: Config)(opiskeluoikeus: KoskeenTallennettavaOpiskeluoikeus): HttpStatus =
+    opiskeluoikeus match {
+      case oo: DIAOpiskeluoikeus =>
+        oo.alkamispäivä match {
+          case Some(alkamispäivä) => validateLaajuusyksiköt(oo, alkamispäivä, rajapäivä(config))
+          case None => HttpStatus.ok
+        }
+      case _ => HttpStatus.ok
+    }
+
+  private def rajapäivä(config: Config): LocalDate =
+    LocalDate.parse(config.getString("validaatiot.diaLaajuudetOpintopisteinäAlkaen"))
+
+  private def validateLaajuusyksiköt(oo: DIAOpiskeluoikeus, alkamispäivä: LocalDate, rajapäivä: LocalDate): HttpStatus =
+    HttpStatus.fold(kaikkiLaajuudet(oo).map(validateLaajuusyksikkö(_, alkamispäivä, rajapäivä)))
+
+  private def kaikkiLaajuudet(oo: DIAOpiskeluoikeus): List[Laajuus] =
+    oo.suoritukset.flatMap(s => s :: s.rekursiivisetOsasuoritukset).flatMap(_.koulutusmoduuli.getLaajuus)
+
+  private def validateLaajuusyksikkö(laajuus: Laajuus, alkamispäivä: LocalDate, rajapäivä: LocalDate): HttpStatus =
+    laajuus match {
+      case _: LaajuusVuosiviikkotunneissa if alkamispäivä.isEqualOrAfter(rajapäivä) =>
+        KoskiErrorCategory.badRequest.validation.laajuudet.osauoritusVääräLaajuus(
+          s"DIA-tutkinnon laajuus on ilmoitettava opintopisteissä ${FinnishDateFormat.format(rajapäivä)} tai myöhemmin alkaneille opiskeluoikeuksille"
+        )
+      case _: LaajuusOpintopisteissä if alkamispäivä.isBefore(rajapäivä) =>
+        KoskiErrorCategory.badRequest.validation.laajuudet.osauoritusVääräLaajuus(
+          s"DIA-tutkinnon laajuuden voi ilmoittaa opintopisteissä vain ${FinnishDateFormat.format(rajapäivä)} tai myöhemmin alkaneille opiskeluoikeuksille"
+        )
+      case _ => HttpStatus.ok
+    }
+}

--- a/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
+++ b/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
@@ -165,6 +165,7 @@ class KoskiValidator(
           EuropeanSchoolOfHelsinkiValidation.validateOpiskeluoikeus(config)(henkilöRepository, koskiOpiskeluoikeudet, henkilö, opiskeluoikeus),
           TaiteenPerusopetusValidation.validateOpiskeluoikeus(config)(opiskeluoikeus, suostumuksenPeruutusService),
           IBValidation.validateIbOpiskeluoikeus(config)(opiskeluoikeus),
+          DIAValidation.validateOpiskeluoikeus(config)(opiskeluoikeus),
           ToimintaAlueetValidation.validateToimintaAlueellinenOpiskeluoikeus(config)(opiskeluoikeus),
           KielitutkintoValidation.validateOpiskeluoikeus(opiskeluoikeus),
           EsiopetusValidation.validateOpiskeluoikeus(config)(opiskeluoikeus),

--- a/src/test/scala/fi/oph/koski/api/oppijavalidation/OppijaValidationDIASpec.scala
+++ b/src/test/scala/fi/oph/koski/api/oppijavalidation/OppijaValidationDIASpec.scala
@@ -7,14 +7,14 @@ import fi.oph.koski.documentation.DIAExampleData._
 import fi.oph.koski.documentation.ExampleData._
 import fi.oph.koski.documentation.ExamplesDIA
 import fi.oph.koski.http.{ErrorMatcher, KoskiErrorCategory}
-import fi.oph.koski.schema.{DIAOpiskeluoikeudenTila, DIAOpiskeluoikeusjakso, Koodistokoodiviite}
+import fi.oph.koski.schema.{DIAOpiskeluoikeudenTila, DIAOpiskeluoikeusjakso, DIAOppiaineenTutkintovaiheenOsasuorituksenSuoritus, DIAOppiaineenTutkintovaiheenSuoritus, Koodistokoodiviite, LocalizedString, OsaamisenTunnustaminen}
 import org.scalatest.freespec.AnyFreeSpec
 
 import java.time.LocalDate
 
 class OppijaValidationDIASpec extends AnyFreeSpec with KoskiHttpSpec with OpiskeluoikeusTestMethodsDIA {
   "Laajuudet" - {
-    """Lukukauden laajuusyksikkö muu kuin "vuosiviikkotuntia" -> HTTP 400""" in {
+    """Lukukauden laajuusyksikkö muu kuin "vuosiviikkotuntia" tai "opintopistettä" -> HTTP 400""" in {
       val laajuudenYksikköKurssia = "4"
       val oo = defaultOpiskeluoikeus.copy(suoritukset = List(tutkintoSuoritus.copy(
         osasuoritukset = Some(List(diaTutkintoAineSuoritus(diaOppiaineMuu("MA", osaAlue = "2", laajuus(8)), Some(List(
@@ -23,7 +23,7 @@ class OppijaValidationDIASpec extends AnyFreeSpec with KoskiHttpSpec with Opiske
       )))
 
       setupOppijaWithOpiskeluoikeus(oo) {
-        verifyResponseStatus(400, ErrorMatcher.regex(KoskiErrorCategory.badRequest.validation.jsonSchema, ".*enumValueMismatch.*".r))
+        verifyResponseStatus(400, ErrorMatcher.regex(KoskiErrorCategory.badRequest.validation.jsonSchema, ".*notAnyOf.*".r))
       }
     }
 
@@ -107,6 +107,62 @@ class OppijaValidationDIASpec extends AnyFreeSpec with KoskiHttpSpec with Opiske
     }
   }
 
+  "Laajuusyksikkö alkamispäivän mukaan" - {
+    val ennenRajapäivää = LocalDate.of(2026, 7, 31)
+    val rajapäivä = LocalDate.of(2026, 8, 1)
+
+    def opiskeluoikeusAlkaen(alkamispäivä: LocalDate, aineSuoritus: DIAOppiaineenTutkintovaiheenSuoritus) =
+      defaultOpiskeluoikeus.copy(
+        tila = DIAOpiskeluoikeudenTila(List(
+          DIAOpiskeluoikeusjakso(alkamispäivä, opiskeluoikeusLäsnä, Some(valtionosuusRahoitteinen))
+        )),
+        suoritukset = List(tutkintoSuoritus.copy(osasuoritukset = Some(List(aineSuoritus))))
+      )
+
+    "1.8.2026 tai myöhemmin alkaneessa opiskeluoikeudessa opintopistelaajuus -> HTTP 200" in {
+      val oo = opiskeluoikeusAlkaen(rajapäivä, diaTutkintoAineSuoritus(
+        diaOppiaineMuu("MA", osaAlue = "2", laajuusOpintopisteinä(8)),
+        Some(List((diaTutkintoLukukausi("3", laajuusOpintopisteinä(8)), "2")))
+      ))
+      setupOppijaWithOpiskeluoikeus(oo) {
+        verifyResponseStatusOk()
+      }
+    }
+
+    "1.8.2026 tai myöhemmin alkaneessa opiskeluoikeudessa oppiaineen vuosiviikkotuntilaajuus -> HTTP 400" in {
+      val oo = opiskeluoikeusAlkaen(rajapäivä, diaTutkintoAineSuoritus(
+        diaOppiaineMuu("MA", osaAlue = "2", laajuus(8))
+      ))
+      setupOppijaWithOpiskeluoikeus(oo) {
+        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.laajuudet.osauoritusVääräLaajuus(
+          "DIA-tutkinnon laajuus on ilmoitettava opintopisteissä 1.8.2026 tai myöhemmin alkaneille opiskeluoikeuksille"
+        ))
+      }
+    }
+
+    "ennen 1.8.2026 alkaneessa opiskeluoikeudessa vuosiviikkotuntilaajuus -> HTTP 200" in {
+      val oo = opiskeluoikeusAlkaen(ennenRajapäivää, diaTutkintoAineSuoritus(
+        diaOppiaineMuu("MA", osaAlue = "2", laajuus(8)),
+        Some(List((diaTutkintoLukukausi("3", laajuus(8f)), "2")))
+      ))
+      setupOppijaWithOpiskeluoikeus(oo) {
+        verifyResponseStatusOk()
+      }
+    }
+
+    "ennen 1.8.2026 alkaneessa opiskeluoikeudessa lukukauden opintopistelaajuus -> HTTP 400" in {
+      val oo = opiskeluoikeusAlkaen(ennenRajapäivää, diaTutkintoAineSuoritus(
+        diaOppiaineMuu("MA", osaAlue = "2"),
+        Some(List((diaTutkintoLukukausi("3", laajuusOpintopisteinä(8)), "2")))
+      ))
+      setupOppijaWithOpiskeluoikeus(oo) {
+        verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.laajuudet.osauoritusVääräLaajuus(
+          "DIA-tutkinnon laajuuden voi ilmoittaa opintopisteissä vain 1.8.2026 tai myöhemmin alkaneille opiskeluoikeuksille"
+        ))
+      }
+    }
+  }
+
   "Kaksi äidinkieltä" - {
     "Samalla kielivalinnalla -> HTTP 400" in {
       val oo = defaultOpiskeluoikeus.copy(suoritukset = List(tutkintoSuoritus.copy(
@@ -136,6 +192,27 @@ class OppijaValidationDIASpec extends AnyFreeSpec with KoskiHttpSpec with Opiske
           )))
         ))
       )))
+
+      setupOppijaWithOpiskeluoikeus(oo) {
+        verifyResponseStatusOk()
+      }
+    }
+  }
+
+  "Tunnustettu" - {
+    "Suoritus kesken, tutkintovaiheen osasuorituksen osasuoritus tunnustettu -> HTTP 200" in {
+      val oo = defaultOpiskeluoikeus.copy(suoritukset = List(tutkintoSuoritus.copy(
+        osasuoritukset = Some(List(diaTutkintoAineSuoritus(diaOppiaineMuu("MA", osaAlue = "2", laajuus(1))).copy(
+          osasuoritukset = Some(List(DIAOppiaineenTutkintovaiheenOsasuorituksenSuoritus(
+            koulutusmoduuli = diaTutkintoLukukausi("3", laajuus(1.0f)),
+            arviointi = diaTutkintovaiheenArviointi("2"),
+            tunnustettu = Some(OsaamisenTunnustaminen(
+              osaaminen = None,
+              selite = LocalizedString.finnish("Tunnustettu aiemman osaamisen perusteella")
+            ))
+          )))
+        ))))
+      ))
 
       setupOppijaWithOpiskeluoikeus(oo) {
         verifyResponseStatusOk()

--- a/tiedonsiirtoprotokollan_muutoshistoria.md
+++ b/tiedonsiirtoprotokollan_muutoshistoria.md
@@ -1,3 +1,8 @@
+# 17.7.2026
+
+- DIA-tutkinnon opiskeluoikeudessa laajuusyksikkönä voi käyttää opintopistettä 1.8.2026 tai myöhemmin alkaneissa opiskeluoikeuksissa. Aiemmin alkaneissa opiskeluoikeuksissa käytetään vuosiviikkotuntia.
+- DIA-tutkinnon tutkintovaiheen osasuorituksen osasuoritukselle lisätty vapaaehtoinen `tunnustettu`-kenttä, jolla voidaan ilmaista, että osasuorituksen osasuoritus on tunnustettu.
+
 # 7.7.2026
 
 - Lisätty OmaData OAuth2 -rajapinnan opiskeluoikeuspakettien `oppilaitos`-rakenteeseen `oppilaitostyyppi`-kenttä. Kenttä palautetaan rajapinnan vastauksissa oppilaitoksille ja tieto haetaan Organisaatiopalvelusta; kenttää ei siirretä Koskeen syöttörajapinnoissa eikä sitä palauteta toimipisteille.

--- a/validaation_muutoshistoria.md
+++ b/validaation_muutoshistoria.md
@@ -1,5 +1,9 @@
 # Koskeen tallennettavien tietojen validaatiosäännöt
 
+## 17.7.2026
+
+- DIA-tutkinnon opiskeluoikeuksissa laajuusyksikkönä pakotetaan opintopiste 1.8.2026 tai myöhemmin alkaneissa opiskeluoikeuksissa. Sitä ennen alkaneissa opiskeluoikeuksissa pakotetaan edelleen vuosiviikkotunti.
+
 ## 23.6.2026
 
 - Lisättiin validaatio, että lähdejärjestelmäkytkentää ei voi purkaa kielitutkinto-opiskeluoikeuksilta.

--- a/web/app/types/fi/oph/koski/schema/DIAOppiaineAidinkieli.ts
+++ b/web/app/types/fi/oph/koski/schema/DIAOppiaineAidinkieli.ts
@@ -1,6 +1,6 @@
 import { Koodistokoodiviite } from './Koodistokoodiviite'
 import { LocalizedString } from './LocalizedString'
-import { LaajuusVuosiviikkotunneissa } from './LaajuusVuosiviikkotunneissa'
+import { LaajuusVuosiviikkotunneissaTaiOpintopisteissä } from './LaajuusVuosiviikkotunneissaTaiOpintopisteissa'
 
 /**
  * DIA-oppiaineen tunnistetiedot
@@ -10,14 +10,14 @@ import { LaajuusVuosiviikkotunneissa } from './LaajuusVuosiviikkotunneissa'
 export type DIAOppiaineÄidinkieli = {
   $class: 'fi.oph.koski.schema.DIAOppiaineÄidinkieli'
   tunniste: Koodistokoodiviite<'oppiaineetdia', 'AI'>
-  laajuus?: LaajuusVuosiviikkotunneissa
+  laajuus?: LaajuusVuosiviikkotunneissaTaiOpintopisteissä
   kieli: Koodistokoodiviite<'oppiainediaaidinkieli', 'FI' | 'S2' | 'DE'>
   osaAlue: Koodistokoodiviite<'diaosaalue', '1'>
 }
 
 export const DIAOppiaineÄidinkieli = (o: {
   tunniste?: Koodistokoodiviite<'oppiaineetdia', 'AI'>
-  laajuus?: LaajuusVuosiviikkotunneissa
+  laajuus?: LaajuusVuosiviikkotunneissaTaiOpintopisteissä
   kieli: Koodistokoodiviite<'oppiainediaaidinkieli', 'FI' | 'S2' | 'DE'>
   osaAlue?: Koodistokoodiviite<'diaosaalue', '1'>
 }): DIAOppiaineÄidinkieli => ({

--- a/web/app/types/fi/oph/koski/schema/DIAOppiaineKieli.ts
+++ b/web/app/types/fi/oph/koski/schema/DIAOppiaineKieli.ts
@@ -1,6 +1,6 @@
 import { Koodistokoodiviite } from './Koodistokoodiviite'
 import { LocalizedString } from './LocalizedString'
-import { LaajuusVuosiviikkotunneissa } from './LaajuusVuosiviikkotunneissa'
+import { LaajuusVuosiviikkotunneissaTaiOpintopisteissä } from './LaajuusVuosiviikkotunneissaTaiOpintopisteissa'
 
 /**
  * DIA-oppiaineen tunnistetiedot
@@ -12,7 +12,7 @@ export type DIAOppiaineKieli = {
   pakollinen: boolean
   osaAlue: Koodistokoodiviite<'diaosaalue', '1'>
   kieli: Koodistokoodiviite<'kielivalikoima', 'EN' | 'FR' | 'SV' | 'RU'>
-  laajuus?: LaajuusVuosiviikkotunneissa
+  laajuus?: LaajuusVuosiviikkotunneissaTaiOpintopisteissä
   tunniste: Koodistokoodiviite<'oppiaineetdia', 'A' | 'B1' | 'B3'>
 }
 
@@ -20,7 +20,7 @@ export const DIAOppiaineKieli = (o: {
   pakollinen: boolean
   osaAlue?: Koodistokoodiviite<'diaosaalue', '1'>
   kieli: Koodistokoodiviite<'kielivalikoima', 'EN' | 'FR' | 'SV' | 'RU'>
-  laajuus?: LaajuusVuosiviikkotunneissa
+  laajuus?: LaajuusVuosiviikkotunneissaTaiOpintopisteissä
   tunniste: Koodistokoodiviite<'oppiaineetdia', 'A' | 'B1' | 'B3'>
 }): DIAOppiaineKieli => ({
   $class: 'fi.oph.koski.schema.DIAOppiaineKieli',

--- a/web/app/types/fi/oph/koski/schema/DIAOppiaineLisaaine.ts
+++ b/web/app/types/fi/oph/koski/schema/DIAOppiaineLisaaine.ts
@@ -1,6 +1,6 @@
 import { Koodistokoodiviite } from './Koodistokoodiviite'
 import { LocalizedString } from './LocalizedString'
-import { LaajuusVuosiviikkotunneissa } from './LaajuusVuosiviikkotunneissa'
+import { LaajuusVuosiviikkotunneissaTaiOpintopisteissä } from './LaajuusVuosiviikkotunneissaTaiOpintopisteissa'
 
 /**
  * DIA-oppiaineen tunnistetiedot
@@ -22,7 +22,7 @@ export type DIAOppiaineLisäaine = {
     | 'RALI'
     | 'VT'
   >
-  laajuus?: LaajuusVuosiviikkotunneissa
+  laajuus?: LaajuusVuosiviikkotunneissaTaiOpintopisteissä
 }
 
 export const DIAOppiaineLisäaine = (o: {
@@ -39,7 +39,7 @@ export const DIAOppiaineLisäaine = (o: {
     | 'RALI'
     | 'VT'
   >
-  laajuus?: LaajuusVuosiviikkotunneissa
+  laajuus?: LaajuusVuosiviikkotunneissaTaiOpintopisteissä
 }): DIAOppiaineLisäaine => ({
   $class: 'fi.oph.koski.schema.DIAOppiaineLisäaine',
   ...o

--- a/web/app/types/fi/oph/koski/schema/DIAOppiaineLisaaineKieli.ts
+++ b/web/app/types/fi/oph/koski/schema/DIAOppiaineLisaaineKieli.ts
@@ -1,6 +1,6 @@
 import { Koodistokoodiviite } from './Koodistokoodiviite'
 import { LocalizedString } from './LocalizedString'
-import { LaajuusVuosiviikkotunneissa } from './LaajuusVuosiviikkotunneissa'
+import { LaajuusVuosiviikkotunneissaTaiOpintopisteissä } from './LaajuusVuosiviikkotunneissaTaiOpintopisteissa'
 
 /**
  * DIA-oppiaineen tunnistetiedot
@@ -10,14 +10,14 @@ import { LaajuusVuosiviikkotunneissa } from './LaajuusVuosiviikkotunneissa'
 export type DIAOppiaineLisäaineKieli = {
   $class: 'fi.oph.koski.schema.DIAOppiaineLisäaineKieli'
   tunniste: Koodistokoodiviite<'oppiaineetdia', 'B2'>
-  laajuus?: LaajuusVuosiviikkotunneissa
+  laajuus?: LaajuusVuosiviikkotunneissaTaiOpintopisteissä
   kieli: Koodistokoodiviite<'kielivalikoima', 'LA'>
 }
 
 export const DIAOppiaineLisäaineKieli = (
   o: {
     tunniste?: Koodistokoodiviite<'oppiaineetdia', 'B2'>
-    laajuus?: LaajuusVuosiviikkotunneissa
+    laajuus?: LaajuusVuosiviikkotunneissaTaiOpintopisteissä
     kieli?: Koodistokoodiviite<'kielivalikoima', 'LA'>
   } = {}
 ): DIAOppiaineLisäaineKieli => ({

--- a/web/app/types/fi/oph/koski/schema/DIAOppiaineMuu.ts
+++ b/web/app/types/fi/oph/koski/schema/DIAOppiaineMuu.ts
@@ -1,6 +1,6 @@
 import { Koodistokoodiviite } from './Koodistokoodiviite'
 import { LocalizedString } from './LocalizedString'
-import { LaajuusVuosiviikkotunneissa } from './LaajuusVuosiviikkotunneissa'
+import { LaajuusVuosiviikkotunneissaTaiOpintopisteissä } from './LaajuusVuosiviikkotunneissaTaiOpintopisteissa'
 
 /**
  * DIA-oppiaineen tunnistetiedot
@@ -26,7 +26,7 @@ export type DIAOppiaineMuu = {
     | 'FI'
     | 'ET'
   >
-  laajuus?: LaajuusVuosiviikkotunneissa
+  laajuus?: LaajuusVuosiviikkotunneissaTaiOpintopisteissä
   osaAlue: Koodistokoodiviite<'diaosaalue', string>
   pakollinen: boolean
 }
@@ -49,7 +49,7 @@ export const DIAOppiaineMuu = (o: {
     | 'FI'
     | 'ET'
   >
-  laajuus?: LaajuusVuosiviikkotunneissa
+  laajuus?: LaajuusVuosiviikkotunneissaTaiOpintopisteissä
   osaAlue: Koodistokoodiviite<'diaosaalue', string>
   pakollinen: boolean
 }): DIAOppiaineMuu => ({ $class: 'fi.oph.koski.schema.DIAOppiaineMuu', ...o })

--- a/web/app/types/fi/oph/koski/schema/DIAOppiaineenTutkintovaiheenLukukausi.ts
+++ b/web/app/types/fi/oph/koski/schema/DIAOppiaineenTutkintovaiheenLukukausi.ts
@@ -1,6 +1,6 @@
 import { Koodistokoodiviite } from './Koodistokoodiviite'
 import { LocalizedString } from './LocalizedString'
-import { LaajuusVuosiviikkotunneissa } from './LaajuusVuosiviikkotunneissa'
+import { LaajuusVuosiviikkotunneissaTaiOpintopisteissä } from './LaajuusVuosiviikkotunneissaTaiOpintopisteissa'
 
 /**
  * DIA-oppiaineen tutkintovaiheen lukukauden tunnistetiedot
@@ -10,12 +10,12 @@ import { LaajuusVuosiviikkotunneissa } from './LaajuusVuosiviikkotunneissa'
 export type DIAOppiaineenTutkintovaiheenLukukausi = {
   $class: 'fi.oph.koski.schema.DIAOppiaineenTutkintovaiheenLukukausi'
   tunniste: Koodistokoodiviite<'dialukukausi', '3' | '4' | '5' | '6'>
-  laajuus?: LaajuusVuosiviikkotunneissa
+  laajuus?: LaajuusVuosiviikkotunneissaTaiOpintopisteissä
 }
 
 export const DIAOppiaineenTutkintovaiheenLukukausi = (o: {
   tunniste: Koodistokoodiviite<'dialukukausi', '3' | '4' | '5' | '6'>
-  laajuus?: LaajuusVuosiviikkotunneissa
+  laajuus?: LaajuusVuosiviikkotunneissaTaiOpintopisteissä
 }): DIAOppiaineenTutkintovaiheenLukukausi => ({
   $class: 'fi.oph.koski.schema.DIAOppiaineenTutkintovaiheenLukukausi',
   ...o

--- a/web/app/types/fi/oph/koski/schema/DIAOppiaineenTutkintovaiheenOsasuorituksenSuoritus.ts
+++ b/web/app/types/fi/oph/koski/schema/DIAOppiaineenTutkintovaiheenOsasuorituksenSuoritus.ts
@@ -1,7 +1,8 @@
-import { DIAOppiaineenTutkintovaiheenOsasuoritus } from './DIAOppiaineenTutkintovaiheenOsasuoritus'
 import { DIATutkintovaiheenArviointi } from './DIATutkintovaiheenArviointi'
 import { Koodistokoodiviite } from './Koodistokoodiviite'
 import { LocalizedString } from './LocalizedString'
+import { DIAOppiaineenTutkintovaiheenOsasuoritus } from './DIAOppiaineenTutkintovaiheenOsasuoritus'
+import { OsaamisenTunnustaminen } from './OsaamisenTunnustaminen'
 
 /**
  * DIAOppiaineenTutkintovaiheenOsasuorituksenSuoritus
@@ -10,30 +11,32 @@ import { LocalizedString } from './LocalizedString'
  */
 export type DIAOppiaineenTutkintovaiheenOsasuorituksenSuoritus = {
   $class: 'fi.oph.koski.schema.DIAOppiaineenTutkintovaiheenOsasuorituksenSuoritus'
-  koulutusmoduuli: DIAOppiaineenTutkintovaiheenOsasuoritus
   arviointi?: Array<DIATutkintovaiheenArviointi>
   tyyppi: Koodistokoodiviite<
     'suorituksentyyppi',
     'diaoppiaineentutkintovaiheenosasuorituksensuoritus'
   >
   tila?: Koodistokoodiviite<'suorituksentila', string>
+  koulutusmoduuli: DIAOppiaineenTutkintovaiheenOsasuoritus
+  tunnustettu?: OsaamisenTunnustaminen
 }
 
 export const DIAOppiaineenTutkintovaiheenOsasuorituksenSuoritus = (o: {
-  koulutusmoduuli: DIAOppiaineenTutkintovaiheenOsasuoritus
   arviointi?: Array<DIATutkintovaiheenArviointi>
   tyyppi?: Koodistokoodiviite<
     'suorituksentyyppi',
     'diaoppiaineentutkintovaiheenosasuorituksensuoritus'
   >
   tila?: Koodistokoodiviite<'suorituksentila', string>
+  koulutusmoduuli: DIAOppiaineenTutkintovaiheenOsasuoritus
+  tunnustettu?: OsaamisenTunnustaminen
 }): DIAOppiaineenTutkintovaiheenOsasuorituksenSuoritus => ({
-  $class:
-    'fi.oph.koski.schema.DIAOppiaineenTutkintovaiheenOsasuorituksenSuoritus',
   tyyppi: Koodistokoodiviite({
     koodiarvo: 'diaoppiaineentutkintovaiheenosasuorituksensuoritus',
     koodistoUri: 'suorituksentyyppi'
   }),
+  $class:
+    'fi.oph.koski.schema.DIAOppiaineenTutkintovaiheenOsasuorituksenSuoritus',
   ...o
 })
 

--- a/web/app/types/fi/oph/koski/schema/DIAOppiaineenValmistavanVaiheenLukukausi.ts
+++ b/web/app/types/fi/oph/koski/schema/DIAOppiaineenValmistavanVaiheenLukukausi.ts
@@ -1,6 +1,6 @@
 import { Koodistokoodiviite } from './Koodistokoodiviite'
 import { LocalizedString } from './LocalizedString'
-import { LaajuusVuosiviikkotunneissa } from './LaajuusVuosiviikkotunneissa'
+import { LaajuusVuosiviikkotunneissaTaiOpintopisteissä } from './LaajuusVuosiviikkotunneissaTaiOpintopisteissa'
 
 /**
  * DIA-oppiaineen valmistavan vaiheen lukukauden tunnistetiedot
@@ -10,12 +10,12 @@ import { LaajuusVuosiviikkotunneissa } from './LaajuusVuosiviikkotunneissa'
 export type DIAOppiaineenValmistavanVaiheenLukukausi = {
   $class: 'fi.oph.koski.schema.DIAOppiaineenValmistavanVaiheenLukukausi'
   tunniste: Koodistokoodiviite<'dialukukausi', '1' | '2'>
-  laajuus?: LaajuusVuosiviikkotunneissa
+  laajuus?: LaajuusVuosiviikkotunneissaTaiOpintopisteissä
 }
 
 export const DIAOppiaineenValmistavanVaiheenLukukausi = (o: {
   tunniste: Koodistokoodiviite<'dialukukausi', '1' | '2'>
-  laajuus?: LaajuusVuosiviikkotunneissa
+  laajuus?: LaajuusVuosiviikkotunneissaTaiOpintopisteissä
 }): DIAOppiaineenValmistavanVaiheenLukukausi => ({
   $class: 'fi.oph.koski.schema.DIAOppiaineenValmistavanVaiheenLukukausi',
   ...o

--- a/web/app/types/fi/oph/koski/schema/LaajuusVuosiviikkotunneissaTaiOpintopisteissa.ts
+++ b/web/app/types/fi/oph/koski/schema/LaajuusVuosiviikkotunneissaTaiOpintopisteissa.ts
@@ -1,0 +1,21 @@
+import {
+  LaajuusOpintopisteissä,
+  isLaajuusOpintopisteissä
+} from './LaajuusOpintopisteissa'
+import {
+  LaajuusVuosiviikkotunneissa,
+  isLaajuusVuosiviikkotunneissa
+} from './LaajuusVuosiviikkotunneissa'
+
+/**
+ * LaajuusVuosiviikkotunneissaTaiOpintopisteissä
+ *
+ * @see `fi.oph.koski.schema.LaajuusVuosiviikkotunneissaTaiOpintopisteissä`
+ */
+export type LaajuusVuosiviikkotunneissaTaiOpintopisteissä =
+  LaajuusOpintopisteissä | LaajuusVuosiviikkotunneissa
+
+export const isLaajuusVuosiviikkotunneissaTaiOpintopisteissä = (
+  a: any
+): a is LaajuusVuosiviikkotunneissaTaiOpintopisteissä =>
+  isLaajuusOpintopisteissä(a) || isLaajuusVuosiviikkotunneissa(a)


### PR DESCRIPTION
Kaksi muutosta DIA-tutkinnon opiskeluoikeuteen:

- **Opintopiste-laajuusyksikkö.** Mahdollistetaan ja pakotetaan opintopiste (laajuusyksikkö `"2"`) 1.8.2026 tai myöhemmin alkaneissa DIA-opiskeluoikeuksissa; sitä ennen alkaneissa pakotetaan edelleen vuosiviikkotunti (`"3"`). DIA:n laajuuskentät perivät uuden `LaajuusVuosiviikkotunneissaTaiOpintopisteissä`-traitin, ja yksikkö validoidaan alkamispäivän mukaan uudessa DIA-validaatiossa (rajapäivä config-avaimesta `validaatiot.diaLaajuudetOpintopisteinäAlkaen`).
- **Tunnustettu osasuoritus.** DIA-tutkintovaiheen osasuorituksen osasuoritukselle (`DIAOppiaineenTutkintovaiheenOsasuorituksenSuoritus`) lisätään `tunnustettu: Option[OsaamisenTunnustaminen]`.
- `OppijaValidationDIASpec`: testataan laajuusyksikön 4 tapausta (opintopiste/vuosiviikkotunti × ennen/jälkeen rajapäivän, oppiaine- ja lukukausitasolla) sekä tunnustettu-osasuoritus.
