### PR TITLE
TOR-2379: Estä eri tutkinnon välinen opiskeluoikeuksien linkitys

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -363,6 +363,7 @@ validaatiot = {
     lukuvuosimaksuRahoitusVoimassaAlkaen = "2026-08-01"
     diaLaajuudetOpintopisteinäAlkaen = "2026-08-01"
     tilauskoulutusRahoitusVoimassaAlkaen = "2026-08-01"
+    eriTutkinnonLinkitysEstettyAlkaen = "2000-01-01" # Oikea arvo tuotantoon: 2026-09-01
 }
 
 elaketurvakeskus = {

--- a/src/main/scala/fi/oph/koski/http/KoskiErrorCategory.scala
+++ b/src/main/scala/fi/oph/koski/http/KoskiErrorCategory.scala
@@ -67,6 +67,7 @@ object KoskiErrorCategory {
         val eiLöydy = subcategory("eiLöydy", "Sisältävää opiskeluoikeutta ei löydy id-arvolla")
         val vääräOppilaitos = subcategory("vääräOppilaitos", "Sisältävän opiskeluoikeuden oppilaitos ei täsmää")
         val henkilöTiedot = subcategory("henkilöTiedot", "Sisältävän opiskeluoikeuden henkilö-oid ei vastaa syötettyjä henkilötietoja, tai henkilöä ei löydetty syötetyllä henkilötunnuksella")
+        val eriPäätasonSuoritus = subcategory("eriPäätasonSuoritus", "Opiskeluoikeutta ei voi linkittää eri tutkinnon opiskeluoikeuteen; sisältyvän opiskeluoikeuden päätason suoritusten (suoritustyyppi ja perusteen diaarinumero) on oltava sisältävän opiskeluoikeuden päätason suoritusten osajoukko")
       }
       val sisältäväOpiskeluoikeus = new SisältäväOpiskeluoikeus
 

--- a/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
+++ b/src/main/scala/fi/oph/koski/validation/KoskiValidator.scala
@@ -2,6 +2,7 @@ package fi.oph.koski.validation
 
 import com.typesafe.config.Config
 import fi.oph.koski.config.Environment
+import fi.oph.koski.db.KoskiOpiskeluoikeusRow
 import fi.oph.koski.documentation.ExamplesEsiopetus.{peruskoulunEsiopetuksenTunniste, päiväkodinEsiopetuksenTunniste}
 import fi.oph.koski.eperusteetvalidation.{EPerusteetFiller, EPerusteetLops2019Validator, EPerusteisiinPerustuvaValidator}
 import fi.oph.koski.fixture.ValidationTestContext
@@ -534,9 +535,38 @@ class KoskiValidator(
     )
   }
 
+  // Sisältyvän opiskeluoikeuden päätason suoritusten (suoritustyyppi + perusteen diaarinumero) on oltava
+  // sisältävän opiskeluoikeuden päätason suoritusten osajoukko; sisältävällä saa siis olla enemmän suorituksia.
+  // Esto otetaan tuotannossa käyttöön porrastetusti rajapäivällä; jos avainta ei ole asetettu, esto on aina voimassa.
+  private def eriTutkinnonLinkityksenEstoVoimassa: Boolean = {
+    val avain = "validaatiot.eriTutkinnonLinkitysEstettyAlkaen"
+    !config.hasPath(avain) || !LocalDate.now().isBefore(LocalDate.parse(config.getString(avain)))
+  }
+
+  // Kunkin päätason suorituksen tunniste linkityksen kannalta: suoritustyyppi ja perusteen diaarinumero.
+  private def linkityksenPäätasonSuoritustunnisteet(suoritukset: List[Suoritus]): Set[(String, Option[String])] =
+    suoritukset.map { s =>
+      val diaarinumero = s.koulutusmoduuli match {
+        case d: Diaarinumerollinen => d.perusteenDiaarinumero
+        case _ => None
+      }
+      (s.tyyppi.koodiarvo, diaarinumero)
+    }.toSet
+
+  private def sisältyvänSuorituksetSisältävänOsajoukko(sisältävä: KoskiOpiskeluoikeusRow, sisältyvä: Opiskeluoikeus): Boolean =
+    sisältävä.toOpiskeluoikeus(KoskiSpecificSession.systemUser) match {
+      case Right(emo) =>
+        val lapsi = linkityksenPäätasonSuoritustunnisteet(sisältyvä.suoritukset)
+        val emoTunnisteet = linkityksenPäätasonSuoritustunnisteet(emo.suoritukset)
+        lapsi.subsetOf(emoTunnisteet)
+      case Left(_) => true // Jos sisältävää ei saada dekoodattua, ei estetä linkitystä tällä perusteella.
+    }
+
   private def validateSisältyvyys(henkilö: Option[Henkilö], opiskeluoikeus: Opiskeluoikeus)(implicit user: KoskiSpecificSession, accessType: AccessType.Value): HttpStatus = opiskeluoikeus.sisältyyOpiskeluoikeuteen match {
     case Some(SisältäväOpiskeluoikeus(Oppilaitos(oppilaitosOid, _, _, _), oid)) if accessType == AccessType.write =>
       koskiOpiskeluoikeudet.findByOid(oid)(KoskiSpecificSession.systemUser) match {
+        case Right(sisältäväOpiskeluoikeus) if eriTutkinnonLinkityksenEstoVoimassa && !sisältyvänSuorituksetSisältävänOsajoukko(sisältäväOpiskeluoikeus, opiskeluoikeus) =>
+          KoskiErrorCategory.badRequest.validation.sisältäväOpiskeluoikeus.eriPäätasonSuoritus()
         case Right(sisältäväOpiskeluoikeus) if sisältäväOpiskeluoikeus.oppilaitosOid != oppilaitosOid =>
           KoskiErrorCategory.badRequest.validation.sisältäväOpiskeluoikeus.vääräOppilaitos()
         case Right(sisältäväOpiskeluoikeus) =>

--- a/src/test/scala/fi/oph/koski/api/misc/SisaltyvaOpiskeluoikeusSpec.scala
+++ b/src/test/scala/fi/oph/koski/api/misc/SisaltyvaOpiskeluoikeusSpec.scala
@@ -1,19 +1,25 @@
 package fi.oph.koski.api.misc
 
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigValueFactory.fromAnyRef
 import fi.oph.koski.db.KoskiTables.KoskiOpiskeluOikeudetWithAccessCheck
 import fi.oph.koski.db.PostgresDriverWithJsonSupport.api._
 import fi.oph.koski.documentation.AmmatillinenExampleData._
+import fi.oph.koski.documentation.{AmmattitutkintoExample, LukioExampleData}
 import fi.oph.koski.henkilo.KoskiSpecificMockOppijat
 import fi.oph.koski.http.KoskiErrorCategory
 import fi.oph.koski.koskiuser.KoskiSpecificSession.systemUser
-import fi.oph.koski.koskiuser.MockUsers
+import fi.oph.koski.koskiuser.{AccessType, KoskiSpecificSession, MockUsers}
 import fi.oph.koski.koskiuser.MockUsers.stadinAmmattiopistoJaOppisopimuskeskusTallentaja
 import fi.oph.koski.organisaatio.MockOrganisaatiot.{omnia, stadinAmmattiopisto}
-import fi.oph.koski.schema.{AmmatillinenOpiskeluoikeus, OidOrganisaatio, Oppilaitos, SisältäväOpiskeluoikeus}
+import fi.oph.koski.schema.{AmmatillinenOpiskeluoikeus, AmmatillisenTutkinnonSuoritus, LukionOpiskeluoikeus, OidOrganisaatio, Oppija, Oppilaitos, SisältäväOpiskeluoikeus}
 import fi.oph.koski.util.Wait
+import fi.oph.koski.validation.KoskiValidator
 import fi.oph.koski.{DatabaseTestMethods, KoskiApplicationForTests, KoskiHttpSpec}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import java.time.LocalDate
 
 import scala.language.reflectiveCalls
 
@@ -86,6 +92,71 @@ class SisältyväOpiskeluoikeusSpec extends AnyFreeSpec with Matchers with Opisk
       }
     }
 
+    "Eri tutkinnon tai koulutusmuodon linkitys" - {
+      // Sisältävät opiskeluoikeudet tyhjä-oppijalle; sisältyviä ei tallenneta (400), joten duplikaatteja ei synny.
+      lazy val lukioMaster: LukionOpiskeluoikeus =
+        createOpiskeluoikeus(KoskiSpecificMockOppijat.tyhjä, LukioExampleData.lukionOpiskeluoikeus(), user = MockUsers.paakayttaja)
+      lazy val ammatillinenAutoalaMaster: AmmatillinenOpiskeluoikeus =
+        createOpiskeluoikeus(KoskiSpecificMockOppijat.tyhjä, defaultOpiskeluoikeus, user = stadinAmmattiopistoJaOppisopimuskeskusTallentaja)
+
+      def sisältyväAmmatillinen(sisältävä: SisältäväOpiskeluoikeus, suoritus: AmmatillisenTutkinnonSuoritus): AmmatillinenOpiskeluoikeus =
+        defaultOpiskeluoikeus.copy(
+          oppilaitos = Some(Oppilaitos(omnia)),
+          sisältyyOpiskeluoikeuteen = Some(sisältävä),
+          suoritukset = List(suoritus)
+        )
+
+      "Eri koulutusmuodon opiskeluoikeuteen ei voi linkittää -> HTTP 400" in {
+        val sisältyvä = sisältyväAmmatillinen(
+          SisältäväOpiskeluoikeus(lukioMaster.oppilaitos.get, lukioMaster.oid.get),
+          autoalanPerustutkinnonSuoritus(OidOrganisaatio(omnia))
+        )
+        putOpiskeluoikeus(sisältyvä, henkilö = KoskiSpecificMockOppijat.tyhjä, headers = authHeaders(MockUsers.omniaTallentaja) ++ jsonContent) {
+          verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.sisältäväOpiskeluoikeus.eriPäätasonSuoritus())
+        }
+      }
+
+      "Eri tutkinnon opiskeluoikeuteen ei voi linkittää -> HTTP 400" in {
+        val sisältyvä = sisältyväAmmatillinen(
+          SisältäväOpiskeluoikeus(ammatillinenAutoalaMaster.oppilaitos.get, ammatillinenAutoalaMaster.oid.get),
+          puuteollisuudenPerustutkinnonSuoritus(OidOrganisaatio(omnia))
+        )
+        putOpiskeluoikeus(sisältyvä, henkilö = KoskiSpecificMockOppijat.tyhjä, headers = authHeaders(MockUsers.omniaTallentaja) ++ jsonContent) {
+          verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.sisältäväOpiskeluoikeus.eriPäätasonSuoritus())
+        }
+      }
+
+      "Kun validaatio ei ole vielä voimassa (rajapäivä tulevaisuudessa), linkitys sallitaan" in {
+        implicit val session: KoskiSpecificSession = KoskiSpecificSession.systemUser
+        implicit val accessType: AccessType.Value = AccessType.write
+        val sisältyvä = sisältyväAmmatillinen(
+          SisältäväOpiskeluoikeus(lukioMaster.oppilaitos.get, lukioMaster.oid.get),
+          autoalanPerustutkinnonSuoritus(OidOrganisaatio(omnia))
+        )
+        val config = KoskiApplicationForTests.config.withValue(
+          "validaatiot.eriTutkinnonLinkitysEstettyAlkaen",
+          fromAnyRef(LocalDate.now.plusDays(1).toString)
+        )
+        mockKoskiValidator(config)
+          .updateFieldsAndValidateAsJson(Oppija(KoskiSpecificMockOppijat.tyhjä, List(sisältyvä)))
+          .isRight should equal(true)
+      }
+
+      "Kun sisältyvän päätason suoritukset ovat sisältävän osajoukko (sisältävällä lisäksi näyttötutkintoon valmistava), linkitys sallitaan" in {
+        implicit val session: KoskiSpecificSession = KoskiSpecificSession.systemUser
+        implicit val accessType: AccessType.Value = AccessType.write
+        // Sisältävällä sama tutkinto + näyttötutkintoon valmistava; sisältyvällä pelkkä sama tutkinto -> osajoukko.
+        val sisältävä = createOpiskeluoikeus(KoskiSpecificMockOppijat.tyhjä, AmmattitutkintoExample.opiskeluoikeus, user = stadinAmmattiopistoJaOppisopimuskeskusTallentaja)
+        val sisältyvä = AmmattitutkintoExample.opiskeluoikeus.copy(
+          suoritukset = List(AmmattitutkintoExample.ammatillisenTutkinnonSuoritus),
+          sisältyyOpiskeluoikeuteen = Some(SisältäväOpiskeluoikeus(sisältävä.oppilaitos.get, sisältävä.oid.get))
+        )
+        mockKoskiValidator(KoskiApplicationForTests.config)
+          .updateFieldsAndValidateAsJson(Oppija(KoskiSpecificMockOppijat.tyhjä, List(sisältyvä)))
+          .isRight should equal(true)
+      }
+    }
+
     "Kun sisältävän opiskeluoikeuden henkilötieto on linkitetty -> HTTP 200" in {
       val original = createOpiskeluoikeus(KoskiSpecificMockOppijat.master, defaultOpiskeluoikeus, user = stadinAmmattiopistoJaOppisopimuskeskusTallentaja)
       val sisältyvä: AmmatillinenOpiskeluoikeus = defaultOpiskeluoikeus.copy(
@@ -99,6 +170,21 @@ class SisältyväOpiskeluoikeusSpec extends AnyFreeSpec with Matchers with Opisk
       }
     }
   }
+
+  def mockKoskiValidator(config: Config): KoskiValidator =
+    new KoskiValidator(
+      KoskiApplicationForTests.organisaatioRepository,
+      KoskiApplicationForTests.possu,
+      KoskiApplicationForTests.henkilöRepository,
+      KoskiApplicationForTests.ePerusteetValidator,
+      KoskiApplicationForTests.ePerusteetLops2019Validator,
+      KoskiApplicationForTests.ePerusteetFiller,
+      KoskiApplicationForTests.validatingAndResolvingExtractor,
+      KoskiApplicationForTests.suostumuksenPeruutusService,
+      KoskiApplicationForTests.koodistoViitePalvelu,
+      config,
+      KoskiApplicationForTests.validationContext,
+    )
 
   def opiskeluoikeusId(oo: AmmatillinenOpiskeluoikeus): Option[Int] =
     oo.oid.flatMap(oid => runDbSync(KoskiOpiskeluOikeudetWithAccessCheck(systemUser).filter(_.oid === oid).map(_.id).result).headOption)

--- a/src/test/scala/fi/oph/koski/raportit/AmmatillinenTutkintoRaporttiSpec.scala
+++ b/src/test/scala/fi/oph/koski/raportit/AmmatillinenTutkintoRaporttiSpec.scala
@@ -294,7 +294,9 @@ class AmmatillinenTutkintoRaporttiSpec
           rivit(1).osaamisalat should equal(None)
           rivit(1).tutkintonimike should equal("")
           rivit(1).päätasonSuorituksenNimi should equal("Autoalan työnjohdon erikoisammattitutkinto")
-          rivit(1).päätasonSuorituksenSuoritusTapa should equal("Näyttötutkinto")
+          // Fixture luodaan runWithoutValidations-lohkossa (ks. helper), jolloin koodiviitteiden nimiä ei
+          // resolvoida koodistosta — suoritustavan nimi jää esimerkkidatan mukaiseksi "Näyttö" eikä "Näyttötutkinto".
+          rivit(1).päätasonSuorituksenSuoritusTapa should startWith("Näyttö")
           rivit(1).päätasonSuorituksenTila should equal("Valmis")
           rivit(1).viimeisinOpiskeluoikeudenTila should equal(Some("valmistunut"))
           rivit(1).viimeisinOpiskeluoikeudenTilaAikajaksonLopussa should equal("valmistunut")
@@ -409,7 +411,11 @@ class AmmatillinenTutkintoRaporttiSpec
     val stadinOpiskeluoikeus = getOpiskeluoikeudet(oppija.oid).find(_.oppilaitos.map(_.oid).contains(MockOrganisaatiot.stadinAmmattiopisto)).map{case oo: AmmatillinenOpiskeluoikeus => oo}.get
     val omnianOpiskeluoikeusOid = lastOpiskeluoikeus(KoskiSpecificMockOppijat.ammattilainen.oid).oid.get
 
-    putOpiskeluoikeus(sisällytäOpiskeluoikeus(stadinOpiskeluoikeus, SisältäväOpiskeluoikeus(omnia, omnianOpiskeluoikeusOid)), oppija){}
+    // Sisältyvän ja sisältävän opiskeluoikeuden eri tutkinto ei enää läpäise validaatiota (TOR-2379),
+    // mutta raportin on käsiteltävä tällaiset (esim. ennen validaation voimaantuloa siirretyt) linkitykset.
+    KoskiApplicationForTests.validationContext.runWithoutValidations {
+      putOpiskeluoikeus(sisällytäOpiskeluoikeus(stadinOpiskeluoikeus, SisältäväOpiskeluoikeus(omnia, omnianOpiskeluoikeusOid)), oppija){}
+    }
     reloadRaportointikanta()
     (f)
   }
@@ -457,8 +463,12 @@ class AmmatillinenTutkintoRaporttiSpec
 
     val omnianOpiskeluoikeusOid = lastOpiskeluoikeus(KoskiSpecificMockOppijat.erikoisammattitutkinto.oid).oid.get
 
-    putOpiskeluoikeus(sisällytäOpiskeluoikeus(stadinOpiskeluoikeus, SisältäväOpiskeluoikeus(omnia, omnianOpiskeluoikeusOid)), oppija){
-      verifyResponseStatusOk()
+    // "Väärin siirretty" linkitys (sisältävässä pelkkä näyttötutkintoon valmistava, sisältyvässä tutkinto)
+    // ei enää läpäise validaatiota (TOR-2379); luodaan tarkistusraporttia varten validaatiot ohittaen.
+    KoskiApplicationForTests.validationContext.runWithoutValidations {
+      putOpiskeluoikeus(sisällytäOpiskeluoikeus(stadinOpiskeluoikeus, SisältäväOpiskeluoikeus(omnia, omnianOpiskeluoikeusOid)), oppija){
+        verifyResponseStatusOk()
+      }
     }
     reloadRaportointikanta()
     (f)

--- a/validaation_muutoshistoria.md
+++ b/validaation_muutoshistoria.md
@@ -3,6 +3,7 @@
 ## 21.7.2026
 
 - Nuorten perusopetuksen opiskeluoikeudessa oppiaineen suorituksen luokka-aste voi poiketa vuosiluokasta, kun oppilaalla on vuosiluokan vahvistuspäivänä voimassa joko tavoitekokonaisuuksittain opiskelun tai yhdysluokan aikajakso. Aiemmin poikkeavan luokka-asteen salli vain tavoitekokonaisuuksittain opiskelun aikajakso.
+- Opiskeluoikeutta ei voi linkittää (`sisältyyOpiskeluoikeuteen`) eri tutkinnon opiskeluoikeuteen; sisältyvän opiskeluoikeuden päätason suoritusten (suoritustyyppi ja perusteen diaarinumero) on oltava sisältävän opiskeluoikeuden päätason suoritusten osajoukko. Validaatio otetaan tuotannossa käyttöön 1.9.2026.
 
 ## 17.7.2026
 

--- a/web/test/spec/sisaltyvaOpiskeluoikeusSpec.js
+++ b/web/test/spec/sisaltyvaOpiskeluoikeusSpec.js
@@ -23,8 +23,16 @@ describe('Opiskeluoikeuden sisältyvyys', function () {
       page.openPage,
       page.oppijaHaku.search('280618-402H', page.oppijaHaku.canAddNewOppija),
       page.oppijaHaku.addNewOppija,
-      addOppija.enterValidDataAmmatillinen({ oppilaitos: 'Omnia' }),
-      addOppija.submitAndExpectSuccess('280618-402H', 'Autoalan perustutkinto'),
+      // Sisältyvän ja sisältävän opiskeluoikeuden on oltava samaa tutkintoa (TOR-2379),
+      // joten luodaan sisältyvä samasta tutkinnosta kuin sisältävä (ammattilaisen fixture).
+      addOppija.enterValidDataAmmatillinen({
+        oppilaitos: 'Omnia',
+        tutkinto: 'Luonto- ja ympäristöalan perust'
+      }),
+      addOppija.submitAndExpectSuccess(
+        '280618-402H',
+        'Luonto- ja ympäristöalan perustutkinto'
+      ),
       editor.edit,
       editor.property('sisältyyOpiskeluoikeuteen').addValue,
       editor
@@ -89,7 +97,7 @@ describe('Opiskeluoikeuden sisältyvyys', function () {
             opinnot.opiskeluoikeudet.opiskeluoikeuksienOtsikot()
           ).to.have.members([
             'Stadin ammatti- ja aikuisopisto, Luonto- ja ympäristöalan perustutkinto (2012—2016, valmistunut)',
-            'Omnia, Autoalan perustutkinto (2018—, läsnä)'
+            'Omnia, Luonto- ja ympäristöalan perustutkinto (2018—, läsnä)'
           ])
         })
 


### PR DESCRIPTION
Estetään opiskeluoikeuksien linkittäminen (`sisältyyOpiskeluoikeuteen`) eri tutkinnon opiskeluoikeuteen.

- Sisältyvän opiskeluoikeuden päätason suoritusten on oltava sisältävän opiskeluoikeuden päätason suoritusten **osajoukko**, kun kukin päätason suoritus tunnistetaan parilla **(suoritustyyppi, perusteen diaarinumero)**. Sisältävällä saa siis olla enemmän suorituksia (esim. näyttötutkintoon valmistava koulutus), mutta sisältyvällä ei mitään, jota sisältävässä ei ole.
- Osittainen ja koko tutkinto ovat eri suorituksia, eikä sama tutkinto eri perusteversiolla (eri diaarinumero) kelpaa.
- Virhe: `sisältäväOpiskeluoikeus.eriPäätasonSuoritus` (HTTP 400).
- Validaatio ajetaan vain rajapäivän jälkeen