### PR TITLE
TOR-2643: Korjaa js-yaml-haavoittuvuus smoketesteissä (CVE-2026-59869)

### DIFF
--- a/smoketests/package.json
+++ b/smoketests/package.json
@@ -25,7 +25,8 @@
   "pnpm": {
     "overrides": {
       "basic-ftp": ">=5.2.1",
-      "ws": ">=8.21.0"
+      "ws": ">=8.21.0",
+      "js-yaml": "^4.3.0"
     }
   },
   "devDependencies": {

--- a/smoketests/pnpm-lock.yaml
+++ b/smoketests/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   basic-ftp: '>=5.2.1'
   ws: '>=8.21.0'
+  js-yaml: ^4.3.0
 
 importers:
 
@@ -306,8 +307,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   json-parse-even-better-errors@2.3.1:
@@ -650,7 +651,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -764,7 +765,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
Korjataan Trivyn löytämä HIGH-haavoittuvuus (`smoketests/pnpm-lock.yaml`, js-yaml 4.2.0, CVE-2026-59869)

Kirjasto js-yaml on transitiivinen depsu (`puppeteer → cosmiconfig → js-yaml`), korjataan lisäämällä pnpm-override `js-yaml: ^4.3.0`