### PR TITLE
TOR-2433: ammatillisen osasuoritustaulukon käyttöliittymän fiksauksia

### DIFF
--- a/src/main/scala/fi/oph/koski/documentation/AmmatillinenExampleData.scala
+++ b/src/main/scala/fi/oph/koski/documentation/AmmatillinenExampleData.scala
@@ -823,6 +823,20 @@ object AmmatillinenExampleData {
     todistuksellaNäkyvätLisätiedot = Some("Suorittaa toista osaamisalaa")
   )
 
+  def ammatillisenTutkinnonOsittainenSuoritusLaaja = {
+    val pohja = ammatillisenTutkinnonOsittainenSuoritusRapsa
+    pohja.copy(
+      osasuoritukset = pohja.osasuoritukset.map(
+        _ ++ List(
+          osittaisenTutkinnonTutkinnonOsanSuoritus(k3, ammatillisetTutkinnonOsat, "100160", "Vesistöjen hoito", 15),
+          osittaisenTutkinnonTutkinnonOsanSuoritus(h2, ammatillisetTutkinnonOsat, "100165", "Vesistötutkimuksen näytteenotto", 10),
+          osittaisenTutkinnonTutkinnonOsanSuoritus(k3, ammatillisetTutkinnonOsat, "100339", "Ympäristöanalytiikka", 20),
+          osittaisenTutkinnonTutkinnonOsanSuoritus(h2, ammatillisetTutkinnonOsat, "100155", "Vesiviljely", 15)
+        )
+      )
+    )
+  }
+
   def ammatillisenTutkinnonOsittainenUseastaTutkinnostaSuoritus = AmmatillisenTutkinnonOsittainenUseastaTutkinnostaSuoritus(
     koulutusmoduuli = AmmatillinenOsiaUseastaTutkinnosta(Koodistokoodiviite("ammatillinentutkintoosittainenuseastatutkinnosta", "suorituksentyyppi")),
     suoritustapa = suoritustapaReformi,

--- a/src/main/scala/fi/oph/koski/documentation/ExamplesAmmatillinen.scala
+++ b/src/main/scala/fi/oph/koski/documentation/ExamplesAmmatillinen.scala
@@ -780,6 +780,10 @@ object AmmatillinenOsittainenReformi {
       )
     )
   )
+
+  val opiskeluoikeusLaaja = opiskeluoikeusRapsa.copy(
+    suoritukset = List(AmmatillinenExampleData.ammatillisenTutkinnonOsittainenSuoritusLaaja)
+  )
 }
 
 object AmmatillinenOsittainenUseistaTutkinnoista {

--- a/src/main/scala/fi/oph/koski/fixture/KoskiSpecificDatabaseFixtureCreator.scala
+++ b/src/main/scala/fi/oph/koski/fixture/KoskiSpecificDatabaseFixtureCreator.scala
@@ -351,6 +351,10 @@ class KoskiSpecificDatabaseFixtureCreator(application: KoskiApplication) extends
         KoskiSpecificMockOppijat.lahdejarjestelmanPurku,
         ExamplesKielitutkinto.ValtionhallinnonKielitutkinnot.Opiskeluoikeus.lähdejärjestelmällinenOpiskeluoikeus
       ),
+      (
+        KoskiSpecificMockOppijat.ammatillinenOsittainenLaaja,
+        AmmatillinenOsittainenReformi.opiskeluoikeusLaaja
+      ),
     )
   }
 

--- a/src/main/scala/fi/oph/koski/henkilo/KoskiSpecificMockOppijat.scala
+++ b/src/main/scala/fi/oph/koski/henkilo/KoskiSpecificMockOppijat.scala
@@ -397,6 +397,8 @@ object KoskiSpecificMockOppijat {
 
   val kielitutkintoEnnenRajapäivää = koskiSpecificOppijat.oppija("Vanha-Kielitutkinto", "Veera", "150385-731L", syntymäaika = Some(LocalDate.of(1985, 3, 15)))
 
+  val ammatillinenOsittainenLaaja = koskiSpecificOppijat.oppija("Ammatillinen-Osittainen-Laaja", "Lassi", "120590-123Y")
+
   def defaultOppijat = koskiSpecificOppijat.getOppijat
   def defaultKuntahistoriat: mutable.Map[String, Seq[OppijanumerorekisteriKotikuntahistoriaRow]] = koskiSpecificOppijat.getKuntahistoriat
   def defaultTurvakieltoKuntahistoriat: mutable.Map[String, Seq[OppijanumerorekisteriKotikuntahistoriaRow]] = koskiSpecificOppijat.getTurvakieltoKuntahistoriat

--- a/web/app/components-v2/opiskeluoikeus/OsasuoritusProperty.less
+++ b/web/app/components-v2/opiskeluoikeus/OsasuoritusProperty.less
@@ -3,6 +3,12 @@
     display: flex;
     align-items: center;
     min-height: 1.5 * @baseline;
+    // Työpöytäleveyksillä pitkät kentän nimet (esim. "Kuullun ymmärtämisen
+    // taitotaso") eivät rivity vaan käyttävät nimisarakkeen ja arvon välissä
+    // olevan tyhjän tilan. min-width estää nimeä venyttämästä ruudukkosaraketta,
+    // jolloin arvot pysyvät linjassa. Kapeilla näytöillä rivitys sallitaan alla.
+    white-space: nowrap;
+    min-width: 0;
   }
   .OsasuoritusPropertyValue {
     display: block;
@@ -14,5 +20,13 @@
   // korkeuden, joka tekee rivistä tarpeettoman korkean. Tiivistä omiin rajoihin.
   .Column {
     min-height: 1.5 * @baseline;
+  }
+}
+
+// Kapeilla näytöillä (esim. kansalaisen mobiilinäkymä) nimisarake on niin kapea,
+// että rivittymätön pitkä nimi menisi arvon päälle. Sallitaan silloin rivitys.
+@media screen and (max-width: @Columns-phone-breakpoint) {
+  .OsasuoritusProperty .OsasuoritusPropertyLabel {
+    white-space: normal;
   }
 }

--- a/web/app/components-v2/opiskeluoikeus/OsasuoritusTable.less
+++ b/web/app/components-v2/opiskeluoikeus/OsasuoritusTable.less
@@ -56,6 +56,18 @@
   width: 100%;
 }
 
+.OsasuoritusRow__cellContent--clickable {
+  cursor: pointer;
+  color: @color-link-blue;
+}
+
+// Completed-merkin sarake varaa kokonaisen ruudukkosarakkeen, vaikka itse
+// merkki on kapea. Vedetään nimisaraketta vasemmalle, jotta nimi asettuu
+// lähelle completed-merkkiä (joka puolestaan on kiinni laajennuspainikkeessa).
+.OsasuoritusRow__nameColumn--completedAdjacent {
+  margin-left: -(2 * @baseline);
+}
+
 .OsasuoritusPropertyLabel {
   opacity: 0.5;
 }

--- a/web/app/components-v2/opiskeluoikeus/OsasuoritusTable.tsx
+++ b/web/app/components-v2/opiskeluoikeus/OsasuoritusTable.tsx
@@ -160,19 +160,24 @@ export const OsasuoritusHeader = <DATA_KEYS extends string>(
         {spans.indent > 0 && (
           <Column span={spans.indent} className="OsasuoritusHeader__indent" />
         )}
-        {/* Tyhjät sarakkeet laajennus- ja completed-painikkeille, jotta
-            ensimmäisen sarakkeen otsikko on rivien nimien yläpuolella. */}
-        {!props.skipExpandableColumn && <Column span={spans.leftIcons} />}
-        {spans.completed > 0 && <Column span={spans.completed} />}
-        {props.columns.map((column, index) => (
-          <Column
-            key={index}
-            span={index === 0 ? spans.name : spans.data[index - 1]}
-            align={column.align}
-          >
-            {getColumnLabel(column)}
-          </Column>
-        ))}
+        {props.columns.map((column, index) => {
+          const isNameColumn = index === 0
+          // Nimisarakkeen otsikko ("… tutkinnon osat") venytetään alkamaan rivin
+          // vasemmasta reunasta laajennus- ja completed-ikonisarakkeiden yli,
+          // jotta se on linjassa alapuolisen vaakaviivan ja muun vasempaan
+          // tasatun sisällön kanssa — ei sisennettynä osasuoritusten nimien
+          // yläpuolelle.
+          const leadingSpan =
+            (props.skipExpandableColumn ? 0 : spans.leftIcons) + spans.completed
+          const span = isNameColumn
+            ? mapResponsiveValue((w: number) => leadingSpan + w)(spans.name)
+            : spans.data[index - 1]
+          return (
+            <Column key={index} span={span} align={column.align}>
+              {getColumnLabel(column)}
+            </Column>
+          )
+        })}
         {spans.rightIcons > 0 && (
           <Column
             span={spans.rightIcons}
@@ -200,6 +205,9 @@ export const OsasuoritusRow = <DATA_KEYS extends string>(
 
   const { TreeNode, ...tree } = useTree(props.initiallyOpen)
   const isOpen = props.forceOpen || tree.isOpen
+
+  const nameTogglesRow =
+    expandable && Boolean(props.row.content) && !props.forceOpen
 
   return (
     <TreeNode>
@@ -239,22 +247,48 @@ export const OsasuoritusRow = <DATA_KEYS extends string>(
             )}
           </Column>
         )}
-        {props.columns.map((column, index) => (
-          <Column
-            key={index}
-            span={index === 0 ? spans.name : spans.data[index - 1]}
-            align={column.align}
-            className={
-              index === 0
-                ? 'OsasuoritusRow__nameColumn'
-                : 'OsasuoritusRow__dataColumn'
-            }
-          >
-            <div className="OsasuoritusRow__cellContent">
-              {props.row.columns[column.key]}
-            </div>
-          </Column>
-        ))}
+        {props.columns.map((column, index) => {
+          const isNameColumn = index === 0
+          const clickableName = isNameColumn && nameTogglesRow
+          return (
+            <Column
+              key={index}
+              span={isNameColumn ? spans.name : spans.data[index - 1]}
+              align={column.align}
+              className={
+                isNameColumn
+                  ? cx(
+                      'OsasuoritusRow__nameColumn',
+                      props.showCompleted &&
+                        'OsasuoritusRow__nameColumn--completedAdjacent'
+                    )
+                  : 'OsasuoritusRow__dataColumn'
+              }
+            >
+              <div
+                className={cx(
+                  'OsasuoritusRow__cellContent',
+                  clickableName && 'OsasuoritusRow__cellContent--clickable'
+                )}
+                onClick={
+                  clickableName
+                    ? (e) => {
+                        if (
+                          !(e.target as HTMLElement).closest(
+                            'input, button, a, select, textarea, label, .Select'
+                          )
+                        ) {
+                          tree.toggle()
+                        }
+                      }
+                    : undefined
+                }
+              >
+                {props.row.columns[column.key]}
+              </div>
+            </Column>
+          )
+        })}
         {props.editMode && props.onRemove && (
           <Column
             span={spans.rightIcons}

--- a/web/test/spec/oppijataulukkoSpec.js
+++ b/web/test/spec/oppijataulukkoSpec.js
@@ -105,6 +105,7 @@ describe('Oppijataulukko', function () {
         expect(page.oppijataulukko.names()).to.deep.equal([
           'Amis, Antti',
           'Ammatillinen-Osittainen, Raitsu',
+          'Ammatillinen-Osittainen-Laaja, Lassi',
           'Ammattilainen, Aarne',
           'Erityisoppilaitoksessa, Emppu',
           'Erityisoppilaitoksessa, Emppu',
@@ -116,7 +117,7 @@ describe('Oppijataulukko', function () {
           'Rikkinäinen, Kela',
           'Tuleva-ammattilainen, Tuure'
         ])
-        expect(page.opiskeluoikeudeTotal()).to.equal('12')
+        expect(page.opiskeluoikeudeTotal()).to.equal('13')
       })
     })
 
@@ -130,6 +131,7 @@ describe('Oppijataulukko', function () {
         expect(page.oppijataulukko.names()).to.deep.equal([
           'Amis, Antti',
           'Ammatillinen-Osittainen, Raitsu',
+          'Ammatillinen-Osittainen-Laaja, Lassi',
           'Ammattilainen, Aarne',
           'Erityisoppilaitoksessa, Emppu',
           'Erityisoppilaitoksessa, Emppu',
@@ -141,7 +143,7 @@ describe('Oppijataulukko', function () {
           'Rikkinäinen, Kela',
           'Tuleva-ammattilainen, Tuure'
         ])
-        expect(page.opiskeluoikeudeTotal()).to.equal('12')
+        expect(page.opiskeluoikeudeTotal()).to.equal('13')
       })
     })
 
@@ -155,6 +157,7 @@ describe('Oppijataulukko', function () {
         expect(page.oppijataulukko.names()).to.deep.equal([
           'Amikseenvalmistautuja, Anneli',
           'Ammatillinen-Osittainen, Raitsu',
+          'Ammatillinen-Osittainen-Laaja, Lassi',
           'Ammattilainen, Aarne',
           'Erikoinen, Erja',
           'Erityisoppilaitoksessa, Emppu',
@@ -170,7 +173,7 @@ describe('Oppijataulukko', function () {
           'Telmanen, Tuula',
           'Valviralle, Veera'
         ])
-        expect(page.opiskeluoikeudeTotal()).to.equal('16')
+        expect(page.opiskeluoikeudeTotal()).to.equal('17')
       })
     })
 
@@ -252,6 +255,7 @@ describe('Oppijataulukko', function () {
           'Amikseenvalmistautuja, Anneli',
           'Amis, Antti',
           'Ammatillinen-Osittainen, Raitsu',
+          'Ammatillinen-Osittainen-Laaja, Lassi',
           'Ammattilainen, Aarne',
           'Çelik-Eerola, Jouni',
           'Demo, Nordea',
@@ -340,10 +344,9 @@ describe('Oppijataulukko', function () {
           'Tehtävään-Valmistava-vahvistettu, Tauno',
           'Tekijä, Teija',
           'Telmanen, Tuula',
-          'Tiedonsiirto, Tiina',
-          'Toiminta, Tommi'
+          'Tiedonsiirto, Tiina'
         ])
-        expect(page.opiskeluoikeudeTotal()).to.equal('124')
+        expect(page.opiskeluoikeudeTotal()).to.equal('125')
       })
     })
 


### PR DESCRIPTION
Kokoelma osasuoritustaulukon käyttöliittymän parannuksia (TOR-2433).

## Muutokset

- **Osasuorituksen nimestä klikattava** ja nimisarakkeen asettelu tiivistetty. Klikkaus laukaisee rivin laajennuksen; klikkaus lomake-elementtien päällä (input, button, select yms.) ei laukaise, joten kentät toimivat normaalisti. Näppäimistö-/AT-käyttö hoituu edelleen vieressä olevan `ExpandButton`-painikkeen kautta.
- **Nimiotsikko tasattu vasempaan reunaan** osasuoritustaulukossa.
- **Completed-merkin ja nimen väliä väljennetty.**
- **Kenttien nimet pysyvät yhdellä rivillä työpöytäleveyksillä** (esim. "Kuullun ymmärtämisen taitotaso" ei rivity). Kapeilla näytöillä (mm. kansalaisen mobiilinäkymä, jossa nimisarake on hyvin kapea) rivitys sallitaan, jottei pitkä nimi mene arvon päälle.
- **Testidata:** uusi mock-oppija (Lassi Ammatillinen-Osittainen-Laaja) laajalla ammatillisella osittaissuorituksella (12 osasuoritusta), jotta taulukon renderöintiä voi testata useammalla rivillä. Lisätty `KoskiSpecificMockOppijat`-listan loppuun (OID-järjestys säilyy).

## Testaus

- Osasuorituskomponentit (`components-v2/opiskeluoikeus`) renderöityvät sekä virkailijan että kansalaisen näkymässä; rivittymismuutos varmennettu molemmilla leveyksillä (työpöytä + ~400–500px).
- Uuden mock-oppijan lisäys ei muuta raportointikannan aggregaattimääriä: ammatillisen osittaisen raportit rajataan hetulla ja opiskeluoikeus-OID:lla, ja raportointikannan kokonaismäärät ovat alarajoja tai testin sisäisiä suhteellisia deltoja.