### PR TITLE
TOR-2340: DIA-tutkinnon laajuusyksikkö opintopisteeksi 1.8.2026 alkaen editorissa

### DIFF
--- a/src/main/scala/fi/oph/koski/config/ConfigForFrontend.scala
+++ b/src/main/scala/fi/oph/koski/config/ConfigForFrontend.scala
@@ -17,12 +17,14 @@ object ConfigForFrontend {
 
 case class Rajapäivät(
   ibLaajuusOpintopisteinäAlkaen: String,
+  diaLaajuusOpintopisteinäAlkaen: String,
   kielitutkintotodistusAikaisinAlkamispäivä: String,
 )
 
 object Rajapäivät {
   def apply(config: Config): Rajapäivät = Rajapäivät(
     ibLaajuusOpintopisteinäAlkaen = dateString(config, "validaatiot.ibLaajuudetOpintopisteinäAlkaen"),
+    diaLaajuusOpintopisteinäAlkaen = dateString(config, "validaatiot.diaLaajuudetOpintopisteinäAlkaen"),
     kielitutkintotodistusAikaisinAlkamispäivä = dateString(config, "todistus.yleinenKielitutkinto.earliestDate"),
   )
 

--- a/web/app/dia/diaLaajuus.ts
+++ b/web/app/dia/diaLaajuus.ts
@@ -1,8 +1,6 @@
 import { config } from '../util/config'
 
-// DIA-tutkinnon laajuus ilmoitetaan opintopisteinä 1.8.2026 tai myöhemmin alkaneille
-// opiskeluoikeuksille, sitä ennen vuosiviikkotunteina. Yksikkö määräytyy siis
-// opiskeluoikeuden alkamispäivän perusteella.
+// DIA-laajuus opintopisteinä 1.8.2026 alkaen, ennen vuosiviikkotunteina.
 export const diaLaajuusOpintopisteinä = (alkamispäivä?: string): boolean =>
   typeof alkamispäivä === 'string' &&
   alkamispäivä >= config().rajapäivät.diaLaajuusOpintopisteinäAlkaen

--- a/web/app/dia/diaLaajuus.ts
+++ b/web/app/dia/diaLaajuus.ts
@@ -1,0 +1,8 @@
+import { config } from '../util/config'
+
+// DIA-tutkinnon laajuus ilmoitetaan opintopisteinä 1.8.2026 tai myöhemmin alkaneille
+// opiskeluoikeuksille, sitä ennen vuosiviikkotunteina. Yksikkö määräytyy siis
+// opiskeluoikeuden alkamispäivän perusteella.
+export const diaLaajuusOpintopisteinä = (alkamispäivä?: string): boolean =>
+  typeof alkamispäivä === 'string' &&
+  alkamispäivä >= config().rajapäivät.diaLaajuusOpintopisteinäAlkaen

--- a/web/app/editor/EditorModel.ts
+++ b/web/app/editor/EditorModel.ts
@@ -500,11 +500,8 @@ export const optionalPrototypeModel = <
   return R.mergeRight(prototype, createOptionalEmpty(model)) as P // Ensure that the prototype model has optional flag and optionalPrototype
 }
 
-// Tunnistaa DIA-tutkinnon laajuuskentän, joka on unioni (vuosiviikkotunti/opintopiste).
-// Tunnistus tehdään unionin oneOfClass-kentästä — EI value.classes-listasta: unionin trait
-// `LaajuusVuosiviikkotunneissaTaiOpintopisteissä` on periytetty myös tavallisiin
-// LaajuusVuosiviikkotunneissa/LaajuusOpintopisteissä-luokkiin, joten sen nimi esiintyy myös
-// ei-unioni-laajuuksien (esim. ESH, lukio) classes-listassa. Vain aito unionikenttä on OneOfModel.
+// Tunnistus oneOfClassista, EI value.classesista: unionin trait on periytetty myös tavallisiin
+// laajuusluokkiin, joten vain aito unionikenttä on OneOfModel.
 export const onDiaLaajuusUnioni = (
   model?: EditorModel & OptionalModel & MaybeOneOfModel & Contextualized
 ): boolean => {
@@ -527,14 +524,7 @@ export const onDiaLaajuusUnioni = (
   return false
 }
 
-// Palauttaa tyhjälle DIA-laajuudelle opintopisteoletusta käyttävän prototyyppimallin (samalla
-// polulla ja kontekstilla kuin alkuperäinen malli), kun opiskeluoikeus on alkanut 1.8.2026 tai
-// myöhemmin. Muutoin (esim. ennen rajapäivää) palautetaan tavallinen prototyyppi (vuosiviikkotunti).
-//
-// Tämä on tarpeen, koska laajuuden arvoa syötettäessä muutos sovelletaan juurimalliin ilman
-// opiskeluoikeuskontekstia (context.opiskeluoikeus lisätään vain renderöinnissä), jolloin yksikkö
-// ratkeaisi aina backendin globaaliksi oletukseksi (vuosiviikkotunti). Siksi LaajuusEditor
-// rakentaa ja työntää koko laajuusmallin oikealla yksiköllä jo renderöintikontekstissa.
+// Tyhjän DIA-laajuuden prototyyppi opintopisteoletuksella (1.8.2026+), muuten vuosiviikkotunnein.
 export const diaLaajuudenOletusprototyyppi = <
   M extends EditorModel & OptionalModel & MaybeOneOfModel & Contextualized
 >(
@@ -555,16 +545,8 @@ export const diaLaajuudenOletusprototyyppi = <
 const diaLaajuusOneOfClass = 'laajuusvuosiviikkotunneissataiopintopisteissa'
 const diaLaajuusOpintopisteKey = 'laajuusopintopisteissa'
 
-// DIA-tutkinnon laajuusyksikkö on unioni (vuosiviikkotunti/opintopiste). Backendin globaali
-// oletus on vuosiviikkotunti, mutta 1.8.2026 tai myöhemmin alkaneille DIA-opiskeluoikeuksille
-// laajuus on ilmoitettava opintopisteinä, joten oletukseksi valitaan tällöin opintopiste-vaihtoehto.
-// Prototyypit rakennetaan backendissä globaalisti ilman opiskeluoikeuskohtaista tietoa, joten
-// oletus tarkennetaan tässä opiskeluoikeuden alkamispäivän perusteella.
-//
-// Vaihtoehto tunnistetaan ratkaistun mallin luokasta (value.classes), EI PrototypeModelin
-// key-kentästä: oneOfPrototypes on jaettu globaalisti kaikkien laajuuskenttien kesken, ja
-// prototyypin ratkaiseminen poistaa key-kentän — key-vertailu toimisi siis vain ensimmäisellä
-// kutsulla ja palaisi sen jälkeen vuosiviikkotuntiin.
+// Opintopistevaihtoehto rajapäivän jälkeen. Tunnistus value.classesista, ei keystä, koska
+// prototyypin ratkaisu poistaa keyn ja jaettu oneOfPrototypes-taulukko mutatoituu.
 const diaLaajuusOpintopistePrototype = (
   oneOfModel: OneOfModel & Contextualized,
   forModel: EditorModel & Contextualized

--- a/web/app/editor/EditorModel.ts
+++ b/web/app/editor/EditorModel.ts
@@ -500,16 +500,23 @@ export const optionalPrototypeModel = <
   return R.mergeRight(prototype, createOptionalEmpty(model)) as P // Ensure that the prototype model has optional flag and optionalPrototype
 }
 
-// Tunnistaa DIA-tutkinnon laajuuskentän (unioni vuosiviikkotunti/opintopiste), sekä tyhjän
-// (optionalPrototype) että täytetyn (value.classes) tapauksen.
+// Tunnistaa DIA-tutkinnon laajuuskentän, joka on unioni (vuosiviikkotunti/opintopiste).
+// Tunnistus tehdään unionin oneOfClass-kentästä — EI value.classes-listasta: unionin trait
+// `LaajuusVuosiviikkotunneissaTaiOpintopisteissä` on periytetty myös tavallisiin
+// LaajuusVuosiviikkotunneissa/LaajuusOpintopisteissä-luokkiin, joten sen nimi esiintyy myös
+// ei-unioni-laajuuksien (esim. ESH, lukio) classes-listassa. Vain aito unionikenttä on OneOfModel.
 export const onDiaLaajuusUnioni = (
   model?: EditorModel & OptionalModel & MaybeOneOfModel & Contextualized
 ): boolean => {
   if (!model) return false
-  if (hasValue(model)) {
-    return !!(model as any).value?.classes?.includes(diaLaajuusOneOfClass)
+  if (isOneOfModel(model as any)) {
+    return (model as any).oneOfClass === diaLaajuusOneOfClass
   }
-  if (isSomeOptionalModel(model) && (model as any).optionalPrototype) {
+  if (
+    isSomeOptionalModel(model) &&
+    !hasValue(model) &&
+    (model as any).optionalPrototype
+  ) {
     const proto = preparePrototypeModel((model as any).optionalPrototype, model)
     return (
       !!proto &&

--- a/web/app/editor/EditorModel.ts
+++ b/web/app/editor/EditorModel.ts
@@ -48,6 +48,7 @@ import {
 import { flatMapArray, notUndefined } from '../util/util'
 import { hashAdd, hashCode } from './hashcode'
 import { filterObjByKey } from '../util/fp/objects'
+import { diaLaajuusOpintopisteinä } from '../dia/diaLaajuus'
 
 export type EditorElement = JSX.Element & {
   isEmpty?: (model: EditorModel) => boolean
@@ -497,6 +498,87 @@ export const optionalPrototypeModel = <
     )!
   }
   return R.mergeRight(prototype, createOptionalEmpty(model)) as P // Ensure that the prototype model has optional flag and optionalPrototype
+}
+
+// Tunnistaa DIA-tutkinnon laajuuskentän (unioni vuosiviikkotunti/opintopiste), sekä tyhjän
+// (optionalPrototype) että täytetyn (value.classes) tapauksen.
+export const onDiaLaajuusUnioni = (
+  model?: EditorModel & OptionalModel & MaybeOneOfModel & Contextualized
+): boolean => {
+  if (!model) return false
+  if (hasValue(model)) {
+    return !!(model as any).value?.classes?.includes(diaLaajuusOneOfClass)
+  }
+  if (isSomeOptionalModel(model) && (model as any).optionalPrototype) {
+    const proto = preparePrototypeModel((model as any).optionalPrototype, model)
+    return (
+      !!proto &&
+      isOneOfModel(proto) &&
+      (proto as any).oneOfClass === diaLaajuusOneOfClass
+    )
+  }
+  return false
+}
+
+// Palauttaa tyhjälle DIA-laajuudelle opintopisteoletusta käyttävän prototyyppimallin (samalla
+// polulla ja kontekstilla kuin alkuperäinen malli), kun opiskeluoikeus on alkanut 1.8.2026 tai
+// myöhemmin. Muutoin (esim. ennen rajapäivää) palautetaan tavallinen prototyyppi (vuosiviikkotunti).
+//
+// Tämä on tarpeen, koska laajuuden arvoa syötettäessä muutos sovelletaan juurimalliin ilman
+// opiskeluoikeuskontekstia (context.opiskeluoikeus lisätään vain renderöinnissä), jolloin yksikkö
+// ratkeaisi aina backendin globaaliksi oletukseksi (vuosiviikkotunti). Siksi LaajuusEditor
+// rakentaa ja työntää koko laajuusmallin oikealla yksiköllä jo renderöintikontekstissa.
+export const diaLaajuudenOletusprototyyppi = <
+  M extends EditorModel & OptionalModel & MaybeOneOfModel & Contextualized
+>(
+  model: M
+): M => {
+  if (isSomeOptionalModel(model) && !hasValue(model)) {
+    const proto = preparePrototypeModel(model.optionalPrototype as any, model)
+    if (proto && isOneOfModel(proto)) {
+      const opintopiste = diaLaajuusOpintopistePrototype(proto, model)
+      if (opintopiste) {
+        ;(model as any).optionalPrototype = opintopiste
+      }
+    }
+  }
+  return optionalPrototypeModel(model) as M
+}
+
+const diaLaajuusOneOfClass = 'laajuusvuosiviikkotunneissataiopintopisteissa'
+const diaLaajuusOpintopisteKey = 'laajuusopintopisteissa'
+
+// DIA-tutkinnon laajuusyksikkö on unioni (vuosiviikkotunti/opintopiste). Backendin globaali
+// oletus on vuosiviikkotunti, mutta 1.8.2026 tai myöhemmin alkaneille DIA-opiskeluoikeuksille
+// laajuus on ilmoitettava opintopisteinä, joten oletukseksi valitaan tällöin opintopiste-vaihtoehto.
+// Prototyypit rakennetaan backendissä globaalisti ilman opiskeluoikeuskohtaista tietoa, joten
+// oletus tarkennetaan tässä opiskeluoikeuden alkamispäivän perusteella.
+//
+// Vaihtoehto tunnistetaan ratkaistun mallin luokasta (value.classes), EI PrototypeModelin
+// key-kentästä: oneOfPrototypes on jaettu globaalisti kaikkien laajuuskenttien kesken, ja
+// prototyypin ratkaiseminen poistaa key-kentän — key-vertailu toimisi siis vain ensimmäisellä
+// kutsulla ja palaisi sen jälkeen vuosiviikkotuntiin.
+const diaLaajuusOpintopistePrototype = (
+  oneOfModel: OneOfModel & Contextualized,
+  forModel: EditorModel & Contextualized
+): (EditorModel & OneOfModel) | undefined => {
+  if (oneOfModel.oneOfClass !== diaLaajuusOneOfClass) return undefined
+  const alkamispäivä = modelData(
+    (forModel.context as any)?.opiskeluoikeus,
+    'alkamispäivä'
+  ) as string | undefined
+  if (!diaLaajuusOpintopisteinä(alkamispäivä)) return undefined
+  const opintopiste = oneOfModel.oneOfPrototypes
+    .map((proto) => preparePrototypeModel(proto, forModel))
+    .find(
+      (proto) =>
+        !!(proto as any)?.value?.classes?.includes(diaLaajuusOpintopisteKey)
+    )
+  if (!opintopiste) return undefined
+  return R.mergeRight(opintopiste as any, {
+    oneOfClass: oneOfModel.oneOfClass,
+    oneOfPrototypes: oneOfModel.oneOfPrototypes
+  }) as EditorModel & OneOfModel
 }
 
 export const createOptionalEmpty = <M extends EditorModel & OptionalModel>(

--- a/web/app/suoritus/LaajuusEditor.jsx
+++ b/web/app/suoritus/LaajuusEditor.jsx
@@ -1,19 +1,25 @@
 import React from 'react'
 import { Editor } from '../editor/Editor'
 import {
+  diaLaajuudenOletusprototyyppi,
   modelData,
   modelEmpty,
   modelLookup,
   modelSetValue,
   modelValid,
+  onDiaLaajuusUnioni,
   oneOfPrototypes,
+  pushModel,
+  resetOptionalModel,
   wrapOptional
 } from '../editor/EditorModel'
+import { hasValue } from '../types/EditorModels'
 import {
   EnumEditor,
   fetchAlternativesBasedOnPrototypes
 } from '../editor/EnumEditor'
 import { parseBool } from '../util/util'
+import { numberToString } from '../util/format'
 import { t } from '../i18n/i18n'
 import { hyphenate } from '../util/hyphenate'
 
@@ -25,13 +31,55 @@ export class LaajuusEditor extends React.Component {
       <span>
         <span className="property laajuus arvo" data-testid="laajuus-editor">
           <span className={modelValid(wrappedModel) ? 'value' : 'value error'}>
-            <Editor model={wrappedModel} path="arvo" disabled={disabled} />
+            {onDiaLaajuusUnioni(model) ? (
+              <DiaLaajuudenArvoEditor model={model} disabled={disabled} />
+            ) : (
+              <Editor model={wrappedModel} path="arvo" disabled={disabled} />
+            )}
           </span>
         </span>
         <LaajuudenYksikköEditor {...{ model, compact, showReadonlyScope }} />
       </span>
     )
   }
+}
+
+// DIA-tutkinnon laajuuden arvokenttä. Laajuuden yksikkö määräytyy opiskeluoikeuden alkamispäivän
+// mukaan (opintopisteet 1.8.2026 tai myöhemmin), mutta arvon syöttö sovelletaan juurimalliin ilman
+// opiskeluoikeuskontekstia. Siksi työnnetään koko laajuusmalli oikealla yksiköllä (opintopisteet
+// tyhjälle rajapäivän jälkeiselle laajuudelle, muutoin nykyinen/oletusyksikkö) laajuuden polkuun,
+// jotta yksikkö säilyy tallennettaessa.
+const DiaLaajuudenArvoEditor = ({ model, disabled }) => {
+  const data = modelData(model, 'arvo')
+  if (!model.context.edit || disabled) {
+    return <span className="inline number">{numberToString(data)}</span>
+  }
+  const onChange = (event) => {
+    const raw = event.target.value
+    if (!raw) {
+      resetOptionalModel(model)
+      return
+    }
+    const base = hasValue(model)
+      ? wrapOptional(model)
+      : diaLaajuudenOletusprototyyppi(model)
+    pushModel(modelSetValue(base, { data: parseNumber(raw) }, 'arvo'))
+  }
+  return (
+    <input
+      type="text"
+      defaultValue={numberToString(data)}
+      onChange={onChange}
+      className="editor-input inline number"
+      data-testid="number-editor"
+    />
+  )
+}
+
+const parseNumber = (s) => {
+  s = s.replace(',', '.')
+  if (isNaN(s)) return s
+  return parseFloat(s)
 }
 LaajuusEditor.isEmpty = (m) => modelEmpty(m, 'arvo')
 LaajuusEditor.createEmpty = (m) => modelSetValue(m, undefined, 'arvo')

--- a/web/app/suoritus/LaajuusEditor.jsx
+++ b/web/app/suoritus/LaajuusEditor.jsx
@@ -65,12 +65,13 @@ const DiaLaajuudenArvoEditor = ({ model, disabled }) => {
       : diaLaajuudenOletusprototyyppi(model)
     pushModel(modelSetValue(base, { data: parseNumber(raw) }, 'arvo'))
   }
+  const error = !modelValid(model)
   return (
     <input
       type="text"
       defaultValue={numberToString(data)}
       onChange={onChange}
-      className="editor-input inline number"
+      className={'editor-input inline number' + (error ? ' error' : '')}
       data-testid="number-editor"
     />
   )

--- a/web/app/suoritus/LaajuusEditor.jsx
+++ b/web/app/suoritus/LaajuusEditor.jsx
@@ -44,11 +44,8 @@ export class LaajuusEditor extends React.Component {
   }
 }
 
-// DIA-tutkinnon laajuuden arvokenttä. Laajuuden yksikkö määräytyy opiskeluoikeuden alkamispäivän
-// mukaan (opintopisteet 1.8.2026 tai myöhemmin), mutta arvon syöttö sovelletaan juurimalliin ilman
-// opiskeluoikeuskontekstia. Siksi työnnetään koko laajuusmalli oikealla yksiköllä (opintopisteet
-// tyhjälle rajapäivän jälkeiselle laajuudelle, muutoin nykyinen/oletusyksikkö) laajuuden polkuun,
-// jotta yksikkö säilyy tallennettaessa.
+// Työntää koko laajuusmallin oikealla yksiköllä laajuuden polkuun (yksikkö valitaan
+// renderöinnissä alkamispäivän mukaan; changeBus ei näe opiskeluoikeuskontekstia).
 const DiaLaajuudenArvoEditor = ({ model, disabled }) => {
   const data = modelData(model, 'arvo')
   if (!model.context.edit || disabled) {

--- a/web/app/suoritus/RyhmiteltyOppiaineetEditor.jsx
+++ b/web/app/suoritus/RyhmiteltyOppiaineetEditor.jsx
@@ -11,6 +11,7 @@ import {
   diaLukukausiAlternativesCompletionFn,
   diaRyhmät
 } from '../dia/DIA'
+import { diaLaajuusOpintopisteinä } from '../dia/diaLaajuus'
 import Text from '../i18n/Text'
 
 const diaCustomizations = {
@@ -118,6 +119,16 @@ export default ({
     customKurssitSortFn
   } = resolvePropertiesByType(päätasonSuorituksenTyyppi)
 
+  // DIA-tutkinnon laajuus ilmoitetaan opintopisteinä 1.8.2026 tai myöhemmin alkaneille
+  // opiskeluoikeuksille, joten sarakeotsikon yksikkö määräytyy alkamispäivän perusteella.
+  const alkamispäivä = modelData(
+    suorituksetModel.context.opiskeluoikeus,
+    'alkamispäivä'
+  )
+  const efektiivinenLaajuusyksikkö = diaLaajuusOpintopisteinä(alkamispäivä)
+    ? 'opintopistettä'
+    : laajuusyksikkö
+
   const { aineryhmät, muutAineet, footnotes } = groupAineet(
     oppiaineet,
     päätasonSuoritusModel,
@@ -140,7 +151,7 @@ export default ({
     <div>
       <table className="suoritukset oppiaineet">
         <LukionOppiaineetTableHead
-          laajuusyksikkö={laajuusyksikkö}
+          laajuusyksikkö={efektiivinenLaajuusyksikkö}
           showArviointi={showArviointi}
         />
         <tbody>

--- a/web/app/suoritus/RyhmiteltyOppiaineetEditor.jsx
+++ b/web/app/suoritus/RyhmiteltyOppiaineetEditor.jsx
@@ -119,8 +119,7 @@ export default ({
     customKurssitSortFn
   } = resolvePropertiesByType(päätasonSuorituksenTyyppi)
 
-  // DIA-tutkinnon laajuus ilmoitetaan opintopisteinä 1.8.2026 tai myöhemmin alkaneille
-  // opiskeluoikeuksille, joten sarakeotsikon yksikkö määräytyy alkamispäivän perusteella.
+  // Sarakeotsikon yksikkö alkamispäivän mukaan (opintopisteet 1.8.2026+).
   const alkamispäivä = modelData(
     suorituksetModel.context.opiskeluoikeus,
     'alkamispäivä'

--- a/web/app/types/fi/oph/koski/config/Rajapaivat.ts
+++ b/web/app/types/fi/oph/koski/config/Rajapaivat.ts
@@ -6,11 +6,13 @@
 export type Rajapäivät = {
   $class: 'fi.oph.koski.config.Rajapäivät'
   ibLaajuusOpintopisteinäAlkaen: string
+  diaLaajuusOpintopisteinäAlkaen: string
   kielitutkintotodistusAikaisinAlkamispäivä: string
 }
 
 export const Rajapäivät = (o: {
   ibLaajuusOpintopisteinäAlkaen: string
+  diaLaajuusOpintopisteinäAlkaen: string
   kielitutkintotodistusAikaisinAlkamispäivä: string
 }): Rajapäivät => ({ $class: 'fi.oph.koski.config.Rajapäivät', ...o })
 


### PR DESCRIPTION
Näyttää ja tallentaa DIA-tutkinnon laajuuden yksikön opiskeluoikeuden alkamispäivän mukaan editorissa: opintopistettä 1.8.2026 tai myöhemmin alkaneille, muutoin vuosiviikkotuntia. Jatkoa mergetylle TOR-2340:lle jossa laajuusyksikkö validoidaan. 

- Sarakeotsikon yksikkö alkamispäivän mukaan (`RyhmiteltyOppiaineetEditor`).
- Uuden laajuuden oletusyksikkö opintopisteeksi 1.8.2026+ opiskeluoikeuksille (`LaajuusEditor`).
- Rajapäivä frontendille `ConfigForFrontend`-kautta (kuten IB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)