### PR TITLE
TOR-2433: rajaa osasuoritustaulukon uusi tyyli vain ammatillinen-v2:een

### DIFF
--- a/web/app/ammatillinen-v2/AmmatillinenEditor.tsx
+++ b/web/app/ammatillinen-v2/AmmatillinenEditor.tsx
@@ -33,6 +33,7 @@ import {
 } from '../components-v2/opiskeluoikeus/KoodistoField'
 import { Spacer } from '../components-v2/layout/Spacer'
 import { SuorituksenVahvistusField } from '../components-v2/opiskeluoikeus/SuorituksenVahvistus'
+import { AmmatillinenTyyliContext } from '../components-v2/opiskeluoikeus/OsasuoritusTable'
 import { PerusteView } from '../components-v2/opiskeluoikeus/PerusteField'
 import { AmmatillisenTutkinnonOsittainenSuoritus } from '../types/fi/oph/koski/schema/AmmatillisenTutkinnonOsittainenSuoritus'
 import { FormListField } from '../components-v2/forms/FormListField'
@@ -99,7 +100,9 @@ const AmmatillinenEditor: React.FC<AmmatillinenEditorProps> = (props) => {
       opiskeluoikeus={form.state}
       opiskeluoikeudenNimi={suorituksenNimi(form.state)}
     >
-      <AmmatillinenPäätasonSuoritusEditor {...props} form={form} />
+      <AmmatillinenTyyliContext.Provider value={true}>
+        <AmmatillinenPäätasonSuoritusEditor {...props} form={form} />
+      </AmmatillinenTyyliContext.Provider>
     </VirkailijaKansalainenContainer>
   )
 }

--- a/web/app/components-v2/opiskeluoikeus/OsasuoritusTable.less
+++ b/web/app/components-v2/opiskeluoikeus/OsasuoritusTable.less
@@ -61,6 +61,12 @@
   color: @color-link-blue;
 }
 
+// Keskeneräisen osasuorituksen tiimalasi-ikoni (Icon = FontAwesome) näytetään
+// muun tekstin/valmis-merkin värissä sinisen sijaan.
+.OsasuoritusRow__completedColumn .Icon {
+  color: inherit;
+}
+
 // Completed-merkin sarake varaa kokonaisen ruudukkosarakkeen, vaikka itse
 // merkki on kapea. Vedetään nimisaraketta vasemmalle, jotta nimi asettuu
 // lähelle completed-merkkiä (joka puolestaan on kiinni laajennuspainikkeessa).

--- a/web/app/components-v2/opiskeluoikeus/OsasuoritusTable.tsx
+++ b/web/app/components-v2/opiskeluoikeus/OsasuoritusTable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useCallback } from 'react'
+import React, { createContext, ReactNode, useCallback, useContext } from 'react'
 import { useTree } from '../../appstate/tree'
 import { t } from '../../i18n/i18n'
 import { Opiskeluoikeus } from '../../types/fi/oph/koski/schema/Opiskeluoikeus'
@@ -19,11 +19,21 @@ import { ExpandButton } from '../controls/ExpandButton'
 import { IconButton } from '../controls/IconButton'
 import { FormModel, FormOptic } from '../forms/FormModel'
 import { Spacer } from '../layout/Spacer'
-import { CHARCODE_REMOVE } from '../texts/Icon'
+import {
+  CHARCODE_KESKEN,
+  CHARCODE_REMOVE,
+  CHARCODE_VALMIS,
+  Icon
+} from '../texts/Icon'
 import { useNewItems } from '../../appstate/newItems'
 import { TestIdLayer } from '../../appstate/useTestId'
 
 export const OSASUORITUSTABLE_DEPTH_KEY = 'OsasuoritusTable'
+
+// Ammatillinen-v2:n osasuoritustaulukon tyyli (klikattava nimi, otsikko
+// vasempaan reunaan, tiivis completed-merkki FontAwesome-ikonein). Muut
+// suoritustyypit käyttävät oletusarvoa (false) eli perinteistä asettelua.
+export const AmmatillinenTyyliContext = createContext(false)
 
 type Completed = (osasuoritusIndex: number) => boolean | undefined
 
@@ -147,6 +157,7 @@ export const OsasuoritusHeader = <DATA_KEYS extends string>(
   props: OsasuoritusHeaderProps<DATA_KEYS>
 ) => {
   const [indentation] = useLayout(OSASUORITUSTABLE_DEPTH_KEY)
+  const ammatillinenTyyli = useContext(AmmatillinenTyyliContext)
   const spans = getSpans(
     props.columns,
     indentation,
@@ -160,24 +171,42 @@ export const OsasuoritusHeader = <DATA_KEYS extends string>(
         {spans.indent > 0 && (
           <Column span={spans.indent} className="OsasuoritusHeader__indent" />
         )}
-        {props.columns.map((column, index) => {
-          const isNameColumn = index === 0
-          // Nimisarakkeen otsikko ("… tutkinnon osat") venytetään alkamaan rivin
-          // vasemmasta reunasta laajennus- ja completed-ikonisarakkeiden yli,
-          // jotta se on linjassa alapuolisen vaakaviivan ja muun vasempaan
-          // tasatun sisällön kanssa — ei sisennettynä osasuoritusten nimien
-          // yläpuolelle.
-          const leadingSpan =
-            (props.skipExpandableColumn ? 0 : spans.leftIcons) + spans.completed
-          const span = isNameColumn
-            ? mapResponsiveValue((w: number) => leadingSpan + w)(spans.name)
-            : spans.data[index - 1]
-          return (
-            <Column key={index} span={span} align={column.align}>
-              {getColumnLabel(column)}
-            </Column>
-          )
-        })}
+        {ammatillinenTyyli ? (
+          props.columns.map((column, index) => {
+            const isNameColumn = index === 0
+            // Nimisarakkeen otsikko ("… tutkinnon osat") venytetään alkamaan
+            // rivin vasemmasta reunasta laajennus- ja completed-ikonisarakkeiden
+            // yli, jotta se on linjassa alapuolisen vaakaviivan ja muun
+            // vasempaan tasatun sisällön kanssa.
+            const leadingSpan =
+              (props.skipExpandableColumn ? 0 : spans.leftIcons) +
+              spans.completed
+            const span = isNameColumn
+              ? mapResponsiveValue((w: number) => leadingSpan + w)(spans.name)
+              : spans.data[index - 1]
+            return (
+              <Column key={index} span={span} align={column.align}>
+                {getColumnLabel(column)}
+              </Column>
+            )
+          })
+        ) : (
+          <>
+            {/* Tyhjät sarakkeet laajennus- ja completed-painikkeille, jotta
+                ensimmäisen sarakkeen otsikko on rivien nimien yläpuolella. */}
+            {!props.skipExpandableColumn && <Column span={spans.leftIcons} />}
+            {spans.completed > 0 && <Column span={spans.completed} />}
+            {props.columns.map((column, index) => (
+              <Column
+                key={index}
+                span={index === 0 ? spans.name : spans.data[index - 1]}
+                align={column.align}
+              >
+                {getColumnLabel(column)}
+              </Column>
+            ))}
+          </>
+        )}
         {spans.rightIcons > 0 && (
           <Column
             span={spans.rightIcons}
@@ -193,6 +222,7 @@ export const OsasuoritusRow = <DATA_KEYS extends string>(
   props: OsasuoritusRowProps<DATA_KEYS>
 ) => {
   const [indentation, LayoutProvider] = useLayout(OSASUORITUSTABLE_DEPTH_KEY)
+  const ammatillinenTyyli = useContext(AmmatillinenTyyliContext)
   const spans = getSpans(
     props.columns,
     indentation,
@@ -207,7 +237,10 @@ export const OsasuoritusRow = <DATA_KEYS extends string>(
   const isOpen = props.forceOpen || tree.isOpen
 
   const nameTogglesRow =
-    expandable && Boolean(props.row.content) && !props.forceOpen
+    ammatillinenTyyli &&
+    expandable &&
+    Boolean(props.row.content) &&
+    !props.forceOpen
 
   return (
     <TreeNode>
@@ -237,14 +270,26 @@ export const OsasuoritusRow = <DATA_KEYS extends string>(
         )}
         {props.showCompleted && (
           <Column span={1} className="OsasuoritusRow__completedColumn">
-            {props.completed === true && (
-              // eslint-disable-next-line react/jsx-no-literals
-              <span aria-label={t('Suoritus valmis')}>&#x2713;</span>
-            )}
-            {props.completed === false && (
-              // eslint-disable-next-line react/jsx-no-literals
-              <span aria-label={t('Suoritus kesken')}>&#x29D6;</span>
-            )}
+            {props.completed === true &&
+              (ammatillinenTyyli ? (
+                // Vanhan käyttöliittymän valmis-ikoni (FontAwesome check)
+                <span aria-label={t('Suoritus valmis')}>
+                  <Icon charCode={CHARCODE_VALMIS} />
+                </span>
+              ) : (
+                // eslint-disable-next-line react/jsx-no-literals
+                <span aria-label={t('Suoritus valmis')}>&#x2713;</span>
+              ))}
+            {props.completed === false &&
+              (ammatillinenTyyli ? (
+                // Vanhan käyttöliittymän tiimalasi-ikoni (FontAwesome hourglass-half)
+                <span aria-label={t('Suoritus kesken')}>
+                  <Icon charCode={CHARCODE_KESKEN} />
+                </span>
+              ) : (
+                // eslint-disable-next-line react/jsx-no-literals
+                <span aria-label={t('Suoritus kesken')}>&#x29D6;</span>
+              ))}
           </Column>
         )}
         {props.columns.map((column, index) => {
@@ -260,6 +305,7 @@ export const OsasuoritusRow = <DATA_KEYS extends string>(
                   ? cx(
                       'OsasuoritusRow__nameColumn',
                       props.showCompleted &&
+                        ammatillinenTyyli &&
                         'OsasuoritusRow__nameColumn--completedAdjacent'
                     )
                   : 'OsasuoritusRow__dataColumn'

--- a/web/app/components-v2/texts/Icon.tsx
+++ b/web/app/components-v2/texts/Icon.tsx
@@ -33,3 +33,5 @@ export const CHARCODE_ADD = 'f055'
 export const CHARCODE_REMOVE = 'f1f8'
 export const CHARCODE_OPEN = 'f0fe'
 export const CHARCODE_CLOSE = 'f146'
+export const CHARCODE_VALMIS = 'f00c' // check (valmis suoritus)
+export const CHARCODE_KESKEN = 'f252' // hourglass-half (keskeneräinen suoritus)


### PR DESCRIPTION
Osasuoritustaulukon uusi ulkoasu vuoti PR #4302:ssa kaikkiin v2-suoritustyyppeihin. Tämä rajaa sen ammatilliseen.

- Uusi `AmmatillinenTyyliContext`, jonka `AmmatillinenEditor` asettaa todeksi. Muilla suoritustyypeillä oletus `false` → vanha asettelu.
- Kontekstin takana: klikattava osasuorituksen nimi, nimiotsikon tasaus rivin vasempaan reunaan ja completed-merkin viereen tiivistetty nimisarake.
- Valmis/kesken-merkit vanhan käyttöliittymän FontAwesome-ikoneina (`f00c` / `f252`) ammatillisessa; muilla säilyvät unicode-merkit ✓ / ⧖.