### PR TITLE
TOR-2587: Näytä opiskelijalistassa vain Ahvenanmaan oppimäärän suoritus

### DIFF
--- a/src/main/scala/fi/oph/koski/perustiedot/OpiskeluoikeudenPerustiedot.scala
+++ b/src/main/scala/fi/oph/koski/perustiedot/OpiskeluoikeudenPerustiedot.scala
@@ -70,6 +70,15 @@ case class OpiskeluoikeusJaksonPerustiedot(
 object OpiskeluoikeudenPerustiedot {
   val serializationContext = SerializationContext(KoskiSchema.schemaFactory, omitEmptyFields = false)
 
+  // Vuosiluokkien suorituksia ei näytetä opiskelijalistan Koulutus-sarakkeessa, vaan sarakkeessa
+  // näkyy pelkkä oppimäärän suoritus. Suodatus on rajattu perusopetuksen tyyppeihin: European
+  // School of Helsingin ja International Schoolin skeemat eivät salli päätason suorituksiksi
+  // muuta kuin vuosiluokkia, joten niiden suodattaminen tyhjentäisi sarakkeen kokonaan.
+  private val opiskelijalistaltaPiilotetutSuoritusTyypit = Set(
+    "perusopetuksenvuosiluokka",
+    "ahvenanmaanperusopetuksenvuosiluokka"
+  )
+
   def makePerustiedot(row: KoskiOpiskeluoikeusRow, henkilöRow: HenkilöRow, masterHenkilöRow: Option[HenkilöRow]): OpiskeluoikeudenPerustiedot = {
     makePerustiedot(
       row.id,
@@ -108,7 +117,7 @@ object OpiskeluoikeudenPerustiedot {
           extract[OidOrganisaatio](suoritus \ "toimipiste", ignoreExtras = true)
         )
       }
-      .filter(_.tyyppi.koodiarvo != "perusopetuksenvuosiluokka")
+      .filterNot(s => opiskelijalistaltaPiilotetutSuoritusTyypit.contains(s.tyyppi.koodiarvo))
     OpiskeluoikeudenPerustiedot(
       id,
       Some(henkilö.henkilö),

--- a/src/test/scala/fi/oph/koski/perustiedot/OpiskeluoikeudenPerustiedotSpec.scala
+++ b/src/test/scala/fi/oph/koski/perustiedot/OpiskeluoikeudenPerustiedotSpec.scala
@@ -1,0 +1,32 @@
+package fi.oph.koski.perustiedot
+
+import fi.oph.koski.documentation.{AhvenanmaanPerusopetusExampleData, ExamplesPerusopetus}
+import fi.oph.koski.henkilo.{KoskiSpecificMockOppijat, OppijaHenkilö, OppijaHenkilöWithMasterInfo}
+import fi.oph.koski.schema.Opiskeluoikeus
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class OpiskeluoikeudenPerustiedotSpec extends AnyFreeSpec with Matchers {
+
+  "Opiskelijalistan Koulutus-sarakkeessa näytettävät suoritukset" - {
+    "manner-Suomen perusopetuksesta näytetään vain oppimäärän suoritus" in {
+      suoritusTyypit(
+        ExamplesPerusopetus.ysiluokkalaisenOpiskeluoikeus,
+        KoskiSpecificMockOppijat.ysiluokkalainen
+      ) should be(List("perusopetuksenoppimaara"))
+    }
+
+    "Ahvenanmaan perusopetuksesta näytetään vain oppimäärän suoritus" in {
+      suoritusTyypit(
+        AhvenanmaanPerusopetusExampleData.opiskeluoikeus,
+        KoskiSpecificMockOppijat.ahvenanmaanPerusoppilas
+      ) should be(List("ahvenanmaanperusopetuksenoppimaara"))
+    }
+  }
+
+  private def suoritusTyypit(oo: Opiskeluoikeus, oppija: OppijaHenkilö): List[String] =
+    OpiskeluoikeudenPerustiedot
+      .makePerustiedot(1, oo, OppijaHenkilöWithMasterInfo(oppija, None))
+      .suoritukset
+      .map(_.tyyppi.koodiarvo)
+}


### PR DESCRIPTION
Opiskelijalistan Koulutus-sarake listasi Ahvenanmaan perusopetuksen opiskeluoikeudelta kaikki päätason suoritukset (oppimäärä + jokainen vuosiluokka), kun manner-Suomen perusopetuksessa sarakkeessa näkyy pelkkä oppimäärän suoritus. Ero johtui siitä, että perustietojen suodatus oli kirjoitettu yhtenä kovakoodattuna koodiarvovertailuna ("perusopetuksenvuosiluokka"), johon Ahvenanmaan oma vuosiluokkatyyppi ei osu.

Suodatus on nyt joukkona, jossa mukana myös
ahvenanmaanperusopetuksenvuosiluokka. Suodatus on tarkoituksella rajattu nimettyihin tyyppeihin eikä esim. koodiarvon "vuosiluokka"-osumaan: European School of Helsingin ja International Schoolin skeemat eivät salli päätason suorituksiksi muuta kuin vuosiluokkia (EuropeanSchoolOfHelsinkiPäätasonSuoritus-traitilla on vain neljä vuosiluokkaluokkaa, InternationalSchoolOpiskeluoikeus.suoritukset on List[InternationalSchoolVuosiluokanSuoritus]), joten niiden suodattaminen tyhjentäisi sarakkeen kokonaan.

Uusi OpiskeluoikeudenPerustiedotSpec ajaa makePerustiedot-metodin esimerkkiopiskeluoikeuksilla, joissa on oppimäärä ja kaksi vuosiluokkaa. Manner-Suomen tapaus on mukana muutoksen regressiotestinä.

Huom. jo indeksoidut opiskeluoikeudet säilyttävät vanhan suorituslistan kunnes ne synkronoidaan uudelleen (tallennus tai perustiedot_manual_sync).

Havainto tuli Ahvenanmaan käyttöliittymän katselmoinnista (kesäkuu 2026, "Ahvenanmaan käyttöliittymän huomiot" osa 1, dia 2).