### PR TITLE
TOR-2433: korjaa VST-lukutaidon arvioinnin alikenttien pinoutuminen

### DIFF
--- a/web/app/components-v2/opiskeluoikeus/OsasuoritusProperty.less
+++ b/web/app/components-v2/opiskeluoikeus/OsasuoritusProperty.less
@@ -21,6 +21,19 @@
   .Column {
     min-height: 1.5 * @baseline;
   }
+
+  // FormListField kääritään Removable-komponentin div-elementteihin. Suoraan
+  // OsasuoritusPropertyn ruudukossa nämä käärö-divit asettuisivat kapeaan
+  // sarakkeeseen, jolloin alikentät (esim. VST-lukutaidon Taitotaso/Arvosana/
+  // Päivämäärä) pinoutuisivat päällekkäin. display: contents poistaa kääröt
+  // asettelusta, jolloin alikentät asettuvat oikein nimi/arvo-sarakkeisiin.
+  > .NotRemovable {
+    display: contents;
+
+    > .NotRemovable__content {
+      display: contents;
+    }
+  }
 }
 
 // Kapeilla näytöillä (esim. kansalaisen mobiilinäkymä) nimisarake on niin kapea,

--- a/web/app/vst/lukutaito/VSTLukutaitoKielitaitotasoField.tsx
+++ b/web/app/vst/lukutaito/VSTLukutaitoKielitaitotasoField.tsx
@@ -78,7 +78,6 @@ export const VSTLukutaitoKielitaitotasoEdit = (
   props: VSTLukutaitoKielitaitotasoEditProps
 ) => {
   const startRow = (props.index || 0) * 2
-  console.log('VSTLukutaitoKielitaitotasoEdit', props)
   return props.value ? (
     <>
       <OsasuoritusSubproperty rowNumber={startRow} label="Taitotaso">

--- a/web/app/vst/lukutaito/VSTLukutaitoKielitaitotasoField.tsx
+++ b/web/app/vst/lukutaito/VSTLukutaitoKielitaitotasoField.tsx
@@ -49,7 +49,7 @@ export type VSTLukutaitoKielitaitotasoViewProps = CommonProps<
 export const VSTLukutaitoKielitaitotasoView = (
   props: VSTLukutaitoKielitaitotasoViewProps
 ) => {
-  const startRow = (props.index || 0) * 2
+  const startRow = (props.index || 0) * 3
   return props.value ? (
     <>
       <OsasuoritusSubproperty rowNumber={startRow} label="Taitotaso">
@@ -77,7 +77,7 @@ export type VSTLukutaitoKielitaitotasoEditProps = CommonProps<
 export const VSTLukutaitoKielitaitotasoEdit = (
   props: VSTLukutaitoKielitaitotasoEditProps
 ) => {
-  const startRow = (props.index || 0) * 2
+  const startRow = (props.index || 0) * 3
   return props.value ? (
     <>
       <OsasuoritusSubproperty rowNumber={startRow} label="Taitotaso">


### PR DESCRIPTION
VST-lukutaitokoulutuksen osasuorituksen arviointikentän asettelu, jossa alikentät (Taitotaso / Arvosana / Päivämäärä) pinoutuivat päällekkäin kapeaan sarakkeeseen.