### PR TITLE
TOR-2587: Poista vuosiluokan koodiarvo uusista perusopetuksen käyttöl…

### DIFF
--- a/web/app/ahvenanmaan-perusopetus/AhvenanmaanPerusopetuksenSuorituksenTiedot.tsx
+++ b/web/app/ahvenanmaan-perusopetus/AhvenanmaanPerusopetuksenSuorituksenTiedot.tsx
@@ -67,8 +67,7 @@ export const AhvenanmaanPerusopetuksenSuorituksenTiedot: React.FC<
         >
           {[
             <TestIdText key="tunniste" id="koulutus">
-              {t(suoritus.koulutusmoduuli.tunniste.nimi)}{' '}
-              {suoritus.koulutusmoduuli.tunniste.koodiarvo}
+              {t(suoritus.koulutusmoduuli.tunniste.nimi)}
             </TestIdText>,
             // Ahvenanmaan ops (ÅLp21) ei ole ePerusteissa, joten diaarinumero
             // linkitetään suoraan laroplan.ax-sivustolle (ei ePerusteet-hakua).

--- a/web/app/perusopetus-v2/PerusopetuksenSuorituksenTiedot.tsx
+++ b/web/app/perusopetus-v2/PerusopetuksenSuorituksenTiedot.tsx
@@ -93,8 +93,7 @@ export const PerusopetuksenSuorituksenTiedot: React.FC<
         >
           {[
             <TestIdText key="tunniste" id="koulutus">
-              {t(suoritus.koulutusmoduuli.tunniste.nimi)}{' '}
-              {suoritus.koulutusmoduuli.tunniste.koodiarvo}
+              {t(suoritus.koulutusmoduuli.tunniste.nimi)}
             </TestIdText>,
             isNuortenPerusopetuksenOppimääränSuoritus(suoritus) ? (
               <FormField

--- a/web/test/e2e/ahvenanmaan-perusopetus.spec.ts
+++ b/web/test/e2e/ahvenanmaan-perusopetus.spec.ts
@@ -62,7 +62,7 @@ test.describe('Ahvenanmaan perusopetuksen käyttöliittymä', () => {
     // Oletustabi on 9. vuosiluokka. Sen oppiaineita ei näytetä, koska oppilas ei
     // jää luokalle: päättövuoden arvosanat ovat päättötodistuksella (kuten
     // manner-Suomessa).
-    await expect(page.getByTestId('oo.0.suoritukset.1.koulutus')).toContainText(
+    await expect(page.getByTestId('oo.0.suoritukset.1.koulutus')).toHaveText(
       '9. vuosiluokka'
     )
     await expect(page.locator('.oppiaineet')).toHaveCount(0)
@@ -70,6 +70,9 @@ test.describe('Ahvenanmaan perusopetuksen käyttöliittymä', () => {
     // 8. luokan läsårsbetyg sen sijaan sisältää oppiaineet arvosanoineen
     // (Ruotsi = 9).
     await page.getByTestId(vuosiluokkaTab).click()
+    await expect(page.getByTestId('oo.0.suoritukset.2.koulutus')).toHaveText(
+      '8. vuosiluokka'
+    )
     await expect(page.locator('.oppiaineet')).toBeVisible()
     await expect(
       page.locator('.perusopetuksen-arvosteluasteikko')

--- a/web/test/e2e/perusopetus-v2.spec.ts
+++ b/web/test/e2e/perusopetus-v2.spec.ts
@@ -166,8 +166,8 @@ test.describe('Perusopetuksen uusi käyttöliittymä', () => {
     await page.getByTestId('oo.0.suoritusTabs.2.tab').click()
 
     // Suorituksen tiedot
-    await expect(page.getByTestId('oo.0.suoritukset.2.koulutus')).toContainText(
-      '8. vuosiluokka 8'
+    await expect(page.getByTestId('oo.0.suoritukset.2.koulutus')).toHaveText(
+      '8. vuosiluokka'
     )
     await expect(
       page.getByTestId('oo.0.suoritukset.2.luokka.value')
@@ -222,8 +222,8 @@ test.describe('Perusopetuksen uusi käyttöliittymä', () => {
     // 9. vuosiluokka on toinen tabi (oppimäärä, 9, 8, 7)
     await page.getByTestId('oo.0.suoritusTabs.1.tab').click()
 
-    await expect(page.getByTestId('oo.0.suoritukset.1.koulutus')).toContainText(
-      '9. vuosiluokka 9'
+    await expect(page.getByTestId('oo.0.suoritukset.1.koulutus')).toHaveText(
+      '9. vuosiluokka'
     )
     await expect(
       page.getByTestId('oo.0.suoritukset.1.luokka.value')
@@ -245,8 +245,8 @@ test.describe('Perusopetuksen uusi käyttöliittymä', () => {
     // 7. vuosiluokka on viimeinen tabi (oppimäärä, 9, 8, 7)
     await page.getByTestId('oo.0.suoritusTabs.3.tab').click()
 
-    await expect(page.getByTestId('oo.0.suoritukset.3.koulutus')).toContainText(
-      '7. vuosiluokka 7'
+    await expect(page.getByTestId('oo.0.suoritukset.3.koulutus')).toHaveText(
+      '7. vuosiluokka'
     )
     await expect(
       page.getByTestId('oo.0.suoritukset.3.luokka.value')


### PR DESCRIPTION
…iittymistä

Vuosiluokan nimi sisältää jo koodiarvon, joten erillinen koodiarvo teki tekstistä esimerkiksi muotoa "Årskurs 8 8". Näytetään manner-Suomen ja Ahvenanmaan uusissa perusopetuksen käyttöliittymissä vain lokalisoitu vuosiluokan nimi.

Tarkennetaan Playwright-testit tarkistamaan kentän koko teksti, jotta koodiarvon palautuminen näkymään havaitaan.