### PR TITLE
TOR-2587: Säilytä koulutuskoodi päättötodistuksen tiedoissa

### DIFF
--- a/web/app/ahvenanmaan-perusopetus/AhvenanmaanPerusopetuksenSuorituksenTiedot.tsx
+++ b/web/app/ahvenanmaan-perusopetus/AhvenanmaanPerusopetuksenSuorituksenTiedot.tsx
@@ -50,6 +50,7 @@ export const AhvenanmaanPerusopetuksenSuorituksenTiedot: React.FC<
 > = ({ form, päätasonSuoritus }) => {
   const path = päätasonSuoritus.path
   const suoritus = päätasonSuoritus.suoritus
+  const isVuosiluokka = isAhvenanmaanPerusopetuksenVuosiluokanSuoritus(suoritus)
   const luokalleSiirtymisenTeksti = getLuokalleSiirtymisenTeksti(suoritus)
 
   return (
@@ -57,28 +58,42 @@ export const AhvenanmaanPerusopetuksenSuorituksenTiedot: React.FC<
       {/* labelWidth pitää pisimmätkin nimet yhdellä rivillä ja tasaa arvot
           samaan sarakkeeseen vanhan käyttöliittymän tapaan. */}
       <KeyValueTable labelWidth={6}>
-        <KeyColumnedValuesRow
-          localizableName={
-            isAhvenanmaanPerusopetuksenVuosiluokanSuoritus(suoritus)
-              ? 'Luokka-aste'
-              : 'Koulutus'
-          }
-          columnSpans={{ default: [3, '*'], phone: [24, '*'] }}
-        >
-          {[
-            <TestIdText key="tunniste" id="koulutus">
-              {t(suoritus.koulutusmoduuli.tunniste.nimi)}
-              {!isAhvenanmaanPerusopetuksenVuosiluokanSuoritus(suoritus) &&
-                ` ${suoritus.koulutusmoduuli.tunniste.koodiarvo}`}
-            </TestIdText>,
-            // Ahvenanmaan ops (ÅLp21) ei ole ePerusteissa, joten diaarinumero
-            // linkitetään suoraan laroplan.ax-sivustolle (ei ePerusteet-hakua).
-            <PerusteLinkki
-              key="peruste"
-              diaarinumero={suoritus.koulutusmoduuli.perusteenDiaarinumero}
-            />
-          ]}
-        </KeyColumnedValuesRow>
+        {isVuosiluokka ? (
+          <KeyColumnedValuesRow
+            localizableName="Luokka-aste"
+            columnSpans={{ default: [3, '*'], phone: [24, 24] }}
+          >
+            {[
+              <TestIdText key="tunniste" id="koulutus">
+                {t(suoritus.koulutusmoduuli.tunniste.nimi)}
+              </TestIdText>,
+              <PerusteLinkki
+                key="peruste"
+                diaarinumero={suoritus.koulutusmoduuli.perusteenDiaarinumero}
+              />
+            ]}
+          </KeyColumnedValuesRow>
+        ) : (
+          <KeyColumnedValuesRow
+            localizableName="Koulutus"
+            columnSpans={{ default: [4, 2, '*'], phone: [24, 24, 24] }}
+          >
+            {[
+              <TestIdText key="tunniste" id="koulutus">
+                {t(suoritus.koulutusmoduuli.tunniste.nimi)}
+              </TestIdText>,
+              <TestIdText key="koodiarvo" id="koulutuskoodi">
+                {suoritus.koulutusmoduuli.tunniste.koodiarvo}
+              </TestIdText>,
+              // Ahvenanmaan ops (ÅLp21) ei ole ePerusteissa, joten diaarinumero
+              // linkitetään suoraan laroplan.ax-sivustolle (ei ePerusteet-hakua).
+              <PerusteLinkki
+                key="peruste"
+                diaarinumero={suoritus.koulutusmoduuli.perusteenDiaarinumero}
+              />
+            ]}
+          </KeyColumnedValuesRow>
+        )}
 
         {isAhvenanmaanPerusopetuksenVuosiluokanSuoritus(suoritus) && (
           <VuosiluokanLuokkaRow form={form} path={path} />

--- a/web/app/ahvenanmaan-perusopetus/AhvenanmaanPerusopetuksenSuorituksenTiedot.tsx
+++ b/web/app/ahvenanmaan-perusopetus/AhvenanmaanPerusopetuksenSuorituksenTiedot.tsx
@@ -68,6 +68,8 @@ export const AhvenanmaanPerusopetuksenSuorituksenTiedot: React.FC<
           {[
             <TestIdText key="tunniste" id="koulutus">
               {t(suoritus.koulutusmoduuli.tunniste.nimi)}
+              {!isAhvenanmaanPerusopetuksenVuosiluokanSuoritus(suoritus) &&
+                ` ${suoritus.koulutusmoduuli.tunniste.koodiarvo}`}
             </TestIdText>,
             // Ahvenanmaan ops (ÅLp21) ei ole ePerusteissa, joten diaarinumero
             // linkitetään suoraan laroplan.ax-sivustolle (ei ePerusteet-hakua).

--- a/web/app/perusopetus-v2/PerusopetuksenSuorituksenTiedot.tsx
+++ b/web/app/perusopetus-v2/PerusopetuksenSuorituksenTiedot.tsx
@@ -76,6 +76,7 @@ export const PerusopetuksenSuorituksenTiedot: React.FC<
 > = ({ form, päätasonSuoritus }) => {
   const path = päätasonSuoritus.path
   const suoritus = päätasonSuoritus.suoritus
+  const isVuosiluokka = isPerusopetuksenVuosiluokanSuoritus(suoritus)
   const luokalleSiirtymisenTeksti = getLuokalleSiirtymisenTeksti(suoritus)
 
   return (
@@ -83,37 +84,15 @@ export const PerusopetuksenSuorituksenTiedot: React.FC<
       {/* labelWidth pitää pisimmätkin nimet yhdellä rivillä ja tasaa arvot
           samaan sarakkeeseen vanhan käyttöliittymän tapaan. */}
       <KeyValueTable labelWidth={6}>
-        <KeyColumnedValuesRow
-          localizableName={
-            isPerusopetuksenVuosiluokanSuoritus(suoritus)
-              ? 'Luokka-aste'
-              : 'Koulutus'
-          }
-          columnSpans={{ default: [3, '*'], phone: [24, '*'] }}
-        >
-          {[
-            <TestIdText key="tunniste" id="koulutus">
-              {t(suoritus.koulutusmoduuli.tunniste.nimi)}
-              {!isPerusopetuksenVuosiluokanSuoritus(suoritus) &&
-                ` ${suoritus.koulutusmoduuli.tunniste.koodiarvo}`}
-            </TestIdText>,
-            isNuortenPerusopetuksenOppimääränSuoritus(suoritus) ? (
-              <FormField
-                key="peruste"
-                form={form}
-                path={(
-                  path as unknown as FormOptic<
-                    PerusopetuksenOpiskeluoikeus,
-                    NuortenPerusopetuksenOppimääränSuoritus
-                  >
-                )
-                  .prop('koulutusmoduuli')
-                  .prop('perusteenDiaarinumero')}
-                view={PerusteView}
-                edit={PerusteEdit}
-                editProps={{ suorituksenTyyppi: suoritus.tyyppi.koodiarvo }}
-              />
-            ) : isPerusopetuksenVuosiluokanSuoritus(suoritus) ? (
+        {isVuosiluokka ? (
+          <KeyColumnedValuesRow
+            localizableName="Luokka-aste"
+            columnSpans={{ default: [3, '*'], phone: [24, 24] }}
+          >
+            {[
+              <TestIdText key="tunniste" id="koulutus">
+                {t(suoritus.koulutusmoduuli.tunniste.nimi)}
+              </TestIdText>,
               <FormField
                 key="peruste"
                 form={form}
@@ -129,11 +108,42 @@ export const PerusopetuksenSuorituksenTiedot: React.FC<
                 edit={PerusteEdit}
                 editProps={{ suorituksenTyyppi: suoritus.tyyppi.koodiarvo }}
               />
-            ) : (
-              <React.Fragment key="peruste" />
-            )
-          ]}
-        </KeyColumnedValuesRow>
+            ]}
+          </KeyColumnedValuesRow>
+        ) : (
+          <KeyColumnedValuesRow
+            localizableName="Koulutus"
+            columnSpans={{ default: [4, 2, '*'], phone: [24, 24, 24] }}
+          >
+            {[
+              <TestIdText key="tunniste" id="koulutus">
+                {t(suoritus.koulutusmoduuli.tunniste.nimi)}
+              </TestIdText>,
+              <TestIdText key="koodiarvo" id="koulutuskoodi">
+                {suoritus.koulutusmoduuli.tunniste.koodiarvo}
+              </TestIdText>,
+              isNuortenPerusopetuksenOppimääränSuoritus(suoritus) ? (
+                <FormField
+                  key="peruste"
+                  form={form}
+                  path={(
+                    path as unknown as FormOptic<
+                      PerusopetuksenOpiskeluoikeus,
+                      NuortenPerusopetuksenOppimääränSuoritus
+                    >
+                  )
+                    .prop('koulutusmoduuli')
+                    .prop('perusteenDiaarinumero')}
+                  view={PerusteView}
+                  edit={PerusteEdit}
+                  editProps={{ suorituksenTyyppi: suoritus.tyyppi.koodiarvo }}
+                />
+              ) : (
+                <React.Fragment key="peruste" />
+              )
+            ]}
+          </KeyColumnedValuesRow>
+        )}
 
         {isPerusopetuksenVuosiluokanSuoritus(suoritus) && (
           <VuosiluokanLuokkaRow form={form} path={path} />

--- a/web/app/perusopetus-v2/PerusopetuksenSuorituksenTiedot.tsx
+++ b/web/app/perusopetus-v2/PerusopetuksenSuorituksenTiedot.tsx
@@ -94,6 +94,8 @@ export const PerusopetuksenSuorituksenTiedot: React.FC<
           {[
             <TestIdText key="tunniste" id="koulutus">
               {t(suoritus.koulutusmoduuli.tunniste.nimi)}
+              {!isPerusopetuksenVuosiluokanSuoritus(suoritus) &&
+                ` ${suoritus.koulutusmoduuli.tunniste.koodiarvo}`}
             </TestIdText>,
             isNuortenPerusopetuksenOppimääränSuoritus(suoritus) ? (
               <FormField

--- a/web/test/e2e/ahvenanmaan-perusopetus.spec.ts
+++ b/web/test/e2e/ahvenanmaan-perusopetus.spec.ts
@@ -83,6 +83,9 @@ test.describe('Ahvenanmaan perusopetuksen käyttöliittymä', () => {
 
     // Avgångsbetyg (oppimäärä) sisältää lopulliset arvosanat.
     await page.getByTestId(avgångsbetygTab).click()
+    await expect(page.getByTestId('oo.0.suoritukset.0.koulutus')).toHaveText(
+      'Perusopetus 201101'
+    )
     await expect(
       page.getByTestId('oo.0.suoritukset.0.suoritustapa.value')
     ).toContainText('Koulutus')

--- a/web/test/e2e/ahvenanmaan-perusopetus.spec.ts
+++ b/web/test/e2e/ahvenanmaan-perusopetus.spec.ts
@@ -84,8 +84,11 @@ test.describe('Ahvenanmaan perusopetuksen käyttöliittymä', () => {
     // Avgångsbetyg (oppimäärä) sisältää lopulliset arvosanat.
     await page.getByTestId(avgångsbetygTab).click()
     await expect(page.getByTestId('oo.0.suoritukset.0.koulutus')).toHaveText(
-      'Perusopetus 201101'
+      'Perusopetus'
     )
+    await expect(
+      page.getByTestId('oo.0.suoritukset.0.koulutuskoodi')
+    ).toHaveText('201101')
     await expect(
       page.getByTestId('oo.0.suoritukset.0.suoritustapa.value')
     ).toContainText('Koulutus')

--- a/web/test/e2e/perusopetus-v2.spec.ts
+++ b/web/test/e2e/perusopetus-v2.spec.ts
@@ -36,8 +36,11 @@ test.describe('Perusopetuksen uusi käyttöliittymä', () => {
 
     // Suorituksen tiedot
     await expect(page.getByTestId('oo.0.suoritukset.0.koulutus')).toHaveText(
-      'Perusopetus 201101'
+      'Perusopetus'
     )
+    await expect(
+      page.getByTestId('oo.0.suoritukset.0.koulutuskoodi')
+    ).toHaveText('201101')
     await expect(
       page.getByTestId('oo.0.suoritukset.0.suoritustapa.value')
     ).toContainText('Koulutus')
@@ -286,8 +289,11 @@ test.describe('Perusopetuksen uusi käyttöliittymä', () => {
 
     // Suorituksen tiedot
     await expect(page.getByTestId('oo.0.suoritukset.0.koulutus')).toHaveText(
-      'Perusopetus 201101'
+      'Perusopetus'
     )
+    await expect(
+      page.getByTestId('oo.0.suoritukset.0.koulutuskoodi')
+    ).toHaveText('201101')
     await expect(
       page.getByTestId('oo.0.suoritukset.0.suoritustapa.value')
     ).toContainText('Erityinen tutkinto')

--- a/web/test/e2e/perusopetus-v2.spec.ts
+++ b/web/test/e2e/perusopetus-v2.spec.ts
@@ -35,8 +35,8 @@ test.describe('Perusopetuksen uusi käyttöliittymä', () => {
     ).toContainText('15.8.2008 — 4.6.2016')
 
     // Suorituksen tiedot
-    await expect(page.getByTestId('oo.0.suoritukset.0.koulutus')).toContainText(
-      'Perusopetus'
+    await expect(page.getByTestId('oo.0.suoritukset.0.koulutus')).toHaveText(
+      'Perusopetus 201101'
     )
     await expect(
       page.getByTestId('oo.0.suoritukset.0.suoritustapa.value')
@@ -285,8 +285,8 @@ test.describe('Perusopetuksen uusi käyttöliittymä', () => {
     ).toContainText('15.8.2017 — 18.10.2024')
 
     // Suorituksen tiedot
-    await expect(page.getByTestId('oo.0.suoritukset.0.koulutus')).toContainText(
-      'Perusopetus'
+    await expect(page.getByTestId('oo.0.suoritukset.0.koulutus')).toHaveText(
+      'Perusopetus 201101'
     )
     await expect(
       page.getByTestId('oo.0.suoritukset.0.suoritustapa.value')


### PR DESCRIPTION
Koodiarvon poistaminen rajataan vuosiluokan suorituksiin, joiden lokalisoitu nimi sisältää jo luokka-asteen. Päättötodistuksen Koulutus-kentässä näytetään edelleen nimi ja erillinen koulutuskoodi, esimerkiksi "Perusopetus 201101".

Tarkennetaan Playwright-testit varmistamaan sekä vuosiluokan koodiarvon puuttuminen että päättötodistuksen koulutuskoodin säilyminen.