### PR TITLE
TOR-2587: Karsi Ahvenanmaan vuosiluokka opiskelijalistan Koulutus-val…

### DIFF
--- a/src/main/scala/fi/oph/koski/documentation/KoodistoServlet.scala
+++ b/src/main/scala/fi/oph/koski/documentation/KoodistoServlet.scala
@@ -4,6 +4,7 @@ import fi.oph.koski.config.KoskiApplication
 import fi.oph.koski.http.KoskiErrorCategory
 import fi.oph.koski.koodisto.{Koodisto, KoodistoKoodi, KoodistoPalvelu, KoodistoViite}
 import fi.oph.koski.koskiuser.Unauthenticated
+import fi.oph.koski.perustiedot.OpiskeluoikeudenPerustiedot
 import fi.oph.koski.schema.Opiskeluoikeus
 import fi.oph.koski.servlet.{KoskiSpecificApiServlet, KoskiSpecificBaseServlet, NoCache}
 
@@ -24,7 +25,8 @@ class KoodistoServlet(implicit val application: KoskiApplication) extends KoskiS
     val opiskeluoikeudenTyyppi = params.get("opiskeluoikeudentyyppi").map(tyyppi => opiskeluoikeudet.filter(oo => oo.tyyppi.koodiarvo == tyyppi)).getOrElse(opiskeluoikeudet)
     koodistoPalvelu.getKoodistoKoodit(koodistoPalvelu.getLatestVersionRequired("suorituksentyyppi"))
       .filter(koodi => koodiarvot(opiskeluoikeudenTyyppi).contains(koodi.koodiArvo))
-      .filterNot(_.koodiArvo == "perusopetuksenvuosiluokka")
+      // Näillä tyypeillä hakeminen palauttaisi aina tyhjän tuloksen, ks. OpiskeluoikeudenPerustiedot.
+      .filterNot(koodi => OpiskeluoikeudenPerustiedot.opiskelijalistaltaPiilotetutSuoritusTyypit.contains(koodi.koodiArvo))
   }
 
   def koodistoPalvelu: KoodistoPalvelu = application.koodistoPalvelu

--- a/src/main/scala/fi/oph/koski/perustiedot/OpiskeluoikeudenPerustiedot.scala
+++ b/src/main/scala/fi/oph/koski/perustiedot/OpiskeluoikeudenPerustiedot.scala
@@ -74,7 +74,11 @@ object OpiskeluoikeudenPerustiedot {
   // näkyy pelkkä oppimäärän suoritus. Suodatus on rajattu perusopetuksen tyyppeihin: European
   // School of Helsingin ja International Schoolin skeemat eivät salli päätason suorituksiksi
   // muuta kuin vuosiluokkia, joten niiden suodattaminen tyhjentäisi sarakkeen kokonaan.
-  private val opiskelijalistaltaPiilotetutSuoritusTyypit = Set(
+  //
+  // Koska näitä tyyppejä ei indeksoida, niillä ei voi myöskään hakea: KoodistoServlet karsii saman
+  // joukon opiskelijalistan Koulutus-sarakkeen suodatinvalikosta, jottei valikossa ole vaihtoehtoja
+  // joilla hakutulos on aina tyhjä. Tästä syystä tämä on julkinen.
+  val opiskelijalistaltaPiilotetutSuoritusTyypit = Set(
     "perusopetuksenvuosiluokka",
     "ahvenanmaanperusopetuksenvuosiluokka"
   )


### PR DESCRIPTION
…ikosta

Opiskelijalistan Koulutus-sarakkeen suodatinvalikko tarjosi vaihtoehtoa "Ahvenanmaan perusopetuksen vuosiluokka", vaikka näitä suorituksia ei commitin b602542 jälkeen enää indeksoida perustietoihin. Valinnalla hakutulos oli siis aina tyhjä.

Manner-Suomen vastaava vaihtoehto on karsittu valikosta jo vuodesta 2016 (6fa8ddd), mutta karsinta oli kirjoitettu KoodistoServletiin omaksi kovakoodatuksi koodiarvovertailuksi. Se ei siksi päivittynyt, kun perustietojen suodatus laajeni Ahvenanmaan vuosiluokkiin.

Suodatettavat tyypit ovat nyt yhdessä paikassa,
OpiskeluoikeudenPerustiedot.opiskelijalistaltaPiilotetutSuoritusTyypit, jota KoodistoServlet käyttää. Kun listaan lisätään jatkossa uusi tyyppi, myös valikko pysyy ajan tasalla.

Huom. valikon vaihtoehdot johdetaan edelleen Examples.oppijaExamples- esimerkkidatasta, joten valikossa näkyy vain niitä suoritustyyppejä, joille on olemassa dokumentaatioesimerkki.