### PR TITLE
TOR-2433: Väljennä opiskeluoikeuden tilan nimisarake

### DIFF
--- a/web/app/components-v2/opiskeluoikeus/OpiskeluoikeudenTila.less
+++ b/web/app/components-v2/opiskeluoikeus/OpiskeluoikeudenTila.less
@@ -1,3 +1,12 @@
+// Vanhassa kälissä nimisarake oli vähintään 100px leveä, joten "Tila"-nimen ja
+// arvosarakkeen alussa olevan nuolen väliin jäi ilmaa. Uudessa kälissä
+// nimisarake mitoittuu sisällön mukaan (max-content), jolloin lyhyt nimi jättää
+// nuolen kiinni tekstiin. Ruudukon sarakeväli tulee nimisarakkeen leveyden
+// päälle, joten se vähennetään minimileveydestä.
+.OpiskeluoikeudenTila > .KeyValueRow > .KeyValueRow__name {
+  min-width: 100px - @Columns-gutter;
+}
+
 .OpiskeluoikeudenTila-viimeisin {
   .KeyValueRow__value {
     font-weight: 600;

--- a/web/app/components-v2/opiskeluoikeus/OpiskeluoikeudenTila.tsx
+++ b/web/app/components-v2/opiskeluoikeus/OpiskeluoikeudenTila.tsx
@@ -64,7 +64,7 @@ export const OpiskeluoikeudenTilaView = <T extends OpiskeluoikeudenTila>(
 
   return (
     <TestIdLayer id="tila.value">
-      <KeyValueTable>
+      <KeyValueTable className="OpiskeluoikeudenTila">
         <TestIdLayer id="items">
           {sortedJaksot.map((jakso, index) => (
             <TestIdLayer key={index} id={index}>
@@ -130,7 +130,7 @@ export const OpiskeluoikeudenTilaEdit = <T extends OpiskeluoikeudenTila>(
 
   return (
     <TestIdLayer id="tila.edit">
-      <KeyValueTable>
+      <KeyValueTable className="OpiskeluoikeudenTila">
         <TestIdLayer id="items">
           {oo.jaksot.map(
             ({ jakso, index, min, max, isLatest, isCurrent }, arrIndex) => (


### PR DESCRIPTION
Nimisarakkeen mitoitus muuttui commitissa 471d35db7a kiinteästä 4/24 ruudukkosarakkeesta max-content-leveyteen. Lyhyellä "Tila"-nimellä sarake kutistui ~41 pikseliin, jolloin viimeisintä jaksoa merkitsevä nuoli tuli kiinni nimeen. Vanhassa kälissä td.label oli vähintään 100px leveä.

Palautetaan vastaava minimileveys opiskeluoikeuden tilan taulukkoon. Ruudukon sarakeväli (12px) tulee nimisarakkeen leveyden päälle, joten se vähennetään minimileveydestä, jolloin arvosarake alkaa samasta kohtaa kuin vanhassa kälissä.

Mitattuna ajossa olevasta sovelluksesta (perusopetus-v2 ja ammatillinen-v2, sekä katselu- että muokkaustila): nimen ja nuolen väli 10px -> 57px, vanhassa kälissä 62px.

Korjaus on opiskeluoikeuden tilan taulukossa, joten se näkyy kaikissa uusissa käyttöliittymissä. Muiden avain-arvotaulukoiden nimisarake mitoittuu edelleen sisällön mukaan.