### PR TITLE
Korjaa flaky MyData-kielenvaihtotesti

### DIFF
--- a/web/test/page/myDataPage.js
+++ b/web/test/page/myDataPage.js
@@ -40,6 +40,9 @@ function MyDataPage() {
     getMemberName: function () {
       return extractAsText(S('.acceptance-member-name'))
     },
+    isMemberNameVisible: function () {
+      return isElementVisible(S('.acceptance-member-name'))
+    },
     getMemberPurpose: function () {
       return extractAsText(S('.acceptance-member-purpose'))
     },

--- a/web/test/spec/myDataSpec.js
+++ b/web/test/spec/myDataSpec.js
@@ -142,7 +142,13 @@ describe('MyData', function () {
   describe('Käyttäjä voi vaihtaa kielen ruotsiksi', function () {
     // eslint-disable-next-line prefer-spread
     before.apply(null, login('fi', '100869-192W', 'Dippainssi', 'Dilbert'))
-    before(mydata.clickChangeLangSwedish, wait.until(mydata.isInSwedish))
+    // Kielen vaihto lataa sivun uudelleen: otsikko ja kielivalinnat renderöityvät heti,
+    // mutta kumppanin nimi vasta kun /koski/api/omadata/kumppani-kutsu on valmis.
+    before(
+      mydata.clickChangeLangSwedish,
+      wait.until(mydata.isInSwedish),
+      wait.until(mydata.isMemberNameVisible)
+    )
 
     it('Otsikko näytetään ruotsiksi', function () {
       expect(extractAsText(S('.title > h1'))).equal('Min Studieinfo')
@@ -156,7 +162,11 @@ describe('MyData', function () {
   describe('Käyttäjä voi vaihtaa kielen englanniksi', function () {
     // eslint-disable-next-line prefer-spread
     before.apply(null, login('fi', '100869-192W', 'Dippainssi', 'Dilbert'))
-    before(mydata.clickChangeLangEnglish, wait.until(mydata.isInEnglish))
+    before(
+      mydata.clickChangeLangEnglish,
+      wait.until(mydata.isInEnglish),
+      wait.until(mydata.isMemberNameVisible)
+    )
 
     it('Otsikko näytetään englanniksi', function () {
       expect(extractAsText(S('.title > h1'))).equal('My Studyinfo')


### PR DESCRIPTION
Kielen vaihto lataa sivun uudelleen (setLang -> window.location.reload). HyvaksyntaLanding renderöi headerin (otsikko ja kielivalinnat) heti ensimmäisessä renderissä, mutta kumppanin nimen vasta kun /koski/api/omadata/kumppani-kutsu on palannut; siihen asti näytössä on spinneri.

Testit odottivat kielenvaihdon jälkeen vain headerin kielivalintanappeja (isInSwedish / isInEnglish), joten getMemberName saattoi osua vielä spinneriin. Tyhjällä valitsimella extractAsText kaatui:

  TypeError: Cannot read properties of undefined (reading 'tagName')
      at extractAsText (test/util/testHelpers.js)
      at Object.getMemberName (test/page/myDataPage.js)

Odotetaan nyt kielivalintojen lisäksi myös kumppanin nimen näkymistä. Odotus on kielitarkistuksen jälkeen, jottei osuta vanhan sivun DOMiin ennen uudelleenlatausta. Sama kuvio on jo käytössä omatTiedotSpec:n suoritusjaon kielenvaihdossa. Sivuhyötynä rikkinäinen kumppani-API näkyy nyt selkeänä wait.until-timeoutina eikä TypeErrorina.