### PR TITLE
TOR-2683: Päivitä brace-expansion korjattuihin versioihin

### DIFF
--- a/omadata-oauth2-sample/server/package.json
+++ b/omadata-oauth2-sample/server/package.json
@@ -59,8 +59,8 @@
   },
   "pnpm": {
     "overrides": {
-      "brace-expansion@^1": "1.1.15",
-      "brace-expansion@^2": "5.0.9"
+      "brace-expansion@^1": "1.1.18",
+      "brace-expansion@^5": "5.0.9"
     }
   },
   "packageManager": "pnpm@10.34.4"

--- a/omadata-oauth2-sample/server/pnpm-lock.yaml
+++ b/omadata-oauth2-sample/server/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@^1: 1.1.15
-  brace-expansion@^2: 5.0.9
+  brace-expansion@^1: 1.1.18
+  brace-expansion@^5: 5.0.9
 
 importers:
 
@@ -575,12 +575,12 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1809,12 +1809,12 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2220,11 +2220,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.18
 
   ms@2.1.3: {}
 

--- a/renovate.json
+++ b/renovate.json
@@ -15,8 +15,7 @@
   "platformAutomerge": false,
   "rangeStrategy": "replace",
   "ignoreDeps": [
-    "com.github.Opetushallitus.java-utils:oid-generator",
-    "brace-expansion"
+    "com.github.Opetushallitus.java-utils:oid-generator"
   ],
   "packageRules": [
     {

--- a/valpas-web/package.json
+++ b/valpas-web/package.json
@@ -103,8 +103,8 @@
   },
   "pnpm": {
     "overrides": {
-      "brace-expansion@^1": "1.1.15",
-      "brace-expansion@^2": "5.0.9",
+      "brace-expansion@^1": "1.1.18",
+      "brace-expansion@^5": "5.0.9",
       "js-yaml@^3": "4.3.0",
       "js-yaml@^4": "4.3.0",
       "@eslint/plugin-kit": "^0.7.0",

--- a/valpas-web/pnpm-lock.yaml
+++ b/valpas-web/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@^1: 1.1.15
-  brace-expansion@^2: 5.0.9
+  brace-expansion@^1: 1.1.18
+  brace-expansion@^5: 5.0.9
   js-yaml@^3: 4.3.0
   js-yaml@^4: 4.3.0
   '@eslint/plugin-kit': ^0.7.0
@@ -1432,12 +1432,12 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5293,12 +5293,12 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6749,11 +6749,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 

--- a/web/package.json
+++ b/web/package.json
@@ -123,7 +123,10 @@
       "glob": "^10.5.0",
       "js-yaml": "4.3.0",
       "flatted": "^3.4.2",
-      "serialize-javascript": "^7.0.3"
+      "serialize-javascript": "^7.0.3",
+      "brace-expansion@^1": "1.1.18",
+      "brace-expansion@^2": "2.1.4",
+      "brace-expansion@^5": "5.0.9"
     }
   },
   "packageManager": "pnpm@10.34.4"

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -9,6 +9,9 @@ overrides:
   js-yaml: 4.3.0
   flatted: ^3.4.2
   serialize-javascript: ^7.0.3
+  brace-expansion@^1: 1.1.18
+  brace-expansion@^2: 2.1.4
+  brace-expansion@^5: 5.0.9
 
 importers:
 
@@ -1835,15 +1838,15 @@ packages:
   blacklist@1.1.4:
     resolution: {integrity: sha512-DWdfwimA1WQxVC69Vs1Fy525NbYwisMSCdYQmW9zyzOByz9OB/tQwrKZ3T3pbTkuFjnkJFlJuyiDjPiXL5kzew==}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -6313,16 +6316,16 @@ snapshots:
 
   blacklist@1.1.4: {}
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.1:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7760,19 +7763,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.18
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.4
 
   minimist-options@4.1.0:
     dependencies:


### PR DESCRIPTION
Kaikki riippuvuuspuun brace-expansion-kopiot olivat haavoittuvia (CVE-2026-13149, CVE-2026-14257, CVE-2026-69152 — kaikki DoS). Jokainen major-linja kiinnitetään nyt oman linjansa korjattuun versioon: 1.1.18, 2.1.4 ja 5.0.9.

web/: lisätty pnpm-overrides-lohko, jota ei aiemmin ollut lainkaan. Riippuvuudet tulevat minimatch@3:n (eslint 9), minimatch@5:n (mocha), minimatch@9:n (glob@10) ja minimatch@10:n (typescript-estree) kautta.

valpas-web/ ja omadata-oauth2-sample/server/: ^1 päivitetty 1.1.15 ->
1.1.18 ja lisätty ^5-valitsin. Kuollut ^2-valitsin poistettu, koska kummassakaan puussa ei ole yhtään ^2-riippuvuutta.

Kaikkia ei voi yhtenäistää v5:een: brace-expansion vaihtoi major-versiossa 2+ CommonJS-viennin muodosta `module.exports = expand` nimettyyn vientiin `exports.expand`, joten v5:n pakottaminen ^1- tai ^2-paikkaan kaataa minimatch@3/5/9:n virheeseen "expand is not a function".

renovate.json: poistettu ignoreDeps-merkintä "brace-expansion", joka ei osunut mihinkään. pnpm-overrides-riippuvuuden depName on "brace-expansion@^1" valitsimineen, ja ignoreDeps vaatii tarkan osuman depNameen. Tavalliset major-päivitykset estää jo olemassa oleva matchUpdateTypes-sääntö.

Korvaa PR #4297:n ("Update dependency brace-expansion@^1 to v5 [SECURITY]"), joka ehdotti versiota 5.0.7: se rikkoisi eslintin eikä korjaisi kahta kolmesta haavoittuvuudesta.