### PR TITLE
Näytä tunnisteen koodiarvo katselutilassa ilman verkkokutsua

### DIFF
--- a/web/app/suoritus/TunnisteenKoodiarvoEditor.jsx
+++ b/web/app/suoritus/TunnisteenKoodiarvoEditor.jsx
@@ -6,10 +6,22 @@ import Dropdown from '../components/Dropdown'
 export const TunnisteenKoodiarvoEditor = ({ model }) => {
   if (hideTunnisteenKoodiarvo(model)) return null
 
+  const tunnisteModel = modelLookup(model, 'tunniste')
+
+  // Katselutilassa koodiarvo luetaan suoraan mallista, joten sitä ei pidä
+  // viivyttää perusteen koulutuksien hakemisella: niitä tarvitaan vain
+  // muokkaustilan dropdownissa ja koodiarvon automaattisessa päivityksessä.
+  if (!model.context.edit) {
+    return (
+      <span>
+        <Koodiarvo model={tunnisteModel} />
+      </span>
+    )
+  }
+
   const koulutuksetDiaarinumerolleP = fetchKoulutuksetDiaarille(
     modelData(model, 'perusteenDiaarinumero')
   ).map((obs) => obs.map((k) => k.data))
-  const tunnisteModel = modelLookup(model, 'tunniste')
   const updateTunniste = (koulutus) =>
     pushModelValue(tunnisteModel, { data: koulutus })
   const automaticUpdatePossible = (koulutukset) =>

--- a/web/test/spec/muuAmmatillinenSpec.js
+++ b/web/test/spec/muuAmmatillinenSpec.js
@@ -10,7 +10,8 @@ describe('Muu ammatillinen koulutus', function () {
     before(
       resetFixtures,
       page.openPage,
-      page.oppijaHaku.searchAndSelect('130320-899Y')
+      page.oppijaHaku.searchAndSelect('130320-899Y'),
+      wait.forAjax
     )
 
     describe('Kaikki tiedot näkyvissä', function () {


### PR DESCRIPTION
TunnisteenKoodiarvoEditor odotti kutsun
/koski/api/editor/koodit/koulutukset/koulutus/<diaari> vastausta ennen kuin renderöi mitään – myös silloin kun se vain näyttää koodiarvon, joka on jo valmiina mallissa. Vastausta tarvitaan ainoastaan muokkaustilassa: dropdowniin silloin kun perusteella on useita koulutuksia, sekä vanhentuneen koodiarvon automaattiseen päivittämiseen. Molemmat olivat jo ennestään edit-ehdon takana, eli katselutilassa vastaus haettiin, sitä odotettiin ja se heitettiin pois.

Katselutilassa koodiarvo luetaan nyt suoraan mallista eikä kutsua tehdä lainkaan. Muokkaustila toimii täsmälleen kuten ennenkin.

Tämä korjaa satunnaisesti pätkineen mocha-testin (muuAmmatillinenSpec, "näyttää suorituksen tiedot"): testi ehti lukea DOMin ennen vastauksen saapumista, jolloin "Täydentää tutkintoa" -riviltä puuttui koulutuskoodi
351301. Mittaus vahvisti syy-yhteyden – ennen korjausta koodiarvo ilmestyi aina vasta vastauksen jälkeen, korjauksen jälkeen kutsua ei tehdä lainkaan. Paikallisesti päätepiste vastaa 0–15 ms:ssa ja mahtuu yleensä testin kiinteän 50 ms:n odotuksen sisään, mutta CI:llä tai kylmällä ePerusteet-välimuistilla ei.

Samalla jää pois yksi verkkokutsu per koulutusmoduuli jokaisella sivulatauksella, mukaan lukien turha .../koulutus/undefined ylioppilas- ja korkeakoulututkinnoille, joilla ei ole perusteen diaarinumeroa.

Lisäksi muuAmmatillinenSpecin before-lohkoon lisättiin wait.forAjax samaan tapaan kuin koulutuksenKoodiPoistettuEPerusteistaSpecissä.