### PR TITLE
Laske raportointikannan lease-varoitus WARN-tasolle

### DIFF
--- a/src/main/scala/fi/oph/koski/raportointikanta/RaportointikantaService.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/RaportointikantaService.scala
@@ -73,7 +73,7 @@ class RaportointikantaService(application: KoskiApplication) extends Logging {
   def loadRaportointikantaAndExit(fullReload: Boolean, forceReload: Boolean, enableYtr: Boolean, incrementalLoadMaxRows: Int): Unit = {
     leaseElector.start()
     if (!waitForLease(leaseAcquireTimeout)) {
-      logger.error(s"Raportointikannan generoinnin leasea ei saatu ${leaseAcquireTimeout} sisällä, keskeytetään.")
+      logger.warn(s"Raportointikannan generoinnin leasea ei saatu ${leaseAcquireTimeout} sisällä, keskeytetään.")
       leaseElector.shutdown()
       shutdown
     } else {

--- a/src/test/scala/fi/oph/koski/migration/MigrationSpec.scala
+++ b/src/test/scala/fi/oph/koski/migration/MigrationSpec.scala
@@ -51,7 +51,7 @@ class MigrationSpec extends AnyFreeSpec with Matchers with RaportointikantaTestM
         "RaportointiDatabase.scala"                                 -> "a70f7d0384ddc0f2f7d7013a6db35aea",
         "RaportointiDatabaseCustomFunctions.scala"                  -> "956f101d1219c49ac9134b72a30caf3a",
         "RaportointiDatabaseSchema.scala"                           -> "b01cfed01583f64ab9b285b3a5e64675",
-        "RaportointikantaService.scala"                             -> "46b176ad238ce88673edc305eb58c58a",
+        "RaportointikantaService.scala"                             -> "770421a82e67640436ee2d129de3af68",
         "RaportointikantaStatusServlet.scala"                       -> "bfb4d4d668ecbff866468ae2dc5c1e0b",
         "RaportointikantaTestServlet.scala"                         -> "ad92e33c2f816ed65c0693f5dc0143b4",
         "RaportointikantaTableQueries.scala"                        -> "f2f26c217992539c1e61dcbd031fc642",


### PR DESCRIPTION
Kun generointi ei saa lease-lukkoa 5 minuutissa, se tarkoittaa että ajo on jo käynnissä toisessa instanssissa. Rinnakkaisen ajon estäminen on lukon tarkoitus, joten tilanne ei ole virhe: mitään ei jää kesken eikä data vahingoitu, vaan toinen ajo poistuu siististi.

Tuli esiin 5.8.2026, kun latauslambdan aikakatkaisu johti Lambdan uudelleenyritykseen ja sitä kautta kahteen rinnakkaiseen latausajoon. Lambdan aikakatkaisu on korjattu erikseen koski-aws-infrassa; tämä muutos poistaa turhan ERROR-tason hälytyksen siltä varalta, että rinnakkainen käynnistys tapahtuu vielä joskus.