### PR TITLE
Korjaa flaky IntervalSchedulerSpec

### DIFF
--- a/src/test/scala/fi/oph/koski/schedule/IntervalSchedulerSpec.scala
+++ b/src/test/scala/fi/oph/koski/schedule/IntervalSchedulerSpec.scala
@@ -59,9 +59,11 @@ class IntervalSchedulerSpec extends AnyFreeSpec with TestEnvironment with Matche
           shouldFireCheckIntervalMillis = 1
         )
         val start = System.currentTimeMillis
-        Wait.until(sharedResource.get == 1, timeoutMs = 1000, retryIntervalMs = 10)
+        // >= eikä ==, jottei hidas pollaus voi ohittaa arvoa kokonaan ja jäädä odottamaan turhaan.
+        // Päällekkäisyyden puuttumisen varmistavat joka tapauksessa alla olevat aikaväitteet.
+        Wait.until(sharedResource.get >= 1, timeoutMs = 3000, retryIntervalMs = 10)
         (System.currentTimeMillis() - start >= 500) should be(true)
-        Wait.until(sharedResource.get == 2, timeoutMs = 1000, retryIntervalMs = 10)
+        Wait.until(sharedResource.get >= 2, timeoutMs = 3000, retryIntervalMs = 10)
         (System.currentTimeMillis() - start >= 1000) should be(true)
         scheduler.shutdown()
       }
@@ -74,9 +76,11 @@ class IntervalSchedulerSpec extends AnyFreeSpec with TestEnvironment with Matche
           shouldFireCheckIntervalMillis = 1, concurrency = 0
         )
         val start = System.currentTimeMillis
-        Wait.until(sharedResource.get == 1, timeoutMs = 1000, retryIntervalMs = 10)
+        // >= eikä ==, jottei hidas pollaus voi ohittaa arvoa kokonaan ja jäädä odottamaan turhaan.
+        // Päällekkäisyyden puuttumisen varmistavat joka tapauksessa alla olevat aikaväitteet.
+        Wait.until(sharedResource.get >= 1, timeoutMs = 3000, retryIntervalMs = 10)
         (System.currentTimeMillis() - start >= 500) should be(true)
-        Wait.until(sharedResource.get == 2, timeoutMs = 1000, retryIntervalMs = 10)
+        Wait.until(sharedResource.get >= 2, timeoutMs = 3000, retryIntervalMs = 10)
         (System.currentTimeMillis() - start >= 1000) should be(true)
         scheduler.shutdown()
       }
@@ -99,8 +103,9 @@ class IntervalSchedulerSpec extends AnyFreeSpec with TestEnvironment with Matche
           },
           shouldFireCheckIntervalMillis = 1
         )
-        Thread.sleep(50)
-        errorCount.get should be > 0
+        // Odota ensimmäistä epäonnistunutta ajoa: lease-hankinta, DB-kyselyt ja taskin
+        // oma sleep vievät hitaalla CI-agentilla helposti yli kiinteän odotuksen.
+        Wait.until(errorCount.get > 0, timeoutMs = 5000, retryIntervalMs = 10)
         successCount.set(1)
         Wait.until(successCount.get >= 2, timeoutMs = 1000, retryIntervalMs = 10)
         scheduler.shutdown()
@@ -118,8 +123,7 @@ class IntervalSchedulerSpec extends AnyFreeSpec with TestEnvironment with Matche
           },
           shouldFireCheckIntervalMillis = 1, concurrency = 0
         )
-        Thread.sleep(50)
-        errorCount.get should be > 0
+        Wait.until(errorCount.get > 0, timeoutMs = 5000, retryIntervalMs = 10)
         successCount.set(1)
         Wait.until(successCount.get >= 2, timeoutMs = 1000, retryIntervalMs = 10)
         scheduler.shutdown()


### PR DESCRIPTION
"recovers from errors" nukkui kiinteät 50 ms ja vaati sen jälkeen, että epäonnistunut ajo on jo kirjattu. Ensimmäinen ajo vaatii kuitenkin asynkronisen lease-hankinnan (oma executor, yksi DB-kysely), scheduler-rivin SELECTin, nextFireTime-UPDATEn ja vielä taskin oman 10 ms:n sleepin ennen kuin errorCount kasvaa. Kuormitetulla CI-agentilla tämä ei mahdu 50 millisekuntiin: lokista näkyy, että ajo epäonnistui odotetusti, mutta vasta väitteen jälkeen. Kiinteän odotuksen tilalle Wait.until, jolloin deadlinea ei ole lainkaan — nopealla koneella testi etenee ~10 ms:ssä, hitaalla se odottaa tarvittavan ajan ja aito regressio kaatuu edelleen 5 sekunnissa.

Lisäksi kovennettu samaa sukua olevaa "does not run overlapping tasks" -testiä, jonka aikakatkaisua on jouduttu jo kerran nostamaan (f1216765ab): taski itse blokkaa 500 ms, joten 1000 ms:n budjetista jäi lease-hankinnalle ja ensimmäiselle ajolle vain ~500 ms. Aikakatkaisut nostettu 3000 ms:iin ja == -vertailut muutettu >= -muotoon, jottei hidas pollaus voi ohittaa arvoa kokonaan ja jäädä sen jälkeen odottamaan turhaan. Testin tiukkuus ei muutu: päällekkäisyyden puuttumisen varmistavat edelleen elapsed-väitteet, jotka kaatuisivat heti jos ajoja tehtäisiin rinnakkain.