### PR TITLE
Korjaa fronttityylien välimuistituksesta johtuva tyylitön sivu

### DIFF
--- a/web/app/AktiivisetJaPaattyneetOpinnot.tsx
+++ b/web/app/AktiivisetJaPaattyneetOpinnot.tsx
@@ -16,10 +16,12 @@ import { Trans } from './components-v2/texts/Trans'
 import { Flex } from './components-v2/containers/Flex'
 import ReactDOM from 'react-dom'
 import { fetchAktiivisetJaPäättyneetOpinnot } from './util/koskiApi'
+import { loadStyles } from './util/loadStyles'
+
 // @ts-ignore
 __webpack_nonce__ = window.nonce
 // @ts-ignore
-import(/* webpackChunkName: "styles" */ './style/main.less')
+loadStyles(() => import(/* webpackChunkName: "styles" */ './style/main.less'))
 
 const secret = R.last(document.location.pathname.split('/')) ?? ''
 const AktiivisetJaPäättyneetOpinnot = () => {

--- a/web/app/EiSuorituksia.jsx
+++ b/web/app/EiSuorituksia.jsx
@@ -3,8 +3,10 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { EiSuorituksiaInfo } from './omattiedot/EiSuorituksiaInfo'
 import { t } from './i18n/i18n'
+import { loadStyles } from './util/loadStyles'
+
 __webpack_nonce__ = window.nonce
-import(/* webpackChunkName: "styles" */ './style/main.less')
+loadStyles(() => import(/* webpackChunkName: "styles" */ './style/main.less'))
 
 ReactDOM.render(
   <div>

--- a/web/app/Kayttooikeudet.jsx
+++ b/web/app/Kayttooikeudet.jsx
@@ -4,8 +4,10 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { LuvanHallinta } from './omadata/luvanhallinta/LuvanHallinta'
 import OmatTiedotTopBar from './topbar/OmatTiedotTopBar'
+import { loadStyles } from './util/loadStyles'
+
 __webpack_nonce__ = window.nonce
-import(/* webpackChunkName: "styles" */ './style/main.less')
+loadStyles(() => import(/* webpackChunkName: "styles" */ './style/main.less'))
 
 ReactDOM.render(
   <div>

--- a/web/app/Korhopankki.jsx
+++ b/web/app/Korhopankki.jsx
@@ -5,8 +5,10 @@ import ReactDOM from 'react-dom'
 import HetuLogin from './korhopankki/HetuLogin'
 import Text from './i18n/Text'
 import { currentLocation } from './util/location'
+import { loadStyles } from './util/loadStyles'
+
 __webpack_nonce__ = window.nonce
-import(/* webpackChunkName: "styles" */ './style/main.less')
+loadStyles(() => import(/* webpackChunkName: "styles" */ './style/main.less'))
 
 const getParam = (parameter) => {
   return currentLocation().params

--- a/web/app/Lander.jsx
+++ b/web/app/Lander.jsx
@@ -5,8 +5,10 @@ import Text from './i18n/Text'
 import { t } from './i18n/i18n'
 import { patchSaavutettavuusLeima } from './saavutettavuusLeima'
 import ReactDOM from 'react-dom'
+import { loadStyles } from './util/loadStyles'
+
 __webpack_nonce__ = window.nonce
-import(/* webpackChunkName: "styles" */ './style/main.less')
+loadStyles(() => import(/* webpackChunkName: "styles" */ './style/main.less'))
 
 const LanderInfo = () => (
   <div>

--- a/web/app/OmatTiedot.jsx
+++ b/web/app/OmatTiedot.jsx
@@ -24,9 +24,10 @@ import { Header } from './omattiedot/header/Header'
 import { EiSuorituksiaInfo } from './omattiedot/EiSuorituksiaInfo'
 import { patchSaavutettavuusLeima } from './saavutettavuusLeima'
 import { OmatTiedotAppStateProvider } from './appstate/OmatTiedotAppStateProvider'
+import { loadStyles } from './util/loadStyles'
 
 __webpack_nonce__ = window.nonce
-import(/* webpackChunkName: "styles" */ './style/main.less')
+loadStyles(() => import(/* webpackChunkName: "styles" */ './style/main.less'))
 
 const omatTiedotP = (oid) => {
   const url = oid

--- a/web/app/Pulssi.jsx
+++ b/web/app/Pulssi.jsx
@@ -6,8 +6,12 @@ import ReactDOM from 'react-dom'
 import Http from './util/http'
 import Text from './i18n/Text'
 import * as R from 'ramda'
+import { loadStyles } from './util/loadStyles'
+
 __webpack_nonce__ = window.nonce
-import(/* webpackChunkName: "pulssi-styles" */ './style/pulssi.less')
+loadStyles(
+  () => import(/* webpackChunkName: "pulssi-styles" */ './style/pulssi.less')
+)
 
 class Pulssi extends React.Component {
   constructor(props) {

--- a/web/app/SuoritetutTutkinnot.tsx
+++ b/web/app/SuoritetutTutkinnot.tsx
@@ -18,10 +18,12 @@ import { isSuoritetutTutkinnotOpiskeluoikeus } from './types/fi/oph/koski/suorit
 import { isSuoritetutTutkinnotKoskeenTallennettavaOpiskeluoikeus } from './types/fi/oph/koski/suoritetuttutkinnot/SuoritetutTutkinnotKoskeenTallennettavaOpiskeluoikeus'
 import Text from './i18n/Text'
 import { SuoritetutTutkinnotOppijaJakolinkillä } from './types/fi/oph/koski/suoritusjako/SuoritetutTutkinnotOppijaJakolinkilla'
+import { loadStyles } from './util/loadStyles'
+
 // @ts-ignore
 __webpack_nonce__ = window.nonce
 // @ts-ignore
-import(/* webpackChunkName: "styles" */ './style/main.less')
+loadStyles(() => import(/* webpackChunkName: "styles" */ './style/main.less'))
 
 const secret = R.last(document.location.pathname.split('/')) ?? ''
 

--- a/web/app/Suoritusjako.jsx
+++ b/web/app/Suoritusjako.jsx
@@ -20,8 +20,10 @@ import { addContext } from './editor/EditorModel'
 import { locationP } from './util/location'
 import { ChangeLang } from './components/ChangeLang'
 import { SuoritusjakoHeader } from './components-v2/suoritusjako/SuoritusjakoHeader'
+import { loadStyles } from './util/loadStyles'
+
 __webpack_nonce__ = window.nonce
-import(/* webpackChunkName: "styles" */ './style/main.less')
+loadStyles(() => import(/* webpackChunkName: "styles" */ './style/main.less'))
 
 const secret = R.last(document.location.pathname.split('/'))
 

--- a/web/app/Virkailija.jsx
+++ b/web/app/Virkailija.jsx
@@ -17,9 +17,10 @@ import { locationP } from './util/location.js'
 import LocalizationEditBar from './i18n/LocalizationEditBar'
 import { t } from './i18n/i18n'
 import { VirkailijaAppStateProvider } from './appstate/VirkailijaAppStateProvider'
+import { loadStyles } from './util/loadStyles'
 
 __webpack_nonce__ = window.nonce
-import(/* webpackChunkName: "styles" */ './style/main.less')
+loadStyles(() => import(/* webpackChunkName: "styles" */ './style/main.less'))
 
 const noAccessControlPaths = ['/koski/dokumentaatio']
 

--- a/web/app/VirkailijaLogin.jsx
+++ b/web/app/VirkailijaLogin.jsx
@@ -10,8 +10,10 @@ import { TopBar } from './topbar/TopBar'
 import { t } from './i18n/i18n'
 import Text from './i18n/Text'
 import Input from './components/Input'
+import { loadStyles } from './util/loadStyles'
+
 __webpack_nonce__ = window.nonce
-import(/* webpackChunkName: "styles" */ './style/main.less')
+loadStyles(() => import(/* webpackChunkName: "styles" */ './style/main.less'))
 
 const Login = () => {
   const state = Atom({ username: '', password: '' })

--- a/web/app/omadata/AnnaHyvaksynta.jsx
+++ b/web/app/omadata/AnnaHyvaksynta.jsx
@@ -1,7 +1,9 @@
 import React from 'baret'
 import Text from '../i18n/Text'
 import { t } from '../i18n/i18n'
-import(/* webpackChunkName: "styles" */ '../style/main.less')
+import { loadStyles } from '../util/loadStyles'
+
+loadStyles(() => import(/* webpackChunkName: "styles" */ '../style/main.less'))
 
 export default ({ memberName, onAcceptClick, logoutURL }) => (
   <div>

--- a/web/app/omadata/HyvaksyntaAnnettu.jsx
+++ b/web/app/omadata/HyvaksyntaAnnettu.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import Text from '../i18n/Text'
-import(/* webpackChunkName: "styles" */ '../style/main.less')
+import { loadStyles } from '../util/loadStyles'
+
+loadStyles(() => import(/* webpackChunkName: "styles" */ '../style/main.less'))
 
 export default class HyvaksyntaAnnettu extends React.Component {
   constructor(props) {

--- a/web/app/omadata/OmaDataOAuth2AnnaHyvaksynta.jsx
+++ b/web/app/omadata/OmaDataOAuth2AnnaHyvaksynta.jsx
@@ -3,8 +3,9 @@ import Text from '../i18n/Text'
 import { useKoodisto } from '../appstate/koodisto'
 import { t, tExists } from '../i18n/i18n'
 import { buildLocalizedPaattymisajankohtaText } from './expirationTime'
+import { loadStyles } from '../util/loadStyles'
 
-import(/* webpackChunkName: "styles" */ '../style/main.less')
+loadStyles(() => import(/* webpackChunkName: "styles" */ '../style/main.less'))
 
 export default ({
   clientId,

--- a/web/app/util/loadStyles.ts
+++ b/web/app/util/loadStyles.ts
@@ -1,0 +1,48 @@
+// Tyylit ladataan omana chunkkinaan, jotta CSP-nonce ehditään asettaa ennen kuin
+// style-loader lisää <style>-elementit sivulle. Lataus on irrallinen promise,
+// jota mikään ei yritä uudelleen, joten epäonnistuessaan sivu jää pysyvästi
+// ilman tyylejä. Näin käy esimerkiksi julkaisun aikana, jos selain ehtii pyytää
+// chunkkia vasta kun palvelin on jo vaihtunut uuteen versioon eikä vanhan
+// nimistä tiedostoa enää ole.
+//
+// Sivun lataaminen uudelleen hakee tuoreen HTML:n ja sitä vastaavan chunkin
+// osoitteen. Se tehdään vain kerran välilehteä kohden, jottei pysyvästi puuttuva
+// tiedosto jätä sivua latautumaan loputtomiin.
+
+const RELOAD_STORAGE_KEY = 'styleChunkReloadAttempted'
+
+// Palauttaa true vain kerran välilehteä kohden. sessionStorage on kääritty
+// try-catchiin, koska se ei ole käytettävissä kaikissa selaimen
+// tallennusasetuksissa eikä virheenkäsittely saa itse kaatua. Ilman
+// tallennustilaa uudelleenlatausta ei tehdä lainkaan, koska sitä ei silloin voi
+// rajata yhteen kertaan.
+const claimReloadAttempt = (): boolean => {
+  try {
+    if (sessionStorage.getItem(RELOAD_STORAGE_KEY) !== null) {
+      return false
+    }
+    sessionStorage.setItem(RELOAD_STORAGE_KEY, '1')
+    return true
+  } catch (e) {
+    console.warn('sessionStorage ei ole käytettävissä', e)
+    return false
+  }
+}
+
+export const loadStyles = (load: () => Promise<unknown>): void => {
+  load().then(
+    () => {
+      try {
+        sessionStorage.removeItem(RELOAD_STORAGE_KEY)
+      } catch (e) {
+        console.warn('sessionStorage ei ole käytettävissä', e)
+      }
+    },
+    (error) => {
+      console.error('Tyylien lataus epäonnistui', error)
+      if (claimReloadAttempt()) {
+        window.location.reload()
+      }
+    }
+  )
+}

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -23,6 +23,17 @@ module.exports = (_, argv = {}) => ({
   output: {
     path: path.join(__dirname, '..', 'target/webapp/koski'),
     filename: 'js/koski-[name].js',
+    // Entry-bundlet saavat välimuistin ohituksen HtmlNodes.scala:n
+    // ?buildVersion-parametrista, mutta async-chunkkien osoitteen muodostaa
+    // webpackin oma runtime, joten niiden nimeen tarvitaan sisältöhash. Ilman
+    // sitä selain voi julkaisun jälkeen käyttää välimuistista vanhaa chunkkia,
+    // jonka tunniste ei enää vastaa uutta runtimea, jolloin sivu jää kokonaan
+    // ilman tyylejä. Kehitystilassa hash jätetään pois: target-hakemistoa ei
+    // siivota, joten jokainen käännös jättäisi vanhat tiedostot jäljelle.
+    chunkFilename:
+      argv.mode === 'production'
+        ? 'js/koski-[name].[contenthash:8].js'
+        : 'js/koski-[name].js',
     publicPath: '/koski/'
   },
   stats: 'normal',


### PR DESCRIPTION
Tuotannossa ja QA:ssa sivu latautui ajoittain kokonaan ilman tyylejä, ja tilanne korjaantui vasta ctrl+F5:llä.

Kosken CSS ei ole omana tiedostonaan vaan style-loader injektoi sen ajossa, ja tyylit ladataan erillisenä async-chunkkina, jotta CSP-nonce ehditään asettaa ennen injektointia. HtmlNodes lisää välimuistin ohittavan ?buildVersion-parametrin vain entry-bundlen osoitteeseen; async-chunkin osoitteen muodostaa webpackin runtime, ja se oli kiinteä /koski/js/koski-styles.js. Jetty ei myöskään lähettänyt staattisille tiedostoille Cache-Control-otsaketta lainkaan, jolloin selain päätteli tuoreuden Last-Modifiedin perusteella ja saattoi käyttää samaa osoitetta tunteja julkaisun jälkeen. Kun chunkin tunniste vaihtui julkaisussa, vanha välimuistista saatu tiedosto rekisteröi eri tunnisteen kuin uusi runtime odotti, lataus kaatui ChunkLoadErroriin eikä mikään yrittänyt uudelleen.

Kolme muutosta:

- webpack antaa async-chunkeille sisältöhashin tuotantokäännöksessä, joten vanha ja uusi versio eivät voi enää osua samaan välimuistiavaimeen. Kehitystilassa hash jätetään pois, koska target-hakemistoa ei siivota.
- Jetty asettaa staattisille tiedostoille lyhyen max-agen, mikä poistaa heuristisen tuoreuden myös niistä tiedostoista, joiden nimessä ei ole hashia (external_css, css). Lokaalisti revalidoidaan aina.
- Tyylien lataus kulkee loadStyles-apurin kautta, joka lataa sivun kerran uudelleen jos chunkin haku epäonnistuu. Tätä tarvitaan yhä julkaisun aikaiseen tilanteeseen, jossa ALB:n sticky-kohde vaihtuu kesken sivunlatauksen.