### PR TITLE
TOR-2696: Poista aikaikkuna lockFileMaintenancelta

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,11 +13,9 @@
     ]
   },
   "lockFileMaintenance": {
-    "description": "Only mechanism that updates transitive dependencies absent from every package.json. Daily rather than the inherited schedule:weekly (Mon 00:00-03:59 UTC) to cut worst-case exposure from seven days to one; costs no extra PR noise since lockFileMaintenance maintains a single branch. Note: the narrow window is not why this job stopped running after 2026-06-08 — oppijanumerorekisteri runs the identical inherited schedule and has not missed a run. See the commit body.",
+    "description": "Only mechanism that updates transitive dependencies absent from every package.json. Do not delete the empty schedule: Renovate's built-in default for this block is ['before 4am on monday'], so removing the key restores a four-hour weekly window instead of removing the restriction. A repository schedule cannot start a Renovate run — isScheduledNow() only filters a run that is already in progress — so any window is a bet that Mend's scheduler happens to land inside it. That bet lost every week between 2026-06-08 and 2026-08-14. An empty schedule always passes the check, and costs no extra PR noise because lockFileMaintenance maintains a single branch.",
     "enabled": true,
-    "schedule": [
-      "* 0-5 * * *"
-    ]
+    "schedule": []
   },
   "prConcurrentLimit": 8,
   "platformAutomerge": false,


### PR DESCRIPTION
Edellinen korjaus (d238a1a4b5) vaihtoi periytyneen viikkoikkunan päivittäiseksi (* 0-5 * * *). Se ei riitä, koska mikä tahansa aikaikkuna on veto siitä, että Mendin ajastin sattuu käynnistämään ajon juuri silloin.

Repositorion schedule ei käynnistä ajoa vaan suodattaa jo käynnissä olevaa. isScheduledNow() tarkistetaan kesken ajon
(lib/workers/repository/update/branch/index.ts), ja jos ikkuna ei ole auki, päivitys palautuu tuloksella 'not-scheduled'. Juuri se näkyy Dependency Dashboardissa (#3939) otsikon "Awaiting Schedule" alla, missä lockFileMaintenance on istunut 2026-06-08 lähtien.

Tyhjä schedule ohittaa tarkistuksen: isScheduledNow palauttaa true heti, jos schedule puuttuu, on tyhjä tai on "at any time".

Avainta ei kuitenkaan voi poistaa. Renovaten sisäänrakennettu oletus lockFileMaintenance-lohkolle on schedule: ['before 4am on monday'] (lib/config/options/index.ts), joten avaimen poistaminen palauttaisi juuri sen neljän tunnin viikkoikkunan, joka rikkoi huoltoajon. Siitä on varoitus description-kentässä, koska tyhjä taulukko näyttää turhalta ja houkuttelee poistamaan.

Edellisen commitin hypoteesi ei pitänyt paikkaansa. PR-slotit eivät ole täynnä: avoimia Renovate-PR:iä on 3 ja renovate-brancheja 6, kun prConcurrentLimit on 8. Myös ONR-vertailu johti harhaan — ero ei ole automergessä vaan siinä, kuinka usein Mend ajaa repon.

Tämä muutos ei yksin palauta huoltoajoa. Koskessa ei ole ollut yhtään Renovate-ajoa 2026-08-06 jälkeen (viimeinen branch-push 08:45Z, viimeinen dashboard-muokkaus 18:09Z), vaikka organisaation muut repot saavat PR:iä päivittäin (136 kpl 2026-08-06 alkaen, ONR viimeksi 2026-08-13). Dashboardin valintaruutu rastitettiin 2026-08-14 11:33Z, eikä sitäkään oltu kulutettu 40 minuutin kuluttua. Ajojen puuttuminen on Mendin puolella eikä korjaudu konfiguraatiolla; ks. developer.mend.io/github/Opetushallitus/koski.

Myöskään lockfile-ajon epäonnistuminen ei selitä hiljaisuutta: jos pnpm kaatuu, Renovate kirjaa artifactErrorin ja luo branchin ja PR:n silti, ja kommentoi "Renovate failed to update an artifact related to this branch" (lib/workers/repository/update/branch/index.ts:1061). Vika olisi siis äänekäs, ei hiljainen.

packageRulesin prPriority-sääntö jätettiin paikoilleen, vaikka se osoittautui tarpeettomaksi: se ei haittaa, ja slottien täyttyminen voi myöhemmin olla todellinen ongelma.