### PR TITLE
TOR-2631: Rahoituslähde opiskeluoikeuden lisätietoihin (3a)

### DIFF
--- a/src/main/resources/localization/koski-default-texts.json
+++ b/src/main/resources/localization/koski-default-texts.json
@@ -1576,6 +1576,8 @@
   "Purettu koeajalla": "Purettu koeajalla",
   "Rahoituksen piirissä": "Rahoituksen piirissä",
   "Rahoitus": "Rahoitus",
+  "Rahoituslähde": "Rahoituslähde",
+  "Rahoituslähteet": "Rahoituslähteet",
   "Rajattu oppimäärä": "Rajattu oppimäärä",
   "Raportille valitaan kaikki kurssisuoritukset riippumatta niiden suoritusajankohdasta": "Raportille valitaan kaikki osasuoritukset riippumatta niiden suoritusajankohdasta",
   "Raportille valitaan kaikki opinnot riippumatta niiden suoritusajankohdasta": "Raportille valitaan kaikki opinnot riippumatta niiden suoritusajankohdasta",

--- a/src/main/resources/mockdata/koodisto/koodistot/virtarahoituslahde.json
+++ b/src/main/resources/mockdata/koodisto/koodistot/virtarahoituslahde.json
@@ -1,0 +1,35 @@
+{
+  "codesGroupUri": "virta",
+  "codesVersions": [],
+  "includesCodes": [],
+  "koodistoUri": "virtarahoituslahde",
+  "levelsWithCodes": [],
+  "lukittu": null,
+  "metadata": [
+    {
+      "kieli": "FI",
+      "nimi": "VIRTA Rahoituslähde",
+      "kuvaus": "Rahoituslähde (ks. https://confluence.csc.fi/display/VIRTA/Tietovarannon+koodistot)",
+      "kayttoohje": null,
+      "kasite": null,
+      "kohdealue": null,
+      "sitovuustaso": null,
+      "kohdealueenOsaAlue": null,
+      "toimintaymparisto": null,
+      "tarkentaaKoodistoa": null,
+      "huomioitavaKoodisto": null,
+      "koodistonLahde": null
+    }
+  ],
+  "omistaja": "",
+  "organisaatioOid": "1.2.246.562.10.2013112012294919827487",
+  "paivittajaOid": null,
+  "paivitysPvm": "2016-02-12",
+  "resourceUri": "https://virkailija.opintopolku.fi/koodisto-service/rest/codes/virtarahoituslahde",
+  "tila": "LUONNOS",
+  "versio": 1,
+  "version": 2,
+  "voimassaAlkuPvm": "2013-01-01",
+  "voimassaLoppuPvm": null,
+  "withinCodes": []
+}

--- a/src/main/resources/mockdata/koodisto/koodit/virtarahoituslahde.json
+++ b/src/main/resources/mockdata/koodisto/koodit/virtarahoituslahde.json
@@ -1,0 +1,234 @@
+[
+  {
+    "metadata": [
+      {
+        "nimi": "Perusrahoitus",
+        "kuvaus": "Opetushallinnon (tai ammattikorkeakoulun) rahoittama koulutus",
+        "lyhytNimi": "",
+        "kieli": "FI"
+      },
+      {
+        "nimi": "Basfinansiering",
+        "kuvaus": null,
+        "kieli": "SV"
+      },
+      {
+        "nimi": "Core funding",
+        "kuvaus": null,
+        "kieli": "EN"
+      }
+    ],
+    "withinCodeElements": [],
+    "includesCodeElements": [],
+    "levelsWithCodeElements": [],
+    "koodiUri": "virtarahoituslahde_1",
+    "versio": 1,
+    "koodiArvo": "1"
+  },
+  {
+    "metadata": [
+      {
+        "nimi": "ESR-rahoitus, vain ammattikorkeakoulukoulutus",
+        "kuvaus": "Kokonaan (ml. kansallinen osuus) ESR-rahoituksella tai muulla rakennerahastorahoituksella järjestettävä tutkintoon johtava koulutus",
+        "lyhytNimi": "ESR-rahoitus, AMK",
+        "kieli": "FI"
+      },
+      {
+        "nimi": "ESF-finansiering",
+        "kuvaus": null,
+        "kieli": "SV"
+      },
+      {
+        "nimi": "ESF-finance",
+        "kuvaus": null,
+        "kieli": "EN"
+      }
+    ],
+    "withinCodeElements": [],
+    "includesCodeElements": [],
+    "levelsWithCodeElements": [],
+    "koodiUri": "virtarahoituslahde_2",
+    "versio": 1,
+    "koodiArvo": "2"
+  },
+  {
+    "metadata": [
+      {
+        "nimi": "TE-rahoitus, vain ammattikorkeakoulukoulutus",
+        "kuvaus": "Työvoimahallinnon ostama AMK-tutkintoon johtava koulutus",
+        "lyhytNimi": "TE-rahoitus, AMK",
+        "kieli": "FI"
+      },
+      {
+        "nimi": "AN-finansiering",
+        "kuvaus": null,
+        "kieli": "SV"
+      },
+      {
+        "nimi": "TE-finance",
+        "kuvaus": null,
+        "kieli": "EN"
+      }
+    ],
+    "withinCodeElements": [],
+    "includesCodeElements": [],
+    "levelsWithCodeElements": [],
+    "koodiUri": "virtarahoituslahde_3",
+    "versio": 1,
+    "koodiArvo": "3"
+  },
+  {
+    "metadata": [
+      {
+        "nimi": "Maksullinen tilauskoulutus",
+        "kuvaus": "Yo-tiedonkeruussa \"2\"",
+        "lyhytNimi": "",
+        "kieli": "FI"
+      },
+      {
+        "nimi": "Uppdragsutbildning",
+        "kuvaus": null,
+        "kieli": "SV"
+      },
+      {
+        "nimi": "Commissioned education",
+        "kuvaus": null,
+        "kieli": "EN"
+      }
+    ],
+    "withinCodeElements": [],
+    "includesCodeElements": [],
+    "levelsWithCodeElements": [],
+    "koodiUri": "virtarahoituslahde_4",
+    "versio": 1,
+    "koodiArvo": "4"
+  },
+  {
+    "metadata": [
+      {
+        "nimi": "Lukuvuosimaksu",
+        "kuvaus": "Tilastokeskus Yo-tiedonkeruussa vastaa arvoa \"1\"",
+        "lyhytNimi": "",
+        "kieli": "FI"
+      },
+      {
+        "nimi": "Läsårsavgift",
+        "kuvaus": "",
+        "lyhytNimi": "",
+        "kieli": "SV"
+      },
+      {
+        "nimi": "Tuition fee",
+        "kuvaus": "",
+        "lyhytNimi": "",
+        "kieli": "EN"
+      }
+    ],
+    "withinCodeElements": [],
+    "includesCodeElements": [],
+    "levelsWithCodeElements": [],
+    "koodiUri": "virtarahoituslahde_5",
+    "versio": 1,
+    "koodiArvo": "5"
+  },
+  {
+    "metadata": [
+      {
+        "nimi": "Jotpa Valtionavustus",
+        "kuvaus": "Koodia käytetään koulutukselle, jonka rahoituslähde on Jatkuvan oppimisen ja työllisyyden palvelukeskuksen-valtionavustuksena myönnetty",
+        "kieli": "FI"
+      },
+      {
+        "nimi": "Skols Statsunderstöd",
+        "kuvaus": "",
+        "kieli": "SV"
+      },
+      {
+        "nimi": "SECLE Discretionary Government Grant",
+        "kuvaus": "",
+        "kieli": "EN"
+      }
+    ],
+    "withinCodeElements": [],
+    "includesCodeElements": [],
+    "levelsWithCodeElements": [],
+    "koodiUri": "virtarahoituslahde_6",
+    "versio": 1,
+    "koodiArvo": "6"
+  },
+  {
+    "metadata": [
+      {
+        "nimi": "Jotpa hankintakoulutus",
+        "kuvaus": "Koodia käytetään koulutukselle, joka on Jatkuvan oppimisen ja työllisyyden palvelukeskuksen (Jotpa) hankintakoulutuksena hankittu",
+        "kieli": "FI"
+      },
+      {
+        "nimi": "Skols Upphandlad utbildning",
+        "kuvaus": "",
+        "kieli": "SV"
+      },
+      {
+        "nimi": "SECLE Education; Procurement",
+        "kuvaus": null,
+        "kieli": "EN"
+      }
+    ],
+    "withinCodeElements": [],
+    "includesCodeElements": [],
+    "levelsWithCodeElements": [],
+    "koodiUri": "virtarahoituslahde_7",
+    "versio": 1,
+    "koodiArvo": "7"
+  },
+  {
+    "metadata": [
+      {
+        "nimi": "Jotpan RRF - rahoituksen valtionavustuskoulutus",
+        "kuvaus": "Koodia käytetään Jatkuvan oppimisen ja työllisyyden palvelukeskuksen (Jotpa) RRF - rahoituksen valtionavustuskoulutukselle",
+        "kieli": "FI"
+      },
+      {
+        "nimi": "Skols RRF-finansierad utbildning (statsunderstöd)",
+        "kuvaus": null,
+        "kieli": "SV"
+      },
+      {
+        "nimi": "SECLE Education; RRF funding, Discretionary Government Grant",
+        "kuvaus": null,
+        "kieli": "EN"
+      }
+    ],
+    "withinCodeElements": [],
+    "includesCodeElements": [],
+    "levelsWithCodeElements": [],
+    "koodiUri": "virtarahoituslahde_8",
+    "versio": 1,
+    "koodiArvo": "8"
+  },
+  {
+    "metadata": [
+      {
+        "nimi": "Jotpan RRF-rahoituksen hankintakoulutus",
+        "kuvaus": "Koodia käytetään Jatkuvan oppimisen ja työllisyyden palvelukeskuksen (Jotpa) RRF-rahoituksen hankintakoulutukselle",
+        "kieli": "FI"
+      },
+      {
+        "nimi": "Skols RRF-finansierad utbildning (upphandling)",
+        "kuvaus": null,
+        "kieli": "SV"
+      },
+      {
+        "nimi": "SECLE Education; RRF funding, Procurement",
+        "kuvaus": null,
+        "kieli": "EN"
+      }
+    ],
+    "withinCodeElements": [],
+    "includesCodeElements": [],
+    "levelsWithCodeElements": [],
+    "koodiUri": "virtarahoituslahde_9",
+    "versio": 1,
+    "koodiArvo": "9"
+  }
+]

--- a/src/main/scala/fi/oph/koski/koodisto/Koodistot.scala
+++ b/src/main/scala/fi/oph/koski/koodisto/Koodistot.scala
@@ -172,6 +172,7 @@ object Koodistot {
     KoodistoAsetus("virtaopiskeluoikeudentyyppi"),
     KoodistoAsetus("virtaopsuorluokittelu"),
     KoodistoAsetus("virtapatevyys"),
+    KoodistoAsetus("virtarahoituslahde"),
     KoodistoAsetus("moduulikoodistolops2021"),
     KoodistoAsetus("yhteystietojenalkupera"),
     KoodistoAsetus("yhteystietotyypit"),

--- a/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
+++ b/src/main/scala/fi/oph/koski/schema/Korkeakoulu.scala
@@ -63,6 +63,8 @@ case class KorkeakoulunOpiskeluoikeudenLisätiedot(
   järjestäväOrganisaatio: Option[Oppilaitos] = None,
   @Title("Koulutuskunnat")
   koulutuskuntaJaksot: List[KoulutuskuntaJakso] = Nil,
+  @Title("Rahoituslähteet")
+  rahoituslähdeJaksot: Option[List[RahoituslähdeJakso]] = None,
   @Title("Opettajan pedagogiset opinnot")
   @InfoDescription("opettajan kelpoisuuden määritelmä")
   @KoodistoUri("virtapatevyys")
@@ -80,6 +82,13 @@ case class KoulutuskuntaJakso(
   loppu: Option[LocalDate],
   @KoodistoUri("kunta")
   koulutuskunta: Koodistokoodiviite
+) extends Jakso
+
+case class RahoituslähdeJakso(
+  alku: LocalDate,
+  loppu: Option[LocalDate],
+  @KoodistoUri("virtarahoituslahde")
+  rahoituslähde: Koodistokoodiviite
 ) extends Jakso
 
 @Description("Korkeakoulun opiskeluoikeuden lukuvuosimaksut")

--- a/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
+++ b/src/main/scala/fi/oph/koski/virta/VirtaXMLConverter.scala
@@ -81,6 +81,7 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
           järjestäväOrganisaatio = järjestäväOrganisaatio(opiskeluoikeusNode, oppilaitoksenNimiPäivä),
           maksettavatLukuvuosimaksut = Some(lukuvuosimaksut),
           koulutuskuntaJaksot = koulutuskuntajaksot(opiskeluoikeusNode),
+          rahoituslähdeJaksot = noneIfEmpty(rahoituslähdejaksot(opiskeluoikeusNode)),
           opettajanPedagogisetOpinnot = opettajanPatevyydet.map(
             _.distinct
               .filter(v => Set("ik","il","im","in","io","ip","iq","ir","is","it","iu","iv","iw","ix","iy","ja","jb","jc","jd","ke","oa","ob","oe","of","og","pv","rv","sv","va","vo","vs").contains(v.koodiarvo))
@@ -576,6 +577,18 @@ case class VirtaXMLConverter(oppilaitosRepository: OppilaitosRepository, koodist
       , loppu = loppuPvm(jakso)
       , koulutuskunta = requiredKoodi("kunta", (jakso \ "Koulutuskunta").text))).toList.sortBy(_.alku)
   }
+
+  // Tuntematon rahoituslähde ohitetaan, jottei yksittäinen jakso kaada koko oppijan konversiota
+  private def rahoituslähdejaksot(opiskeluoikeusNode: Node): List[RahoituslähdeJakso] =
+    (opiskeluoikeusNode \ "Jakso").toList.flatMap { jakso =>
+      koodistoViitePalvelu
+        .validate(Koodistokoodiviite((jakso \ "Rahoituslahde").text, "virtarahoituslahde"))
+        .map(rahoituslähde => RahoituslähdeJakso(
+          alku = alkuPvm(jakso),
+          loppu = loppuPvm(jakso),
+          rahoituslähde = rahoituslähde
+        ))
+    }.sortBy(_.alku)(DateOrdering.localDateOrdering)
 
 }
 

--- a/src/test/scala/fi/oph/koski/virta/VirtaXMLConverterSpec.scala
+++ b/src/test/scala/fi/oph/koski/virta/VirtaXMLConverterSpec.scala
@@ -94,7 +94,8 @@ class VirtaXMLConverterSpec extends AnyFreeSpec with TestEnvironment with Matche
     päättynyt: Boolean = false,
     luokittelu: Option[Int] = None,
     ilmanAinePätevyyksiä: Boolean = false,
-    ilmanOpePätevyyksiä: Boolean = false
+    ilmanOpePätevyyksiä: Boolean = false,
+    rahoituslähde: Option[String] = Some("1")
   ): Elem = <virta:Opiskeluoikeudet>
     <virta:Opiskeluoikeus opiskelijaAvain="avopH1" avain="avopH1O1">
       <virta:AlkuPvm>2008-08-01</virta:AlkuPvm>
@@ -123,7 +124,11 @@ class VirtaXMLConverterSpec extends AnyFreeSpec with TestEnvironment with Matche
         <virta:Koulutuskoodi>621702</virta:Koulutuskoodi>
         <virta:Koulutuskunta>091</virta:Koulutuskunta>
         <virta:Koulutuskieli>en</virta:Koulutuskieli>
-        <virta:Rahoituslahde>1</virta:Rahoituslahde>
+        {
+          if (rahoituslähde.isDefined) {
+            <virta:Rahoituslahde>{rahoituslähde.get}</virta:Rahoituslahde>
+          }
+        }
         {
           if (luokittelu.isDefined) {
             <virta:Luokittelu>{luokittelu.get}</virta:Luokittelu>
@@ -138,7 +143,11 @@ class VirtaXMLConverterSpec extends AnyFreeSpec with TestEnvironment with Matche
         <virta:Koulutuskoodi>621702</virta:Koulutuskoodi>
         <virta:Koulutuskunta>091</virta:Koulutuskunta>
         <virta:Koulutuskieli>en</virta:Koulutuskieli>
-        <virta:Rahoituslahde>1</virta:Rahoituslahde>
+        {
+          if (rahoituslähde.isDefined) {
+            <virta:Rahoituslahde>{rahoituslähde.get}</virta:Rahoituslahde>
+          }
+        }
         {
           if (luokittelu.isDefined) {
             <virta:Luokittelu>{luokittelu.get}</virta:Luokittelu>
@@ -253,6 +262,38 @@ class VirtaXMLConverterSpec extends AnyFreeSpec with TestEnvironment with Matche
         oo should have size (1)
         val opePatevyydet = oo.head.lisätiedot.get.opettajanPedagogisetOpinnot
         opePatevyydet should equal(None)
+      }
+    }
+
+    "Rahoituslähde" - {
+      def rahoituslähdeJaksot(rahoituslähde: Option[String]) =
+        converter
+          .convertToOpiskeluoikeudet(opiskeluoikeusWithOrganisaatio(None, rahoituslähde = rahoituslähde))
+          .head
+          .lisätiedot
+          .get
+          .rahoituslähdeJaksot
+
+      "parsitaan jaksoittain alkupäivän mukaan järjestettynä" in {
+        val jaksot = rahoituslähdeJaksot(Some("1")).get
+        jaksot should have length 2
+
+        jaksot.head.alku should be(LocalDate.of(2008, 8, 1))
+        jaksot.head.loppu should be(Some(LocalDate.of(2008, 8, 2)))
+        jaksot.head.rahoituslähde.koodiarvo should be("1")
+        jaksot.head.rahoituslähde.koodistoUri should be("virtarahoituslahde")
+
+        jaksot(1).alku should be(LocalDate.of(2008, 8, 3))
+        jaksot(1).loppu should be(None)
+        jaksot(1).rahoituslähde.koodiarvo should be("1")
+      }
+
+      "on None jos yhdelläkään jaksolla ei ole rahoituslähdettä" in {
+        rahoituslähdeJaksot(None) should be(None)
+      }
+
+      "tuntematon koodiarvo ohitetaan eikä konversio kaadu" in {
+        rahoituslähdeJaksot(Some("99")) should be(None)
       }
     }
 

--- a/web/app/types/fi/oph/koski/schema/KorkeakoulunOpiskeluoikeudenLisatiedot.ts
+++ b/web/app/types/fi/oph/koski/schema/KorkeakoulunOpiskeluoikeudenLisatiedot.ts
@@ -5,6 +5,7 @@ import { Koodistokoodiviite } from './Koodistokoodiviite'
 import { LocalizedString } from './LocalizedString'
 import { Lukukausi_Ilmoittautuminen } from './LukukausiIlmoittautuminen'
 import { Aikajakso } from './Aikajakso'
+import { RahoituslähdeJakso } from './RahoituslahdeJakso'
 
 /**
  * Korkeakoulun opiskeluoikeuden lisätiedot
@@ -19,13 +20,14 @@ export type KorkeakoulunOpiskeluoikeudenLisätiedot = {
   opettajanPedagogisetOpinnot?: Array<
     Koodistokoodiviite<'virtapatevyys', string>
   >
+  lukukausiIlmoittautuminen?: Lukukausi_Ilmoittautuminen
+  opetettavanAineenOpinnot?: Array<Koodistokoodiviite<'virtapatevyys', string>>
+  ensisijaisuus?: Array<Aikajakso>
   virtaOpiskeluoikeudenTyyppi?: Koodistokoodiviite<
     'virtaopiskeluoikeudentyyppi',
     string
   >
-  lukukausiIlmoittautuminen?: Lukukausi_Ilmoittautuminen
-  opetettavanAineenOpinnot?: Array<Koodistokoodiviite<'virtapatevyys', string>>
-  ensisijaisuus?: Array<Aikajakso>
+  rahoituslähdeJaksot?: Array<RahoituslähdeJakso>
 }
 
 export const KorkeakoulunOpiskeluoikeudenLisätiedot = (
@@ -36,15 +38,16 @@ export const KorkeakoulunOpiskeluoikeudenLisätiedot = (
     opettajanPedagogisetOpinnot?: Array<
       Koodistokoodiviite<'virtapatevyys', string>
     >
-    virtaOpiskeluoikeudenTyyppi?: Koodistokoodiviite<
-      'virtaopiskeluoikeudentyyppi',
-      string
-    >
     lukukausiIlmoittautuminen?: Lukukausi_Ilmoittautuminen
     opetettavanAineenOpinnot?: Array<
       Koodistokoodiviite<'virtapatevyys', string>
     >
     ensisijaisuus?: Array<Aikajakso>
+    virtaOpiskeluoikeudenTyyppi?: Koodistokoodiviite<
+      'virtaopiskeluoikeudentyyppi',
+      string
+    >
+    rahoituslähdeJaksot?: Array<RahoituslähdeJakso>
   } = {}
 ): KorkeakoulunOpiskeluoikeudenLisätiedot => ({
   koulutuskuntaJaksot: [],

--- a/web/app/types/fi/oph/koski/schema/RahoituslahdeJakso.ts
+++ b/web/app/types/fi/oph/koski/schema/RahoituslahdeJakso.ts
@@ -1,0 +1,28 @@
+import { Koodistokoodiviite } from './Koodistokoodiviite'
+import { LocalizedString } from './LocalizedString'
+
+/**
+ * RahoituslähdeJakso
+ *
+ * @see `fi.oph.koski.schema.RahoituslähdeJakso`
+ */
+export type RahoituslähdeJakso = {
+  $class: 'fi.oph.koski.schema.RahoituslähdeJakso'
+  alku: string
+  loppu?: string
+  rahoituslähde: Koodistokoodiviite<'virtarahoituslahde', string>
+}
+
+export const RahoituslähdeJakso = (o: {
+  alku: string
+  loppu?: string
+  rahoituslähde: Koodistokoodiviite<'virtarahoituslahde', string>
+}): RahoituslähdeJakso => ({
+  $class: 'fi.oph.koski.schema.RahoituslähdeJakso',
+  ...o
+})
+
+RahoituslähdeJakso.className = 'fi.oph.koski.schema.RahoituslähdeJakso' as const
+
+export const isRahoituslähdeJakso = (a: any): a is RahoituslähdeJakso =>
+  a?.$class === 'fi.oph.koski.schema.RahoituslähdeJakso'


### PR DESCRIPTION
Kolmannen erän ensimmäinen osa. Yksi kenttä `KorkeakoulunOpiskeluoikeudenLisätiedot`-luokkaan (TR4).

- `rahoituslähdeJaksot` (`Opiskeluoikeus/Jakso/Rahoituslahde`), mallinnettu jaksolistana `koulutuskuntaJaksot`-kentän tapaan. Arvo voi vaihtua kesken opiskeluoikeuden, jolloin Virta siirtää uuden jakson
- Uusi koodisto `virtarahoituslahde` haettu tuotannosta

Huom kaksi tietoista poikkeamaa naapurifunktiosta `koulutuskuntajaksot`:

1. Tuntematon koodiarvo ohitetaan `validate`-funktiolla eikä `requiredKoodi`-funktiolla, joka heittäisi poikkeuksen. Poikkeusta ei napata konversiossa, joten yksi tuntematon arvo kaataisi koko oppijan tiedot. Tälle on testi
2. `Option[List]` eikä `List = Nil`, koska useimmilla opiskeluoikeuksilla ei ole rahoituslähdettä

Testit: `VirtaXMLConverterSpec` 45 vihreää. TypeScript-tyypit regeneroitu.

Tunnettu kattavuusaukko: mockdatassa ei ole opiskeluoikeutta, jonka rahoituslähde vaihtuisi jaksojen välillä. Masterissa esiintyy vain arvoja 1, 2 ja 5; arvo 3 (TE-rahoitus) tulee mockdataan PR #4356:n mukana.

Pohjautuu masteriin. Koskee samoja tiedostoja kuin #4356 ja #4357 eri kohdista.

🤖 Generated with [Claude Code](https://claude.com/claude-code)