### PR TITLE
TOR-2534: Ota Suomi.fi rekisteritiedot -rajapinta käyttöön tuotannossa

### DIFF
--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -140,9 +140,7 @@ class ScalatraBootstrap extends LifeCycle with Logging with Timing with GlobalEx
     mount("/koski/api/luovutuspalvelu/ytl", new YtlServlet)
     mount("/koski/api/luovutuspalvelu/keha/sdg", new SdgServlet)
     mount("/koski/api/palveluvayla", new PalveluvaylaServlet)
-    if (!Environment.isProdEnvironment(application.config)) {
-      mount("/koski/api/luovutuspalvelu/suomifi", new SuomiFiServlet)
-    }
+    mount("/koski/api/luovutuspalvelu/suomifi", new SuomiFiServlet)
     mount("/koski/api/omadata", new MyDataServlet)
     mount("/koski/api/omaopintopolkuloki", new OmaOpintoPolkuLokiServlet)
     mount("/koski/api/ytrkoesuoritukset", new YtrKoesuoritusApiServlet)


### PR DESCRIPTION
Mountaa `POST /koski/api/luovutuspalvelu/suomifi/rekisteritiedot` tuotantoon poistamalla eksplisiittinen rajaus.

- Vanha SOAP-rajapinta `/koski/api/palveluvayla/suomi-fi-rekisteritiedot` jää ennalleen, eli DVV voi migroitua omaan tahtiinsa — poistetaan erikseen myöhemmin
- **Edellyttää** client list päivitystä