### PR TITLE
TOR-2631: Korkeakoulun Kela-tietomalli

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -494,21 +494,12 @@ kotikuntahistoria = {
     maksuttomuusValidation = true
 }
 
+# Opiskeluoikeustyypit, joita EI palauteta Kelalle. Tyhjänä kaikki Kelan skeemassa tuetut
+# tyypit palautetaan. Tarkoitettu hätäjarruksi: yksittäisen tyypin saa suljettua pois
+# ilman koodimuutosta ja deployta.
 # kela = {
-#     palautettavatOpiskeluoikeustyypit = [
-#         "aikuistenperusopetus",
-#         "ammatillinenkoulutus",
-#         "ibtutkinto",
-#         "diatutkinto",
-#         "internationalschool",
-#         "lukiokoulutus",
-#         "luva",
-#         "perusopetukseenvalmistavaopetus",
-#         "perusopetuksenlisaopetus",
-#         "perusopetus",
-#         "ylioppilastutkinto",
-#         "vapaansivistystyonkoulutus",
-#         "tuva"
+#     eiPalautettavatOpiskeluoikeustyypit = [
+#         "korkeakoulutus"
 #     ]
 # }
 

--- a/src/main/scala/fi/oph/koski/kela/KelaKorkeakouluSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaKorkeakouluSchema.scala
@@ -1,0 +1,389 @@
+package fi.oph.koski.kela
+
+import fi.oph.koski.schema
+import fi.oph.koski.koskiuser.Rooli
+import fi.oph.koski.schema.annotation.{KoodistoKoodiarvo, KoodistoUri, SensitiveData}
+import fi.oph.scalaschema.annotation.{Description, Title}
+
+import java.time.LocalDate
+
+object KelaKorkeakoulunOpiskeluoikeus {
+  def fromKoskiSchema(kk: schema.KorkeakoulunOpiskeluoikeus) = KelaKorkeakoulunOpiskeluoikeus(
+    lähdejärjestelmänId = kk.lähdejärjestelmänId.flatMap(_.id),
+    oppilaitos = kk.oppilaitos.map(oppilaitos),
+    koulutustoimija = kk.koulutustoimija.map(kt =>
+      Koulutustoimija(
+        kt.oid,
+        kt.nimi,
+        kt.yTunnus,
+        kt.kotipaikka.map(KelaKoodistokoodiviite.fromKoskiSchema)
+      )
+    ),
+    päättymispäivä = kk.päättymispäivä,
+    tila = KelaKorkeakoulunOpiskeluoikeudenTila(
+      kk.tila.opiskeluoikeusjaksot.map(oj =>
+        KelaKorkeakoulunOpiskeluoikeusjakso(oj.alku, KelaKoodistokoodiviite.fromKoskiSchema(oj.tila))
+      )
+    ),
+    lisätiedot = kk.lisätiedot.map(lisätiedot),
+    suoritukset = kk.suoritukset.map(suoritus),
+    luokittelu = kk.luokittelu.map(_.map(KelaKoodistokoodiviite.fromKoskiSchema)),
+    tyyppi = kk.tyyppi
+  )
+
+  private def lisätiedot(l: schema.KorkeakoulunOpiskeluoikeudenLisätiedot) = KelaKorkeakoulunOpiskeluoikeudenLisätiedot(
+    virtaOpiskeluoikeudenTyyppi = l.virtaOpiskeluoikeudenTyyppi.map(KelaKoodistokoodiviite.fromKoskiSchema),
+    lukukausiIlmoittautuminen = l.lukukausiIlmoittautuminen.map(li =>
+      KelaKorkeakoulunLukukausiIlmoittautuminen(
+        li.ilmoittautumisjaksot.map(j =>
+          KelaKorkeakoulunLukukausiIlmoittautumisjakso(
+            alku = j.alku,
+            loppu = j.loppu,
+            tila = KelaKoodistokoodiviite.fromKoskiSchema(j.tila),
+            ilmoittautumispäivä = j.ilmoittautumispäivä
+          )
+        )
+      )
+    ),
+    koulutuskuntaJaksot = l.koulutuskuntaJaksot.map(j =>
+      KelaKorkeakoulunKoulutuskuntaJakso(j.alku, j.loppu, KelaKoodistokoodiviite.fromKoskiSchema(j.koulutuskunta))
+    ),
+    rahoituslähdeJaksot = l.rahoituslähdeJaksot.map(_.map(j =>
+      KelaKorkeakoulunRahoituslähdeJakso(j.alku, j.loppu, KelaKoodistokoodiviite.fromKoskiSchema(j.rahoituslähde))
+    )),
+    liikkuvuusjaksot = l.liikkuvuusjaksot.map(_.map(j =>
+      KelaKorkeakoulunLiikkuvuusjakso(
+        alku = j.alku,
+        loppu = j.loppu,
+        suunta = KelaKoodistokoodiviite.fromKoskiSchema(j.suunta),
+        maa = KelaKoodistokoodiviite.fromKoskiSchema(j.maa),
+        tyyppi = KelaKoodistokoodiviite.fromKoskiSchema(j.tyyppi),
+        liikkuvuusohjelma = KelaKoodistokoodiviite.fromKoskiSchema(j.liikkuvuusohjelma),
+        luokittelu = j.luokittelu.map(_.map(KelaKoodistokoodiviite.fromKoskiSchema))
+      )
+    )),
+    siirtoOpiskelija = l.siirtoOpiskelija.map(s =>
+      KelaKorkeakoulunSiirtoOpiskelija(s.siirtoPäivä, s.lähdeOrganisaatio.map(oppilaitos))
+    ),
+    koulutusala = l.koulutusala.map(koulutusala)
+  )
+
+  private def suoritus(s: schema.KorkeakouluSuoritus): KelaKorkeakoulunPäätasonSuoritus = s match {
+    case t: schema.KorkeakoulututkinnonSuoritus => KelaKorkeakoulututkinnonSuoritus(
+      koulutusmoduuli = KelaKorkeakoulututkinto(
+        tunniste = KelaKoodistokoodiviite.fromKoskiSchema(t.koulutusmoduuli.tunniste),
+        koulutustyyppi = t.koulutusmoduuli.koulutustyyppi.map(KelaKoodistokoodiviite.fromKoskiSchema),
+        virtaNimi = t.koulutusmoduuli.virtaNimi,
+        koulutusala = t.koulutusmoduuli.koulutusala.map(koulutusala)
+      ),
+      toimipiste = toimipiste(t.toimipiste),
+      vahvistus = t.vahvistus.map(v => Vahvistus(v.päivä)),
+      osasuoritukset = t.osasuoritukset.map(_.map(osasuoritus)),
+      hyväksilukupäivä = t.hyväksilukupäivä,
+      lisätieto = t.lisätieto,
+      vaadittuLaajuus = t.vaadittuLaajuus.map(laajuus),
+      liittyvätOpiskeluoikeudet = t.liittyvätOpiskeluoikeudet.map(_.map(liittyväOpiskeluoikeus)),
+      tyyppi = t.tyyppi
+    )
+    case o: schema.KorkeakoulunOpintojaksonSuoritus => KelaKorkeakoulunOpintojaksonSuoritus(
+      koulutusmoduuli = opintojakso(o.koulutusmoduuli),
+      toimipiste = toimipiste(o.toimipiste),
+      vahvistus = o.vahvistus.map(v => Vahvistus(v.päivä)),
+      osasuoritukset = o.osasuoritukset.map(_.map(osasuoritus)),
+      luokittelu = o.luokittelu.map(_.map(KelaKoodistokoodiviite.fromKoskiSchema)),
+      hyväksilukupäivä = o.hyväksilukupäivä,
+      opinnäytetyö = o.opinnäytetyö,
+      lisätieto = o.lisätieto,
+      tyyppi = o.tyyppi
+    )
+    case m: schema.MuuKorkeakoulunSuoritus => KelaMuuKorkeakoulunSuoritus(
+      koulutusmoduuli = KelaMuuKorkeakoulunOpinto(
+        tunniste = KelaKoodistokoodiviite.fromKoskiSchema(m.koulutusmoduuli.tunniste),
+        nimi = m.koulutusmoduuli.nimi,
+        laajuus = m.koulutusmoduuli.laajuus.map(laajuus)
+      ),
+      toimipiste = toimipiste(m.toimipiste),
+      vahvistus = m.vahvistus.map(v => Vahvistus(v.päivä)),
+      osasuoritukset = m.osasuoritukset.map(_.map(osasuoritus)),
+      vaadittuLaajuus = m.vaadittuLaajuus.map(laajuus),
+      tyyppi = m.tyyppi
+    )
+  }
+
+  private def osasuoritus(o: schema.KorkeakoulunOpintojaksonSuoritus): KelaKorkeakoulunOpintojaksonOsasuoritus =
+    KelaKorkeakoulunOpintojaksonOsasuoritus(
+      koulutusmoduuli = opintojakso(o.koulutusmoduuli),
+      toimipiste = toimipiste(o.toimipiste),
+      vahvistus = o.vahvistus.map(v => Vahvistus(v.päivä)),
+      osasuoritukset = o.osasuoritukset.map(_.map(osasuoritus)),
+      luokittelu = o.luokittelu.map(_.map(KelaKoodistokoodiviite.fromKoskiSchema)),
+      hyväksilukupäivä = o.hyväksilukupäivä,
+      opinnäytetyö = o.opinnäytetyö,
+      lisätieto = o.lisätieto,
+      tyyppi = o.tyyppi
+    )
+
+  private def opintojakso(k: schema.KorkeakoulunOpintojakso) = KelaKorkeakoulunOpintojakso(
+    tunniste = KelaPaikallinenKoodiviite(k.tunniste.koodiarvo, Some(k.tunniste.nimi), k.tunniste.koodistoUri),
+    nimi = k.nimi,
+    laajuus = k.laajuus.map(laajuus),
+    koulutusala = k.koulutusala.map(koulutusala)
+  )
+
+  private def liittyväOpiskeluoikeus(lo: schema.LiittyväOpiskeluoikeus) = KelaLiittyväOpiskeluoikeus(
+    lähdejärjestelmänId = lo.lähdejärjestelmänId,
+    oppilaitos = lo.oppilaitos.map(oppilaitos),
+    tyyppi = lo.tyyppi.map(KelaKoodistokoodiviite.fromKoskiSchema)
+  )
+
+  private def koulutusala(k: schema.KorkeakoulunKoulutusala) = KelaKorkeakoulunKoulutusala(
+    opintoala1995 = k.opintoala1995.map(KelaKoodistokoodiviite.fromKoskiSchema),
+    okmOhjausala = k.okmOhjausala.map(KelaKoodistokoodiviite.fromKoskiSchema),
+    koulutusala2002 = k.koulutusala2002.map(KelaKoodistokoodiviite.fromKoskiSchema),
+    osuus = k.osuus
+  )
+
+  private def laajuus(l: schema.Laajuus) =
+    KelaLaajuus(l.arvo, KelaKoodistokoodiviite.fromKoskiSchema(l.yksikkö))
+
+  private def oppilaitos(o: schema.Oppilaitos) = Oppilaitos(
+    o.oid,
+    o.oppilaitosnumero.map(KelaKoodistokoodiviite.fromKoskiSchema),
+    o.nimi,
+    o.kotipaikka.map(KelaKoodistokoodiviite.fromKoskiSchema)
+  )
+
+  private def toimipiste(o: schema.Oppilaitos) =
+    Toimipiste(o.oid, o.nimi, o.kotipaikka.map(KelaKoodistokoodiviite.fromKoskiSchema))
+}
+
+@Title("Korkeakoulun opiskeluoikeus")
+@Description("Korkeakoulun opiskeluoikeus. Tiedot haetaan Virrasta, eikä niitä tallenneta Koskeen.")
+case class KelaKorkeakoulunOpiskeluoikeus(
+  @Description("Opiskeluoikeuden tunniste Virrassa. Korkeakoulun opiskeluoikeudella ei ole Koski-oidia, joten tämä on ainoa yksilöivä tunniste.")
+  lähdejärjestelmänId: Option[String],
+  oppilaitos: Option[Oppilaitos],
+  koulutustoimija: Option[Koulutustoimija],
+  override val päättymispäivä: Option[LocalDate],
+  tila: KelaKorkeakoulunOpiskeluoikeudenTila,
+  lisätiedot: Option[KelaKorkeakoulunOpiskeluoikeudenLisätiedot],
+  suoritukset: List[KelaKorkeakoulunPäätasonSuoritus],
+  @Title("Opiskeluoikeuden luokittelu")
+  @KoodistoUri("virtaopiskeluoikeudenluokittelu")
+  luokittelu: Option[List[KelaKoodistokoodiviite]],
+  @KoodistoKoodiarvo(schema.OpiskeluoikeudenTyyppi.korkeakoulutus.koodiarvo)
+  tyyppi: schema.Koodistokoodiviite,
+) extends KelaOpiskeluoikeus {
+  override def oid = None
+  override def versionumero = None
+  override def aikaleima = None
+  override def arvioituPäättymispäivä = None
+  override def sisältyyOpiskeluoikeuteen = None
+  override def organisaatioHistoria = None
+  override def organisaatiohistoria = None
+
+  override def withHyväksyntämerkinnälläKorvattuArvosana: KelaOpiskeluoikeus = this
+  override def withOrganisaatiohistoria: KelaOpiskeluoikeus = this
+}
+
+case class KelaKorkeakoulunOpiskeluoikeudenTila(
+  opiskeluoikeusjaksot: List[KelaKorkeakoulunOpiskeluoikeusjakso]
+) extends KelaOpiskeluoikeudenTilaTrait
+
+case class KelaKorkeakoulunOpiskeluoikeusjakso(
+  alku: LocalDate,
+  tila: KelaKoodistokoodiviite
+) extends KelaOpiskeluoikeusjaksoTrait {
+  override def opiskeluoikeusPäättynyt: Boolean =
+    schema.Opiskeluoikeus.OpiskeluoikeudenPäättymistila.korkeakoulu(tila.koodiarvo)
+}
+
+@Title("Korkeakoulun opiskeluoikeuden lisätiedot")
+case class KelaKorkeakoulunOpiskeluoikeudenLisätiedot(
+  @Title("Korkeakoulun opiskeluoikeuden tyyppi")
+  @KoodistoUri("virtaopiskeluoikeudentyyppi")
+  virtaOpiskeluoikeudenTyyppi: Option[KelaKoodistokoodiviite],
+  lukukausiIlmoittautuminen: Option[KelaKorkeakoulunLukukausiIlmoittautuminen],
+  @Title("Koulutuskunnat")
+  koulutuskuntaJaksot: List[KelaKorkeakoulunKoulutuskuntaJakso] = Nil,
+  @Title("Rahoituslähteet")
+  @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
+  rahoituslähdeJaksot: Option[List[KelaKorkeakoulunRahoituslähdeJakso]],
+  @Title("Liikkuvuusjaksot")
+  liikkuvuusjaksot: Option[List[KelaKorkeakoulunLiikkuvuusjakso]],
+  siirtoOpiskelija: Option[KelaKorkeakoulunSiirtoOpiskelija],
+  koulutusala: Option[KelaKorkeakoulunKoulutusala]
+) extends KelaOpiskeluoikeudenLisätiedot
+
+case class KelaKorkeakoulunLukukausiIlmoittautuminen(
+  ilmoittautumisjaksot: List[KelaKorkeakoulunLukukausiIlmoittautumisjakso]
+)
+
+case class KelaKorkeakoulunLukukausiIlmoittautumisjakso(
+  alku: LocalDate,
+  loppu: Option[LocalDate],
+  @KoodistoUri("virtalukukausiilmtila")
+  tila: KelaKoodistokoodiviite,
+  @Description("Päivämäärä, jolloin ilmoittautuminen on tehty")
+  ilmoittautumispäivä: Option[LocalDate]
+) extends KelaJakso
+
+case class KelaKorkeakoulunKoulutuskuntaJakso(
+  alku: LocalDate,
+  loppu: Option[LocalDate],
+  @KoodistoUri("kunta")
+  koulutuskunta: KelaKoodistokoodiviite
+) extends KelaJakso
+
+case class KelaKorkeakoulunRahoituslähdeJakso(
+  alku: LocalDate,
+  loppu: Option[LocalDate],
+  @KoodistoUri("virtarahoituslahde")
+  rahoituslähde: KelaKoodistokoodiviite
+) extends KelaJakso
+
+case class KelaKorkeakoulunLiikkuvuusjakso(
+  alku: LocalDate,
+  loppu: Option[LocalDate],
+  @KoodistoUri("virtaliikkuvuudensuunta")
+  suunta: KelaKoodistokoodiviite,
+  @KoodistoUri("maatjavaltiot2")
+  maa: KelaKoodistokoodiviite,
+  @KoodistoUri("virtaliikkuvuudentyyppi")
+  tyyppi: KelaKoodistokoodiviite,
+  @KoodistoUri("virtaliikkuvuusohjelma")
+  liikkuvuusohjelma: KelaKoodistokoodiviite,
+  @KoodistoUri("liikkuvuudenluokittelu")
+  luokittelu: Option[List[KelaKoodistokoodiviite]]
+) extends KelaJakso
+
+case class KelaKorkeakoulunSiirtoOpiskelija(
+  siirtoPäivä: LocalDate,
+  lähdeOrganisaatio: Option[Oppilaitos]
+)
+
+@Description("Koulutusala Virran luokituksen mukaan")
+case class KelaKorkeakoulunKoulutusala(
+  @KoodistoUri("opintoalaoph1995")
+  opintoala1995: Option[KelaKoodistokoodiviite],
+  @KoodistoUri("okmohjauksenala")
+  okmOhjausala: Option[KelaKoodistokoodiviite],
+  @KoodistoUri("koulutusalaoph2002")
+  koulutusala2002: Option[KelaKoodistokoodiviite],
+  osuus: Option[Double]
+)
+
+@Description("Opiskeluoikeus, johon tämä opiskeluoikeus antaa mahdollisuuden jatkaa")
+case class KelaLiittyväOpiskeluoikeus(
+  @Description("Liittyvän opiskeluoikeuden lähdejärjestelmän id, sama tunniste jolla se esiintyy tässä vastauksessa")
+  lähdejärjestelmänId: String,
+  oppilaitos: Option[Oppilaitos],
+  @KoodistoUri("virtaopiskeluoikeudentyyppi")
+  tyyppi: Option[KelaKoodistokoodiviite]
+)
+
+trait KelaKorkeakoulunPäätasonSuoritus extends KelaSuoritus {
+  def toimipiste: Toimipiste
+  def vahvistus: Option[Vahvistus]
+  override def withHyväksyntämerkinnälläKorvattuArvosana: KelaSuoritus = this
+}
+
+@Title("Korkeakoulututkinnon suoritus")
+case class KelaKorkeakoulututkinnonSuoritus(
+  koulutusmoduuli: KelaKorkeakoulututkinto,
+  toimipiste: Toimipiste,
+  vahvistus: Option[Vahvistus],
+  @Title("Opintojaksot")
+  osasuoritukset: Option[List[KelaKorkeakoulunOpintojaksonOsasuoritus]],
+  @Description("Päivämäärä, jolloin suoritus on hyväksiluettu")
+  hyväksilukupäivä: Option[LocalDate],
+  @Description("Opintosuorituksen julkinen lisätieto")
+  @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
+  lisätieto: Option[schema.LocalizedString],
+  @Description("Tutkinnon tai opintojen vaadittu laajuus")
+  vaadittuLaajuus: Option[KelaLaajuus],
+  liittyvätOpiskeluoikeudet: Option[List[KelaLiittyväOpiskeluoikeus]],
+  @KoodistoKoodiarvo("korkeakoulututkinto")
+  tyyppi: schema.Koodistokoodiviite
+) extends KelaKorkeakoulunPäätasonSuoritus
+
+@Title("Korkeakoulun opintojakson suoritus")
+case class KelaKorkeakoulunOpintojaksonSuoritus(
+  koulutusmoduuli: KelaKorkeakoulunOpintojakso,
+  toimipiste: Toimipiste,
+  vahvistus: Option[Vahvistus],
+  @Title("Sisältyvät opintojaksot")
+  osasuoritukset: Option[List[KelaKorkeakoulunOpintojaksonOsasuoritus]],
+  @KoodistoUri("virtaopsuorluokittelu")
+  luokittelu: Option[List[KelaKoodistokoodiviite]],
+  @Description("Päivämäärä, jolloin suoritus on hyväksiluettu")
+  hyväksilukupäivä: Option[LocalDate],
+  @Description("Tieto siitä, onko opintosuoritus opinnäytetyö")
+  opinnäytetyö: Option[Boolean],
+  @Description("Opintosuorituksen julkinen lisätieto")
+  @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
+  lisätieto: Option[schema.LocalizedString],
+  @KoodistoKoodiarvo("korkeakoulunopintojakso")
+  tyyppi: schema.Koodistokoodiviite
+) extends KelaKorkeakoulunPäätasonSuoritus
+
+@Title("Muu korkeakoulun suoritus")
+case class KelaMuuKorkeakoulunSuoritus(
+  koulutusmoduuli: KelaMuuKorkeakoulunOpinto,
+  toimipiste: Toimipiste,
+  vahvistus: Option[Vahvistus],
+  osasuoritukset: Option[List[KelaKorkeakoulunOpintojaksonOsasuoritus]],
+  @Description("Tutkinnon tai opintojen vaadittu laajuus")
+  vaadittuLaajuus: Option[KelaLaajuus],
+  @KoodistoKoodiarvo("muukorkeakoulunsuoritus")
+  tyyppi: schema.Koodistokoodiviite
+) extends KelaKorkeakoulunPäätasonSuoritus
+
+@Title("Korkeakoulun opintojakson osasuoritus")
+case class KelaKorkeakoulunOpintojaksonOsasuoritus(
+  koulutusmoduuli: KelaKorkeakoulunOpintojakso,
+  toimipiste: Toimipiste,
+  vahvistus: Option[Vahvistus],
+  @Title("Sisältyvät opintojaksot")
+  osasuoritukset: Option[List[KelaKorkeakoulunOpintojaksonOsasuoritus]],
+  @KoodistoUri("virtaopsuorluokittelu")
+  luokittelu: Option[List[KelaKoodistokoodiviite]],
+  @Description("Päivämäärä, jolloin suoritus on hyväksiluettu")
+  hyväksilukupäivä: Option[LocalDate],
+  @Description("Tieto siitä, onko opintosuoritus opinnäytetyö")
+  opinnäytetyö: Option[Boolean],
+  @Description("Opintosuorituksen julkinen lisätieto")
+  @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
+  lisätieto: Option[schema.LocalizedString],
+  @KoodistoKoodiarvo("korkeakoulunopintojakso")
+  tyyppi: schema.Koodistokoodiviite
+) extends Osasuoritus {
+  override def withHyväksyntämerkinnälläKorvattuArvosana: Osasuoritus = this
+}
+
+@Description("Korkeakoulututkinnon tunnistetiedot")
+case class KelaKorkeakoulututkinto(
+  @KoodistoUri("koulutus")
+  tunniste: KelaKoodistokoodiviite,
+  koulutustyyppi: Option[KelaKoodistokoodiviite],
+  @Description("Tutkinnon nimi sellaisena kuin se Virrassa on")
+  virtaNimi: Option[schema.LocalizedString],
+  koulutusala: Option[KelaKorkeakoulunKoulutusala]
+) extends SuorituksenKoulutusmoduuli
+
+@Description("Korkeakoulun opintojakson tunnistetiedot")
+case class KelaKorkeakoulunOpintojakso(
+  tunniste: KelaPaikallinenKoodiviite,
+  nimi: schema.LocalizedString,
+  laajuus: Option[KelaLaajuus],
+  koulutusala: Option[KelaKorkeakoulunKoulutusala]
+) extends SuorituksenKoulutusmoduuli with OsasuorituksenKoulutusmoduuli
+
+@Description("Muun korkeakoulun opinnon tunnistetiedot")
+case class KelaMuuKorkeakoulunOpinto(
+  @Title("Opiskeluoikeuden tyyppi")
+  @KoodistoUri("virtaopiskeluoikeudentyyppi")
+  tunniste: KelaKoodistokoodiviite,
+  nimi: schema.LocalizedString,
+  laajuus: Option[KelaLaajuus]
+) extends SuorituksenKoulutusmoduuli

--- a/src/main/scala/fi/oph/koski/kela/KelaService.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaService.scala
@@ -8,7 +8,7 @@ import fi.oph.koski.http.{HttpStatus, KoskiErrorCategory}
 import fi.oph.koski.json.JsonSerializer
 import fi.oph.koski.koskiuser.KoskiSpecificSession
 import fi.oph.koski.log._
-import fi.oph.koski.schema.{KoskiSchema, YlioppilastutkinnonOpiskeluoikeus}
+import fi.oph.koski.schema.{KorkeakoulunOpiskeluoikeus, KoskiSchema, OpiskeluoikeudenTyyppi, YlioppilastutkinnonOpiskeluoikeus}
 import fi.oph.koski.util.Futures
 import org.json4s.JsonAST.JValue
 import rx.lang.scala.Observable
@@ -17,6 +17,7 @@ import java.time.LocalDateTime
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success, Try}
 
 class KelaService(application: KoskiApplication) extends GlobalExecutionContext with Logging {
   private val kelaOpiskeluoikeusRepository = new KelaOpiskeluoikeusRepository(
@@ -27,10 +28,11 @@ class KelaService(application: KoskiApplication) extends GlobalExecutionContext 
   def findKelaOppijaByHetu(hetu: String)
     (implicit koskiSession: KoskiSpecificSession): Either[HttpStatus, KelaOppija] = {
 
-    val (opiskeluoikeudet, ytrResult) = haeOpiskeluoikeudet(List(hetu), true)
+    val (opiskeluoikeudet, ytrResult, virtaResult) = haeOpiskeluoikeudet(List(hetu), haeUlkoisetJärjestelmät = true)
 
     val oppija = opiskeluoikeudet.headOption.map {
-      case (hlö, oos) => teePalautettavaKelaOppija(hlö, oos, ytrResult(hlö))
+      case (hlö, oos) => virtaResult.getOrElse(hlö, Right(Nil))
+        .flatMap(virta => teePalautettavaKelaOppija(hlö, oos, ytrResult(hlö), virta))
     }.toRight(
       KoskiErrorCategory.notFound.oppijaaEiLöydyTaiEiOikeuksia(
         "Oppijaa (hetu) ei löydy tai käyttäjällä ei ole oikeuksia tietojen katseluun."
@@ -41,7 +43,7 @@ class KelaService(application: KoskiApplication) extends GlobalExecutionContext 
   }
 
   def streamOppijatByHetu(hetut: Seq[String])(implicit koskiSession: KoskiSpecificSession): Observable[JValue] = {
-    val (opiskeluoikeudet, _) = haeOpiskeluoikeudet(hetut, false)
+    val (opiskeluoikeudet, _, _) = haeOpiskeluoikeudet(hetut, haeUlkoisetJärjestelmät = false)
 
     Observable
       .from(
@@ -49,6 +51,7 @@ class KelaService(application: KoskiApplication) extends GlobalExecutionContext 
           case (oppijaMasterOid, opiskeluoikeusRows) => teePalautettavaKelaOppija(
             oppijaMasterOid,
             opiskeluoikeusRows,
+            Seq.empty,
             Seq.empty
           )
         }
@@ -62,9 +65,13 @@ class KelaService(application: KoskiApplication) extends GlobalExecutionContext 
       .map(JsonSerializer.serializeWithUser(koskiSession))
   }
 
-  private def haeOpiskeluoikeudet(hetut: Seq[String], haeYtr: Boolean)(
+  private def haeOpiskeluoikeudet(hetut: Seq[String], haeUlkoisetJärjestelmät: Boolean)(
     implicit user: KoskiSpecificSession
-  ): (Map[LaajatOppijaHenkilöTiedot, Seq[RawOpiskeluoikeusData]], Map[LaajatOppijaHenkilöTiedot, Seq[KelaYlioppilastutkinnonOpiskeluoikeus]]) = {
+  ): (
+    Map[LaajatOppijaHenkilöTiedot, Seq[RawOpiskeluoikeusData]],
+    Map[LaajatOppijaHenkilöTiedot, Seq[KelaYlioppilastutkinnonOpiskeluoikeus]],
+    Map[LaajatOppijaHenkilöTiedot, Either[HttpStatus, Seq[KelaKorkeakoulunOpiskeluoikeus]]]
+  ) = {
     val masterHenkilötFut: Future[Map[String, LaajatOppijaHenkilöTiedot]] = Future(
       application.opintopolkuHenkilöFacade.findMasterOppijat(
         application.opintopolkuHenkilöFacade.findOppijatByHetusNoSlaveOids(hetut).map(_.oid).toList
@@ -72,7 +79,7 @@ class KelaService(application: KoskiApplication) extends GlobalExecutionContext 
     )
 
     val ytrResultFut: Future[Map[LaajatOppijaHenkilöTiedot, Seq[KelaYlioppilastutkinnonOpiskeluoikeus]]] = {
-      if (haeYtr) {
+      if (haeUlkoisetJärjestelmät) {
         masterHenkilötFut
           .map { masterHenkilöt =>
             masterHenkilöt.values
@@ -81,6 +88,15 @@ class KelaService(application: KoskiApplication) extends GlobalExecutionContext 
                   KelaYlioppilastutkinnonOpiskeluoikeus.fromKoskiSchema(yo)
               }
               ).toMap
+          }
+      } else Future.successful(Map.empty)
+    }
+
+    val virtaResultFut: Future[Map[LaajatOppijaHenkilöTiedot, Either[HttpStatus, Seq[KelaKorkeakoulunOpiskeluoikeus]]]] = {
+      if (haeUlkoisetJärjestelmät) {
+        masterHenkilötFut
+          .map { masterHenkilöt =>
+            masterHenkilöt.values.map(hlö => hlö -> haeVirranOpiskeluoikeudet(hlö)).toMap
           }
       } else Future.successful(Map.empty)
     }
@@ -95,15 +111,31 @@ class KelaService(application: KoskiApplication) extends GlobalExecutionContext 
           }.toMap
         }
 
-    val (opiskeluoikeudet, ytrResult) = Futures.await(
+    val (opiskeluoikeudet, ytrResult, virtaResult) = Futures.await(
       future = for {
         opiskeluoikeudet <- opiskeluoikeudetFut
         ytrResult <- ytrResultFut
-      } yield (opiskeluoikeudet, ytrResult),
+        virtaResult <- virtaResultFut
+      } yield (opiskeluoikeudet, ytrResult, virtaResult),
       atMost = if (Environment.isUnitTestEnvironment(application.config)) { 10.seconds } else { 20.minutes }
     )
-    (opiskeluoikeudet, ytrResult)
+    (opiskeluoikeudet, ytrResult, virtaResult)
   }
+
+  private def haeVirranOpiskeluoikeudet(hlö: LaajatOppijaHenkilöTiedot)(
+    implicit user: KoskiSpecificSession
+  ): Either[HttpStatus, Seq[KelaKorkeakoulunOpiskeluoikeus]] =
+    if (!kelallePalautettavaOpiskeluoikeusTyyppi(OpiskeluoikeudenTyyppi.korkeakoulutus.koodiarvo)) {
+      Right(Nil)
+    } else Try(application.virta.findByOppija(hlö)) match {
+      case Success(opiskeluoikeudet) => Right(opiskeluoikeudet
+        .collect { case kk: KorkeakoulunOpiskeluoikeus => kk }
+        .filter(kk => kelallePalautettavaOpiskeluoikeusTyyppi(kk.tyyppi.koodiarvo))
+        .map(KelaKorkeakoulunOpiskeluoikeus.fromKoskiSchema))
+      case Failure(e) =>
+        logger.error(e)(s"Virta-haku epäonnistui oppijalle ${hlö.oid}")
+        Left(KoskiErrorCategory.unavailable.virta())
+    }
 
   def opiskeluoikeudenHistoria(opiskeluoikeusOid: String)
     (implicit koskiSession: KoskiSpecificSession): Option[List[KelaOpiskeluoikeusHistoryPatch]] = {
@@ -139,6 +171,7 @@ class KelaService(application: KoskiApplication) extends GlobalExecutionContext 
       oppija <- teePalautettavaKelaOppija(
         hlö,
         Seq(opiskeluoikeusData),
+        Seq.empty,
         Seq.empty
       )
     } yield oppija
@@ -157,18 +190,19 @@ class KelaService(application: KoskiApplication) extends GlobalExecutionContext 
   private def teePalautettavaKelaOppija(
     oppijaHenkilö: LaajatOppijaHenkilöTiedot,
     rawOpiskeluoikeudet: Seq[RawOpiskeluoikeusData],
-    ytrOpiskeluoikeudet: Seq[KelaYlioppilastutkinnonOpiskeluoikeus]
+    ytrOpiskeluoikeudet: Seq[KelaYlioppilastutkinnonOpiskeluoikeus],
+    virtaOpiskeluoikeudet: Seq[KelaKorkeakoulunOpiskeluoikeus]
   ): Either[HttpStatus, KelaOppija] = {
     val opiskeluoikeudet =
       rawOpiskeluoikeudet
         .map(deserializeAndCleanKelaOpiskeluoikeus)
         .collect { case Right(oo) => oo }
 
-    if (opiskeluoikeudet.nonEmpty || ytrOpiskeluoikeudet.nonEmpty) {
+    if (opiskeluoikeudet.nonEmpty || ytrOpiskeluoikeudet.nonEmpty || virtaOpiskeluoikeudet.nonEmpty) {
       Right(
         KelaOppija(
           henkilö = Henkilo.fromOppijaHenkilö(oppijaHenkilö),
-          opiskeluoikeudet = opiskeluoikeudet.toList ++ ytrOpiskeluoikeudet
+          opiskeluoikeudet = opiskeluoikeudet.toList ++ ytrOpiskeluoikeudet ++ virtaOpiskeluoikeudet
         )
       )
     }
@@ -194,10 +228,10 @@ class KelaService(application: KoskiApplication) extends GlobalExecutionContext 
   }
 
   private def kelallePalautettavaOpiskeluoikeusTyyppi(opiskeluoikeusTyyppi: String): Boolean = {
-    val configKey = "kela.palautettavatOpiskeluoikeustyypit"
+    val configKey = "kela.eiPalautettavatOpiskeluoikeustyypit"
     if (application.config.hasPath(configKey)) {
-      val allowList = application.config.getList(configKey)
-      allowList.unwrapped().asScala.toList.contains(opiskeluoikeusTyyppi)
+      val estetyt = application.config.getList(configKey)
+      !estetyt.unwrapped().asScala.toList.contains(opiskeluoikeusTyyppi)
     } else {
       true
     }

--- a/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
+++ b/src/test/scala/fi/oph/koski/kela/KelaSpec.scala
@@ -7,6 +7,8 @@ import fi.oph.koski.henkilo.KoskiSpecificMockOppijat
 import fi.oph.koski.history.OpiskeluoikeusHistoryPatch
 import fi.oph.koski.http.KoskiErrorCategory
 import fi.oph.koski.json.JsonSerializer
+import org.json4s.{JArray, JObject, JValue}
+import org.json4s.jackson.JsonMethods
 import fi.oph.koski.koskiuser.MockUsers
 import fi.oph.koski.log.{AccessLogTester, AuditLogTester}
 import fi.oph.koski.organisaatio.MockOrganisaatiot.{EuropeanSchoolOfHelsinki, MuuKuinSäänneltyKoulutusToimija}
@@ -61,8 +63,37 @@ class KelaSpec
         verifyResponseStatus(400, KoskiErrorCategory.badRequest.validation.henkilötiedot.hetu("Virheellinen tarkistusmerkki hetussa: 230305A015A"))
       }
     }
-    "Palautetaan 404 jos opiskelijalla ei ole ollenkaan Kelaa kiinnostavia opiskeluoikeuksia" in {
+    "Korkeakoulun opiskeluoikeudet haetaan Virrasta ja palautetaan Kelalle" in {
       postHetu(KoskiSpecificMockOppijat.monimutkainenKorkeakoululainen.hetu.get) {
+        verifyResponseStatusOk()
+        val oppija = JsonSerializer.parse[KelaOppija](body)
+
+        oppija.henkilö.hetu should equal(KoskiSpecificMockOppijat.monimutkainenKorkeakoululainen.hetu)
+
+        val korkeakoulut = oppija.opiskeluoikeudet.collect { case oo: KelaKorkeakoulunOpiskeluoikeus => oo }
+        korkeakoulut should not be empty
+        oppija.opiskeluoikeudet.map(_.tyyppi.koodiarvo).distinct should equal(
+          List(schema.OpiskeluoikeudenTyyppi.korkeakoulutus.koodiarvo)
+        )
+
+        korkeakoulut.flatMap(_.lähdejärjestelmänId) should contain("1927")
+
+        val ilmoittautumispäivät = korkeakoulut
+          .flatMap(_.lisätiedot)
+          .flatMap(_.lukukausiIlmoittautuminen)
+          .flatMap(_.ilmoittautumisjaksot)
+          .flatMap(_.ilmoittautumispäivä)
+        ilmoittautumispäivät should not be empty
+      }
+    }
+    "Virran katkoksesta palautetaan virhe eikä vaillinaista dataa" in {
+      postHetu(KoskiSpecificMockOppijat.virtaEiVastaa.hetu.get) {
+        verifyResponseStatus(503, KoskiErrorCategory.unavailable.virta())
+      }
+    }
+
+    "Palautetaan 404 jos opiskelijalla ei ole ollenkaan Kelaa kiinnostavia opiskeluoikeuksia" in {
+      postHetu(KoskiSpecificMockOppijat.taiteenPerusopetusAloitettu.hetu.get) {
         verifyResponseStatus(404, KoskiErrorCategory.notFound.oppijaaEiLöydyTaiEiOikeuksia("Oppijaa (hetu) ei löydy tai käyttäjällä ei ole oikeuksia tietojen katseluun."))
       }
     }
@@ -576,6 +607,18 @@ class KelaSpec
     }
   }
 
+  private def arvosanaanViittaavatKentät(json: JValue): List[String] = {
+    def kentät(j: JValue): List[String] = j match {
+      case JObject(fields) => fields.flatMap { case (nimi, arvo) => nimi :: kentät(arvo) }
+      case JArray(alkiot) => alkiot.flatMap(kentät)
+      case _ => Nil
+    }
+    kentät(json).filter { nimi =>
+      val n = nimi.toLowerCase
+      n.contains("arvosana") || n.contains("taitotaso")
+    }.distinct
+  }
+
   "Arvosanadataa sisältäviltä vaikuttavia kenttiä ei palauteta" in {
     var iteraatioLkm = 0
 
@@ -593,8 +636,7 @@ class KelaSpec
             val oppija = JsonSerializer.parse[KelaOppija](body)
             withClue(s"${hetu} ${oppija.henkilö.sukunimi} ${oppija.henkilö.etunimet} ${oppija.opiskeluoikeudet.map(_.tyyppi.koodiarvo).mkString(",")}") {
               iteraatioLkm = iteraatioLkm + 1
-              body.toLowerCase.contains("arvosana") should be(false)
-              body.toLowerCase.contains("taitotaso") should be(false)
+              arvosanaanViittaavatKentät(JsonMethods.parse(body)) should be(empty)
             }
           }
         }


### PR DESCRIPTION
Lisää `KelaKorkeakouluSchema`-skeema ja Virta-haku `KelaServiceen`. 

**Pohjautuu #4356:een**, ei masteriin, koska tarvitsee siinä lisätyt kentät.



**1. Virran katkoksesta palautetaan 503 eikä vaillinaista dataa.**

**2. Opiskeluoikeustyyppien suodatus on nyt blacklist**
 
**3. Massahaussa (`/hetut`) korkeakoulutietoja ei haeta.**

### Tietosuoja

`rahoituslähdeJaksot` ja `lisätieto`-kentät `@SensitiveData(LUOTTAMUKSELLINEN_KELA_LAAJA)`, mikä on muiden Kela-skeemojen käytäntö (28 kenttää).