### PR TITLE
TOR-2275 siivoa käyttämätön suoritusjako-toiminnallisuus auditloki-rajapinnasta

### DIFF
--- a/src/main/scala/fi/oph/koski/omaopintopolkuloki/AuditLogMockData.scala
+++ b/src/main/scala/fi/oph/koski/omaopintopolkuloki/AuditLogMockData.scala
@@ -175,24 +175,6 @@ object AuditLogMockData extends Logging {
     ),
     MockData(
       studentOid = KoskiSpecificMockOppijat.ylioppilasLukiolainen.oid,
-      time = "2000-01-12T20:31:32.104+03",
-      organizationOid = List(MockOrganisaatiot.helsinginKaupunki),
-      raw = rawAuditlog("KANSALAINEN_SUORITUSJAKO_KATSOMINEN")
-    ),
-    MockData(
-      studentOid = KoskiSpecificMockOppijat.ylioppilasLukiolainen.oid,
-      time = "2000-01-13T20:31:32.104+03",
-      organizationOid = List(MockOrganisaatiot.helsinginKaupunki),
-      raw = rawAuditlog("KANSALAINEN_SUORITUSJAKO_KATSOMINEN_SUORITETUT_TUTKINNOT")
-    ),
-    MockData(
-      studentOid = KoskiSpecificMockOppijat.ylioppilasLukiolainen.oid,
-      time = "2000-01-14T20:31:32.104+03",
-      organizationOid = List(MockOrganisaatiot.helsinginKaupunki),
-      raw = rawAuditlog("KANSALAINEN_SUORITUSJAKO_KATSOMINEN_AKTIIVISET_JA_PAATTYNEET_OPINNOT")
-    ),
-    MockData(
-      studentOid = KoskiSpecificMockOppijat.ylioppilasLukiolainen.oid,
       time = "2000-01-15T20:31:32.104+03",
       organizationOid = List(MockOrganisaatiot.dvv),
       raw = rawAuditlog("OAUTH2_KATSOMINEN_KAIKKI_TIEDOT")

--- a/src/main/scala/fi/oph/koski/omaopintopolkuloki/AuditLogService.scala
+++ b/src/main/scala/fi/oph/koski/omaopintopolkuloki/AuditLogService.scala
@@ -50,9 +50,6 @@ class AuditLogService(val application: KoskiApplication) extends Logging with My
           |  contains (#rawEntry, :oauth2_katsominen_kaikki_tiedot_ja_valintatiedot) or
           |  contains (#rawEntry, :oauth2_katsominen_suoritetut_tutkinnot) or
           |  contains (#rawEntry, :oauth2_katsominen_aktiiviset_ja_paattyneet_opinnot) or
-          |  contains (#rawEntry, :suoritusjako_katsominen) or
-          |  contains (#rawEntry, :suoritusjako_katsominen_suoritetut_tutkinnot) or
-          |  contains (#rawEntry, :suoritusjako_katsominen_aktiiviset_ja_paattyneet_opinnot) or
           |  contains (#rawEntry, :valpas_oppija_katsominen) or
           |  contains (#rawEntry, :valpas_kuntailmoituksen_katsominen) or
           |  contains (#rawEntry, :oppivelvollisuusrekisteri_luovutus) or
@@ -67,9 +64,6 @@ class AuditLogService(val application: KoskiApplication) extends Logging with My
         valueMap.put(":katsominen", AttributeValue.builder.s("\"OPISKELUOIKEUS_KATSOMINEN\"").build)
         valueMap.put(":muutoshistoria_katsominen", AttributeValue.builder.s("\"MUUTOSHISTORIA_KATSOMINEN\"").build)
         valueMap.put(":ytr_katsominen", AttributeValue.builder.s("\"YTR_OPISKELUOIKEUS_KATSOMINEN\"").build)
-        valueMap.put(":suoritusjako_katsominen", AttributeValue.builder.s("\"KANSALAINEN_SUORITUSJAKO_KATSOMINEN\"").build)
-        valueMap.put(":suoritusjako_katsominen_suoritetut_tutkinnot", AttributeValue.builder.s("\"KANSALAINEN_SUORITUSJAKO_KATSOMINEN_SUORITETUT_TUTKINNOT\"").build)
-        valueMap.put(":suoritusjako_katsominen_aktiiviset_ja_paattyneet_opinnot", AttributeValue.builder.s("\"KANSALAINEN_SUORITUSJAKO_KATSOMINEN_AKTIIVISET_JA_PAATTYNEET_OPINNOT\"").build)
         valueMap.put(":oauth2_katsominen_kaikki_tiedot", AttributeValue.builder.s("\"OAUTH2_KATSOMINEN_KAIKKI_TIEDOT\"").build)
         valueMap.put(":oauth2_katsominen_kaikki_tiedot_ja_valintatiedot", AttributeValue.builder.s("\"OAUTH2_KATSOMINEN_KAIKKI_TIEDOT_JA_VALINTATIEDOT\"").build)
         valueMap.put(":oauth2_katsominen_suoritetut_tutkinnot", AttributeValue.builder.s("\"OAUTH2_KATSOMINEN_SUORITETUT_TUTKINNOT\"").build)
@@ -123,23 +117,20 @@ class AuditLogService(val application: KoskiApplication) extends Logging with My
         val timestampString = parsedRow.time
         val serviceName = AuditLogService.resolveServiceName(parsedRaw.operation, parsedRaw.serviceName)
         val isMyDataUse = parsedRaw.operation.startsWith("OAUTH2_KATSOMINEN") || parsedRow.organizationOid.headOption.exists(isMyDataOrg)
-        // TODO: Jakolinkkien käyttöjen palauttaminen frontille on toteutettu valmiiksi, mutta oma-opintopolku-lokin DynamoDB-parsinta skippaa näiden
-        // entryjen käsittelyn, minkä vuoksi tuotantoympäristöissä näitä entryjä ei vielä käytännössä DynamoDB:ssä ole.
-        val isJakolinkkiUse = parsedRaw.operation.startsWith("KANSALAINEN_SUORITUSJAKO_KATSOMINEN")
-        (organisaatioOidit, serviceName, isMyDataUse, isJakolinkkiUse, timestampString)
+        (organisaatioOidit, serviceName, isMyDataUse, timestampString)
       })
       .toSeq
-      .groupBy(x => (x._1, x._2, x._3, x._4))
+      .groupBy(x => (x._1, x._2, x._3))
       .view
-      .mapValues(_.map(_._5))
+      .mapValues(_.map(_._4))
       .toMap
 
     HttpStatus.foldEithers(
       timestampsGrouped
         .map {
-          case ((orgs, serviceName, isMyDataUse, isJakolinkkiUse), timestamps) =>
+          case ((orgs, serviceName, isMyDataUse), timestamps) =>
             HttpStatus.foldEithers(orgs.map(toOrganisaatio))
-              .map(orgs => OrganisaationAuditLogit(orgs, serviceName, isMyDataUse, isJakolinkkiUse, timestamps.sorted.reverse))
+              .map(orgs => OrganisaationAuditLogit(orgs, serviceName, isMyDataUse, timestamps.sorted.reverse))
         }
         .toSeq
     ).map(_.sortBy(_.timestamps.headOption)(Ordering[Option[String]].reverse))
@@ -218,7 +209,6 @@ case class OrganisaationAuditLogit(
   organizations: Seq[Organisaatio],
   serviceName: String,
   isMyDataUse: Boolean,
-  isJakolinkkiUse: Boolean,
   timestamps: Seq[String]
 )
 

--- a/src/test/scala/fi/oph/koski/omaopintopolkuloki/OmaOpintoPolkuLokiServletSpec.scala
+++ b/src/test/scala/fi/oph/koski/omaopintopolkuloki/OmaOpintoPolkuLokiServletSpec.scala
@@ -37,16 +37,13 @@ class OmaOpintoPolkuLokiServletSpec extends AnyFreeSpec with Matchers with Koski
         List(MockOrganisaatiot.stadinAmmattiopisto)
       ))
     }
-    "Näytetään KANSALAINEN_SUORITUSJAKO_KATSOMINEN_* - ja OAUTH2_KATSOMINEN_* -auditlogeja" in {
+    "Näytetään OAUTH2_KATSOMINEN_* -auditlogeja" in {
       val logs = auditlogs(KoskiSpecificMockOppijat.ylioppilasLukiolainen)
-      logs should have length(2)
+      logs should have length(1)
       logs.map(_.organizations.map(_.oid)) should contain theSameElementsAs(List(
-        List(MockOrganisaatiot.helsinginKaupunki),
         List(MockOrganisaatiot.dvv)
       ))
-      def timestamps(oid: String) = logs.find(_.organizations.exists(_.oid == oid)).get.timestamps
-      timestamps(MockOrganisaatiot.helsinginKaupunki) should have length(3)
-      timestamps(MockOrganisaatiot.dvv) should have length(4)
+      logs.head.timestamps should have length(4)
     }
     "Näytetään Valppaan oppija- ja kuntailmoituskatselut sekä oppivelvollisuusrekisterin luovutukset" in {
       auditlogs(KoskiSpecificMockOppijat.ysiluokkalainen).map(_.organizations.map(_.oid)) should contain theSameElementsAs(List(


### PR DESCRIPTION
Suoritusjakojen auditlokit eivät tällä hetkellä päädy DynamoDB:hen, joten ne eivät koskaan tule mukaan tuloksiin. Tällä hetkellä ei ole myöskään aikomusta alkaa tallentaa tapahtumia.