### PR TITLE
TOR-2596: Korjaa v2 dropdownin näppäimistönavigaatio

### DIFF
--- a/web/app/components-v2/controls/Select.tsx
+++ b/web/app/components-v2/controls/Select.tsx
@@ -482,14 +482,36 @@ const useSelectState = <T,>(props: SelectProps<T>) => {
 
   // Filter options
 
-  const options: OptionList<T> = useMemo(() => {
-    const opts =
-      filter === '' || filter === null
-        ? props.options
-        : queryOptions(props.options, filter)
-    // Remove one level of grouping if only one group is present
-    return opts.length === 1 && opts[0].isGroup ? opts[0].children || [] : opts
-  }, [filter, props.options])
+  const options: OptionList<T> = useMemo(
+    () => visibleOptions(props.options, filter),
+    [filter, props.options]
+  )
+
+  /**
+   * Näppäimistönavigaation lista: näkyvät, valittavissa olevat vaihtoehdot
+   * siinä järjestyksessä kuin ne renderöidään.
+   *
+   * Nuolinäppäimet kulkivat aiemmin suodattamattoman listan läpi, jolloin
+   * hakusanalla rajatussa valikossa korostus siirtyi vaihtoehtoihin joita ei
+   * näytetä: valikko näytti reagoimattomalta ja Enter valitsi jotain muuta
+   * kuin mitä käyttäjä näki.
+   */
+  const navigableOptions = useMemo(
+    () => selectableOptions(options, props.maxOptions),
+    [options, props.maxOptions]
+  )
+
+  // Hakutulosten vaihtuessa (esim. palvelinhaku onSearchilla) korostus voi
+  // jäädä osoittamaan vaihtoehtoa, jota ei enää näytetä. Enter ei saa valita
+  // näkymätöntä vaihtoehtoa.
+  useEffect(() => {
+    if (
+      hoveredOption &&
+      !navigableOptions.some((o) => o.key === hoveredOption.key)
+    ) {
+      onMouseOverOption(undefined)
+    }
+  }, [hoveredOption, navigableOptions])
 
   // Interaction
 
@@ -501,7 +523,7 @@ const useSelectState = <T,>(props: SelectProps<T>) => {
           return
         case 'ArrowDown':
           if (dropdownVisible) {
-            onMouseOverOption(selectOption(flatOptions, hoveredOption, 1))
+            onMouseOverOption(stepOption(navigableOptions, hoveredOption, 1))
           }
           setDropdownVisible(true)
           event.preventDefault()
@@ -510,7 +532,7 @@ const useSelectState = <T,>(props: SelectProps<T>) => {
           return
         case 'ArrowUp':
           if (dropdownVisible) {
-            onMouseOverOption(selectOption(flatOptions, hoveredOption, -1))
+            onMouseOverOption(stepOption(navigableOptions, hoveredOption, -1))
           }
           setDropdownVisible(true)
           event.preventDefault()
@@ -539,10 +561,22 @@ const useSelectState = <T,>(props: SelectProps<T>) => {
         // console.log(event.key)
       }
     },
-    [closeDropdown, dropdownVisible, flatOptions, hoveredOption, onClickOption]
+    [
+      closeDropdown,
+      dropdownVisible,
+      hoveredOption,
+      navigableOptions,
+      onClickOption
+    ]
   )
 
-  const { hideEmpty, onSearch, onClear: onClearProp } = props
+  const {
+    hideEmpty,
+    maxOptions,
+    options: allOptions,
+    onSearch,
+    onClear: onClearProp
+  } = props
   const onUserType: React.ChangeEventHandler<HTMLInputElement> = useCallback(
     (event) => {
       setFilter(event.target.value)
@@ -561,18 +595,27 @@ const useSelectState = <T,>(props: SelectProps<T>) => {
         }
       }
 
-      const needle = event.target.value.toLowerCase()
+      // Korostus seuraa suodatettua listaa. Suodatettu lista lasketaan tässä
+      // uudestaan, koska filter-tila päivittyy vasta seuraavassa renderissä.
+      const needle = event.target.value
       if (needle && !hideEmpty) {
-        const firstMatch = flatOptions.arr.find((o) =>
-          o.label.toLowerCase().includes(needle)
+        onMouseOverOption(
+          selectableOptions(visibleOptions(allOptions, needle), maxOptions)[0]
         )
-        onMouseOverOption(firstMatch)
       } else {
         onMouseOverOption(undefined)
       }
       onSearch?.(event.target.value)
     },
-    [flatOptions, hideEmpty, onChangeCb, onClearProp, onSearch]
+    [
+      allOptions,
+      flatOptions,
+      hideEmpty,
+      maxOptions,
+      onChangeCb,
+      onClearProp,
+      onSearch
+    ]
   )
 
   return useMemo(
@@ -743,17 +786,45 @@ export const filterOptions =
 
 // Internal utils
 
-const selectOption = <T,>(
-  flatOptions: FlatOptionList<T>,
+/**
+ * Vaihtoehdot siinä muodossa kuin valikko ne näyttää: hakusanalla
+ * suodatettuna ja yhden ryhmän tapauksessa ryhmittely purettuna.
+ */
+const visibleOptions = <T,>(
+  options: OptionList<T>,
+  filter: string | null
+): OptionList<T> => {
+  const opts =
+    filter === '' || filter === null ? options : queryOptions(options, filter)
+  // Remove one level of grouping if only one group is present
+  return opts.length === 1 && opts[0].isGroup ? opts[0].children || [] : opts
+}
+
+/**
+ * Näkyvistä vaihtoehdoista ne, jotka voi valita: ryhmäotsikot pois ja
+ * maxOptions-katkaisu samalla tavalla kuin OptionList renderöidessään tekee.
+ */
+const selectableOptions = <T,>(
+  options: OptionList<T>,
+  maxOptions?: number
+): OptionList<T> => {
+  const shown = maxOptions ? A.takeLeft(maxOptions)(options) : options
+  return shown.flatMap((o) => [
+    ...(o.isGroup ? [] : [o]),
+    ...(o.children ? selectableOptions(o.children, maxOptions) : [])
+  ])
+}
+
+const stepOption = <T,>(
+  options: OptionList<T>,
   current: SelectOption<T> | undefined,
   steps: number
 ): SelectOption<T> | undefined => {
   const currentIndex = current
-    ? flatOptions.arr.findIndex((o) => o.key === current.key)
+    ? options.findIndex((o) => o.key === current.key)
     : -1
-  const index = clamp(-1, flatOptions.arr.length - 1)(currentIndex + steps)
-  const option = index >= 0 ? flatOptions.arr[index] : undefined
-  return option?.isGroup ? selectOption(flatOptions, option, steps) : option
+  const index = clamp(-1, options.length - 1)(currentIndex + steps)
+  return index >= 0 ? options[index] : undefined
 }
 
 const flattenOptions = <T,>(options: OptionList<T>): FlatOptionList<T> => {

--- a/web/test/e2e/pudotusvalikko.spec.ts
+++ b/web/test/e2e/pudotusvalikko.spec.ts
@@ -83,6 +83,46 @@ test.describe('Pudotusvalikko', () => {
     await expect(kieli).toHaveValue('')
   })
 
+  test('Nuolinäppäimet liikkuvat suodatetussa listassa', async ({
+    page,
+    oppijaPage,
+    fixtures
+  }) => {
+    await fixtures.reset()
+    await avaaMuokkaus(page, oppijaPage, 0)
+
+    const kieli = page.getByTestId(`${KIELI}.input`)
+    const kentta = page.locator('.Select', {
+      has: page.getByTestId(`${KIELI}.input`)
+    })
+    const korostettu = kentta.locator('.Select__optionLabel--hover')
+
+    await kieli.click()
+    await kieli.fill('ma')
+
+    // Ryhmäotsikot eivät ole valittavissa, joten navigaatio ohittaa ne.
+    const valittavat = await kentta
+      .locator('.Select__optionLabel:not(.Select__optionGroup)')
+      .allInnerTexts()
+    expect(valittavat.length).toBeGreaterThan(3)
+
+    // Kirjoittaminen korostaa suodatetun listan ensimmäisen vaihtoehdon...
+    await expect(korostettu).toHaveText(valittavat[0])
+
+    // ...ja nuolet liikkuvat suodatetussa listassa. Aiemmin ne kulkivat
+    // suodattamattoman listan läpi, jolloin korostus katosi näkyvistä ja
+    // Enter valitsi vaihtoehdon, jota käyttäjä ei nähnyt.
+    await page.keyboard.press('ArrowDown')
+    await expect(korostettu).toHaveText(valittavat[1])
+    await page.keyboard.press('ArrowDown')
+    await expect(korostettu).toHaveText(valittavat[2])
+    await page.keyboard.press('ArrowUp')
+    await expect(korostettu).toHaveText(valittavat[1])
+
+    await page.keyboard.press('Enter')
+    await expect(kieli).toHaveValue(valittavat[1])
+  })
+
   test('Arvosanan tyhjentäminen poistaa arvioinnin', async ({
     page,
     oppijaPage,


### PR DESCRIPTION
Select piti kahta eri listaa: renderöinti käytti hakusanalla suodatettua listaa, mutta onKeyDown askelsi flatOptionsia eli kaikkia vaihtoehtoja. Kun kenttään oli kirjoitettu hakusana, nuolinäppäimet siirsivät korostuksen vaihtoehtoihin joita ei näytetty: valikko näytti reagoimattomalta ja Enter valitsi vaihtoehdon, jota käyttäjä ei nähnyt.

Samasta syystä johtui kaksi muuta vikaa:

- Kirjoittaessa korostus haettiin suodattamattomasta listasta eri säännöllä (label.includes) kuin suodatus itse tekee. Ryhmäotsikot ovat mukana samassa listassa, joten osuma saattoi olla ryhmäotsikko - se sai korostuksen, vaikka sitä ei voi valita, ja Enter välitti ryhmän onChangelle arvotta.
- Vanha selectOption ohitti ryhmäotsikot rekursiolla. Jos listan viimeinen alkio oli ryhmä - mahdollista suodatettaessa, kun ryhmän nimi osuu hakuun mutta yksikään lapsi ei - rekursio ei päättynyt.

Navigaatio kulkee nyt samaa listaa kuin renderöinti: visibleOptions tekee suodatuksen ja yhden ryhmän purun yhdessä paikassa, ja selectableOptions poimii siitä valittavat vaihtoehdot renderöintijärjestyksessä maxOptions- katkaisu huomioiden. Ryhmäotsikot on jo karsittu, joten stepOption indeksoi listaa suoraan eikä rekursiota tarvita.

Lisäksi korostus nollataan, jos se ei enää osu näkyvään vaihtoehtoon. Tämä kattaa palvelinhaun (onSearch): uuden kyselyn tulokset ehtivät vaihtua sen jälkeen kun korostus on asetettu edellisen kyselyn tuloksista.

Todennettu ajamalla komponentti erillisessä harnessissa ennen ja jälkeen korjauksen: ryhmitellyssä listassa suodatettuna ArrowDown hukkasi korostuksen ja Enter valitsi suodatuksen ulkopuolisen vaihtoehdon. e2e-testi lisätty, mutta sitä ei ole ajettu - CI kattaa sen.


Claude-Session: https://claude.ai/code/session_01SYEWdDy8x7peJSRcU5j5U1