### PR TITLE
Rename SDG-local traits colliding with main schema class names

### DIFF
--- a/src/main/scala/fi/oph/koski/sdg/SdgAmmatillinenSchema.scala
+++ b/src/main/scala/fi/oph/koski/sdg/SdgAmmatillinenSchema.scala
@@ -12,19 +12,19 @@ case class SdgAmmatillinenOpiskeluoikeus(
   oid: Option[String],
   oppilaitos: Option[schema.Oppilaitos],
   koulutustoimija: Option[schema.Koulutustoimija],
-  tila: OpiskeluoikeudenTila,
-  suoritukset: List[AmmatillinenPäätasonSuoritus],
+  tila: SdgOpiskeluoikeudenTila,
+  suoritukset: List[SdgAmmatillinenPäätasonSuoritus],
   @KoodistoKoodiarvo("ammatillinenkoulutus")
   tyyppi: schema.Koodistokoodiviite,
-) extends Opiskeluoikeus {
-  override def withSuoritukset(suoritukset: List[Suoritus]): SdgAmmatillinenOpiskeluoikeus = {
+) extends SdgOpiskeluoikeus {
+  override def withSuoritukset(suoritukset: List[SdgSuoritus]): SdgAmmatillinenOpiskeluoikeus = {
     this.copy (
-      suoritukset = suoritukset.collect { case s: AmmatillinenPäätasonSuoritus => s }
+      suoritukset = suoritukset.collect { case s: SdgAmmatillinenPäätasonSuoritus => s }
     )
   }
 }
 
-trait AmmatillinenPäätasonSuoritus extends Suoritus
+trait SdgAmmatillinenPäätasonSuoritus extends SdgSuoritus
 
 @Title("Ammatillisen tutkinnon suoritus")
 case class SdgAmmatillisenTutkinnonSuoritus(
@@ -39,7 +39,7 @@ case class SdgAmmatillisenTutkinnonSuoritus(
   tutkintonimike: Option[List[schema.Koodistokoodiviite]],
   osasuoritukset: Option[List[AmmatillisenTutkinnonOsasuoritus]],
   keskiarvo: Option[Double]
-) extends AmmatillinenPäätasonSuoritus {
+) extends SdgAmmatillinenPäätasonSuoritus {
   override def withOsasuoritukset(os: Option[List[Osasuoritus]]): SdgAmmatillisenTutkinnonSuoritus = this.copy(osasuoritukset = os.map(_.collect {
     case s: AmmatillisenTutkinnonOsasuoritus => s
   }))
@@ -64,7 +64,7 @@ case class SdgAmmatillisenTutkinnonOsaTaiOsia(
   keskiarvo: Option[Double] = None,
   korotettuOpiskeluoikeusOid: Option[String] = None,
   korotettuKeskiarvo: Option[Double] = None,
-) extends AmmatillinenPäätasonSuoritus {
+) extends SdgAmmatillinenPäätasonSuoritus {
   override def withOsasuoritukset(os: Option[List[Osasuoritus]]): SdgAmmatillisenTutkinnonOsaTaiOsia = this.copy(osasuoritukset = os.map(_.collect {
     case s: AmmatillisenTutkinnonOsasuoritus => s
   }))
@@ -84,19 +84,19 @@ case class SdgAmmatillisenTutkinnonOsittainenUseastaTutkinnostaSuoritus(
   vahvistus: Option[SdgVahvistus],
   suorituskieli: schema.Koodistokoodiviite,
   @Title("Tutkinnon osat")
-  osasuoritukset: Option[List[OsittaisenAmmatillisenTutkinnonOsanUseastaTutkinnostaSuoritus]],
+  osasuoritukset: Option[List[SdgOsittaisenAmmatillisenTutkinnonOsanUseastaTutkinnostaSuoritus]],
   @KoodistoKoodiarvo("ammatillinentutkintoosittainen")
   tyyppi: schema.Koodistokoodiviite,
   keskiarvo: Option[Double] = None,
-) extends AmmatillinenPäätasonSuoritus {
+) extends SdgAmmatillinenPäätasonSuoritus {
   override def withOsasuoritukset(os: Option[List[Osasuoritus]]): SdgAmmatillisenTutkinnonOsittainenUseastaTutkinnostaSuoritus = this.copy(osasuoritukset = os.map(_.collect {
-    case s: OsittaisenAmmatillisenTutkinnonOsanUseastaTutkinnostaSuoritus => s
+    case s: SdgOsittaisenAmmatillisenTutkinnonOsanUseastaTutkinnostaSuoritus => s
   }))
 }
 
 trait AmmatillisenTutkinnonOsasuoritus extends Osasuoritus
 
-trait OsittaisenAmmatillisenTutkinnonOsanUseastaTutkinnostaSuoritus extends Osasuoritus with WithTunnustettuBoolean
+trait SdgOsittaisenAmmatillisenTutkinnonOsanUseastaTutkinnostaSuoritus extends Osasuoritus with WithTunnustettuBoolean
 
 @Title("Yhteisen tutkinnon osan suoritus")
 case class SdgYhteisenTutkinnonOsanSuoritus(
@@ -112,7 +112,7 @@ case class SdgYhteisenTutkinnonOsanSuoritus(
   @KoodistoKoodiarvo("ammatillisentutkinnonosa")
   tyyppi: schema.Koodistokoodiviite
 ) extends AmmatillisenTutkinnonOsasuoritus
-  with OsittaisenAmmatillisenTutkinnonOsanUseastaTutkinnostaSuoritus
+  with SdgOsittaisenAmmatillisenTutkinnonOsanUseastaTutkinnostaSuoritus
 
 @Title("Muun tutkinnon osan suoritus")
 case class SdgMuunTutkinnonOsanSuoritus(
@@ -127,7 +127,7 @@ case class SdgMuunTutkinnonOsanSuoritus(
   suorituskieli: Option[schema.Koodistokoodiviite],
   tyyppi: schema.Koodistokoodiviite
 ) extends AmmatillisenTutkinnonOsasuoritus
-  with OsittaisenAmmatillisenTutkinnonOsanUseastaTutkinnostaSuoritus
+  with SdgOsittaisenAmmatillisenTutkinnonOsanUseastaTutkinnostaSuoritus
 
 @Title("Korkeakouluopintoja")
 @OnlyWhen("../../suoritustapa/koodiarvo", "reformi")
@@ -143,7 +143,7 @@ case class SdgAmmatillinenKorkeakouluopintoja(
 case class SdgAmmatillisenTutkinnonOsanJatkoOpintovalmiuksiaTukevienOpintojenSuoritus(
   koulutusmoduuli: schema.JatkoOpintovalmiuksiaTukeviaOpintojaTutkinnonOsa,
   tutkinnonOsanRyhmä: Option[schema.Koodistokoodiviite],
-  osasuoritukset: Option[List[YhteistenTutkinnonOsienOsaAlueidenTaiLukioOpintojenTaiMuidenOpintovalmiuksiaTukevienOpintojenOsasuoritus]] = None,
+  osasuoritukset: Option[List[SdgYhteistenTutkinnonOsienOsaAlueidenTaiLukioOpintojenTaiMuidenOpintovalmiuksiaTukevienOpintojenOsasuoritus]] = None,
   tyyppi: schema.Koodistokoodiviite
 ) extends AmmatillisenTutkinnonOsasuoritus
 
@@ -164,7 +164,7 @@ case class SdgAmmatillinenKorkeakouluopintojenSuoritus(
   tyyppi: schema.Koodistokoodiviite
 ) extends WithTunnustettuBoolean
 
-trait YhteistenTutkinnonOsienOsaAlueidenTaiLukioOpintojenTaiMuidenOpintovalmiuksiaTukevienOpintojenOsasuoritus extends WithTunnustettuBoolean {
+trait SdgYhteistenTutkinnonOsienOsaAlueidenTaiLukioOpintojenTaiMuidenOpintovalmiuksiaTukevienOpintojenOsasuoritus extends WithTunnustettuBoolean {
   def koulutusmoduuli: schema.Koulutusmoduuli
   def arviointi: Option[List[SdgAmmatillinenArviointi]]
   def tunnustettu: Option[schema.OsaamisenTunnustaminen]
@@ -180,7 +180,7 @@ case class SdgYhteisenTutkinnonOsanOsaAlueenSuoritus (
   tunnustettu: Option[schema.OsaamisenTunnustaminen],
   suorituskieli: Option[schema.Koodistokoodiviite] = None,
   tyyppi: schema.Koodistokoodiviite,
-) extends YhteistenTutkinnonOsienOsaAlueidenTaiLukioOpintojenTaiMuidenOpintovalmiuksiaTukevienOpintojenOsasuoritus
+) extends SdgYhteistenTutkinnonOsienOsaAlueidenTaiLukioOpintojenTaiMuidenOpintovalmiuksiaTukevienOpintojenOsasuoritus
 
 @Title("Lukion oppiaineen tai lukion kurssin suoritus")
 case class SdgLukioOpintojenSuoritus(
@@ -189,7 +189,7 @@ case class SdgLukioOpintojenSuoritus(
   tunnustettu: Option[schema.OsaamisenTunnustaminen],
   suorituskieli: Option[schema.Koodistokoodiviite] = None,
   tyyppi: schema.Koodistokoodiviite
-) extends YhteistenTutkinnonOsienOsaAlueidenTaiLukioOpintojenTaiMuidenOpintovalmiuksiaTukevienOpintojenOsasuoritus
+) extends SdgYhteistenTutkinnonOsienOsaAlueidenTaiLukioOpintojenTaiMuidenOpintovalmiuksiaTukevienOpintojenOsasuoritus
 
 @Title("Muiden opintovalmiuksia tukevien opintojen suoritus")
 case class SdgMuidenOpintovalmiuksiaTukevienOpintojenSuoritus(
@@ -198,7 +198,7 @@ case class SdgMuidenOpintovalmiuksiaTukevienOpintojenSuoritus(
   tunnustettu: Option[schema.OsaamisenTunnustaminen],
   suorituskieli: Option[schema.Koodistokoodiviite] = None,
   tyyppi: schema.Koodistokoodiviite
-) extends YhteistenTutkinnonOsienOsaAlueidenTaiLukioOpintojenTaiMuidenOpintovalmiuksiaTukevienOpintojenOsasuoritus
+) extends SdgYhteistenTutkinnonOsienOsaAlueidenTaiLukioOpintojenTaiMuidenOpintovalmiuksiaTukevienOpintojenOsasuoritus
 
 @Title("Ammatillinen tutkintokoulutus")
 case class SdgAmmatillinenTutkintoKoulutus(

--- a/src/main/scala/fi/oph/koski/sdg/SdgDiaSchema.scala
+++ b/src/main/scala/fi/oph/koski/sdg/SdgDiaSchema.scala
@@ -10,18 +10,18 @@ case class SdgDIAOpiskeluoikeus(
   versionumero: Option[Int],
   oppilaitos: Option[schema.Oppilaitos],
   koulutustoimija: Option[schema.Koulutustoimija],
-  tila: OpiskeluoikeudenTila,
+  tila: SdgOpiskeluoikeudenTila,
   suoritukset: List[DiaPäätasonSuoritus],
   @KoodistoKoodiarvo(schema.OpiskeluoikeudenTyyppi.diatutkinto.koodiarvo)
   tyyppi: schema.Koodistokoodiviite,
-) extends Opiskeluoikeus {
-  override def withSuoritukset(suoritukset: List[Suoritus]): SdgDIAOpiskeluoikeus =
+) extends SdgOpiskeluoikeus {
+  override def withSuoritukset(suoritukset: List[SdgSuoritus]): SdgDIAOpiskeluoikeus =
     this.copy(
       suoritukset = suoritukset.collect { case s: DiaPäätasonSuoritus => s }
     )
 }
 
-trait DiaPäätasonSuoritus extends Suoritus
+trait DiaPäätasonSuoritus extends SdgSuoritus
 
 @Title("DIA-tutkinnon suoritus")
 case class SdgDIATutkinnonSuoritus(

--- a/src/main/scala/fi/oph/koski/sdg/SdgEBTutkintoSchema.scala
+++ b/src/main/scala/fi/oph/koski/sdg/SdgEBTutkintoSchema.scala
@@ -12,12 +12,12 @@ case class SdgEBTutkinnonOpiskeluoikeus(
   versionumero: Option[Int],
   oppilaitos: Option[schema.Oppilaitos],
   koulutustoimija: Option[schema.Koulutustoimija],
-  tila: OpiskeluoikeudenTila,
+  tila: SdgOpiskeluoikeudenTila,
   suoritukset: List[SdgEBTutkinnonPäätasonSuoritus],
   @KoodistoKoodiarvo(schema.OpiskeluoikeudenTyyppi.ebtutkinto.koodiarvo)
   tyyppi: schema.Koodistokoodiviite,
-) extends Opiskeluoikeus {
-  override def withSuoritukset(suoritukset: List[Suoritus]): SdgEBTutkinnonOpiskeluoikeus =
+) extends SdgOpiskeluoikeus {
+  override def withSuoritukset(suoritukset: List[SdgSuoritus]): SdgEBTutkinnonOpiskeluoikeus =
     this.copy(
       suoritukset = suoritukset.collect { case s: SdgEBTutkinnonPäätasonSuoritus => s }
     )
@@ -32,7 +32,7 @@ case class SdgEBTutkinnonPäätasonSuoritus(
   tyyppi: schema.Koodistokoodiviite,
   osasuoritukset: Option[List[SdgEBTutkinnonOsasuoritus]],
   yleisarvosana: Option[Double]
-) extends Suoritus {
+) extends SdgSuoritus {
   override def withOsasuoritukset(os: Option[List[Osasuoritus]]): SdgEBTutkinnonPäätasonSuoritus =
     this.copy(osasuoritukset = os.map(_.collect { case s: SdgEBTutkinnonOsasuoritus => s }))
 }

--- a/src/main/scala/fi/oph/koski/sdg/SdgEuropeanSchoolOfHelsinki.scala
+++ b/src/main/scala/fi/oph/koski/sdg/SdgEuropeanSchoolOfHelsinki.scala
@@ -10,18 +10,18 @@ case class SdgEuropeanSchoolOfHelsinkiOpiskeluoikeus(
   oid: Option[String] = None,
   oppilaitos: Option[schema.Oppilaitos] = None,
   koulutustoimija: Option[schema.Koulutustoimija] = None,
-  tila: OpiskeluoikeudenTila,
-  suoritukset: List[EuropeanSchoolOfHelsinkiPäätasonSuoritus],
+  tila: SdgOpiskeluoikeudenTila,
+  suoritukset: List[SdgEuropeanSchoolOfHelsinkiPäätasonSuoritus],
   @KoodistoKoodiarvo(schema.OpiskeluoikeudenTyyppi.europeanschoolofhelsinki.koodiarvo)
   tyyppi: schema.Koodistokoodiviite = schema.OpiskeluoikeudenTyyppi.europeanschoolofhelsinki,
-) extends Opiskeluoikeus {
-  override def withSuoritukset(suoritukset: List[Suoritus]): Opiskeluoikeus =
+) extends SdgOpiskeluoikeus {
+  override def withSuoritukset(suoritukset: List[SdgSuoritus]): SdgOpiskeluoikeus =
     this.copy(
-      suoritukset = suoritukset.collect { case s: EuropeanSchoolOfHelsinkiPäätasonSuoritus => s }
+      suoritukset = suoritukset.collect { case s: SdgEuropeanSchoolOfHelsinkiPäätasonSuoritus => s }
     )
 }
 
-trait EuropeanSchoolOfHelsinkiPäätasonSuoritus extends Suoritus
+trait SdgEuropeanSchoolOfHelsinkiPäätasonSuoritus extends SdgSuoritus
 
 // VAIN S5 MUKAAN
 @Title("Secondary Lower -vuosiluokan suoritus")
@@ -33,7 +33,7 @@ case class SdgSecondaryLowerVuosiluokanSuoritus(
   @KoodistoKoodiarvo("europeanschoolofhelsinkivuosiluokkasecondarylower")
   tyyppi: schema.Koodistokoodiviite,
   osasuoritukset: Option[List[SdgSecondaryLowerOppiaineenSuoritus]] = None
-) extends EuropeanSchoolOfHelsinkiPäätasonSuoritus {
+) extends SdgEuropeanSchoolOfHelsinkiPäätasonSuoritus {
   override def withOsasuoritukset(os: Option[List[Osasuoritus]]): SdgSecondaryLowerVuosiluokanSuoritus =
     this.copy(
       osasuoritukset = os.map(_.collect{
@@ -50,12 +50,12 @@ case class SdgSecondaryUpperVuosiluokanSuoritus(
   vahvistus: Option[SdgVahvistus],
   @KoodistoKoodiarvo("europeanschoolofhelsinkivuosiluokkasecondaryupper")
   tyyppi: schema.Koodistokoodiviite,
-  osasuoritukset: Option[List[SecondaryUpperOppiaineenSuoritus]] = None
-) extends EuropeanSchoolOfHelsinkiPäätasonSuoritus {
+  osasuoritukset: Option[List[SdgSecondaryUpperOppiaineenSuoritus]] = None
+) extends SdgEuropeanSchoolOfHelsinkiPäätasonSuoritus {
   override def withOsasuoritukset(os: Option[List[Osasuoritus]]): SdgSecondaryUpperVuosiluokanSuoritus =
     this.copy(
       osasuoritukset = os.map(_.collect{
-        case s: SecondaryUpperOppiaineenSuoritus => s
+        case s: SdgSecondaryUpperOppiaineenSuoritus => s
       })
     )
 }
@@ -70,7 +70,7 @@ case class SdgSecondaryLowerOppiaineenSuoritus(
   suorituskieli: schema.Koodistokoodiviite
 ) extends Osasuoritus
 
-trait SecondaryUpperOppiaineenSuoritus extends Osasuoritus
+trait SdgSecondaryUpperOppiaineenSuoritus extends Osasuoritus
 
 @Title("Secondary upper oppiaineen suoritus S6")
 @OnlyWhen("../../koulutusmoduuli/tunniste/koodiarvo", "S6")
@@ -81,7 +81,7 @@ case class SdgSecondaryUpperOppiaineenSuoritusS6(
   @KoodistoKoodiarvo("europeanschoolofhelsinkiosasuorituss6")
   tyyppi: schema.Koodistokoodiviite,
   suorituskieli: schema.Koodistokoodiviite,
-) extends SecondaryUpperOppiaineenSuoritus
+) extends SdgSecondaryUpperOppiaineenSuoritus
 
 @Title("Secondary numerical mark arviointi")
 case class SdgSecondaryNumericalMarkArviointi(
@@ -99,7 +99,7 @@ case class SdgSecondaryUpperOppiaineenSuoritusS7(
   tyyppi: schema.Koodistokoodiviite,
   suorituskieli: schema.Koodistokoodiviite,
   osasuoritukset: Option[List[SdgS7OppiaineenAlaosasuoritus]] = None
-) extends SecondaryUpperOppiaineenSuoritus
+) extends SdgSecondaryUpperOppiaineenSuoritus
 
 @Title("S7 oppiaineen alaosasuoritus")
 case class SdgS7OppiaineenAlaosasuoritus(

--- a/src/main/scala/fi/oph/koski/sdg/SdgIBSchema.scala
+++ b/src/main/scala/fi/oph/koski/sdg/SdgIBSchema.scala
@@ -11,18 +11,18 @@ case class SdgIBOpiskeluoikeus(
   oid: Option[String] = None,
   oppilaitos: Option[schema.Oppilaitos],
   koulutustoimija: Option[schema.Koulutustoimija] = None,
-  tila: OpiskeluoikeudenTila,
-  suoritukset: List[IBPäätasonSuoritus],
+  tila: SdgOpiskeluoikeudenTila,
+  suoritukset: List[SdgIBPäätasonSuoritus],
   @KoodistoKoodiarvo(schema.OpiskeluoikeudenTyyppi.ibtutkinto.koodiarvo)
   tyyppi: schema.Koodistokoodiviite,
-) extends Opiskeluoikeus {
-  override def withSuoritukset(suoritukset: List[Suoritus]): SdgIBOpiskeluoikeus =
+) extends SdgOpiskeluoikeus {
+  override def withSuoritukset(suoritukset: List[SdgSuoritus]): SdgIBOpiskeluoikeus =
     this.copy(
-      suoritukset = suoritukset.collect { case s: IBPäätasonSuoritus => s }
+      suoritukset = suoritukset.collect { case s: SdgIBPäätasonSuoritus => s }
     )
 }
 
-trait IBPäätasonSuoritus extends Suoritus
+trait SdgIBPäätasonSuoritus extends SdgSuoritus
 
 @Title("IB tutkinnon suoritus")
 case class SdgIBTutkinnonSuoritus(
@@ -30,22 +30,22 @@ case class SdgIBTutkinnonSuoritus(
   toimipiste: Option[SdgToimipiste],
   vahvistus: Option[SdgVahvistus],
   suorituskieli: schema.Koodistokoodiviite,
-  osasuoritukset: Option[List[IBTutkinnonOppiaineenSuoritus]],
+  osasuoritukset: Option[List[SdgIBTutkinnonOppiaineenSuoritus]],
   theoryOfKnowledge: Option[schema.IBTheoryOfKnowledgeSuoritus],
   extendedEssay: Option[schema.IBExtendedEssaySuoritus],
   creativityActionService: Option[schema.IBCASSuoritus],
   @KoodistoKoodiarvo("ibtutkinto")
   tyyppi: schema.Koodistokoodiviite,
-) extends IBPäätasonSuoritus {
+) extends SdgIBPäätasonSuoritus {
   override def withOsasuoritukset(os: Option[List[Osasuoritus]]): SdgIBTutkinnonSuoritus =
     this.copy(
       osasuoritukset = os.map(_.collect{
-        case s: IBTutkinnonOppiaineenSuoritus => s
+        case s: SdgIBTutkinnonOppiaineenSuoritus => s
       })
     )
 }
 
-trait IBTutkinnonOppiaineenSuoritus extends Osasuoritus
+trait SdgIBTutkinnonOppiaineenSuoritus extends Osasuoritus
 
 @Title("IB-oppiaineen suoritus")
 case class SdgIBOppiaineenSuoritus(
@@ -57,7 +57,7 @@ case class SdgIBOppiaineenSuoritus(
   osasuoritukset: Option[List[SdgIBKurssinSuoritus]],
   @KoodistoKoodiarvo("iboppiaine")
   tyyppi: schema.Koodistokoodiviite
-) extends IBTutkinnonOppiaineenSuoritus
+) extends SdgIBTutkinnonOppiaineenSuoritus
 
 @Title("IB kurssin suoritus")
 case class SdgIBKurssinSuoritus(
@@ -76,7 +76,7 @@ case class SdgIBDPCoreSuoritus(
   osasuoritukset: Option[List[SdgIBCoreKurssinSuoritus]] = None,
   @KoodistoKoodiarvo("ibcore")
   tyyppi: schema.Koodistokoodiviite
-) extends IBTutkinnonOppiaineenSuoritus
+) extends SdgIBTutkinnonOppiaineenSuoritus
 
 @Title("IB Core kurssin suoritus")
 case class SdgIBCoreKurssinSuoritus(
@@ -94,19 +94,19 @@ case class SdgPreIBSuoritus2015(
   toimipiste: Option[SdgToimipiste],
   vahvistus: Option[SdgVahvistus],
   suorituskieli: schema.Koodistokoodiviite,
-  osasuoritukset: Option[List[PreIBSuorituksenOsasuoritus2015]],
+  osasuoritukset: Option[List[SdgPreIBSuorituksenOsasuoritus2015]],
   @KoodistoKoodiarvo("preiboppimaara")
   tyyppi: schema.Koodistokoodiviite
-) extends IBPäätasonSuoritus {
+) extends SdgIBPäätasonSuoritus {
   override def withOsasuoritukset(os: Option[List[Osasuoritus]]): SdgPreIBSuoritus2015 =
     this.copy(
       osasuoritukset = os.map(_.collect{
-        case s: PreIBSuorituksenOsasuoritus2015 => s
+        case s: SdgPreIBSuorituksenOsasuoritus2015 => s
       })
     )
 }
 
-trait PreIBSuorituksenOsasuoritus2015 extends Osasuoritus
+trait SdgPreIBSuorituksenOsasuoritus2015 extends Osasuoritus
 
 @Title("Pre IB oppiaineen suoritus 2015")
 case class SdgPreIBOppiaineenSuoritus2015(
@@ -118,7 +118,7 @@ case class SdgPreIBOppiaineenSuoritus2015(
   osasuoritukset: Option[List[SdgPreIBKurssinSuoritus2015]],
   @KoodistoKoodiarvo("preiboppiaine")
   tyyppi: schema.Koodistokoodiviite
-) extends PreIBSuorituksenOsasuoritus2015
+) extends SdgPreIBSuorituksenOsasuoritus2015
 
 @Title("Pre IB kurssin suoritus 2015")
 case class SdgPreIBKurssinSuoritus2015(
@@ -127,7 +127,7 @@ case class SdgPreIBKurssinSuoritus2015(
   suorituskieli: Option[schema.Koodistokoodiviite] = None,
   @KoodistoKoodiarvo("preibkurssi")
   tyyppi: schema.Koodistokoodiviite
-) extends PreIBSuorituksenOsasuoritus2015
+) extends SdgPreIBSuorituksenOsasuoritus2015
 
 @Title("Pre IB suoritus 2019")
 @OnlyWhen("koulutusmoduuli/tunniste/koodiarvo", "preiboppimaara2019")
@@ -140,14 +140,14 @@ case class SdgPreIBSuoritus2019(
   omanÄidinkielenOpinnot: Option[SdgLukionOmanÄidinkielenOpinnot] = None,
   puhviKoe: Option[SdgLukionArviointi],
   suullisenKielitaidonKokeet: Option[List[SdgSuullisenKielitaidonKoe2019]] = None,
-  osasuoritukset: Option[List[PreIBSuorituksenOsasuoritus2019]],
+  osasuoritukset: Option[List[SdgPreIBSuorituksenOsasuoritus2019]],
   @KoodistoKoodiarvo("preiboppimaara")
   tyyppi: schema.Koodistokoodiviite,
-)  extends IBPäätasonSuoritus {
+)  extends SdgIBPäätasonSuoritus {
   override def withOsasuoritukset(os: Option[List[Osasuoritus]]): SdgPreIBSuoritus2019 =
     this.copy(
       osasuoritukset = os.map(_.collect{
-        case s: PreIBSuorituksenOsasuoritus2019 => s
+        case s: SdgPreIBSuorituksenOsasuoritus2019 => s
       })
     )
 }
@@ -182,7 +182,7 @@ case class SdgSuullisenKielitaidonKoe2019(
   päivä: LocalDate
 )
 
-trait PreIBSuorituksenOsasuoritus2019 extends Osasuoritus
+trait SdgPreIBSuorituksenOsasuoritus2019 extends Osasuoritus
 
 @Title("Lukion oppiaineen Pre IB suoritus 2019")
 case class SdgLukionOppiaineenPreIBSuoritus2019(
@@ -194,7 +194,7 @@ case class SdgLukionOppiaineenPreIBSuoritus2019(
   osasuoritukset: Option[List[PreIBLukioOpintojenOsasuoritus]],
   @KoodistoKoodiarvo("lukionoppiaine")
   tyyppi: schema.Koodistokoodiviite
-) extends PreIBSuorituksenOsasuoritus2019
+) extends SdgPreIBSuorituksenOsasuoritus2019
 
 @Title("Muiden lukio opintojen Pre IB suoritus 2019")
 case class SdgMuidenLukioOpintojenPreIBSuoritus2019(
@@ -203,7 +203,7 @@ case class SdgMuidenLukioOpintojenPreIBSuoritus2019(
   osasuoritukset: Option[List[MuidenLukioOpintojenOsasuoritus2019]],
   @KoodistoKoodiarvo("lukionmuuopinto")
   tyyppi: schema.Koodistokoodiviite
-) extends PreIBSuorituksenOsasuoritus2019
+) extends SdgPreIBSuorituksenOsasuoritus2019
 
 trait PreIBLukioOpintojenOsasuoritus extends WithTunnustettuBoolean
 trait PreIBMuidenLukioOpintojenOsasuoritus2019 extends WithTunnustettuBoolean

--- a/src/main/scala/fi/oph/koski/sdg/SdgInternationalSchool.scala
+++ b/src/main/scala/fi/oph/koski/sdg/SdgInternationalSchool.scala
@@ -10,18 +10,18 @@ case class SdgInternationalSchoolOpiskeluoikeus(
   oid: Option[String] = None,
   oppilaitos: Option[schema.Oppilaitos] = None,
   koulutustoimija: Option[schema.Koulutustoimija] = None,
-  tila: OpiskeluoikeudenTila,
-  suoritukset: List[InternationalSchoolVuosiluokanSuoritus],
+  tila: SdgOpiskeluoikeudenTila,
+  suoritukset: List[SdgInternationalSchoolVuosiluokanSuoritus],
   @KoodistoKoodiarvo(schema.OpiskeluoikeudenTyyppi.internationalschool.koodiarvo)
   tyyppi: schema.Koodistokoodiviite,
-) extends Opiskeluoikeus {
-  override def withSuoritukset(suoritukset: List[Suoritus]): Opiskeluoikeus =
+) extends SdgOpiskeluoikeus {
+  override def withSuoritukset(suoritukset: List[SdgSuoritus]): SdgOpiskeluoikeus =
     this.copy(
-      suoritukset = suoritukset.collect { case s: InternationalSchoolVuosiluokanSuoritus => s }
+      suoritukset = suoritukset.collect { case s: SdgInternationalSchoolVuosiluokanSuoritus => s }
     )
 }
 
-trait InternationalSchoolVuosiluokanSuoritus extends Suoritus
+trait SdgInternationalSchoolVuosiluokanSuoritus extends SdgSuoritus
 
 @Title("MYP vuosiluokan suoritus")
 case class SdgMYPVuosiluokanSuoritus(
@@ -34,7 +34,7 @@ case class SdgMYPVuosiluokanSuoritus(
   @KoodistoKoodiarvo("internationalschoolmypvuosiluokka")
   tyyppi: schema.Koodistokoodiviite,
   osasuoritukset: Option[List[SdgMYPOppiaineenSuoritus]] = None // vain 10 koodiarvolla mukaan
-) extends InternationalSchoolVuosiluokanSuoritus {
+) extends SdgInternationalSchoolVuosiluokanSuoritus {
   override def withOsasuoritukset(os: Option[List[Osasuoritus]]): SdgMYPVuosiluokanSuoritus =
     this.copy(
       osasuoritukset = os.map(_.collect{
@@ -62,17 +62,17 @@ case class SdgDiplomaVuosiluokanSuoritus(
   suorituskieli: schema.Koodistokoodiviite,
   @KoodistoKoodiarvo("internationalschooldiplomavuosiluokka")
   tyyppi: schema.Koodistokoodiviite,
-  osasuoritukset: Option[List[DiplomaIBOppiaineenSuoritus]] = None
-) extends InternationalSchoolVuosiluokanSuoritus {
+  osasuoritukset: Option[List[SdgDiplomaIBOppiaineenSuoritus]] = None
+) extends SdgInternationalSchoolVuosiluokanSuoritus {
   override def withOsasuoritukset(os: Option[List[Osasuoritus]]): SdgDiplomaVuosiluokanSuoritus =
     this.copy(
       osasuoritukset = os.map(_.collect{
-        case s: DiplomaIBOppiaineenSuoritus => s
+        case s: SdgDiplomaIBOppiaineenSuoritus => s
       })
     )
 }
 
-trait DiplomaIBOppiaineenSuoritus extends Osasuoritus
+trait SdgDiplomaIBOppiaineenSuoritus extends Osasuoritus
 
 @Title("Diploma oppiaineen suoritus")
 case class SdgDiplomaOppiaineenSuoritus(
@@ -81,7 +81,7 @@ case class SdgDiplomaOppiaineenSuoritus(
   suorituskieli: Option[schema.Koodistokoodiviite] = None,
   @KoodistoKoodiarvo("internationalschooldiplomaoppiaine")
   tyyppi: schema.Koodistokoodiviite
-) extends DiplomaIBOppiaineenSuoritus
+) extends SdgDiplomaIBOppiaineenSuoritus
 
 @Title("Diploma core requirements oppiaineen suoritus")
 case class SdgDiplomaCoreRequirementsOppiaineenSuoritus(
@@ -90,4 +90,4 @@ case class SdgDiplomaCoreRequirementsOppiaineenSuoritus(
   suorituskieli: Option[schema.Koodistokoodiviite] = None,
   @KoodistoKoodiarvo("internationalschoolcorerequirements")
   tyyppi: schema.Koodistokoodiviite
-) extends DiplomaIBOppiaineenSuoritus
+) extends SdgDiplomaIBOppiaineenSuoritus

--- a/src/main/scala/fi/oph/koski/sdg/SdgKorkeakouluSchema.scala
+++ b/src/main/scala/fi/oph/koski/sdg/SdgKorkeakouluSchema.scala
@@ -68,8 +68,8 @@ case class SdgKorkeakoulunOpiskeluoikeus(
   suoritukset: List[SdgKorkeakoulututkinnonSuoritus],
   @KoodistoKoodiarvo(schema.OpiskeluoikeudenTyyppi.korkeakoulutus.koodiarvo)
   tyyppi: schema.Koodistokoodiviite,
-) extends Opiskeluoikeus {
-  override def withSuoritukset(suoritukset: List[Suoritus]): Opiskeluoikeus =
+) extends SdgOpiskeluoikeus {
+  override def withSuoritukset(suoritukset: List[SdgSuoritus]): SdgOpiskeluoikeus =
     this.copy(
       suoritukset = suoritukset.collect { case s: SdgKorkeakoulututkinnonSuoritus => s }
     )
@@ -98,7 +98,7 @@ case class SdgKorkeakoulututkinnonSuoritus(
   vahvistus: Option[SdgVahvistus],
   toimipiste: Option[SdgToimipiste],
   osasuoritukset: Option[List[SdgKorkeakoulunOpintojaksonSuoritus]]
-) extends Suoritus {
+) extends SdgSuoritus {
   override def withOsasuoritukset(os: Option[List[Osasuoritus]]): SdgKorkeakoulututkinnonSuoritus =
     this.copy(osasuoritukset = os.map(_.collect {
       case s: SdgKorkeakoulunOpintojaksonSuoritus => s

--- a/src/main/scala/fi/oph/koski/sdg/SdgLukioSchema.scala
+++ b/src/main/scala/fi/oph/koski/sdg/SdgLukioSchema.scala
@@ -11,19 +11,19 @@ case class SdgLukioOpiskeluoikeus(
   oid: Option[String] = None,
   oppilaitos: Option[schema.Oppilaitos],
   koulutustoimija: Option[schema.Koulutustoimija],
-  tila: OpiskeluoikeudenTila,
+  tila: SdgOpiskeluoikeudenTila,
   suoritukset: List[SdgLukionPäätasonSuoritus],
   @KoodistoKoodiarvo(schema.OpiskeluoikeudenTyyppi.lukiokoulutus.koodiarvo)
   tyyppi: schema.Koodistokoodiviite,
   oppimääräSuoritettu: Option[Boolean] = None,
-) extends Opiskeluoikeus {
-  override def withSuoritukset(suoritukset: List[Suoritus]): Opiskeluoikeus =
+) extends SdgOpiskeluoikeus {
+  override def withSuoritukset(suoritukset: List[SdgSuoritus]): SdgOpiskeluoikeus =
     this.copy(
       suoritukset = suoritukset.collect { case s: SdgLukionPäätasonSuoritus => s }
     )
 }
 
-trait SdgLukionPäätasonSuoritus extends Suoritus
+trait SdgLukionPäätasonSuoritus extends SdgSuoritus
 
 @Title("Lukion oppimäärän suoritus 2015")
 @NotWhen("koulutusmoduuli/perusteenDiaarinumero", List("OPH-2263-2019", "OPH-2267-2019"))
@@ -37,19 +37,19 @@ case class SdgLukionOppimääränSuoritus2015(
   suorituskieli: schema.Koodistokoodiviite,
   omanÄidinkielenOpinnot: Option[SdgLukionOmanÄidinkielenOpinnot],
   @Title("Oppiaineet")
-  osasuoritukset: Option[List[LukionOppimääränOsasuoritus2015]],
+  osasuoritukset: Option[List[SdgLukionOppimääränOsasuoritus2015]],
   @KoodistoKoodiarvo("lukionoppimaara")
   tyyppi: schema.Koodistokoodiviite
 ) extends SdgLukionPäätasonSuoritus {
   override def withOsasuoritukset(os: Option[List[Osasuoritus]]): SdgLukionOppimääränSuoritus2015 =
     this.copy(
       osasuoritukset = os.map(_.collect{
-        case s: LukionOppimääränOsasuoritus2015 => s
+        case s: SdgLukionOppimääränOsasuoritus2015 => s
       })
     )
 }
 
-trait LukionOppimääränOsasuoritus2015 extends Osasuoritus
+trait SdgLukionOppimääränOsasuoritus2015 extends Osasuoritus
 
 @Title("Lukion oppiaineen suoritus 2015")
 case class SdgLukionOppiaineenSuoritus2015(
@@ -60,7 +60,7 @@ case class SdgLukionOppiaineenSuoritus2015(
   osasuoritukset: Option[List[LukionOsasuoritus2015]],
   @KoodistoKoodiarvo("lukionoppiaine")
   tyyppi: schema.Koodistokoodiviite
-) extends LukionOppimääränOsasuoritus2015
+) extends SdgLukionOppimääränOsasuoritus2015
 
 @Title("Muiden lukio opintojen suoritus 2015")
 case class SdgMuidenLukioOpintojenSuoritus2015(
@@ -70,7 +70,7 @@ case class SdgMuidenLukioOpintojenSuoritus2015(
   koulutusmoduuli: schema.MuuLukioOpinto2015,
   @Title("Kurssit")
   osasuoritukset: Option[List[LukionOsasuoritus2015]]
-) extends LukionOppimääränOsasuoritus2015
+) extends SdgLukionOppimääränOsasuoritus2015
 
 trait LukionOsasuoritus2015 extends WithTunnustettuBoolean
 
@@ -102,19 +102,19 @@ case class SdgLukionOppimääränSuoritus2019(
   puhviKoe: Option[SdgLukionArviointi],
   suullisenKielitaidonKokeet: Option[List[SdgSuullisenKielitaidonKoe2019]],
   lukiodiplomit2019: Option[List[SdgLukionArviointi]],
-  osasuoritukset: Option[List[LukionOppimääränOsasuoritus2019]],
+  osasuoritukset: Option[List[SdgLukionOppimääränOsasuoritus2019]],
   @KoodistoKoodiarvo("lukionoppimaara")
   tyyppi: schema.Koodistokoodiviite,
 ) extends SdgLukionPäätasonSuoritus {
   override def withOsasuoritukset(os: Option[List[Osasuoritus]]): SdgLukionOppimääränSuoritus2019 =
     this.copy(
       osasuoritukset = os.map(_.collect{
-        case s: LukionOppimääränOsasuoritus2019 => s
+        case s: SdgLukionOppimääränOsasuoritus2019 => s
       })
     )
 }
 
-trait LukionOppimääränOsasuoritus2019 extends Osasuoritus
+trait SdgLukionOppimääränOsasuoritus2019 extends Osasuoritus
 
 @Title("Lukion oppiaineen suoritus 2019")
 case class SdgLukionOppiaineenSuoritus2019(
@@ -126,7 +126,7 @@ case class SdgLukionOppiaineenSuoritus2019(
   osasuoritukset: Option[List[LukionOppiaineenOsasuoritus2019]],
   @KoodistoKoodiarvo("lukionoppiaine")
   tyyppi: schema.Koodistokoodiviite
-) extends LukionOppimääränOsasuoritus2019
+) extends SdgLukionOppimääränOsasuoritus2019
 
 trait LukionOppiaineenOsasuoritus2019 extends WithTunnustettuBoolean
 
@@ -136,7 +136,7 @@ case class SdgMuidenLukioOpintojenSuoritus2019(
   tyyppi: schema.Koodistokoodiviite,
   koulutusmoduuli: schema.MuutSuorituksetTaiVastaavat2019,
   osasuoritukset: Option[List[MuidenLukioOpintojenOsasuoritus2019]]
-) extends LukionOppimääränOsasuoritus2019
+) extends SdgLukionOppimääränOsasuoritus2019
 
 trait MuidenLukioOpintojenOsasuoritus2019 extends WithTunnustettuBoolean
 

--- a/src/main/scala/fi/oph/koski/sdg/SdgSchema.scala
+++ b/src/main/scala/fi/oph/koski/sdg/SdgSchema.scala
@@ -29,7 +29,7 @@ object SdgSchema {
 @Title("Oppija")
 case class SdgOppija(
   henkilö: SdgHenkilo,
-  opiskeluoikeudet: List[Opiskeluoikeus]
+  opiskeluoikeudet: List[SdgOpiskeluoikeus]
 )
 
 @Title("Henkilo")
@@ -53,10 +53,10 @@ object SdgHenkilo {
   )
 }
 
-trait Opiskeluoikeus {
+trait SdgOpiskeluoikeus {
   def oppilaitos: Option[schema.Oppilaitos]
   def koulutustoimija: Option[schema.Koulutustoimija]
-  def suoritukset: List[Suoritus]
+  def suoritukset: List[SdgSuoritus]
 
   @KoodistoUri("opiskeluoikeudentyyppi")
   @Discriminator
@@ -70,7 +70,7 @@ trait Opiskeluoikeus {
   @SyntheticProperty
   def päättymispäivä: Option[LocalDate] = schema.Opiskeluoikeus.päättymispäivä(this.tyyppi.koodiarvo, this.tila.opiskeluoikeusjaksot.map(j => (j.alku, j.tila.koodiarvo)))
 
-  def withSuoritukset(suoritukset: List[Suoritus]): Opiskeluoikeus
+  def withSuoritukset(suoritukset: List[SdgSuoritus]): SdgOpiskeluoikeus
 }
 
 trait GenericOpiskeluoikeudenTila {
@@ -90,11 +90,11 @@ case class SdgOpiskeluoikeusjakso(
 ) extends GenericOpiskeluoikeusjakso
 
 @Title("Opiskeluoikeuden tila")
-case class OpiskeluoikeudenTila(
+case class SdgOpiskeluoikeudenTila(
   opiskeluoikeusjaksot: List[SdgOpiskeluoikeusjakso]
 ) extends GenericOpiskeluoikeudenTila
 
-trait Suoritus {
+trait SdgSuoritus {
   def koulutusmoduuli: schema.Koulutusmoduuli
 
   @Discriminator
@@ -106,7 +106,7 @@ trait Suoritus {
 
   def osasuoritukset: Option[List[Osasuoritus]]
 
-  def withOsasuoritukset(os: Option[List[Osasuoritus]]): Suoritus
+  def withOsasuoritukset(os: Option[List[Osasuoritus]]): SdgSuoritus
 }
 
 trait Osasuoritus

--- a/src/main/scala/fi/oph/koski/sdg/SdgService.scala
+++ b/src/main/scala/fi/oph/koski/sdg/SdgService.scala
@@ -8,7 +8,7 @@ import fi.oph.koski.log._
 import fi.oph.koski.suoritusjako.common.{OpiskeluoikeusFacade}
 
 class SdgService(application: KoskiApplication) extends GlobalExecutionContext with Logging {
-  private val opiskeluoikeusFacade = new OpiskeluoikeusFacade[Opiskeluoikeus](
+  private val opiskeluoikeusFacade = new OpiskeluoikeusFacade[SdgOpiskeluoikeus](
     application,
     Some(SdgYlioppilastutkinnonOpiskeluoikeus.fromKoskiSchema(application.organisaatioRepository)),
     Some(SdgKorkeakoulunOpiskeluoikeus.fromKoskiSchema)
@@ -42,9 +42,9 @@ class SdgService(application: KoskiApplication) extends GlobalExecutionContext w
   }
 
   private def suodataPalautettavatSuoritukset(
-    opiskeluoikeudet: Seq[Opiskeluoikeus],
+    opiskeluoikeudet: Seq[SdgOpiskeluoikeus],
     queryParams: SdgQueryParams
-  ): Seq[Opiskeluoikeus] = {
+  ): Seq[SdgOpiskeluoikeus] = {
     opiskeluoikeudet
       .map { opiskeluoikeus =>
         val suoritukset = opiskeluoikeus.suoritukset
@@ -65,7 +65,7 @@ class SdgService(application: KoskiApplication) extends GlobalExecutionContext w
       .filter(_.suoritukset.nonEmpty)
   }
 
-  private def josYOTutkintoNiinVainTodistuksellaOlevatKoesuoritukset(s: Suoritus): Suoritus = {
+  private def josYOTutkintoNiinVainTodistuksellaOlevatKoesuoritukset(s: SdgSuoritus): SdgSuoritus = {
     s match {
       case s: SdgYlioppilastutkinnonSuoritus =>
         val filteredOsasuoritukset = s.osasuoritukset.map(_.filter { x =>
@@ -76,7 +76,7 @@ class SdgService(application: KoskiApplication) extends GlobalExecutionContext w
     }
   }
 
-  private def josYOTutkintoNiinVahvistettu(s: Suoritus): Boolean = {
+  private def josYOTutkintoNiinVahvistettu(s: SdgSuoritus): Boolean = {
     s match {
       case s: SdgYlioppilastutkinnonSuoritus
       => s.vahvistus.isDefined

--- a/src/main/scala/fi/oph/koski/sdg/SdgYlioppilastutkintoSchema.scala
+++ b/src/main/scala/fi/oph/koski/sdg/SdgYlioppilastutkintoSchema.scala
@@ -7,7 +7,7 @@ import fi.oph.koski.ytr.YtrConversionUtils
 import fi.oph.scalaschema.annotation.{Description, Title}
 
 object SdgYlioppilastutkinnonOpiskeluoikeus {
-  def fromKoskiSchema(organisaatioRepository: OrganisaatioRepository)(yo: schema.YlioppilastutkinnonOpiskeluoikeus): Opiskeluoikeus = {
+  def fromKoskiSchema(organisaatioRepository: OrganisaatioRepository)(yo: schema.YlioppilastutkinnonOpiskeluoikeus): SdgOpiskeluoikeus = {
     SdgYlioppilastutkinnonOpiskeluoikeus(
       oid = yo.oid,
       oppilaitos = Some(YtrConversionUtils.ytlOppilaitos(organisaatioRepository)),
@@ -19,7 +19,7 @@ object SdgYlioppilastutkinnonOpiskeluoikeus {
           kt.kotipaikka
         )
       ),
-      tila = OpiskeluoikeudenTila(
+      tila = SdgOpiskeluoikeudenTila(
         opiskeluoikeusjaksot = yo.tila.opiskeluoikeusjaksot.map(j => SdgOpiskeluoikeusjakso(
           tila = j.tila,
           alku = j.alku
@@ -48,13 +48,13 @@ case class SdgYlioppilastutkinnonOpiskeluoikeus(
   oid: Option[String],
   oppilaitos: Option[schema.Oppilaitos],
   koulutustoimija: Option[schema.Koulutustoimija],
-  tila: OpiskeluoikeudenTila,
+  tila: SdgOpiskeluoikeudenTila,
   suoritukset: List[SdgYlioppilastutkinnonSuoritus],
   @KoodistoKoodiarvo(schema.OpiskeluoikeudenTyyppi.ylioppilastutkinto.koodiarvo)
   tyyppi: schema.Koodistokoodiviite,
   versionumero: Option[Int] = None
-) extends Opiskeluoikeus {
-  override def withSuoritukset(suoritukset: List[Suoritus]): Opiskeluoikeus =
+) extends SdgOpiskeluoikeus {
+  override def withSuoritukset(suoritukset: List[SdgSuoritus]): SdgOpiskeluoikeus =
     this.copy(
       suoritukset = suoritukset.collect { case s: SdgYlioppilastutkinnonSuoritus => s }
     )
@@ -68,7 +68,7 @@ case class SdgYlioppilastutkinnonSuoritus(
   tyyppi: schema.Koodistokoodiviite,
   koulusivistyskieli: Option[List[schema.Koodistokoodiviite]],
   osasuoritukset: Option[List[SdgYlioppilastutkinnonOsasuoritus]]
-) extends Suoritus {
+) extends SdgSuoritus {
   override def withOsasuoritukset(os: Option[List[Osasuoritus]]): SdgYlioppilastutkinnonSuoritus =
     this.copy(osasuoritukset = os.map(_.collect {
       case s: SdgYlioppilastutkinnonOsasuoritus => s

--- a/src/test/scala/fi/oph/koski/documentation/LocalizedSchemasSpec.scala
+++ b/src/test/scala/fi/oph/koski/documentation/LocalizedSchemasSpec.scala
@@ -23,7 +23,8 @@ class LocalizedSchemasSpec extends AnyFreeSpec with TestEnvironment with Matcher
       "kela-oppija-schema.json",
       "migri-oppija-schema.json",
       "valpas-internal-laaja-schema.json",
-      "omadata-oauth2-kaikki-tiedot-oppija-schema.json"
+      "omadata-oauth2-kaikki-tiedot-oppija-schema.json",
+      "sdg-oppija-schema.json"
     )
     schemaNames.foreach { name =>
       name in {


### PR DESCRIPTION
Fixes `sdg-oppija-schema.json` returning HTTP 500 (JSON Schema Viewer stuck on "Loading...").

- scala-schema keys JSON schema definitions by simple class name only. Several `fi.oph.koski.sdg` traits (`Opiskeluoikeus`, `Suoritus`, `DiplomaIBOppiaineenSuoritus`, `LukionOppimääränOsasuoritus2015`, etc.) shared simple names with unrelated `fi.oph.koski.schema` traits, so once both were reachable from `SdgOppija`'s schema tree, schema generation threw `Duplicate JSON schema definition name`.
- Renamed the colliding sdg-local traits with an `Sdg` prefix, matching the existing convention for case classes in this package.
- Added `sdg-oppija-schema.json` to `LocalizedSchemasSpec`'s covered schemas so a regression fails a test instead of only surfacing in production.