### PR TITLE
TOR-2518 Korjaa muidenkin skeemojen nimikonfliktit

### DIFF
--- a/src/main/scala/fi/oph/koski/kela/KelaAikuistenPerusopetuksenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaAikuistenPerusopetuksenSchema.scala
@@ -48,7 +48,7 @@ case class KelaAikuistenPerusopetuksenOpiskeluoikeudenLisätiedot(
   tehostetunTuenPäätökset: Option[List[KelaTehostetunTuenPäätös]],
   maksuttomuus: Option[List[KelaMaksuttomuus]],
   oikeuttaMaksuttomuuteenPidennetty: Option[List[KelaOikeuttaMaksuttomuuteenPidennetty]]
-) extends OpiskeluoikeudenLisätiedot
+) extends KelaOpiskeluoikeudenLisätiedot
 
 @Title("Aikuisten perusopetuksen suoritus")
 case class KelaAikuistenPerusopetuksenSuoritus(
@@ -59,7 +59,7 @@ case class KelaAikuistenPerusopetuksenSuoritus(
   tyyppi: schema.Koodistokoodiviite,
   arviointi: Option[List[KelaYleissivistävänKoulutuksenArviointi]],
   omanÄidinkielenOpinnot: Option[KelaOmanÄidinkielenOpinnot]
-) extends Suoritus {
+) extends KelaSuoritus {
   def withHyväksyntämerkinnälläKorvattuArvosana: KelaAikuistenPerusopetuksenSuoritus = copy(
     osasuoritukset = osasuoritukset.map(_.map(_.withHyväksyntämerkinnälläKorvattuArvosana)),
     arviointi = arviointi.map(_.map(_.withHyväksyntämerkinnälläKorvattuArvosana)),

--- a/src/main/scala/fi/oph/koski/kela/KelaAmmatillinenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaAmmatillinenSchema.scala
@@ -56,7 +56,7 @@ case class KelaAmmatillisenOpiskeluoikeudenLisätiedot(
   maksuttomuus: Option[List[KelaMaksuttomuus]],
   oikeuttaMaksuttomuuteenPidennetty: Option[List[KelaOikeuttaMaksuttomuuteenPidennetty]],
   koulutusvienti: Option[Boolean],
-) extends OpiskeluoikeudenLisätiedot
+) extends KelaOpiskeluoikeudenLisätiedot
 
 @Title("Ammatillisen koulutuksen suoritus")
 case class KelaAmmatillinenPäätasonSuoritus(
@@ -78,7 +78,7 @@ case class KelaAmmatillinenPäätasonSuoritus(
   täydentääTutkintoa: Option[Tutkinto],     // Muu ammatillinen
   tutkinto: Option[Tutkinto],               // Näyttötutkintoon valmistava
   päättymispäivä: Option[LocalDate]         // Näyttötutkintoon valmistava
-) extends Suoritus {
+) extends KelaSuoritus {
   def withHyväksyntämerkinnälläKorvattuArvosana = copy(
     osasuoritukset = osasuoritukset.map(_.map(_.withHyväksyntämerkinnälläKorvattuArvosana))
   )
@@ -192,23 +192,23 @@ case class AmmatillisenTutkinnonOsanLisätieto(
   kuvaus: schema.LocalizedString
 )
 
-trait OsaamisenHankkimistapa {
+trait KelaOsaamisenHankkimistapa {
   def tunniste: KelaKoodistokoodiviite
 }
 
 case class OsaamisenHankkimistapaIlmanLisätietoja (
   tunniste: KelaKoodistokoodiviite
-) extends OsaamisenHankkimistapa
+) extends KelaOsaamisenHankkimistapa
 
 case class OppisopimuksellinenOsaamisenHankkimistapa (
   tunniste: KelaKoodistokoodiviite,
   oppisopimus: Oppisopimus
-) extends OsaamisenHankkimistapa
+) extends KelaOsaamisenHankkimistapa
 
 case class OsaamisenHankkimistapajakso(
   alku: LocalDate,
   loppu: Option[LocalDate],
-  osaamisenHankkimistapa: OsaamisenHankkimistapa
+  osaamisenHankkimistapa: KelaOsaamisenHankkimistapa
 )
 
 case class Työssäoppimisjakso(

--- a/src/main/scala/fi/oph/koski/kela/KelaDIASchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaDIASchema.scala
@@ -50,7 +50,7 @@ case class KelaDIAOpiskeluoikeudenLisätiedot(
   ulkomainenVaihtoopiskelija: Option[Boolean],
   maksuttomuus: Option[List[KelaMaksuttomuus]],
   oikeuttaMaksuttomuuteenPidennetty: Option[List[KelaOikeuttaMaksuttomuuteenPidennetty]]
-) extends OpiskeluoikeudenLisätiedot
+) extends KelaOpiskeluoikeudenLisätiedot
 
 @Title("DIA-tutkinnon suoritus")
 case class KelaDIAPäätasonSuoritus(
@@ -59,7 +59,7 @@ case class KelaDIAPäätasonSuoritus(
   vahvistus: Option[Vahvistus],
   osasuoritukset: Option[List[KelaDIAOsasuoritus]],
   tyyppi: schema.Koodistokoodiviite,
-) extends Suoritus {
+) extends KelaSuoritus {
   def withOsasuorituksetVastaavuusKopioitu: KelaDIAPäätasonSuoritus = copy(
     osasuoritukset = osasuoritukset.map(os => os.map(_.withVastaavuusKopioitu))
   )

--- a/src/main/scala/fi/oph/koski/kela/KelaEBSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaEBSchema.scala
@@ -29,7 +29,7 @@ case class KelaEBOpiskeluoikeus(
   )
 
   override def sisältyyOpiskeluoikeuteen: Option[SisältäväOpiskeluoikeus] = None
-  override def lisätiedot: Option[OpiskeluoikeudenLisätiedot] = None
+  override def lisätiedot: Option[KelaOpiskeluoikeudenLisätiedot] = None
 }
 
 @Title("EB-tutkinnon suoritus")
@@ -39,7 +39,7 @@ case class KelaEBTutkinnonSuoritus(
   vahvistus: Option[Vahvistus],
   tyyppi: schema.Koodistokoodiviite,
   override val osasuoritukset: Option[List[KelaEBTutkinnonOsasuoritus]]
-) extends Suoritus {
+) extends KelaSuoritus {
   override def withHyväksyntämerkinnälläKorvattuArvosana: KelaEBTutkinnonSuoritus = copy(
     osasuoritukset = osasuoritukset.map(_.map(_.withHyväksyntämerkinnälläKorvattuArvosana))
   )

--- a/src/main/scala/fi/oph/koski/kela/KelaESHSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaESHSchema.scala
@@ -34,7 +34,7 @@ case class KelaESHOpiskeluoikeus(
 }
 
 @Title("European School of Helsingin päätason suoritus")
-trait KelaESHPäätasonSuoritus extends Suoritus {
+trait KelaESHPäätasonSuoritus extends KelaSuoritus {
   def withHyväksyntämerkinnälläKorvattuArvosana: KelaESHPäätasonSuoritus
 }
 
@@ -150,7 +150,7 @@ case class KelaESHS7OppiaineenAlaosasuoritus(
   arviointi: Option[List[KelaESHArviointi]],
   @KoodistoKoodiarvo("europeanschoolofhelsinkialaosasuorituss7")
   tyyppi: schema.Koodistokoodiviite,
-) extends Suoritus {
+) extends KelaSuoritus {
   def osasuoritukset: Option[List[Osasuoritus]] = None
   def withHyväksyntämerkinnälläKorvattuArvosana: KelaESHS7OppiaineenAlaosasuoritus = this.copy(
     arviointi = arviointi.map(_.map(_.withHyväksyntämerkinnälläKorvattuArvosana))
@@ -178,4 +178,4 @@ case class KelaESHOpiskeluoikeudenLisätiedot(
   ulkomaanjaksot: Option[List[Ulkomaanjakso]],
   maksuttomuus: Option[List[KelaMaksuttomuus]],
   oikeuttaMaksuttomuuteenPidennetty: Option[List[KelaOikeuttaMaksuttomuuteenPidennetty]],
-) extends OpiskeluoikeudenLisätiedot
+) extends KelaOpiskeluoikeudenLisätiedot

--- a/src/main/scala/fi/oph/koski/kela/KelaEsiopetuksenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaEsiopetuksenSchema.scala
@@ -38,7 +38,7 @@ case class KelaEsiopetuksenOpiskeluoikeus(
 case class KelaEsiopetuksenOpiskeluoikeudenLisätiedot(
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
   varhennetunOppivelvollisuudenJaksot: Option[List[KelaAikajakso]]
-) extends OpiskeluoikeudenLisätiedot
+) extends KelaOpiskeluoikeudenLisätiedot
 
 @Title("Esiopetuksen suoritus")
 case class KelaEsiopetuksenSuoritus(
@@ -46,7 +46,7 @@ case class KelaEsiopetuksenSuoritus(
   toimipiste: Option[Toimipiste],
   vahvistus: Option[Vahvistus],
   tyyppi: schema.Koodistokoodiviite
-) extends Suoritus {
+) extends KelaSuoritus {
   override def osasuoritukset: Option[List[Osasuoritus]] = None
   def withHyväksyntämerkinnälläKorvattuArvosana: KelaEsiopetuksenSuoritus = this
 }

--- a/src/main/scala/fi/oph/koski/kela/KelaIBSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaIBSchema.scala
@@ -48,7 +48,7 @@ case class KelaIBPäätasonSuoritus(
   omanÄidinkielenOpinnot: Option[KelaLukionOmanÄidinkielenOpinnot],
   puhviKoe: Option[KelaPuhviKoe2019],
   suullisenKielitaidonKokeet: Option[List[KelaSuullisenKielitaidonKoe2019]],
-) extends Suoritus {
+) extends KelaSuoritus {
   def withHyväksyntämerkinnälläKorvattuArvosana: KelaIBPäätasonSuoritus = copy(
     osasuoritukset = osasuoritukset.map(_.map(_.withHyväksyntämerkinnälläKorvattuArvosana)),
     theoryOfKnowledge = theoryOfKnowledge.map(_.withHyväksyntämerkinnälläKorvattuArvosana),

--- a/src/main/scala/fi/oph/koski/kela/KelaInternationalSchoolSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaInternationalSchoolSchema.scala
@@ -39,7 +39,7 @@ case class KelaInternationalSchoolOpiskeluoikeudenLisätiedot(
   ulkomaanjaksot: Option[List[Ulkomaanjakso]],
   maksuttomuus: Option[List[KelaMaksuttomuus]],
   oikeuttaMaksuttomuuteenPidennetty: Option[List[KelaOikeuttaMaksuttomuuteenPidennetty]]
-) extends OpiskeluoikeudenLisätiedot
+) extends KelaOpiskeluoikeudenLisätiedot
 
 @Title("International school suoritus")
 case class KelaInternationalSchoolPäätasonSuoritus(
@@ -49,7 +49,7 @@ case class KelaInternationalSchoolPäätasonSuoritus(
   osasuoritukset: Option[List[KelaInternationalSchoolOsasuoritus]],
   tyyppi: schema.Koodistokoodiviite,
   alkamispäivä: Option[LocalDate]
-) extends Suoritus {
+) extends KelaSuoritus {
   def withHyväksyntämerkinnälläKorvattuArvosana: KelaInternationalSchoolPäätasonSuoritus = copy(
     osasuoritukset = osasuoritukset.map(_.map(_.withHyväksyntämerkinnälläKorvattuArvosana))
   )

--- a/src/main/scala/fi/oph/koski/kela/KelaLukionSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaLukionSchema.scala
@@ -41,7 +41,7 @@ case class KelaLukionOpiskeluoikeudenLisätiedot(
   ulkomainenVaihtoopiskelija: Option[Boolean],
   maksuttomuus: Option[List[KelaMaksuttomuus]],
   oikeuttaMaksuttomuuteenPidennetty: Option[List[KelaOikeuttaMaksuttomuuteenPidennetty]]
-) extends OpiskeluoikeudenLisätiedot
+) extends KelaOpiskeluoikeudenLisätiedot
 
 @Title("Lukion suoritus")
 case class KelaLukionPäätasonSuoritus(
@@ -54,7 +54,7 @@ case class KelaLukionPäätasonSuoritus(
   puhviKoe: Option[KelaPuhviKoe2019],
   suullisenKielitaidonKokeet: Option[List[KelaSuullisenKielitaidonKoe2019]],
   tyyppi: schema.Koodistokoodiviite,
-) extends Suoritus {
+) extends KelaSuoritus {
   def withHyväksyntämerkinnälläKorvattuArvosana: KelaLukionPäätasonSuoritus = copy(
     osasuoritukset = osasuoritukset.map(_.map(_.withHyväksyntämerkinnälläKorvattuArvosana)),
     omanÄidinkielenOpinnot = omanÄidinkielenOpinnot.map(_.withHyväksyntämerkinnälläKorvattuArvosana),

--- a/src/main/scala/fi/oph/koski/kela/KelaLuvaSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaLuvaSchema.scala
@@ -41,7 +41,7 @@ case class KelaLuvaOpiskeluoikeudenLisätiedot(
   ulkomainenVaihtoopiskelija: Option[Boolean],
   maksuttomuus: Option[List[KelaMaksuttomuus]],
   oikeuttaMaksuttomuuteenPidennetty: Option[List[KelaOikeuttaMaksuttomuuteenPidennetty]]
-) extends OpiskeluoikeudenLisätiedot
+) extends KelaOpiskeluoikeudenLisätiedot
 
 @Title("Lukioon valmistavan koulutuksen suoritus")
 case class KelaLuvaPäätasonSuoritus(
@@ -51,7 +51,7 @@ case class KelaLuvaPäätasonSuoritus(
   vahvistus: Option[Vahvistus],
   osasuoritukset: Option[List[KelaLuvaOsasuoritus]],
   tyyppi: schema.Koodistokoodiviite,
-) extends Suoritus {
+) extends KelaSuoritus {
   def withHyväksyntämerkinnälläKorvattuArvosana = copy(
     osasuoritukset = osasuoritukset.map(_.map(_.withHyväksyntämerkinnälläKorvattuArvosana))
   )

--- a/src/main/scala/fi/oph/koski/kela/KelaMUKSSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaMUKSSchema.scala
@@ -33,7 +33,7 @@ case class KelaMUKSOpiskeluoikeus(
   )
   override def sisältyyOpiskeluoikeuteen: Option[SisältäväOpiskeluoikeus] = None
 
-  override def lisätiedot: Option[OpiskeluoikeudenLisätiedot] = None
+  override def lisätiedot: Option[KelaOpiskeluoikeudenLisätiedot] = None
 }
 
 @Title("Muun kuin säännellyn koulutuksen päätason suoritus")
@@ -44,7 +44,7 @@ case class KelaMUKSPäätasonSuoritus(
   toimipiste: Toimipiste,
   osasuoritukset: Option[List[KelaMUKSOsasuoritus]],
   arviointi: Option[List[KelaMUKSArviointi]],
-) extends Suoritus  {
+) extends KelaSuoritus  {
   def withHyväksyntämerkinnälläKorvattuArvosana: KelaMUKSPäätasonSuoritus = copy(
     arviointi = arviointi.map(_.map(_.withHyväksyntämerkinnälläKorvattuArvosana)),
     osasuoritukset = osasuoritukset.map(_.map(_.withHyväksyntämerkinnälläKorvattuArvosana)),

--- a/src/main/scala/fi/oph/koski/kela/KelaPerusopetukseenValmistavanSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaPerusopetukseenValmistavanSchema.scala
@@ -26,7 +26,7 @@ case class KelaPerusopetukseenValmistavanOpiskeluoikeus(
   override def alkamispäivä: Option[LocalDate] = super.alkamispäivä
   override def päättymispäivä: Option[LocalDate] = super.päättymispäivä
   override def arvioituPäättymispäivä = None
-  override def lisätiedot: Option[OpiskeluoikeudenLisätiedot] = None
+  override def lisätiedot: Option[KelaOpiskeluoikeudenLisätiedot] = None
   def withHyväksyntämerkinnälläKorvattuArvosana: KelaPerusopetukseenValmistavanOpiskeluoikeus = copy(
     suoritukset = suoritukset.map(_.withHyväksyntämerkinnälläKorvattuArvosana)
   )
@@ -44,7 +44,7 @@ case class KelaPerusopetukseenValmistavanPäätasonSuoritus(
   osasuoritukset: Option[List[KelaPerusopetukseenValmistavanOsasuoritus]],
   tyyppi: schema.Koodistokoodiviite,
   kokonaislaajuus: Option[KelaLaajuus]
-) extends Suoritus {
+) extends KelaSuoritus {
   def withHyväksyntämerkinnälläKorvattuArvosana: KelaPerusopetukseenValmistavanPäätasonSuoritus = copy(
     osasuoritukset = osasuoritukset.map(_.map(_.withHyväksyntämerkinnälläKorvattuArvosana))
   )

--- a/src/main/scala/fi/oph/koski/kela/KelaPerusopetuksenLisäopetuksenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaPerusopetuksenLisäopetuksenSchema.scala
@@ -52,7 +52,7 @@ case class KelaPerusopetuksenLisäopetuksenOpiskeluoikeudenLisätiedot(
   joustavaPerusopetus: Option[KelaAikajakso],
   maksuttomuus: Option[List[KelaMaksuttomuus]],
   oikeuttaMaksuttomuuteenPidennetty: Option[List[KelaOikeuttaMaksuttomuuteenPidennetty]]
-) extends OpiskeluoikeudenLisätiedot
+) extends KelaOpiskeluoikeudenLisätiedot
 
 @Title("Perusopetuksen lisäopetuksen suoritus")
 case class KelaPerusopetuksenLisäopetuksenPäätasonSuoritus(
@@ -61,7 +61,7 @@ case class KelaPerusopetuksenLisäopetuksenPäätasonSuoritus(
   vahvistus: Option[Vahvistus],
   osasuoritukset: Option[List[KelaPerusopetuksenLisäopetuksenOsasuoritus]],
   tyyppi: schema.Koodistokoodiviite,
-) extends Suoritus {
+) extends KelaSuoritus {
   def withHyväksyntämerkinnälläKorvattuArvosana: KelaPerusopetuksenLisäopetuksenPäätasonSuoritus = copy(
     osasuoritukset = osasuoritukset.map(_.map(_.withHyväksyntämerkinnälläKorvattuArvosana))
   )

--- a/src/main/scala/fi/oph/koski/kela/KelaPerusopetuksenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaPerusopetuksenSchema.scala
@@ -55,7 +55,7 @@ case class KelaPerusopetuksenOpiskeluoikeudenLisätiedot(
   opetuksenJärjestäminenVammanSairaudenTaiRajoitteenPerusteella: Option[List[KelaAikajakso]],
   @SensitiveData(Set(Rooli.LUOTTAMUKSELLINEN_KELA_LAAJA))
   toimintaAlueittainOpiskelu: Option[List[KelaAikajakso]]
-) extends OpiskeluoikeudenLisätiedot
+) extends KelaOpiskeluoikeudenLisätiedot
 
 @Title("Perusopetuksen suoritus")
 case class KelaPerusopetuksenSuoritus(
@@ -68,7 +68,7 @@ case class KelaPerusopetuksenSuoritus(
   jääLuokalle: Option[Boolean],
   arviointi: Option[List[KelaYleissivistävänKoulutuksenArviointi]],
   omanÄidinkielenOpinnot: Option[KelaOmanÄidinkielenOpinnot]
-) extends Suoritus {
+) extends KelaSuoritus {
   def withHyväksyntämerkinnälläKorvattuArvosana: KelaPerusopetuksenSuoritus = copy(
     osasuoritukset = osasuoritukset.map(_.map(_.withHyväksyntämerkinnälläKorvattuArvosana)),
     arviointi = arviointi.map(_.map(_.withHyväksyntämerkinnälläKorvattuArvosana)),

--- a/src/main/scala/fi/oph/koski/kela/KelaSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaSchema.scala
@@ -46,9 +46,9 @@ trait KelaOpiskeluoikeus {
   def koulutustoimija: Option[Koulutustoimija]
   def sisältyyOpiskeluoikeuteen: Option[SisältäväOpiskeluoikeus]
   def arvioituPäättymispäivä: Option[LocalDate]
-  def tila: OpiskeluoikeudenTila
-  def suoritukset: List[Suoritus]
-  def lisätiedot: Option[OpiskeluoikeudenLisätiedot]
+  def tila: KelaOpiskeluoikeudenTilaTrait
+  def suoritukset: List[KelaSuoritus]
+  def lisätiedot: Option[KelaOpiskeluoikeudenLisätiedot]
   @KoodistoUri("opiskeluoikeudentyyppi")
   @Discriminator
   def tyyppi: schema.Koodistokoodiviite
@@ -73,28 +73,28 @@ case class SisältäväOpiskeluoikeus(
 
 case class KelaOpiskeluoikeudenTila(
   opiskeluoikeusjaksot: List[KelaOpiskeluoikeusjakso]
-) extends OpiskeluoikeudenTila
+) extends KelaOpiskeluoikeudenTilaTrait
 
 case class KelaOpiskeluoikeudenTilaRahoitustiedoilla(
   opiskeluoikeusjaksot: List[KelaOpiskeluoikeusjaksoRahoituksella]
-) extends OpiskeluoikeudenTila
+) extends KelaOpiskeluoikeudenTilaTrait
 
-trait OpiskeluoikeudenTila {
-  def opiskeluoikeusjaksot: List[Opiskeluoikeusjakso]
+trait KelaOpiskeluoikeudenTilaTrait {
+  def opiskeluoikeusjaksot: List[KelaOpiskeluoikeusjaksoTrait]
 }
 
 case class KelaOpiskeluoikeusjakso(
   alku: LocalDate,
   tila: KelaKoodistokoodiviite,
-) extends Opiskeluoikeusjakso
+) extends KelaOpiskeluoikeusjaksoTrait
 
 case class KelaOpiskeluoikeusjaksoRahoituksella(
   alku: LocalDate,
   tila: KelaKoodistokoodiviite,
   opintojenRahoitus: Option[KelaKoodistokoodiviite]
-) extends Opiskeluoikeusjakso
+) extends KelaOpiskeluoikeusjaksoTrait
 
-trait Opiskeluoikeusjakso {
+trait KelaOpiskeluoikeusjaksoTrait {
   def alku: LocalDate
   def tila: KelaKoodistokoodiviite
   def opiskeluoikeusPäättynyt = schema.Opiskeluoikeus.OpiskeluoikeudenPäättymistila.koski(tila.koodiarvo)
@@ -106,14 +106,14 @@ case class OrganisaatioHistoria(
   koulutustoimija: Option[Koulutustoimija]
 )
 
-trait OpiskeluoikeudenLisätiedot
+trait KelaOpiskeluoikeudenLisätiedot
 
-trait Suoritus{
+trait KelaSuoritus{
   def osasuoritukset: Option[List[Osasuoritus]]
   def koulutusmoduuli: SuorituksenKoulutusmoduuli
   @Discriminator
   def tyyppi: schema.Koodistokoodiviite
-  def withHyväksyntämerkinnälläKorvattuArvosana: Suoritus
+  def withHyväksyntämerkinnälläKorvattuArvosana: KelaSuoritus
 }
 
 trait Osasuoritus{

--- a/src/main/scala/fi/oph/koski/kela/KelaTutkintokoulutukseenValmentavanKoulutuksenSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaTutkintokoulutukseenValmentavanKoulutuksenSchema.scala
@@ -58,7 +58,7 @@ case class KelaTuvaOpiskeluoikeudenLisätiedot(
   majoitusetu: Option[KelaAikajakso],
   koulukoti: Option[List[KelaAikajakso]],
   koulutusvienti: Option[Boolean],
-) extends OpiskeluoikeudenLisätiedot
+) extends KelaOpiskeluoikeudenLisätiedot
 
 @Title("Tutkintokoulutukseen valmentavan koulutuksen suoritus")
 case class KelaTuvaPäätasonSuoritus(
@@ -67,7 +67,7 @@ case class KelaTuvaPäätasonSuoritus(
   koulutusmoduuli: KelaTuvaSuorituksenKoulutusmoduuli,
   vahvistus: Option[Vahvistus],
   override val osasuoritukset: Option[List[KelaTuvaOsasuoritus]],
-) extends Suoritus {
+) extends KelaSuoritus {
   def withHyväksyntämerkinnälläKorvattuArvosana: KelaTuvaPäätasonSuoritus = copy(
     osasuoritukset = osasuoritukset.map(_.map(_.withHyväksyntämerkinnälläKorvattuArvosana))
   )

--- a/src/main/scala/fi/oph/koski/kela/KelaVapaanSivistystyönSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaVapaanSivistystyönSchema.scala
@@ -39,7 +39,7 @@ case class KelaVapaanSivistystyönOpiskeluoikeus(
 case class KelaVapaanSivistystyönOpiskeluoikeudenLisätiedot(
   maksuttomuus: Option[List[KelaMaksuttomuus]],
   oikeuttaMaksuttomuuteenPidennetty: Option[List[KelaOikeuttaMaksuttomuuteenPidennetty]]
-) extends OpiskeluoikeudenLisätiedot
+) extends KelaOpiskeluoikeudenLisätiedot
 
 @Title("Vapaan sivistystyön suoritus")
 case class KelaVapaanSivistystyönPäätasonSuoritus(
@@ -140,7 +140,7 @@ case class KelaVapaanSivistystyönJotpaOsasuoritus(
   )
 }
 
-trait VstSuoritus extends Suoritus {
+trait VstSuoritus extends KelaSuoritus {
   def withHyväksyntämerkinnälläKorvattuArvosana: VstSuoritus
 }
 

--- a/src/main/scala/fi/oph/koski/kela/KelaYlioppilastutkintoSchema.scala
+++ b/src/main/scala/fi/oph/koski/kela/KelaYlioppilastutkintoSchema.scala
@@ -94,8 +94,8 @@ case class KelaYlioppilastutkinnonPäätasonSuoritus(
   tyyppi: schema.Koodistokoodiviite,
   alkamispäivä: Option[LocalDate],
   pakollisetKokeetSuoritettu: Option[Boolean],
-) extends Suoritus {
-  override def withHyväksyntämerkinnälläKorvattuArvosana: Suoritus = this
+) extends KelaSuoritus {
+  override def withHyväksyntämerkinnälläKorvattuArvosana: KelaSuoritus = this
 }
 
 @Title("Ylioppilastutkinnon osasuoritus")

--- a/src/main/scala/fi/oph/koski/kios/KiosDIASchema.scala
+++ b/src/main/scala/fi/oph/koski/kios/KiosDIASchema.scala
@@ -18,7 +18,7 @@ case class KiosDIAOpiskeluoikeus(
 
   override def lisätiedot: Option[KiosOpiskeluoikeudenLisätiedot] = None
 
-  override def withSuoritukset(suoritukset: List[Suoritus]): KiosKoskeenTallennettavaOpiskeluoikeus =
+  override def withSuoritukset(suoritukset: List[KiosSuoritus]): KiosKoskeenTallennettavaOpiskeluoikeus =
     this.copy(
       suoritukset = suoritukset.collect { case s: KiosDIATutkinnonSuoritus => s }
     )
@@ -32,7 +32,7 @@ case class KiosDIATutkinnonSuoritus(
   vahvistus: Option[Vahvistus],
   @KoodistoKoodiarvo("diatutkintovaihe")
   tyyppi: schema.Koodistokoodiviite,
-) extends Suoritus
+) extends KiosSuoritus
 
 case class KiosDIATutkinto(
   tunniste: KiosKoodistokoodiviite

--- a/src/main/scala/fi/oph/koski/kios/KiosEBTutkintoSchema.scala
+++ b/src/main/scala/fi/oph/koski/kios/KiosEBTutkintoSchema.scala
@@ -18,7 +18,7 @@ case class KiosEBTutkinnonOpiskeluoikeus(
 
   override def lisätiedot: Option[KiosOpiskeluoikeudenLisätiedot] = None
 
-  override def withSuoritukset(suoritukset: List[Suoritus]): KiosKoskeenTallennettavaOpiskeluoikeus =
+  override def withSuoritukset(suoritukset: List[KiosSuoritus]): KiosKoskeenTallennettavaOpiskeluoikeus =
     this.copy(
       suoritukset = suoritukset.collect { case s: KiosEBTutkinnonPäätasonSuoritus => s }
     )
@@ -31,7 +31,7 @@ case class KiosEBTutkinnonPäätasonSuoritus(
   toimipiste: Option[Toimipiste],
   @KoodistoKoodiarvo("ebtutkinto")
   tyyppi: schema.Koodistokoodiviite,
-) extends Suoritus
+) extends KiosSuoritus
 
 case class KiosEBTutkinnonKoulutusmoduuli(
   tunniste: KiosKoodistokoodiviite,

--- a/src/main/scala/fi/oph/koski/kios/KiosKorkeakouluSchema.scala
+++ b/src/main/scala/fi/oph/koski/kios/KiosKorkeakouluSchema.scala
@@ -92,7 +92,7 @@ case class KiosKorkeakoulunOpiskeluoikeus(
   luokittelu: Option[List[KiosKoodistokoodiviite]],
 ) extends KiosOpiskeluoikeus {
 
-  override def withSuoritukset(suoritukset: List[Suoritus]): KiosOpiskeluoikeus =
+  override def withSuoritukset(suoritukset: List[KiosSuoritus]): KiosOpiskeluoikeus =
     this.copy(
       suoritukset = suoritukset.collect { case s: KiosKorkeakoulututkinnonSuoritus => s }
     )
@@ -105,7 +105,7 @@ case class KiosKorkeakoulututkinnonSuoritus(
   tyyppi: schema.Koodistokoodiviite,
   vahvistus: Option[Vahvistus],
   toimipiste: Option[Toimipiste],
-) extends Suoritus
+) extends KiosSuoritus
 
 case class KiosKorkeakoulunOpiskeluoikeudenLisätiedot(
   virtaOpiskeluoikeudenTyyppi: Option[KiosKoodistokoodiviite],

--- a/src/main/scala/fi/oph/koski/kios/KiosSchema.scala
+++ b/src/main/scala/fi/oph/koski/kios/KiosSchema.scala
@@ -48,7 +48,7 @@ trait KiosOpiskeluoikeus {
 
   def koulutustoimija: Option[Koulutustoimija]
 
-  def suoritukset: List[Suoritus]
+  def suoritukset: List[KiosSuoritus]
 
   @KoodistoUri("opiskeluoikeudentyyppi")
   @Discriminator
@@ -64,7 +64,7 @@ trait KiosOpiskeluoikeus {
 
   def lisätiedot: Option[KiosOpiskeluoikeudenLisätiedot]
 
-  def withSuoritukset(suoritukset: List[Suoritus]): KiosOpiskeluoikeus
+  def withSuoritukset(suoritukset: List[KiosSuoritus]): KiosOpiskeluoikeus
 }
 
 trait KiosKoskeenTallennettavaOpiskeluoikeus extends KiosOpiskeluoikeus {
@@ -78,7 +78,7 @@ case class SisältäväOpiskeluoikeus(
   oppilaitos: Oppilaitos
 )
 
-trait Suoritus {
+trait KiosSuoritus {
   def koulutusmoduuli: SuorituksenKoulutusmoduuli
 
   @Discriminator
@@ -173,7 +173,7 @@ case class KiosPäätasonSuoritus(
   tyyppi: schema.Koodistokoodiviite,
   vahvistus: Option[Vahvistus],
   toimipiste: Option[Toimipiste]
-) extends Suoritus
+) extends KiosSuoritus
 
 @Title("Päätason koulutusmoduuli")
 case class KiosPäätasonKoulutusmoduuli(

--- a/src/main/scala/fi/oph/koski/kios/KiosService.scala
+++ b/src/main/scala/fi/oph/koski/kios/KiosService.scala
@@ -55,7 +55,7 @@ class KiosService(application: KoskiApplication) extends GlobalExecutionContext 
       }.filter(_.suoritukset.nonEmpty)
   }
 
-  private def josYOTutkintoNiinVahvistettu(s: Suoritus): Boolean = {
+  private def josYOTutkintoNiinVahvistettu(s: KiosSuoritus): Boolean = {
     s match {
       case s: KiosYlioppilastutkinnonPäätasonSuoritus
       => s.vahvistus.isDefined
@@ -64,7 +64,7 @@ class KiosService(application: KoskiApplication) extends GlobalExecutionContext 
     }
   }
 
-  private def josEBTutkintoNiinVahvistettu(s: Suoritus): Boolean = {
+  private def josEBTutkintoNiinVahvistettu(s: KiosSuoritus): Boolean = {
     s match {
       case s: KiosEBTutkinnonPäätasonSuoritus
       => s.vahvistus.isDefined
@@ -73,7 +73,7 @@ class KiosService(application: KoskiApplication) extends GlobalExecutionContext 
     }
   }
 
-  private def josDIATutkintoNiinVahvistettu(s: Suoritus): Boolean = {
+  private def josDIATutkintoNiinVahvistettu(s: KiosSuoritus): Boolean = {
     s match {
       case s: KiosDIATutkinnonSuoritus
       => s.vahvistus.isDefined

--- a/src/main/scala/fi/oph/koski/kios/KiosYlioppilastutkintoSchema.scala
+++ b/src/main/scala/fi/oph/koski/kios/KiosYlioppilastutkintoSchema.scala
@@ -63,7 +63,7 @@ case class KiosYlioppilastutkinnonOpiskeluoikeus(
 
   override def lisätiedot: Option[KiosOpiskeluoikeudenLisätiedot] = None
 
-  override def withSuoritukset(suoritukset: List[Suoritus]): KiosOpiskeluoikeus =
+  override def withSuoritukset(suoritukset: List[KiosSuoritus]): KiosOpiskeluoikeus =
     this.copy(
       suoritukset = suoritukset.collect { case s: KiosYlioppilastutkinnonPäätasonSuoritus => s }
     )
@@ -75,7 +75,7 @@ case class KiosYlioppilastutkinnonPäätasonSuoritus(
   toimipiste: Option[Toimipiste],
   vahvistus: Option[Vahvistus],
   tyyppi: schema.Koodistokoodiviite,
-) extends Suoritus
+) extends KiosSuoritus
 
 case class KiosYlioppilastutkinnonSuorituksenKoulutusmoduuli(
   tunniste: KiosKoodistokoodiviite,

--- a/src/main/scala/fi/oph/koski/ytl/YtlSchema.scala
+++ b/src/main/scala/fi/oph/koski/ytl/YtlSchema.scala
@@ -62,7 +62,7 @@ trait YtlOpiskeluoikeus {
   def oppilaitos: Option[Oppilaitos]
   def koulutustoimija: Option[Koulutustoimija]
   def tila: OpiskeluoikeudenTila
-  def suoritukset: List[Suoritus]
+  def suoritukset: List[YtlGenericSuoritus]
   def lisätiedot: Option[OpiskeluoikeudenLisätiedot]
   def organisaatiohistoria: Option[List[OrganisaatioHistoria]]
   def alkamispäivä: Option[LocalDate]
@@ -91,20 +91,20 @@ trait LaajatSuoritustiedotSisältäväYtlOpiskeluoikeus extends YtlOpiskeluoikeu
 
   private def suoritustenVahvistustenOrganisaatiot =
     this.suoritukset.flatMap(_.vahvistus.flatMap(_.myöntäjäOrganisaatio.flatMap {
-    case o: OrganisaatioWithOid => Some(o.oid)
+    case o: YtlOrganisaatioWithOid => Some(o.oid)
     case _ => None
   }))
 }
 
-trait Suoritus {
+trait YtlGenericSuoritus {
   @KoodistoUri("suorituksentyyppi")
   @Discriminator
   def tyyppi: schema.Koodistokoodiviite
 }
 
-trait SuoritusLaajatTiedot extends Suoritus {
+trait SuoritusLaajatTiedot extends YtlGenericSuoritus {
   def koulutusmoduuli: SuorituksenKoulutusmoduuli
-  def toimipiste: Option[OrganisaatioWithOid]
+  def toimipiste: Option[YtlOrganisaatioWithOid]
   def vahvistus: Option[Vahvistus]
   @KoodistoUri("kieli")
   def suorituskieli: schema.Koodistokoodiviite
@@ -150,7 +150,7 @@ case class LukionSuoritus(
   @KoodistoKoodiarvo("lukionaineopinnot")
   @KoodistoKoodiarvo("lukionoppimaara")
   tyyppi: schema.Koodistokoodiviite
-) extends Suoritus
+) extends YtlGenericSuoritus
 
 @Title("Ammatillinen opiskeluoikeus")
 case class YtlAmmatillinenOpiskeluoikeus(
@@ -189,7 +189,7 @@ case class AmmatillinenSuoritus(
   @KoodistoKoodiarvo("ammatillinentutkinto")
   tyyppi: schema.Koodistokoodiviite,
   koulutusmoduuli: AmmatillinenTutkintoKoulutus,
-  toimipiste: Option[OrganisaatioWithOid],
+  toimipiste: Option[YtlOrganisaatioWithOid],
   vahvistus: Option[Vahvistus],
   suorituskieli: schema.Koodistokoodiviite
 ) extends SuoritusLaajatTiedot
@@ -240,7 +240,7 @@ case class IBSuoritus(
   @KoodistoKoodiarvo("ibtutkinto")
   tyyppi: schema.Koodistokoodiviite,
   koulutusmoduuli: IBTutkinto,
-  toimipiste: Option[OrganisaatioWithOid],
+  toimipiste: Option[YtlOrganisaatioWithOid],
   vahvistus: Option[Vahvistus],
   suorituskieli: schema.Koodistokoodiviite
 ) extends SuoritusLaajatTiedot
@@ -290,7 +290,7 @@ case class InternationalSchoolSuoritus(
   @KoodistoKoodiarvo("internationalschooldiplomavuosiluokka")
   tyyppi: schema.Koodistokoodiviite,
   koulutusmoduuli: InternationalSchoolLuokkaAste,
-  toimipiste: Option[OrganisaatioWithOid],
+  toimipiste: Option[YtlOrganisaatioWithOid],
   vahvistus: Option[Vahvistus],
   suorituskieli: schema.Koodistokoodiviite
 ) extends SuoritusLaajatTiedot
@@ -306,9 +306,9 @@ case class InternationalSchoolLuokkaAste(
   diplomaType: schema.Koodistokoodiviite
 ) extends SuorituksenKoulutusmoduuli
 
-trait Organisaatio
+trait YtlOrganisaatio
 
-trait OrganisaatioWithOid extends Organisaatio {
+trait YtlOrganisaatioWithOid extends YtlOrganisaatio {
   @Discriminator
   def oid: String
   def nimi: Option[schema.LocalizedString]
@@ -321,7 +321,7 @@ case class OidOrganisaatio(
   oid: String,
   nimi: Option[schema.LocalizedString],
   kotipaikka: Option[schema.Koodistokoodiviite]
-) extends OrganisaatioWithOid
+) extends YtlOrganisaatioWithOid
 
 case class Koulutustoimija(
   oid: String,
@@ -330,7 +330,7 @@ case class Koulutustoimija(
   @Title("Y-tunnus")
   yTunnus: Option[String],
   kotipaikka: Option[schema.Koodistokoodiviite]
-) extends OrganisaatioWithOid
+) extends YtlOrganisaatioWithOid
 
 case class Oppilaitos(
   oid: String,
@@ -339,27 +339,27 @@ case class Oppilaitos(
   oppilaitosnumero: Option[schema.Koodistokoodiviite],
   nimi: Option[schema.LocalizedString],
   kotipaikka: Option[schema.Koodistokoodiviite]
-) extends OrganisaatioWithOid
+) extends YtlOrganisaatioWithOid
 
 @IgnoreInAnyOfDeserialization
 case class Toimipiste(
   oid: String,
   nimi: Option[schema.LocalizedString],
   kotipaikka: Option[schema.Koodistokoodiviite]
-) extends OrganisaatioWithOid
+) extends YtlOrganisaatioWithOid
 
 case class Yritys(
   nimi: schema.LocalizedString,
   @Discriminator
   @Title("Y-tunnus")
   yTunnus: String
-) extends Organisaatio
+) extends YtlOrganisaatio
 
 case class Tutkintotoimikunta(
   nimi: schema.LocalizedString,
   @Discriminator
   tutkintotoimikunnanNumero: String
-) extends Organisaatio
+) extends YtlOrganisaatio
 
 case class OpiskeluoikeudenTila(
   opiskeluoikeusjaksot: List[Opiskeluoikeusjakso]
@@ -373,7 +373,7 @@ case class Opiskeluoikeusjakso(
 
 case class Vahvistus(
   päivä: LocalDate,
-  myöntäjäOrganisaatio: Option[Organisaatio]
+  myöntäjäOrganisaatio: Option[YtlOrganisaatio]
 )
 
 case class OpiskeluoikeudenLisätiedot(

--- a/src/test/scala/fi/oph/koski/documentation/LocalizedSchemasSpec.scala
+++ b/src/test/scala/fi/oph/koski/documentation/LocalizedSchemasSpec.scala
@@ -21,6 +21,8 @@ class LocalizedSchemasSpec extends AnyFreeSpec with TestEnvironment with Matcher
   "all registered viewer schemas are enriched with translations" - {
     val schemaNames = List(
       "kela-oppija-schema.json",
+      "kios-oppija-schema.json",
+      "ytl-oppija-schema.json",
       "migri-oppija-schema.json",
       "valpas-internal-laaja-schema.json",
       "omadata-oauth2-kaikki-tiedot-oppija-schema.json",

--- a/src/test/scala/fi/oph/koski/kios/KiosServiceSpec.scala
+++ b/src/test/scala/fi/oph/koski/kios/KiosServiceSpec.scala
@@ -285,7 +285,7 @@ class KiosServiceSpec
 
   private def verifyOpiskeluoikeusJaSuoritus(
     actualOo: KiosOpiskeluoikeus,
-    actualSuoritukset: Seq[Suoritus],
+    actualSuoritukset: Seq[KiosSuoritus],
     expectedOoData: schema.Opiskeluoikeus,
     expectedSuoritusDatat: Seq[schema.Suoritus]
   ): Unit = {


### PR DESCRIPTION
## Summary

Follow-up to #4394 (already merged), which fixed `sdg-oppija-schema.json` returning HTTP 500.

- Same latent bug class: `fi.oph.koski.kela`, `fi.oph.koski.kios` and `fi.oph.koski.ytl` each define local traits (`Suoritus`, `OpiskeluoikeudenTila`, `Opiskeluoikeusjakso`, `OpiskeluoikeudenLisätiedot`, `OsaamisenHankkimistapa`, `Organisaatio`, `OrganisaatioWithOid`) whose simple names collide with unrelated `fi.oph.koski.schema` traits, while each package also references `schema.*` types directly.
- Not currently broken — nothing makes both versions reachable from the same schema root today (all 22 registered viewer schemas verified locally, all return 200) — but it's the same dormant risk that broke `sdg-oppija-schema.json`.
- Renamed the colliding local traits with a package prefix, matching the existing convention already used for the concrete case classes.
- Added `kios-oppija-schema.json` and `ytl-oppija-schema.json` to `LocalizedSchemasSpec`'s covered schema list (`kela-oppija-schema.json` was already covered).