### PR TITLE
TOR-2644 mitätöi YTR-opiskeluoikeuksien duplikaatit latauksen yhteydessä

### DIFF
--- a/src/main/scala/fi/oph/koski/opiskeluoikeus/PostgresYtrOpiskeluoikeusRepositoryActions.scala
+++ b/src/main/scala/fi/oph/koski/opiskeluoikeus/PostgresYtrOpiskeluoikeusRepositoryActions.scala
@@ -75,8 +75,43 @@ class PostgresYtrOpiskeluoikeusRepositoryActions(
     aiemmatOpiskeluoikeudet match {
       case List(vanhaOpiskeluoikeus) =>
         updateIfSameOppijaAction(oppijaOid, vanhaOpiskeluoikeus, opiskeluoikeus, allowDeleteCompleted, skipValidations)
-      case _ =>
-        DBIO.successful(Left(KoskiErrorCategory.conflict.löytyiEnemmänKuinYksiRivi(s"Löytyi enemmän kuin yksi rivi päivitettäväksi (${aiemmatOpiskeluoikeudet.map(_.oid)})")))
+      case Nil =>
+        // Ei pitäisi olla mahdollista: kutsuja käsittelee tyhjän tuloksen luontina
+        DBIO.successful(Left(KoskiErrorCategory.internalError("Päivitettävää YTR-opiskeluoikeutta ei löytynyt")))
+      case duplikaatit =>
+        mitätöiDuplikaatitJaPäivitäAction(oppijaOid, opiskeluoikeus, duplikaatit, allowDeleteCompleted, skipValidations)
+    }
+  }
+
+  // Oppijalla voi olla useampi YTR-opiskeluoikeus, jos kummallekin hänen oppijanumerolleen on ehditty tallentaa
+  // sellainen ennen oppijanumeroiden yhdistämistä oppijanumerorekisterissä. Ilman duplikaattien mitätöintiä päivitys
+  // jäisi pysyvästi jumiin, koska YTR-opiskeluoikeutta ei tunnisteta muulla kuin oppijan oidilla.
+  // Kutsutaan vain, kun duplikaatteja on vähintään kaksi.
+  private def mitätöiDuplikaatitJaPäivitäAction(
+    oppijaOid: PossiblyUnverifiedHenkilöOid,
+    opiskeluoikeus: KoskeenTallennettavaOpiskeluoikeus,
+    duplikaatit: List[YtrOpiskeluoikeusRow],
+    allowDeleteCompleted: Boolean,
+    skipValidations: Boolean,
+  )(implicit user: KoskiSpecificSession): DBIOAction[Either[HttpStatus, CreateOrUpdateResult], NoStream, Read with Write with Transactional] = {
+    // Säilytetään ensisijaisesti se rivi, jonka oppija-oidiin lataus tällä hetkellä ratkeaa, ja toissijaisesti vanhin
+    // rivi. Näin säilyvän opiskeluoikeuden oid pysyy samana niille palveluille, joille se on jo luovutettu.
+    val säilytettävä = duplikaatit
+      .find(_.oppijaOid == oppijaOid.oppijaOid)
+      .getOrElse(duplikaatit.minBy(_.id))
+    val mitätöitävät = duplikaatit.filterNot(_.id == säilytettävä.id)
+
+    logger.warn(
+      s"Oppijalla ${oppijaOid.oppijaOid} on ${duplikaatit.length} YTR-opiskeluoikeutta " +
+        s"(${duplikaatit.map(rivi => s"${rivi.oid} (oppija ${rivi.oppijaOid})").mkString(", ")}). " +
+        s"Todennäköinen syy: oppijanumerot on yhdistetty oppijanumerorekisterissä vasta opiskeluoikeuksien " +
+        s"tallentamisen jälkeen. Säilytetään ${säilytettävä.oid} ja mitätöidään ${mitätöitävät.map(_.oid).mkString(", ")}."
+    )
+
+    DBIO.sequence(
+      mitätöitävät.map(rivi => Opiskeluoikeudet.filter(_.id === rivi.id).map(_.mitätöity).update(true))
+    ).flatMap { _ =>
+      updateIfSameOppijaAction(oppijaOid, säilytettävä, opiskeluoikeus, allowDeleteCompleted, skipValidations)
     }
   }
 

--- a/src/main/scala/fi/oph/koski/raportointikanta/FullReloadOpiskeluoikeusLoader.scala
+++ b/src/main/scala/fi/oph/koski/raportointikanta/FullReloadOpiskeluoikeusLoader.scala
@@ -84,7 +84,7 @@ class FullReloadOpiskeluoikeusLoader(
 
     val resultOlemassaolevatOot = loadYtrBatchOlemassaolevatOpiskeluoikeudet(olemassaolevatOot)
 
-    // Mitätöityjä ei (toistaiseksi) käsitellä, koska sellaisia ei YTR-datassa voi olla.
+    // Mitätöityjä ei viedä raportointikantaan, ei myöskään r_mitatoitu_opiskeluoikeus-tauluun.
 
     resultOlemassaolevatOot
   }

--- a/src/test/scala/fi/oph/koski/migration/MigrationSpec.scala
+++ b/src/test/scala/fi/oph/koski/migration/MigrationSpec.scala
@@ -58,7 +58,7 @@ class MigrationSpec extends AnyFreeSpec with Matchers with RaportointikantaTestM
         "TOPKSAmmatillinenRaporttiRowBuilder.scala"                 -> "a9c26a13385ff576810f3ef831240437",
         "OpiskeluoikeusLoaderRowBuilder.scala"                      -> "cea96e3bef7b30c4e6448ba8117d480b",
         "IncrementalUpdateOpiskeluoikeusLoader.scala"               -> "ad58afb81edd77fd935ddd1a4f5e0e9c",
-        "FullReloadOpiskeluoikeusLoader.scala"                      -> "b7920c2257afaecf09f1212fbf393326"
+        "FullReloadOpiskeluoikeusLoader.scala"                      -> "71e731a66fb2330a9b41d7a1193b5533"
       )
 
       val errors = getListOfFiles(dir).flatMap(file => {

--- a/src/test/scala/fi/oph/koski/ytr/download/YtrDownloadVirhetilanteetSpec.scala
+++ b/src/test/scala/fi/oph/koski/ytr/download/YtrDownloadVirhetilanteetSpec.scala
@@ -1,7 +1,10 @@
 package fi.oph.koski.ytr.download
 
 import fi.oph.koski.api.misc.OpiskeluoikeusTestMethods
-import fi.oph.koski.{KoskiApplicationForTests, KoskiHttpSpec}
+import fi.oph.koski.{DatabaseTestMethods, KoskiApplicationForTests, KoskiHttpSpec}
+import fi.oph.koski.db.KoskiTables.YtrOpiskeluOikeudet
+import fi.oph.koski.db.PostgresDriverWithJsonSupport.api._
+import fi.oph.koski.db.YtrOpiskeluoikeusRow
 import fi.oph.koski.henkilo.{KoskiSpecificMockOppijat, VerifiedHenkilöOid}
 import fi.oph.koski.koskiuser.{AccessType, KoskiSpecificSession}
 import fi.oph.koski.ytr.YtrSsnWithPreviousSsns
@@ -15,6 +18,7 @@ class YtrDownloadVirhetilanteetSpec
     with Matchers
     with YtrDownloadTestMethods
     with OpiskeluoikeusTestMethods
+    with DatabaseTestMethods
     with BeforeAndAfterEach
 {
 
@@ -28,8 +32,9 @@ class YtrDownloadVirhetilanteetSpec
     resetFixtures()
   }
 
-  "YTR download huomaa konsistentisti tilanteen, missä samalla oppijalla on useampi YTR-opiskeluoikeus ennestään" in {
-    // Näin saattaa tapahtua, jos oppijoita yhdistetään oppijanumerorekisterissä
+  "YTR download mitätöi duplikaatin, jos samalla oppijalla on ennestään useampi YTR-opiskeluoikeus" in {
+    // Näin saattaa tapahtua, jos oppijoita yhdistetään oppijanumerorekisterissä vasta sen jälkeen, kun kummallekin
+    // oppijanumerolle on ehditty tallentaa YTR-opiskeluoikeus
 
     clearYtrData()
 
@@ -39,18 +44,31 @@ class YtrDownloadVirhetilanteetSpec
     implicit val accessType: AccessType.Value = AccessType.write
 
     // Lisää YTR-opiskeluoikeus kahdelle samaan master-oppijaan liitetylle oppijalle ohi normaalin prosessin
-    KoskiApplicationForTests.ytrPossu
+    val masterinTallennus = KoskiApplicationForTests.ytrPossu
       .createOrUpdate(VerifiedHenkilöOid(KoskiSpecificMockOppijat.master), opiskeluoikeus)
-      .isRight should be(true)
-    KoskiApplicationForTests.ytrPossu
+    masterinTallennus.isRight should be(true)
+    val slavenTallennus = KoskiApplicationForTests.ytrPossu
       .actions.createOpiskeluoikeusBypassingUpdateCheckForTests(KoskiSpecificMockOppijat.slave, opiskeluoikeus)
-      .isRight should be(true)
+    slavenTallennus.isRight should be(true)
 
     // Koita tehdä download, jossa tulee uusi YTR-opiskeluikeus kyseisen oppijan hetulla
     downloadYtrData("1997-10", "1997-11", force = true)
 
-    // Varmista, että tästä syntyi virhe
-    verifyDownloadCounts(expectedTotalCount = 1, expectedErrorCount = 1)
+    // Varmista, että lataus onnistui: duplikaatti on mitätöity eikä virhettä syntynyt
+    verifyDownloadCounts(expectedTotalCount = 1, expectedErrorCount = 0)
+
+    val rivit = ytrOpiskeluoikeusRivit(
+      KoskiSpecificMockOppijat.master.oid,
+      KoskiSpecificMockOppijat.slave.henkilö.oid
+    )
+
+    // Lataus ratkeaa master-oppijaan, joten hänen rivinsä säilyy ja slaven rivi mitätöidään
+    rivit.filterNot(_.mitätöity).map(rivi => (rivi.oid, rivi.oppijaOid)) should equal(List(
+      (masterinTallennus.toOption.get.oid, KoskiSpecificMockOppijat.master.oid)
+    ))
+    rivit.filter(_.mitätöity).map(rivi => (rivi.oid, rivi.oppijaOid)) should equal(List(
+      (slavenTallennus.toOption.get.oid, KoskiSpecificMockOppijat.slave.henkilö.oid)
+    ))
   }
 
   "YTR download selviää virheellisistä hetuista" in {
@@ -98,6 +116,9 @@ class YtrDownloadVirhetilanteetSpec
       oppijaConverter.convertOppijastaOpiskeluoikeus(laajaOppija).head
     opiskeluoikeus
   }
+
+  private def ytrOpiskeluoikeusRivit(oppijaOidit: String*): List[YtrOpiskeluoikeusRow] =
+    runDbSync(YtrOpiskeluOikeudet.filter(_.oppijaOid inSetBind oppijaOidit).sortBy(_.id).result).toList
 
   private def verifyDownloadCounts(
     expectedTotalCount: Int,


### PR DESCRIPTION
Jos oppijalla on ennestään useampi YTR-opiskeluoikeus, lataus jäi pysyvästi virheeseen "Löytyi enemmän kuin yksi rivi päivitettäväksi", koska YTR-opiskeluoikeutta ei tunnisteta muulla kuin oppijan oidilla.

Lataus säilyttää nyt yhden rivin ja mitätöi loput. Säilytettäväksi valitaan rivi, jonka oppija-oidiin lataus ratkeaa, tai vanhin rivi, jotta jo luovutettu opiskeluoikeuden oid pysyy samana. Tilanteesta lokitetaan varoitus.