### PR TITLE
TOR-2713: Käsittele Virta-opiskeluoikeuden tila 7

### DIFF
--- a/src/main/resources/mockdata/koodisto/koodit/virtaopiskeluoikeudentila.json
+++ b/src/main/resources/mockdata/koodisto/koodit/virtaopiskeluoikeudentila.json
@@ -163,5 +163,33 @@
     "koodiUri": "virtaopiskeluoikeudentila_6",
     "versio": 1,
     "koodiArvo": "6"
+  },
+  {
+    "metadata": [
+      {
+        "nimi": "päättynyt yhden opiskeluoikeuden säännöksen johdosta",
+        "kuvaus": "",
+        "lyhytNimi": "",
+        "kieli": "FI"
+      },
+      {
+        "nimi": "-",
+        "kuvaus": "",
+        "lyhytNimi": "",
+        "kieli": "SV"
+      },
+      {
+        "nimi": "-",
+        "kuvaus": "",
+        "lyhytNimi": "",
+        "kieli": "EN"
+      }
+    ],
+    "withinCodeElements": [],
+    "includesCodeElements": [],
+    "levelsWithCodeElements": [],
+    "koodiUri": "virtaopiskeluoikeudentila_7",
+    "versio": 1,
+    "koodiArvo": "7"
   }
 ]

--- a/src/main/scala/fi/oph/koski/schema/Opiskeluoikeus.scala
+++ b/src/main/scala/fi/oph/koski/schema/Opiskeluoikeus.scala
@@ -75,13 +75,15 @@ object Opiskeluoikeus {
       "valiaikaisestikeskeytynyt" -> false
     )
 
+    // Koodiarvot vastaavat koodistoa "virtaopiskeluoikeudentila" - pidä nämä synkassa keskenään
     private val onVirtaPäättymistila = Map(
       "1" -> false,
       "2" -> false,
       "3" -> true,
       "4" -> true,
       "5" -> true,
-      "6" -> true
+      "6" -> true,
+      "7" -> true
     )
   }
 }

--- a/src/test/scala/fi/oph/koski/schema/OpiskeluoikeudenPaattymistilaSpec.scala
+++ b/src/test/scala/fi/oph/koski/schema/OpiskeluoikeudenPaattymistilaSpec.scala
@@ -1,0 +1,24 @@
+package fi.oph.koski.schema
+
+import fi.oph.koski.koodisto.MockKoodistoViitePalvelu
+import fi.oph.koski.schema.Opiskeluoikeus.OpiskeluoikeudenPäättymistila
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class OpiskeluoikeudenPaattymistilaSpec extends AnyFreeSpec with Matchers {
+  "korkeakoulu" - {
+    "tunnistaa koodiarvon 7 (päättynyt yhden opiskeluoikeuden säännöksen johdosta) päättyneeksi tilaksi" in {
+      OpiskeluoikeudenPäättymistila.korkeakoulu("7") shouldBe true
+    }
+
+    "tunnistaa jokaisen koodiston \"virtaopiskeluoikeudentila\" koodiarvon, eikä heitä poikkeusta" in {
+      val koodisto = MockKoodistoViitePalvelu.getLatestVersionRequired("virtaopiskeluoikeudentila")
+      val koodiarvot = MockKoodistoViitePalvelu.getKoodistoKoodiViitteet(koodisto).map(_.koodiarvo)
+
+      koodiarvot should not be empty
+      koodiarvot.foreach { koodiarvo =>
+        noException should be thrownBy OpiskeluoikeudenPäättymistila.korkeakoulu(koodiarvo)
+      }
+    }
+  }
+}

--- a/tiedonsiirtoprotokollan_muutoshistoria.md
+++ b/tiedonsiirtoprotokollan_muutoshistoria.md
@@ -1,3 +1,7 @@
+# 31.8.2026
+
+- Korjattu korkeakoulun opiskeluoikeuden tilan käsittely Virta-datassa: tilakoodi 7 ("päättynyt yhden opiskeluoikeuden säännöksen johdosta") aiheutti aiemmin virheen, jonka seurauksena oppijan Virta-tiedot puuttuivat kokonaan Koskesta saatavista tiedoista.
+
 # 27.8.2026
 
 - Ahvenanmaan perusopetuksen opiskeluoikeuteen lisätty uusi päätason suoritus `ahvenanmaanperusopetuksenoppimaaraaikuiset` (Ahvenanmaan perusopetuksen oppimäärän suoritus muille kuin oppivelvollisille). Suoritus vastaa rakenteeltaan oppivelvollisten oppimäärän suoritusta, mutta sillä on lisäksi `alkamispäivä`-kenttä, koska näillä opiskeluoikeuksilla ei ole vuosiluokan suorituksia.


### PR DESCRIPTION
Virta added a new opiskeluoikeuden tila code (`7`, "päättynyt yhden opiskeluoikeuden säännöksen johdosta") that wasn't in Koski's hardcoded `onVirtaPäättymistila` map. Any oppija with that status caused `IllegalArgumentException` on every access (never cached — Guava doesn't cache failed loads), logged at ERROR level, silently dropping that oppija's Virta data from responses.

- Add code `7` to `onVirtaPäättymistila`
- Add the matching entry to the local `virtaopiskeluoikeudentila` koodisto mock
- Add a guard test asserting every koodisto value is covered, so a future new value fails a test instead of erroring in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)