### PR TITLE
TOR-2587: Korjaa suorituskielen oletusta tarkistavan e2e-testin flakyys

### DIFF
--- a/web/test/e2e/ahvenanmaan-perusopetus-luonti.spec.ts
+++ b/web/test/e2e/ahvenanmaan-perusopetus-luonti.spec.ts
@@ -84,7 +84,9 @@ test.describe('Ahvenanmaan perusopetuksen opiskeluoikeuden luonti', () => {
       opiskeluoikeus
     })
 
-    expect(await uusiOppijaPage.controls.suorituskieli.value()).toEqual(
+    // Oletus asettuu vasta kun kieli-koodisto on latautunut, joten arvoa on
+    // odotettava — kertaluontoinen luku ehtii nähdä kentän vielä tyhjänä.
+    await expect(uusiOppijaPage.controls.suorituskieli.input).toHaveValue(
       'ruotsi'
     )
   })


### PR DESCRIPTION
Ahvenanmaan luontidialogin "Suorituskielen oletus on ruotsi" -testi luki kentän arvon kertaluontoisesti (Select.value() -> input.inputValue()), joka odottaa vain elementin olemassaoloa, ei mitään tiettyä arvoa.

Suorituskieli-kentän oletus asettuu kuitenkin vasta kun kieli-koodisto on latautunut: sitä ennen KieliSelectin options on tyhjä, Selectin autoselect-efekti ei ole vielä soveltanut initialValue-arvoa, ja kentän displayValue on "". CI:llä koodistohaku ehti hävitä kisan, ja testi näki tyhjän arvon.

Vaihdettu Playwrightin uudelleenyrittävään toHaveValue-assertioon, jota muutkin pudotusvalikon arvoa tarkistavat testit käyttävät (ks. pudotusvalikko.spec.ts, perusopetus-v2-kielivalinta.spec.ts).